### PR TITLE
feat: Add LLaDA Diffusion Model Support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,8 +9,6 @@ __pycache__/
 # Vim
 *.swp
 
-LLaDA*/
-
 # Distribution / packaging
 .Python
 build/

--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,8 @@ __pycache__/
 # Vim
 *.swp
 
+LLaDA*/
+
 # Distribution / packaging
 .Python
 build/

--- a/mlx_lm/generate.py
+++ b/mlx_lm/generate.py
@@ -24,7 +24,7 @@ DEFAULT_QUANTIZED_KV_START = 5000
 DEFAULT_STEPS = 32
 DEFAULT_GEN_LENGTH = 64
 DEFAULT_NOISE_TEMP = 0.0
-DEFAULT_CFG = 0.0
+DEFAULT_CFG = 1.0
 DEFAULT_UNMASKING = "topk"
 DEFAULT_BLOCK_LENGTH = None
 
@@ -81,13 +81,22 @@ def setup_arg_parser():
         help="Maximum number of tokens to generate",
     )
     parser.add_argument(
-        "--temp", type=float, default=DEFAULT_TEMP, help="Sampling temperature"
+        "--temp",
+        type=float,
+        default=DEFAULT_TEMP,
+        help="Sampling temperature",
     )
     parser.add_argument(
-        "--top-p", type=float, default=DEFAULT_TOP_P, help="Sampling top-p"
+        "--top-p",
+        type=float,
+        default=DEFAULT_TOP_P,
+        help="Sampling top-p",
     )
     parser.add_argument(
-        "--min-p", type=float, default=DEFAULT_MIN_P, help="Sampling min-p"
+        "--min-p",
+        type=float,
+        default=DEFAULT_MIN_P,
+        help="Sampling min-p",
     )
     parser.add_argument(
         "--min-tokens-to-keep",
@@ -167,7 +176,6 @@ def setup_arg_parser():
         help="Number of tokens to draft when using speculative decoding.",
         default=3,
     )
-
     # Diffusion-specific arguments
     parser.add_argument(
         "--steps",
@@ -309,40 +317,28 @@ def main():
             raise ValueError("Draft model tokenizer does not match model tokenizer.")
     else:
         draft_model = None
-
-    if getattr(model.args, "model_type", None) == "llada":
-        # Add diffusion-specific arguments
-        response = generate(
-            model,
-            tokenizer,
-            prompt,
-            verbose=args.verbose,
-            steps=args.steps,
-            gen_length=args.gen_length,
-            noise_temp=args.noise_temp,
-            cfg=args.cfg,
-            block_length=args.block_length,
-            unmasking=args.unmasking,
-        )
-    
-    else:
-        # Add standard autoregressive arguments
-        sampler = make_sampler(args.temp, args.top_p, args.min_p, args.min_tokens_to_keep)
-        response = generate(
-            model,
-            tokenizer,
-            prompt,
-            max_tokens=args.max_tokens,
-            verbose=args.verbose,
-            sampler=sampler,
-            max_kv_size=args.max_kv_size,
-            prompt_cache=prompt_cache if using_cache else None,
-            kv_bits=args.kv_bits,
-            kv_group_size=args.kv_group_size,
-            quantized_kv_start=args.quantized_kv_start,
-            draft_model=draft_model,
-            num_draft_tokens=args.num_draft_tokens,
-        )
+    sampler = make_sampler(args.temp, args.top_p, args.min_p, args.min_tokens_to_keep)
+    response = generate(
+        model,
+        tokenizer,
+        prompt,
+        max_tokens=args.max_tokens,
+        verbose=args.verbose,
+        sampler=sampler,
+        max_kv_size=args.max_kv_size,
+        prompt_cache=prompt_cache if using_cache else None,
+        kv_bits=args.kv_bits,
+        kv_group_size=args.kv_group_size,
+        quantized_kv_start=args.quantized_kv_start,
+        draft_model=draft_model,
+        num_draft_tokens=args.num_draft_tokens,
+        steps=args.steps,
+        gen_length=args.gen_length,
+        noise_temp=args.noise_temp,
+        cfg=args.cfg,
+        block_length=args.block_length,
+        unmasking=args.unmasking,
+    )
     if not args.verbose:
         print(response)
 

--- a/mlx_lm/models/llada.py
+++ b/mlx_lm/models/llada.py
@@ -1,0 +1,243 @@
+# Copyright © 2023-2025 Apple Inc.
+
+from dataclasses import dataclass
+from typing import Any, Optional
+
+import mlx.core as mx
+import mlx.nn as nn
+
+from .base import BaseModelArgs, create_attention_mask, scaled_dot_product_attention
+from .rope_utils import initialize_rope
+
+
+@dataclass
+class ModelArgs(BaseModelArgs):
+    """Configuration arguments for the LLaDA model."""
+
+    model_type: str
+    hidden_size: int
+    num_hidden_layers: int
+    intermediate_size: int
+    num_attention_heads: int
+    rms_norm_eps: float
+    vocab_size: int
+    num_key_value_heads: Optional[int] = None
+    rope_theta: float = 10000.0
+    mask_token_id: Optional[int] = None
+    eos_token_id: Optional[int] = None
+    attention_bias: bool = False
+    mlp_bias: bool = False
+
+    def __post_init__(self):
+        """Set default token IDs and key-value heads if not provided."""
+        self.mask_token_id = self.mask_token_id or 126336
+        self.eos_token_id = self.eos_token_id or 126081
+        self.num_key_value_heads = self.num_key_value_heads or self.num_attention_heads
+
+    @classmethod
+    def from_dict(cls, params):
+        """Create ModelArgs from a configuration dictionary.
+
+        Args:
+            params (dict): Configuration parameters from config.json.
+
+        Returns:
+            ModelArgs: Initialized model arguments.
+        """
+        mapped_params = {
+            "model_type": params.get("model_type"),
+            "hidden_size": params.get("d_model"),
+            "num_hidden_layers": params.get("n_layers"),
+            "intermediate_size": params.get("mlp_hidden_size"),
+            "num_attention_heads": params.get("n_heads"),
+            "rms_norm_eps": params.get("rms_norm_eps"),
+            "vocab_size": params.get("vocab_size"),
+            "num_key_value_heads": params.get("n_kv_heads"),
+            "rope_theta": params.get("rope_theta", 10000.0),
+            "mask_token_id": params.get("mask_token_id"),
+            "eos_token_id": params.get("eos_token_id"),
+            "attention_bias": params.get("include_qkv_bias", False),
+            "mlp_bias": params.get("include_bias", False),
+        }
+        return cls(
+            **{k: v for k, v in mapped_params.items() if k in cls.__annotations__}
+        )
+
+
+class LLaDABlock(nn.Module):
+    """Transformer block for the LLaDA model"""
+
+    def __init__(self, args: ModelArgs):
+        """Initialize the LLaDA transformer block.
+
+        Args:
+            args (ModelArgs): Model configuration arguments.
+        """
+        super().__init__()
+        dim = args.hidden_size
+        self.n_heads = args.num_attention_heads
+        self.n_kv_heads = args.num_key_value_heads
+        self.head_dim = dim // self.n_heads
+        self.scale = self.head_dim**-0.5
+        self.args = args
+
+        self.q_proj = nn.Linear(
+            dim, self.n_heads * self.head_dim, bias=args.attention_bias
+        )
+        self.k_proj = nn.Linear(
+            dim, self.n_kv_heads * self.head_dim, bias=args.attention_bias
+        )
+        self.v_proj = nn.Linear(
+            dim, self.n_kv_heads * self.head_dim, bias=args.attention_bias
+        )
+        self.attn_out = nn.Linear(
+            self.n_heads * self.head_dim, dim, bias=args.attention_bias
+        )
+
+        self.attn_norm = nn.RMSNorm(args.hidden_size, eps=args.rms_norm_eps)
+        self.ff_norm = nn.RMSNorm(args.hidden_size, eps=args.rms_norm_eps)
+
+        hidden_dim = args.intermediate_size
+        self.ff_proj = nn.Linear(dim, hidden_dim, bias=args.mlp_bias)
+        self.up_proj = nn.Linear(dim, hidden_dim, bias=args.mlp_bias)
+        self.ff_out = nn.Linear(hidden_dim, dim, bias=args.mlp_bias)
+
+    def __call__(
+        self, x: mx.array, mask: Optional[mx.array] = None, cache: Optional[Any] = None
+    ) -> mx.array:
+        """Process input through attention and feed-forward layers.
+
+        Args:
+            x (mx.array): Input tensor [batch_size, seq_len, hidden_size].
+            mask (mx.array, optional): Attention mask.
+            cache (Any, optional): Key-value cache (unused in diffusion).
+
+        Returns:
+            mx.array: Output tensor [batch_size, seq_len, hidden_size].
+        """
+        # Attention path
+        h = mx.fast.rms_norm(
+            x, weight=self.attn_norm.weight, eps=self.args.rms_norm_eps
+        )
+        B, L, D = h.shape
+        queries = self.q_proj(h).reshape(B, L, self.n_heads, -1).transpose(0, 2, 1, 3)
+        keys = self.k_proj(h).reshape(B, L, self.n_kv_heads, -1).transpose(0, 2, 1, 3)
+        values = self.v_proj(h).reshape(B, L, self.n_kv_heads, -1).transpose(0, 2, 1, 3)
+
+        queries = mx.fast.rope(
+            queries,
+            dims=self.head_dim,
+            traditional=False,
+            base=self.args.rope_theta,
+            scale=1.0,
+            offset=0,
+        )
+        keys = mx.fast.rope(
+            keys,
+            dims=self.head_dim,
+            traditional=False,
+            base=self.args.rope_theta,
+            scale=1.0,
+            offset=0,
+        )
+
+        attn_output = mx.fast.scaled_dot_product_attention(
+            queries, keys, values, scale=self.scale, mask=mask
+        )
+        attn_output = attn_output.transpose(0, 2, 1, 3).reshape(B, L, -1)
+        h = x + self.attn_out(attn_output)
+
+        # Feed-forward path
+        out = mx.fast.rms_norm(
+            h, weight=self.ff_norm.weight, eps=self.args.rms_norm_eps
+        )
+        ff = self.ff_proj(out)
+        up = self.up_proj(out)
+        out = h + self.ff_out(nn.silu(ff) * up)
+        return out
+
+
+class LLaDAModel(nn.Module):
+    """Core LLaDA model for diffusion-based text generation."""
+
+    def __init__(self, args: ModelArgs):
+        """Initialize the LLaDA core model.
+
+        Args:
+            args (ModelArgs): Model configuration arguments.
+        """
+        super().__init__()
+        self.args = args
+        self.embed_tokens = nn.Embedding(args.vocab_size, args.hidden_size)
+        self.layers = [LLaDABlock(args) for _ in range(args.num_hidden_layers)]
+        self.norm = nn.RMSNorm(args.hidden_size, eps=args.rms_norm_eps)
+        self.lm_head = nn.Linear(args.hidden_size, args.vocab_size, bias=False)
+
+    def __call__(
+        self,
+        inputs: mx.array,
+        mask: Optional[mx.array] = None,
+        cache: Optional[Any] = None,
+    ) -> mx.array:
+        h = self.embed_tokens(inputs)
+        if mask is None and cache is None:  # Only create mask for diffusion (no cache)
+            mask = create_attention_mask(h, cache)
+
+        for layer in self.layers:
+            h = layer(h, mask, cache)
+        h = self.norm(h)
+        return self.lm_head(h)
+
+
+class Model(nn.Module):
+    """Top-level LLaDA model for diffusion-based text generation."""
+
+    def __init__(self, args: ModelArgs):
+        """Initialize the LLaDA model wrapper.
+
+        Args:
+            args (ModelArgs): Model configuration arguments.
+        """
+        super().__init__()
+        self.args = args
+        self.model_type = args.model_type
+        self.model = LLaDAModel(args)
+        self.mask_token_id = args.mask_token_id
+        assert args.vocab_size > 0, "Vocabulary size must be positive."
+
+    def __call__(
+        self,
+        inputs: mx.array,
+        mask: Optional[mx.array] = None,
+        cache: Optional[Any] = None,
+    ) -> mx.array:
+        return self.model(inputs, mask, cache)
+
+    def sanitize(self, weights):
+        """Remap PyTorch weights from transformers to MLX format."""
+        sanitized_weights = {}
+        for key, value in weights.items():
+            new_key = key
+            if "model.transformer.blocks" in key:
+                new_key = key.replace("model.transformer.blocks", "model.layers")
+            elif "model.transformer.wte.weight" in key:
+                new_key = "model.embed_tokens.weight"
+            elif "model.transformer.ln_f.weight" in key:
+                new_key = "model.norm.weight"
+            elif "model.transformer.ff_out.weight" in key:
+                new_key = "model.lm_head.weight"
+            new_key = new_key.replace("attn_norm.weight", "attn_norm.weight")
+            new_key = new_key.replace("ff_norm.weight", "ff_norm.weight")
+            new_key = new_key.replace("q_proj.weight", "q_proj.weight")
+            new_key = new_key.replace("k_proj.weight", "k_proj.weight")
+            new_key = new_key.replace("v_proj.weight", "v_proj.weight")
+            new_key = new_key.replace("attn_out.weight", "attn_out.weight")
+            new_key = new_key.replace("ff_proj.weight", "ff_proj.weight")
+            new_key = new_key.replace("up_proj.weight", "up_proj.weight")
+            new_key = new_key.replace("ff_out.weight", "ff_out.weight")
+            sanitized_weights[new_key] = value
+        return sanitized_weights
+
+    @property
+    def layers(self):
+        return self.model.layers

--- a/mlx_lm/models/llada.py
+++ b/mlx_lm/models/llada.py
@@ -141,6 +141,9 @@ class LLaDABlock(nn.Module):
             offset=0,
         )
 
+        if mask is not None:
+            mask = mask.astype(queries.dtype)
+
         attn_output = mx.fast.scaled_dot_product_attention(
             queries, keys, values, scale=self.scale, mask=mask
         )

--- a/mlx_lm/utils.py
+++ b/mlx_lm/utils.py
@@ -1,4 +1,4 @@
-# Copyright © 2023-2024 Apple Inc.
+# Copyright © 2023-2025 Apple Inc.
 
 import contextlib
 import copy
@@ -219,6 +219,245 @@ def maybe_quantize_kv_cache(prompt_cache, quantized_kv_start, kv_group_size, kv_
                 prompt_cache[i] = prompt_cache[i].to_quantized(
                     group_size=kv_group_size, bits=kv_bits
                 )
+
+
+def generate_diffusion(
+    prompt: mx.array,
+    model: nn.Module,
+    tokenizer,
+    *,
+    steps: int = 64,
+    gen_length: int = 64,
+    block_length: int = None,
+    noise_temp: float = 0.0,
+    cfg: float = 0.0,
+    mask_token_id: int = None,
+    verbose: bool = False,
+    unmasking: str = "topk",
+) -> Generator[GenerationResponse, None, None]:
+    """
+    Generate text using a diffusion-based approach.
+
+    Args:
+        prompt: mx.array, tokenized input prompt of shape (prompt_length,)
+        model: nn.Module, Transformer-based mask predictor
+        tokenizer: tokenizer object with decode method
+        steps: int, total number of diffusion steps
+        gen_length: int, length of the generated sequence
+        block_length: int, size of each block (defaults to gen_length)
+        noise_temp: float, temperature for Gumbel noise sampling
+        cfg: float, classifier-free guidance scale
+        mask_token_id: int, token ID for masking (defaults to model-specific or 126336)
+        verbose: bool, whether to yield intermediate responses
+        unmasking: str, strategy for selecting tokens to unmask ('topk' or 'random')
+    """
+
+    @mx.compile
+    def create_gumbel_noise(key, shape):
+        """
+        Generate stabilized Gumbel noise from a uniform distribution
+        with bounded values as base for diffusion
+        """
+        uniform = mx.random.uniform(
+            low=1e-7, high=1 - 1e-7, shape=shape, dtype=mx.float32, key=key
+        )
+
+        return -mx.log(-mx.log(uniform))
+
+    @mx.compile
+    def sample_noise_or_greedy(logits, temp, key):
+        """Sample token indices from logits using Gumbel noise or softmax based on temperature"""
+        logits = logits - mx.max(logits, axis=-1, keepdims=True)
+        probs = mx.softmax(logits, axis=-1)
+        gumbel_noise = create_gumbel_noise(key, logits.shape) ** temp
+        noisy_probs = mx.where(temp > 0.0, probs / gumbel_noise, probs)
+        sampled_ids = mx.argmax(noisy_probs, axis=-1)
+        return sampled_ids, gumbel_noise
+
+    # Model dtype handling
+    model_dtype = (
+        mx.float16
+        if hasattr(model, "dtype") and model.dtype == mx.float16
+        else mx.float32
+    )
+
+    # Default mask token ID
+    mask_token_id = mask_token_id or getattr(model.args, "mask_token_id", 126336)
+
+    batch_size = 1
+    prompt_length = prompt.shape[0]
+    seq_len = prompt_length + gen_length
+
+    # Block setup
+    block_length = block_length or gen_length
+    num_blocks = (gen_length + block_length - 1) // block_length
+    block_sizes = [
+        min(block_length, gen_length - i * block_length) for i in range(num_blocks)
+    ]
+    base_steps = steps // num_blocks
+    remainder = steps % num_blocks
+    steps_per_block = [
+        base_steps + 1 if i < remainder else base_steps for i in range(num_blocks)
+    ]
+
+    x = mx.full((batch_size, seq_len), mask_token_id, dtype=prompt.dtype)
+    x[:, :prompt_length] = prompt
+    full_mask = mx.zeros((1, 1, seq_len, seq_len), dtype=mx.float16)
+
+    # Initialize random keys (try to inherit from wrapper)m
+    master_key = (
+        mx.random.key(int(time.time_ns()))
+        if mx.random.seed is None
+        else mx.random.key(0)
+    )
+    block_keys = mx.random.split(master_key, num_blocks)
+    # Pre-allocate index_buffer
+    max_unmask = max(block_sizes)
+    index_buffer = mx.arange(max_unmask, dtype=mx.int32)
+
+    tic = time.perf_counter()
+    for block_idx, (block_size, block_steps) in enumerate(
+        zip(block_sizes, steps_per_block)
+    ):
+        block_start = prompt_length + sum(block_sizes[:block_idx])
+        block_end = block_start + block_size
+        seq_indices = mx.arange(seq_len, dtype=mx.int32)
+        block_mask = (seq_indices >= block_start) & (seq_indices < block_end)[None, :]
+
+        timesteps = mx.linspace(1.0, 0.0, block_steps, dtype=mx.float32)
+        step_keys = mx.random.split(block_keys[block_idx], block_steps)
+
+        for step, t in enumerate(timesteps):
+            mask_condition = x == mask_token_id
+            block_mask_condition = mask_condition & block_mask
+            num_masks_in_block = int(mx.sum(block_mask_condition).item())
+
+            # Early stopping logic if all unmasked
+            if num_masks_in_block == 0:
+                break
+
+            # CFG (Classifier-free guidance) and logits
+            if cfg > 0.0:
+                # Create unconditional input by masking only the prompt portion
+                un_x = mx.where(
+                    mx.arange(seq_len, dtype=mx.int32) < prompt_length,
+                    mx.full((batch_size, seq_len), mask_token_id, dtype=x.dtype),
+                    x,
+                )
+                x_ = mx.concatenate([x, un_x], axis=0)
+                logits = model(x_, mask=full_mask).astype(model_dtype)
+                logits, un_logits = mx.split(logits, 2, axis=0)
+                logits = un_logits + (cfg + 1) * (logits - un_logits)
+            else:
+                logits = model(x, mask=full_mask).astype(model_dtype)
+
+            # Sampling
+            x0, gumbel_noise = sample_noise_or_greedy(
+                logits, noise_temp, step_keys[step]
+            )
+
+            # unmasking logic
+            if unmasking == "topk":
+                if noise_temp > 0.0:
+                    confidence_scores = mx.max(
+                        mx.exp(logits - mx.max(logits, axis=-1, keepdims=True))
+                        / gumbel_noise,
+                        axis=-1,
+                    )
+                else:
+                    confidence_scores = mx.max(mx.softmax(logits, axis=-1), axis=-1)
+
+            elif unmasking == "random":
+                confidence_scores = mx.random.uniform(
+                    shape=(batch_size, seq_len), key=step_keys[step], dtype=model_dtype
+                )
+            else:
+                raise ValueError(
+                    f"Invalid unmasking strategy: {unmasking}, must be one of 'topk', or 'random'"
+                )
+
+            masked_confidences = mx.where(block_mask_condition, confidence_scores, -1e9)
+            target_unmasked = int(mx.round(block_size * (1 - t)).item())
+            current_unmasked = block_size - num_masks_in_block
+            num_to_unmask = (
+                num_masks_in_block
+                if step == block_steps - 1
+                else min(max(0, target_unmasked - current_unmasked), num_masks_in_block)
+            )
+
+            if num_to_unmask > 0:
+                sorted_indices = mx.argsort(masked_confidences.flatten())[::-1]
+                unmask_indices = mx.take(sorted_indices, index_buffer[:num_to_unmask])
+                x[:, unmask_indices] = x0[:, unmask_indices]
+
+            # Recalculate masks after unmasking
+            mask_condition = x == mask_token_id
+            block_mask_condition = mask_condition & block_mask
+            num_masks_in_block = int(mx.sum(block_mask_condition).item())
+            unmasked_count = block_size - num_masks_in_block
+
+            if verbose:
+                mx.eval(x)
+                response_tokens = x[0, prompt_length:block_end].tolist()
+                current_text = (
+                    tokenizer.decode(response_tokens, skip_special_tokens=True).strip()
+                    or "(No text revealed yet)"
+                )
+                elapsed_time = time.perf_counter() - tic
+                yield GenerationResponse(
+                    text=f"\033[2J\033[H{'=' * 10}\n"
+                    f"Generating with diffusion model: {steps} steps, {gen_length} tokens\n"
+                    f"Block {block_idx + 1}/{num_blocks} | Step {step + 1}/{block_steps} | "
+                    f"Unmasked {unmasked_count}/{block_size}\n\n{current_text}",
+                    token=0,
+                    logprobs=mx.array([]),
+                    prompt_tokens=prompt.size,
+                    prompt_tps=prompt.size / elapsed_time if elapsed_time > 0 else 0,
+                    generation_tokens=block_end - prompt_length,
+                    generation_tps=(
+                        (block_end - prompt_length) / elapsed_time
+                        if elapsed_time > 0
+                        else 0
+                    ),
+                    peak_memory=mx.metal.get_peak_memory() / 1e9,
+                    finish_reason=None,
+                )
+
+        mx.eval(x)  # Finalize block
+
+    # Final response after all blocks are complete
+    mx.eval(x)
+    final_text = tokenizer.decode(
+        x[0, prompt_length:].tolist(), skip_special_tokens=True
+    ).strip()
+    prompt_time = time.perf_counter() - tic
+    generation_tokens = seq_len - prompt_length
+
+    if not verbose:
+        yield GenerationResponse(
+            text=final_text,
+            token=0,
+            logprobs=mx.array([]),
+            prompt_tokens=prompt.size,
+            prompt_tps=prompt.size / prompt_time if prompt_time > 0 else 0,
+            generation_tokens=generation_tokens,
+            generation_tps=generation_tokens / prompt_time if prompt_time > 0 else 0,
+            peak_memory=mx.metal.get_peak_memory() / 1e9,
+            finish_reason="length",
+        )
+    # In verbose mode, output a final response with finish_reason set
+    elif verbose:
+        yield GenerationResponse(
+            text="",
+            token=0,
+            logprobs=mx.array([]),
+            prompt_tokens=prompt.size,
+            prompt_tps=prompt.size / prompt_time if prompt_time > 0 else 0,
+            generation_tokens=generation_tokens,
+            generation_tps=generation_tokens / prompt_time if prompt_time > 0 else 0,
+            peak_memory=mx.metal.get_peak_memory() / 1e9,
+            finish_reason="length",
+        )
 
 
 def generate_step(
@@ -516,6 +755,9 @@ def speculative_generate_step(
         _rewind_cache(num_draft, n)
 
 
+
+
+
 def stream_generate(
     model: nn.Module,
     tokenizer: Union[PreTrainedTokenizer, TokenizerWrapper],
@@ -534,8 +776,8 @@ def stream_generate(
         draft_model (Optional[nn.Module]): An optional draft model. If provided
           then speculative decoding is used. The draft model must use the same
           tokenizer as the main model. Default: ``None``.
-        kwargs: The remaining options get passed to :func:`generate_step`.
-          See :func:`generate_step` for more details.
+        **kwargs: Options for generation. For autoregressive models,
+            See:func:`generate_step` or for diffusion model func:`generate_diffusion`.
 
     Yields:
         GenerationResponse: An instance containing the generated text segment and
@@ -555,57 +797,97 @@ def stream_generate(
 
     detokenizer = tokenizer.detokenizer
 
-    if draft_model is None:
-        kwargs.pop("num_draft_tokens", None)
-        token_generator = generate_step(prompt, model, **kwargs)
-        # from_draft always false for non-speculative generation
-        token_generator = (
-            (token, logprobs, False) for token, logprobs in token_generator
-        )
-    else:
-        kwargs.pop("max_kv_size", None)
-        token_generator = speculative_generate_step(
-            prompt, model, draft_model, **kwargs
-        )
+        # Define valid argument sets for clarity and filtering
+    AUTOREGRESSIVE_ARGS = {
+        "max_tokens",
+        "sampler",
+        "logits_processors",
+        "max_kv_size",
+        "prompt_cache",
+        "prefill_step_size",
+        "kv_bits",
+        "kv_group_size",
+        "quantized_kv_start",
+        "prompt_progress_callback",
+        "num_draft_tokens",
+        "draft_model",
+    }
+    DIFFUSION_ARGS = {
+        "steps",
+        "gen_length",
+        "block_length",
+        "noise_temp",
+        "cfg",
+        "mask_token_id",
+        "unmasking",
+    }
+
+    # Fork between diffusion and autoregressive models
+    is_diffusion = getattr(model.args, "model_type", None) == "llada"
     with wired_limit(model, [generation_stream]):
-        detokenizer.reset()
-        tic = time.perf_counter()
-        for n, (token, logprobs, from_draft) in enumerate(token_generator):
-            if n == 0:
-                prompt_time = time.perf_counter() - tic
-                prompt_tps = prompt.size / prompt_time
-                tic = time.perf_counter()
-            if token in tokenizer.eos_token_ids:
-                break
+        if is_diffusion:
+            diffusion_args = {k: kwargs.get(k) for k in DIFFUSION_ARGS if k in kwargs}
+            diffusion_args["verbose"] = verbose
+            diffusion_gen = generate_diffusion(
+                prompt, model, tokenizer, **diffusion_args
+            )
+            if verbose:
+                for response in diffusion_gen:
+                    yield response
+            else:
+                final_response = None
+                for final_response in diffusion_gen:
+                    pass
+                yield final_response
+        else:
+            # Autoregressive path
+            autoregressive_args = {
+                k: kwargs.get(k) for k in AUTOREGRESSIVE_ARGS if k in kwargs
+            }
+            if draft_model is None:
+                autoregressive_args.pop("num_draft_tokens", None)
+                token_generator = generate_step(prompt, model, **autoregressive_args)
+            else:
+                autoregressive_args.pop("max_kv_size", None)
+                token_generator = speculative_generate_step(
+                    prompt, model, draft_model, **autoregressive_args
+                )
 
-            detokenizer.add_token(token)
+            detokenizer.reset()
+            tic = time.perf_counter()
+            for n, (token, logprobs) in enumerate(token_generator):
+                if n == 0:
+                    prompt_time = time.perf_counter() - tic
+                    prompt_tps = prompt.size / prompt_time
+                    tic = time.perf_counter()
+                if token in tokenizer.eos_token_ids:
+                    break
 
+                detokenizer.add_token(token)
+                yield GenerationResponse(
+                    text=detokenizer.last_segment,
+                    token=token,
+                    logprobs=logprobs,
+                    prompt_tokens=prompt.size,
+                    prompt_tps=prompt_tps,
+                    generation_tokens=n + 1,
+                    generation_tps=(n + 1) / (time.perf_counter() - tic),
+                    peak_memory=mx.metal.get_peak_memory() / 1e9,
+                    finish_reason=None,
+                )
+
+            detokenizer.finalize()
             yield GenerationResponse(
                 text=detokenizer.last_segment,
                 token=token,
                 logprobs=logprobs,
-                from_draft=from_draft,
                 prompt_tokens=prompt.size,
                 prompt_tps=prompt_tps,
                 generation_tokens=n + 1,
                 generation_tps=(n + 1) / (time.perf_counter() - tic),
                 peak_memory=mx.metal.get_peak_memory() / 1e9,
-                finish_reason=None,
+                finish_reason="stop" if token in tokenizer.eos_token_ids else "length",
             )
-
-        detokenizer.finalize()
-        yield GenerationResponse(
-            text=detokenizer.last_segment,
-            token=token,
-            logprobs=logprobs,
-            from_draft=from_draft,
-            prompt_tokens=prompt.size,
-            prompt_tps=prompt_tps,
-            generation_tokens=n + 1,
-            generation_tps=(n + 1) / (time.perf_counter() - tic),
-            peak_memory=mx.metal.get_peak_memory() / 1e9,
-            finish_reason="stop" if token in tokenizer.eos_token_ids else "length",
-        )
 
 
 def generate(
@@ -620,13 +902,17 @@ def generate(
     Generate a complete response from the model.
 
     Args:
-       model (nn.Module): The language model.
-       tokenizer (PreTrainedTokenizer): The tokenizer.
-       prompt (Union[str, List[int]]): The input prompt string or integer tokens.
-       verbose (bool): If ``True``, print tokens and timing information.
-           Default: ``False``.
-       kwargs: The remaining options get passed to :func:`stream_generate`.
-          See :func:`stream_generate` for more details.
+        model (nn.Module): The language model.
+        tokenizer (PreTrainedTokenizer): The tokenizer.
+        prompt (Union[str, List[int]]): The input prompt string or integer tokens.
+        verbose (bool): If ``True``, print tokens and timing information.
+            Default: ``False``.
+        formatter (Optional[Callable]): Deprecated text formatter. Default: ``None``.
+        **kwargs: Options passed to :func:`stream_generate`. See :func:`stream_generate`
+            for details.
+
+    Returns:
+        str: The generated text.
     """
     if formatter is not None:
         print(


### PR DESCRIPTION
#### Overview
This PR introduces support for diffusion-based language models (e.g., LLaDA) in mlx_lm, extending the framework beyond autoregressive generation to include diffusion paradigms for further research. The implementation adds a new generate_diffusion function in utils.py, respectfully updates the generation pipeline to handle both model types, and resolves issues that arose during integration, being very careful not to affect autoregressive path compatibility. The changes maintain alignment with the mlx-lm principles while ensuring robust initial functionality for diffusion models LLaDA and potentially others going forward.

#### Key Changes
1. **New `generate_diffusion` Function in `utils.py`**  
   - Added a new function to support diffusion-based text generation, tailored for models like LLaDA.
   - Key features:
     - Progressive token unmasking with configurable steps (`steps`), generation length (`gen_length`), and block sizes (`block_length`).
     - Supports Gumbel noise sampling (`noise_temp`) for stochasticity and classifier-free guidance (`cfg`) for controlled generation.
     - Implements semi-autoregressive block-wise diffusion with configurable unmasking strategies (`topk` or `random`).
     - Yields intermediate progress updates in verbose mode or final text otherwise, integrated with the `GenerationResponse` dataclass.
   - Optimizations:
     - Uses `mx.compile` for the sampling step to leverage MLX’s performance benefits.
     - Efficiently handles batch size of 1 (current limitation) with plans for future expansion.

2. **Updated `stream_generate` in `utils.py`**  
   - Modified to detect diffusion models via `model.args.model_type == "llada"` and delegate to `generate_diffusion`.
   - Preserves existing autoregressive paths (`generate_step` and `speculative_generate_step`) for non-diffusion models.
   - Added argument filtering to route diffusion-specific kwargs (e.g., `steps`, `gen_length`) to `generate_diffusion` and autoregressive kwargs (e.g., `max_tokens`, `sampler`) to their respective functions.
   - Ensures consistent streaming behavior across model types using the `GenerationResponse` interface.

3. **Extended CLI in `generate.py`**  
   - Added diffusion-specific arguments with sensible defaults:
     - `--steps` (default: 32): Number of diffusion steps.
     - `--gen-length` (default: 64): Length of the generated sequence.
     - `--noise-temp` (default: 0.0): Temperature for Gumbel noise sampling.
     - `--cfg` (default: 1.0): Classifier-free guidance scale.
     - `--block-length` (default: None): Size of semi-autoregressive blocks.
     - `--unmasking` (default: "topk"): Strategy for unmasking tokens (`topk` or `random`).
   - Integrated these into the `generate` call, ensuring seamless invocation of diffusion generation when using an LLaDA model.

#### Implementation Details
- **Model Detection**: Relies on `model.args.model_type == "llada"` to switch to diffusion mode, ensuring compatibility with custom LLaDA implementations (e.g., your `llada.py`).
- **Performance**: Leverages MLX’s fast operations as much as possible.
- **Backward Compatibility**: Autoregressive generation paths (including speculative decoding) remain unchanged, with diffusion-specific logic isolated to new code paths.


#### Testing
- **Weights Conversion**
  - Works as normal, including quantization.
  - Example:
     ```bash
     mlx_lm.convert --hf-path <llada-hf-repo> --mlx-path ./llada-mlx --quantize --q-bits 4
     ```
- **Diffusion**:
  - Command:
  -  ```bash
     mlx_lm.generate \
       --model mlx-community/LLaDA-8B-Instruct-mlx-fp16 \
       --prompt "Tell me about Leonardo da Vinci." \
       --gen-length 32 \
       --steps 32 \
       --noise-temp 0.3 \
       --cfg 1.0 \
       --verbose true
     ```
  - Recommend using pre converted weights mlx-community/LLaDA-8B-Instruct-mlx-fp16 or quantized also on mlx-community.
  - Output:
     - Verbose mode shows block-wise progress (e.g., "Block 1/1 | Step 32/32 | Unmasked 32/32") with intermediate text.
     - Non-verbose mode prints only the final generated text.

#### Impact
- **New Feature**: Users can now generate text with diffusion model LLaDA, broadening `mlx_lm`’s applicability.
- **Preserved Behaviour**: Autoregressive models unaffected, with minimised intrusion into the repo.

#### Known Limitations
- Verbose output in diffusion mode uses ANSI escape codes (`\033[2J\033[H`), which may not render perfectly in all terminals.

#### Future Work
- Optimise performance
- New research regarding diffusion LLMs drops weekly, there is a lot of scope for improvements
