### PR TITLE
Update mixed_quant_predicate_builder calls to include high_bits parameter

### DIFF
--- a/mlx_lm/utils.py
+++ b/mlx_lm/utils.py
@@ -1052,8 +1052,8 @@ def mixed_quant_predicate_builder(
     return mixed_quant_predicate
 
 
-mixed_3_6 = mixed_quant_predicate_builder(low_bits=3)
-mixed_2_6 = mixed_quant_predicate_builder(low_bits=2)
+mixed_3_6 = mixed_quant_predicate_builder(low_bits=3, high_bits=6)
+mixed_2_6 = mixed_quant_predicate_builder(low_bits=2, high_bits=6)
 
 
 def convert(


### PR DESCRIPTION
Explicitly pass the high_bits parameter in the mixed_2_6 and mixed_3_6 quant predicates instead of using default value.

Fixes [ml-explore/mlx-examples#17](https://github.com/ml-explore/mlx-lm/issues/17)

Migrated from [mlx-examples](https://github.com/ml-explore/mlx-examples/pull/1348) repo. 