### PR TITLE
Remove vision config

### DIFF
--- a/mlx_lm/utils.py
+++ b/mlx_lm/utils.py
@@ -1007,6 +1007,7 @@ def save_config(
     """
     # Clean unused keys
     config.pop("_name_or_path", None)
+    config.pop("vision_config", None)
 
     # sort the config for better readability
     config = dict(sorted(config.items()))


### PR DESCRIPTION
For text only VLMs, so downstream users know it's not a vlm.