### PR TITLE
Enable memory efficient fine tuning for very long sequences

### DIFF
--- a/mlx_lm/lora.py
+++ b/mlx_lm/lora.py
@@ -169,6 +169,12 @@ def build_parser():
         help="Maximum sequence length.",
     )
     parser.add_argument(
+        "--seq-step-size",
+        type=int,
+        default=None,
+        help="",
+    )
+    parser.add_argument(
         "-c",
         "--config",
         type=str,
@@ -238,6 +244,7 @@ def train_model(
         adapter_file=adapter_file,
         max_seq_length=args.max_seq_length,
         grad_checkpoint=args.grad_checkpoint,
+        seq_step_size=args.seq_step_size,
     )
 
     # Initialize the selected optimizer

--- a/mlx_lm/tuner/trainer.py
+++ b/mlx_lm/tuner/trainer.py
@@ -15,8 +15,8 @@ from mlx.nn.utils import average_gradients
 from mlx.utils import tree_flatten, tree_map
 from transformers import PreTrainedTokenizer
 
-from .datasets import CacheDataset
 from ..models.cache import KVCache, make_prompt_cache
+from .datasets import CacheDataset
 
 
 def reset_prompt_cache(cache):
@@ -267,6 +267,7 @@ def train(
 
     model.train()
     seq_step_size = args.seq_step_size or args.max_seq_length
+
     def seq_split_step(batch):
         losses = mx.array(0.0)
         n_tokens = mx.array(0.0)
@@ -299,7 +300,6 @@ def train(
 
     loss_value_and_grad = nn.value_and_grad(model, loss)
 
->>>>>>> 568a8d6 (use gradient accumulation)
     losses = 0
     n_tokens = 0
     steps = 0
@@ -321,7 +321,6 @@ def train(
         # is always measured before any training.
         if it == 1 or it % args.steps_per_eval == 0 or it == args.iters:
             tic = time.perf_counter()
-            val_loss = 0.0
             val_loss = evaluate(
                 model=model,
                 dataset=val_dataset,

--- a/tests/test_finetune.py
+++ b/tests/test_finetune.py
@@ -370,11 +370,10 @@ class TestScheduleConfig(unittest.TestCase):
         mock_iterate_batches = MagicMock()
 
         mock_iterate_batches.return_value = [
-            (MagicMock(), MagicMock()),
-            (MagicMock(), MagicMock()),
-            (MagicMock(), MagicMock()),
-            (MagicMock(), MagicMock()),
-            (MagicMock(), MagicMock()),
+            (mx.ones((2, 8), mx.int32), mx.ones((2, 2), mx.int32)),
+            (mx.ones((2, 8), mx.int32), mx.ones((2, 2), mx.int32)),
+            (mx.ones((2, 8), mx.int32), mx.ones((2, 2), mx.int32)),
+            (mx.ones((2, 8), mx.int32), mx.ones((2, 2), mx.int32)),
         ]
 
         mock_default_loss.side_effect = [
@@ -412,9 +411,9 @@ class TestScheduleConfig(unittest.TestCase):
         mock_iterate_batches = MagicMock()
 
         mock_iterate_batches.return_value = [
-            (MagicMock(), MagicMock()),
-            (MagicMock(), MagicMock()),
-            (MagicMock(), MagicMock()),
+            (mx.ones((2, 8), mx.int32), mx.ones((2, 2), mx.int32)),
+            (mx.ones((2, 8), mx.int32), mx.ones((2, 2), mx.int32)),
+            (mx.ones((2, 8), mx.int32), mx.ones((2, 2), mx.int32)),
         ]
 
         mock_default_loss.side_effect = [


### PR DESCRIPTION
Use a KV cache to split long sequences into shorter sequences and reduce memory. I didn't add gradient accumulation yet.. but we may want to use it so that the results match for different values of `--seq-step-size`.

One can set for example `--seq-step-size 1024` and it will use way less memory when trianing on sequences that are length `4096`. For example:

### Without splitting:

```
mlx_lm.lora --model mlx-community/llama-3.2-1B-Instruct-bf16 --data ../ --train --steps-per-report 5 --max-seq-length 4096
```

```
Iter 5: Train loss 1.520, Learning Rate 1.000e-05, It/sec 0.111, Tokens/sec 1825.855, Trained Tokens 81900, Peak mem 69.810 GB
```

### With splitting:

```
mlx_lm.lora --model mlx-community/llama-3.2-1B-Instruct-bf16 --data ../ --train --steps-per-report 5 --seq-step-size 1024 --max-seq-length 4096
```

```
Iter 5: Train loss 1.496, Learning Rate 1.000e-05, It/sec 0.136, Tokens/sec 2220.005, Trained Tokens 81840, Peak mem 19.704 GB
```