### PR TITLE
Improvements to dataset preprocessing

### DIFF
--- a/mlx_lm/examples/lora_config.yaml
+++ b/mlx_lm/examples/lora_config.yaml
@@ -81,7 +81,7 @@ lora_parameters:
 #  arguments: [1e-5, 1000, 1e-7] # passed to scheduler
 
 #hf_dataset:
-#  name: "billsum"
+#  path: "billsum"
 #  train_split: "train[:1000]"
 #  valid_split: "train[-100:]"
 #  prompt_feature: "text"

--- a/mlx_lm/lora.py
+++ b/mlx_lm/lora.py
@@ -7,6 +7,7 @@ import re
 import types
 from pathlib import Path
 
+import mlx.core as mx
 import mlx.nn as nn
 import mlx.optimizers as optim
 import numpy as np
@@ -191,6 +192,7 @@ def train_model(
     valid_set,
     training_callback: TrainingCallback = None,
 ):
+    mx.random.seed(args.seed)
     model.freeze()
     if args.num_layers > len(model.layers):
         raise ValueError(
@@ -238,8 +240,6 @@ def train_model(
         grad_checkpoint=args.grad_checkpoint,
     )
 
-    model.train()
-
     # Initialize the selected optimizer
     lr = build_schedule(args.lr_schedule) if args.lr_schedule else args.learning_rate
 
@@ -268,8 +268,6 @@ def train_model(
 
 
 def evaluate_model(args, model: nn.Module, tokenizer: TokenizerWrapper, test_set):
-    model.eval()
-
     test_loss = evaluate(
         model=model,
         dataset=test_set,

--- a/tests/test_datsets.py
+++ b/tests/test_datsets.py
@@ -44,7 +44,7 @@ class TestDatasets(unittest.TestCase):
         self.assertEqual(len(test), 0)
         self.assertTrue(len(train[0]) > 0)
         self.assertTrue(len(valid[0]) > 0)
-        self.assertTrue(isinstance(train, datasets.Dataset))
+        self.assertTrue(isinstance(train, datasets.TextDataset))
 
     def test_completions(self):
         data = {"prompt": "What is the capital of France?", "completion": "Paris."}
@@ -80,7 +80,7 @@ class TestDatasets(unittest.TestCase):
 
     def test_hf(self):
         hf_args = {
-            "name": "billsum",
+            "path": "billsum",
             "prompt_feature": "text",
             "completion_feature": "summary",
             "train_split": "train[:2%]",


### PR DESCRIPTION
- Dynamically preprocess and cache the dataset. Really speeds up cold-start time for larger datasets.
- Change padding values for speed (see benchmark)
- Seed RNG for distributed + only save weights on rank 0


Pre / post padding change:
```
Iter 100: Train loss 1.730, Learning Rate 1.000e-05, It/sec 7.039, Tokens/sec 583.184, Trained Tokens 8285, Peak mem 5.805 GB
Iter 200: Train loss 1.259, Learning Rate 1.000e-05, It/sec 7.133, Tokens/sec 573.284, Trained Tokens 16322, Peak mem 6.527 GB
```

```
Iter 100: Train loss 1.719, Learning Rate 1.000e-05, It/sec 7.244, Tokens/sec 600.669, Trained Tokens 8292, Peak mem 5.799 GB
Iter 200: Train loss 1.258, Learning Rate 1.000e-05, It/sec 8.003, Tokens/sec 644.222, Trained Tokens 16342, Peak mem 6.520 GB
```