### PR TITLE
fix missing self references in ChatDataset class

### DIFF
--- a/mlx_lm/tuner/datasets.py
+++ b/mlx_lm/tuner/datasets.py
@@ -58,12 +58,12 @@ class ChatDataset:
         tokens = self.tokenizer.apply_chat_template(messages, tools=tools)
         if self.mask_prompt:
             messages = messages[:-1]
-            offset = len(tokenizer.apply_chat_template(messages, tools=tools))
+            offset = len(self.tokenizer.apply_chat_template(messages, tools=tools))
             return (tokens, offset)
         else:
             return tokens
 
-    def itemlen(idx: int):
+    def itemlen(self, idx: int):
         return len(self._data[idx])
 
     def __getitem__(self, idx: int):

--- a/mlx_lm/tuner/datasets.py
+++ b/mlx_lm/tuner/datasets.py
@@ -63,9 +63,6 @@ class ChatDataset:
         else:
             return tokens
 
-    def itemlen(self, idx: int):
-        return len(self._data[idx])
-
     def __getitem__(self, idx: int):
         return self._data[idx]
 


### PR DESCRIPTION
Instance Attribute Scope Fixing, so added missing `self` in `offset = len(tokenizer.apply_chat_template(...))`, and in `def itemlen(idx: int)`.