### PR TITLE
Modified OpenELM.py code to make it work with mypy

### DIFF
--- a/mlx_lm/models/cache.py
+++ b/mlx_lm/models/cache.py
@@ -45,12 +45,10 @@ def save_prompt_cache(file_name: str, cache: List[Any], metadata: Dict[str, str]
         metadata (Dict[str, str]): Optional metadata to save along with model
             state.
     """
-    cache_data = [c.state for c in cache]
+    cache_data: Dict[Any, Any] = dict(tree_flatten([c.state for c in cache])) 
     cache_info = [c.meta_state for c in cache]
-    cache_data = dict(tree_flatten(cache_data))
     cache_classes = [type(c).__name__ for c in cache]
-    cache_metadata = [cache_info, metadata, cache_classes]
-    cache_metadata = dict(tree_flatten(cache_metadata))
+    cache_metadata: Dict[Any, Any] = dict(tree_flatten([cache_info, metadata, cache_classes]))
     mx.save_safetensors(file_name, cache_data, cache_metadata)
 
 
@@ -102,7 +100,7 @@ def trim_prompt_cache(cache: List[Any], num_tokens: int) -> List[Any]:
         (int): The number of tokens that were trimmed.
     """
     if not can_trim_prompt_cache(cache) or len(cache) == 0:
-        return 0
+        return []
     return [c.trim(num_tokens) for c in cache][0]
 
 

--- a/mlx_lm/models/openelm.py
+++ b/mlx_lm/models/openelm.py
@@ -44,6 +44,8 @@ def make_divisible(
     Returns:
         new_v: new divisible value
     """
+    if divisor is None:
+        raise ValueError("divisor must not be None")
     if min_value is None:
         min_value = divisor
     new_v = max(min_value, int(v + divisor / 2) // divisor * divisor)


### PR DESCRIPTION
on executing the following command before this change: 
`mypy --explicit-package-bases --ignore-missing-imports models/openelm.py`

Output:
```
models\cache.py:50: error: Incompatible types in assignment (expression has type "dict[Any, Any]", variable has type "list[Any]")  [assignment]
models\cache.py:53: error: Incompatible types in assignment (expression has type "dict[Any, Any]", variable has type "list[Collection[Any]]")  [assignment]
models\cache.py:105: error: Incompatible return value type (got "int", expected "list[Any]")  [return-value]
models\openelm.py:49: error: Value of type variable "SupportsRichComparisonT" of "max" cannot be "float | int | None"  [type-var]
models\openelm.py:49: error: Unsupported operand types for // ("int" and "None")  [operator]
models\openelm.py:49: note: Right operand is of type "int | None"
models\openelm.py:49: error: Unsupported operand types for * ("int" and "None")  [operator]
models\openelm.py:49: error: Unsupported operand types for / ("None" and "int")  [operator]
models\openelm.py:49: note: Left operand is of type "int | None"
models\openelm.py:49: note: Left operand is of type "float | int"
models\openelm.py:51: error: Unsupported operand types for > ("float" and "None")  [operator]
models\openelm.py:51: note: Left operand is of type "float | int | None"
models\openelm.py:52: error: Unsupported operand types for + ("float" and "None")  [operator]
models\openelm.py:52: error: Unsupported operand types for + ("int" and "None")  [operator]
models\openelm.py:52: error: Unsupported operand types for + ("None" and "int")  [operator]
models\openelm.py:52: error: Unsupported left operand type for + ("None")  [operator]
models\openelm.py:52: note: Both left and right operands are unions
models\openelm.py:53: error: Incompatible return value type (got "float | int | None", expected "float | int")  [return-value]
Found 13 errors in 2 files (checked 1 source file)
```

After this change: 
```
Success: no issues found in 1 source file
```