### PR TITLE
Adds support for speculative decoding to mlx_lm.server

### DIFF
--- a/mlx_lm/SERVER.md
+++ b/mlx_lm/SERVER.md
@@ -41,6 +41,19 @@ curl localhost:8080/v1/chat/completions \
    }'
 ```
 
+## Speculative Decoding
+
+The server supports speculative decoding to accelerate text generation by using a smaller, faster "draft" model to predict tokens that are then verified by the main model. To enable this feature, use:
+
+```shell
+mlx_lm.server --model mlx-community/Llama-3.2-8B-Instruct-4bit --draft-model mlx-community/Llama-3.2-1B-Instruct-4bit
+```
+
+- `--draft-model`: Specifies a smaller model to use for speculative decoding.
+- `--num-draft-tokens`: Sets how many tokens the draft model should predict at once (default: 3). This is an optional parameter.
+
+The draft model should ideally use the same tokenizer as the main model for best results.
+
 ### Request Fields
 
 - `messages`: An array of message objects representing the conversation

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -12,10 +12,26 @@ from mlx_lm.utils import load
 
 
 class DummyModelProvider:
-    def __init__(self):
+    def __init__(self, with_draft=False):
         HF_MODEL_PATH = "mlx-community/Qwen1.5-0.5B-Chat-4bit"
         self.model, self.tokenizer = load(HF_MODEL_PATH)
         self.model_key = (HF_MODEL_PATH, None)
+        
+        # Add draft model support
+        self.draft_model = None
+        self.draft_model_key = None
+        self.cli_args = type('obj', (object,), {
+            'num_draft_tokens': 2 if with_draft else None,
+            'adapter_path': None,
+            'chat_template': None,
+            'use_default_chat_template': False,
+            'trust_remote_code': False,
+        })
+        
+        if with_draft:
+            # Use the same model as the draft model for testing
+            self.draft_model, _ = load(HF_MODEL_PATH)
+            self.draft_model_key = HF_MODEL_PATH
 
     def load(self, model, adapter=None):
         assert model in ["default_model", "chat_model"]
@@ -128,6 +144,151 @@ class TestServer(unittest.TestCase):
         self.assertFalse(sequence_overlap([1], [2]))
         self.assertFalse(sequence_overlap([1, 2], [3, 4]))
         self.assertFalse(sequence_overlap([1, 2, 3], [4, 1, 2, 3]))
+
+
+class TestServerWithDraftModel(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.model_provider = DummyModelProvider(with_draft=True)
+        cls.server_address = ("localhost", 0)
+        cls.httpd = http.server.HTTPServer(
+            cls.server_address,
+            lambda *args, **kwargs: APIHandler(cls.model_provider, *args, **kwargs),
+        )
+        cls.port = cls.httpd.server_port
+        cls.server_thread = threading.Thread(target=cls.httpd.serve_forever)
+        cls.server_thread.daemon = True
+        cls.server_thread.start()
+
+    @classmethod
+    def tearDownClass(cls):
+        cls.httpd.shutdown()
+        cls.httpd.server_close()
+        cls.server_thread.join()
+
+    def test_handle_completions_with_draft_model(self):
+        url = f"http://localhost:{self.port}/v1/completions"
+
+        post_data = {
+            "model": "default_model",
+            "prompt": "Once upon a time",
+            "max_tokens": 10,
+            "temperature": 0.0,  # Use deterministic sampling for consistent results
+            "top_p": 1.0,
+        }
+
+        response = requests.post(url, json=post_data)
+        self.assertEqual(response.status_code, 200)
+        
+        response_body = json.loads(response.text)
+        self.assertIn("id", response_body)
+        self.assertIn("choices", response_body)
+        self.assertIn("usage", response_body)
+        
+        # Check that tokens were generated
+        self.assertTrue(response_body["usage"]["completion_tokens"] > 0)
+
+    def test_handle_chat_completions_with_draft_model(self):
+        url = f"http://localhost:{self.port}/v1/chat/completions"
+        
+        chat_post_data = {
+            "model": "chat_model",
+            "max_tokens": 10,
+            "temperature": 0.0,  # Use deterministic sampling for consistent results
+            "messages": [
+                {"role": "system", "content": "You are a helpful assistant."},
+                {"role": "user", "content": "Hello!"},
+            ],
+        }
+        
+        response = requests.post(url, json=chat_post_data)
+        self.assertEqual(response.status_code, 200)
+        
+        response_body = json.loads(response.text)
+        self.assertIn("id", response_body)
+        self.assertIn("choices", response_body)
+        self.assertIn("usage", response_body)
+        
+        # Check that tokens were generated
+        self.assertTrue(response_body["usage"]["completion_tokens"] > 0)
+
+    def test_streaming_with_draft_model(self):
+        url = f"http://localhost:{self.port}/v1/chat/completions"
+        
+        chat_post_data = {
+            "model": "chat_model",
+            "max_tokens": 10,
+            "temperature": 0.0,  # Use deterministic sampling for consistent results
+            "stream": True,
+            "messages": [
+                {"role": "system", "content": "You are a helpful assistant."},
+                {"role": "user", "content": "Hello!"},
+            ],
+        }
+        
+        response = requests.post(url, json=chat_post_data, stream=True)
+        self.assertEqual(response.status_code, 200)
+        
+        chunk_count = 0
+        for chunk in response.iter_lines():
+            if chunk:
+                data = chunk.decode('utf-8')
+                if data.startswith('data: ') and data != 'data: [DONE]':
+                    chunk_data = json.loads(data[6:])  # Skip the "data: " prefix
+                    self.assertIn('choices', chunk_data)
+                    self.assertEqual(len(chunk_data['choices']), 1)
+                    self.assertIn('delta', chunk_data['choices'][0])
+                    chunk_count += 1
+        
+        # Make sure we got some streaming chunks
+        self.assertGreater(chunk_count, 0)
+
+    def test_prompt_cache_with_draft_model(self):
+        """Test that the prompt cache works correctly with a draft model."""
+        url = f"http://localhost:{self.port}/v1/chat/completions"
+        
+        # First request to initialize cache
+        chat_post_data = {
+            "model": "chat_model",
+            "max_tokens": 5,
+            "temperature": 0.0,
+            "messages": [
+                {"role": "system", "content": "You are a helpful assistant."},
+                {"role": "user", "content": "Tell me a story about"},
+            ],
+        }
+        
+        first_response = requests.post(url, json=chat_post_data)
+        self.assertEqual(first_response.status_code, 200)
+        
+        # Second request with same prefix should use cache
+        chat_post_data = {
+            "model": "chat_model",
+            "max_tokens": 5,
+            "temperature": 0.0,
+            "messages": [
+                {"role": "system", "content": "You are a helpful assistant."},
+                {"role": "user", "content": "Tell me a story about dragons."},
+            ],
+        }
+        
+        second_response = requests.post(url, json=chat_post_data)
+        self.assertEqual(second_response.status_code, 200)
+        
+        # Both responses should have content
+        first_response_body = json.loads(first_response.text)
+        second_response_body = json.loads(second_response.text)
+        
+        self.assertIn("choices", first_response_body)
+        self.assertIn("choices", second_response_body)
+        self.assertIn("message", first_response_body["choices"][0])
+        self.assertIn("message", second_response_body["choices"][0])
+        self.assertIn("content", first_response_body["choices"][0]["message"])
+        self.assertIn("content", second_response_body["choices"][0]["message"])
+        
+        # Ensure both generated content
+        self.assertIsNotNone(first_response_body["choices"][0]["message"]["content"])
+        self.assertIsNotNone(second_response_body["choices"][0]["message"]["content"])
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
This pull request introduces speculative decoding to the `mlx_lm` server to improve text generation performance. The main changes include adding support for a draft model, modifying the prompt cache, and updating the server to handle speculative decoding. Additionally, new tests are added to ensure the functionality of the draft model.

### Speculative Decoding Support:
* `mlx_lm/SERVER.md`: Added documentation for enabling speculative decoding using a draft model.
* `mlx_lm/server.py`: Introduced a draft model and associated parameters, updated the prompt cache to handle the draft model, and modified the completion handling to use speculative decoding.

### Testing:
* `tests/test_server.py`: Added new tests for the server with the draft model to ensure speculative decoding works correctly, including tests for handling completions, chat completions, streaming, and prompt cache functionality.

### Test Results:
```
$ python -m unittest tests/test_server.py                                 
Fetching 9 files: 100%|███████████████████████████████████████████████████████████████████████████| 9/9 [00:00<00:00, 63019.59it/s]
127.0.0.1 - - [31/Mar/2025 11:27:46] "POST /v1/chat/completions HTTP/1.1" 200 -
.127.0.0.1 - - [31/Mar/2025 11:27:46] "POST /v1/chat/completions HTTP/1.1" 200 -
.127.0.0.1 - - [31/Mar/2025 11:27:46] "POST /v1/completions HTTP/1.1" 200 -
.127.0.0.1 - - [31/Mar/2025 11:27:46] "GET /v1/models HTTP/1.1" 200 -
Fetching 9 files: 100%|███████████████████████████████████████████████████████████████████████████| 9/9 [00:00<00:00, 10169.38it/s]
Fetching 9 files: 100%|███████████████████████████████████████████████████████████████████████████| 9/9 [00:00<00:00, 14080.10it/s]
127.0.0.1 - - [31/Mar/2025 11:27:48] "POST /v1/chat/completions HTTP/1.1" 200 -
.127.0.0.1 - - [31/Mar/2025 11:27:48] "POST /v1/completions HTTP/1.1" 200 -
.127.0.0.1 - - [31/Mar/2025 11:27:48] "POST /v1/chat/completions HTTP/1.1" 200 -
127.0.0.1 - - [31/Mar/2025 11:27:48] "POST /v1/chat/completions HTTP/1.1" 200 -
.127.0.0.1 - - [31/Mar/2025 11:27:48] "POST /v1/chat/completions HTTP/1.1" 200 -
.
----------------------------------------------------------------------
Ran 9 tests in 2.984s

OK
```