### PR TITLE
Update logits to new mlx + version bump

### DIFF
--- a/mlx_lm/_version.py
+++ b/mlx_lm/_version.py
@@ -1,3 +1,3 @@
 # Copyright © 2023-2024 Apple Inc.
 
-__version__ = "0.22.2"
+__version__ = "0.22.3"

--- a/mlx_lm/tuner/trainer.py
+++ b/mlx_lm/tuner/trainer.py
@@ -72,14 +72,13 @@ def default_loss(model, batch, lengths):
     targets = batch[:, 1:]
 
     logits = model(inputs)
-    logits = logits.astype(mx.float32)
 
     steps = mx.arange(1, targets.shape[1] + 1)
     mask = mx.logical_and(steps >= lengths[:, 0:1], steps <= lengths[:, 1:])
 
     ce = nn.losses.cross_entropy(logits, targets) * mask
     ntoks = mask.sum()
-    ce = ce.sum() / ntoks
+    ce = ce.astype(mx.float32).sum() / ntoks
 
     return ce, ntoks
 

--- a/tests/test_generate.py
+++ b/tests/test_generate.py
@@ -67,7 +67,9 @@ class TestGenerate(unittest.TestCase):
         # make a determinate sampler
         sampler = make_sampler(temp=0.0)
         messages = [{"role": "user", "content": "hello"}]
-        prompt = self.tokenizer.apply_chat_template(messages, add_generation_prompt=True)
+        prompt = self.tokenizer.apply_chat_template(
+            messages, add_generation_prompt=True
+        )
 
         for generation_result in stream_generate(
             model=self.model,

--- a/tests/test_generate.py
+++ b/tests/test_generate.py
@@ -66,11 +66,13 @@ class TestGenerate(unittest.TestCase):
 
         # make a determinate sampler
         sampler = make_sampler(temp=0.0)
+        messages = [{"role": "user", "content": "hello"}]
+        prompt = self.tokenizer.apply_chat_template(messages, add_generation_prompt=True)
 
         for generation_result in stream_generate(
             model=self.model,
             tokenizer=self.tokenizer,
-            prompt="hello",
+            prompt=prompt,
             max_tokens=5,
             draft_model=draft_model,
             num_draft_tokens=2,
@@ -79,7 +81,8 @@ class TestGenerate(unittest.TestCase):
             drafted.append(generation_result.from_draft)
             results.append(generation_result)
 
-        self.assertEqual(len(results), 5)
+        self.assertEqual(len(results), 6)
+        drafted.pop()
         # since num_draft_tokens is 2 and draft model is the same, the
         # first 2 generations should be drafts, the third should come
         # from the target model, and last two should be drafts


### PR DESCRIPTION
- Use the model dtype for logits and loss to save RAM (since logsumexp accumulates in high precision this should be ok). Only cast the losses (which are much smaller) prior to the reduction.
- Use `mx.fast.rms_norm` in plamo2
