### PR TITLE
Remove alpha parameter from LoRA defaults

### DIFF
--- a/mlx_lm/lora.py
+++ b/mlx_lm/lora.py
@@ -67,7 +67,7 @@ CONFIG_DEFAULTS = {
     "config": None,
     "grad_checkpoint": False,
     "lr_schedule": None,
-    "lora_parameters": {"rank": 8, "alpha": 16, "dropout": 0.0, "scale": 10.0},
+    "lora_parameters": {"rank": 8, "dropout": 0.0, "scale": 10.0},
     "mask_prompt": False,
 }
 

--- a/tests/test_finetune.py
+++ b/tests/test_finetune.py
@@ -67,7 +67,7 @@ class TestLora(unittest.TestCase):
             )
             self.assertEqual(trainable_params, expected_trainable_parameters)
 
-        params = {"rank": 8, "alpha": 16, "dropout": 0.0, "scale": 10.0}
+        params = {"rank": 8, "dropout": 0.0, "scale": 10.0}
         check_config(params)
 
         params["rank"] = 1
@@ -108,7 +108,7 @@ class TestLora(unittest.TestCase):
         )
 
         num_lora_layers = 4
-        params = {"rank": 8, "alpha": 16, "dropout": 0.0, "scale": 10.0}
+        params = {"rank": 8, "dropout": 0.0, "scale": 10.0}
 
         model = gpt_neox.Model(args)
         model.freeze()


### PR DESCRIPTION
This PR removes the alpha parameter from the default LoRA config. I don't think it's used, per [this comment](https://github.com/ml-explore/mlx-examples/issues/982#issuecomment-2353883500):

> We don't ever explicitly compute α. The scale parameter is used directly W + scale * a @ b.T. If you wanted to work out the implied α you could multiply the scale by the lora rank you are using e.g. scale * rank.

So it's confusing to me to have it in the defaults. Particularly since the default (16) doesn't seem to match the default rank (8) and scale (10.0).

But maybe I've missed something. Feel free to close this PR if so. 