### PR TITLE
Count accept rate of speculative decoding

### DIFF
--- a/mlx_lm/generate.py
+++ b/mlx_lm/generate.py
@@ -153,8 +153,7 @@ def setup_arg_parser():
     parser.add_argument(
         "--kv-bits",
         type=int,
-        help="Number of bits for KV cache quantization. "
-        "Defaults to no quantization.",
+        help="Number of bits for KV cache quantization. Defaults to no quantization.",
         default=None,
     )
     parser.add_argument(
@@ -681,15 +680,25 @@ def generate(
     if verbose:
         print("=" * 10)
 
+    num_from_draft = 0
+    num_response = 0
     text = ""
     for response in stream_generate(model, tokenizer, prompt, **kwargs):
         if verbose:
             print(response.text, end="", flush=True)
+            if response.from_draft:
+                num_from_draft += 1
+            num_response += 1
         text += response.text
 
     if verbose:
         print()
         print("=" * 10)
+        print(
+            f"num_from_draft: {num_from_draft}, "
+            f"num_response: {num_response}, "
+            f"accept rate: {num_from_draft / num_response}"
+        )
         if len(text) == 0:
             print("No text generated for this prompt")
             return

--- a/mlx_lm/generate.py
+++ b/mlx_lm/generate.py
@@ -694,6 +694,8 @@ def generate(
           See :func:`stream_generate` for more details.
     """
     if formatter is not None:
+        print()
+        print("=" * 10)
         print(
             "[Warning] Text formatting is deprecated and no longer used. "
             "The argument will be removed in a future version."

--- a/tests/benchmark_speculative_decoding.py
+++ b/tests/benchmark_speculative_decoding.py
@@ -1,0 +1,30 @@
+import mlx_lm
+
+main_model, tokenizer = mlx_lm.load("mlx-community/Qwen2.5-Coder-32B-Instruct-3bit")
+# draft_model, _ = mlx_lm.load("mlx-community/Qwen2.5-Coder-7B-Instruct-4bit")
+# draft_model, _ = mlx_lm.load("mlx-community/Qwen2.5-Coder-3B-4bit")
+draft_model, _ = mlx_lm.load("mlx-community/Qwen2.5-Coder-0.5B-Instruct-4bit")
+
+
+prompt = "Write a Python program to sum up the Fibonacci series"
+messages = [{"role": "user", "content": prompt}]
+prompt = tokenizer.apply_chat_template(messages, add_generation_prompt=True)
+
+mlx_lm.generate(
+    model=main_model,
+    tokenizer=tokenizer,
+    prompt=prompt,
+    verbose=True,
+    max_tokens=512,
+)
+
+for num_draft_tokens in range(1, 10):
+    mlx_lm.generate(
+        model=main_model,
+        tokenizer=tokenizer,
+        prompt=prompt,
+        verbose=True,
+        draft_model=draft_model,
+        num_draft_tokens=num_draft_tokens,
+        max_tokens=512,
+    )

--- a/tests/benchmark_speculative_decoding.py
+++ b/tests/benchmark_speculative_decoding.py
@@ -1,30 +1,37 @@
 import mlx_lm
 
 main_model, tokenizer = mlx_lm.load("mlx-community/Qwen2.5-Coder-32B-Instruct-3bit")
-# draft_model, _ = mlx_lm.load("mlx-community/Qwen2.5-Coder-7B-Instruct-4bit")
-# draft_model, _ = mlx_lm.load("mlx-community/Qwen2.5-Coder-3B-4bit")
-draft_model, _ = mlx_lm.load("mlx-community/Qwen2.5-Coder-0.5B-Instruct-4bit")
-
 
 prompt = "Write a Python program to sum up the Fibonacci series"
 messages = [{"role": "user", "content": prompt}]
 prompt = tokenizer.apply_chat_template(messages, add_generation_prompt=True)
 
+print(f"\n Autoregression")
 mlx_lm.generate(
     model=main_model,
     tokenizer=tokenizer,
     prompt=prompt,
-    verbose=True,
-    max_tokens=512,
+    max_tokens=256,
 )
 
-for num_draft_tokens in range(1, 10):
-    mlx_lm.generate(
-        model=main_model,
-        tokenizer=tokenizer,
-        prompt=prompt,
-        verbose=True,
-        draft_model=draft_model,
-        num_draft_tokens=num_draft_tokens,
-        max_tokens=512,
-    )
+DRAFT_MODELS = [
+    "mlx-community/Qwen2.5-Coder-7B-Instruct-4bit",
+    "mlx-community/Qwen2.5-Coder-3B-Instruct-4bit",
+    "mlx-community/Qwen2.5-Coder-0.5B-Instruct-4bit",
+]
+
+for DM in DRAFT_MODELS:
+    print(f"\n Draft Model: {DM}")
+    draft_model, _ = mlx_lm.load(DM)
+    assert draft_model
+
+    for num_draft_tokens in range(1, 10):
+        print(f"num_draft_tokens: {num_draft_tokens}")
+        mlx_lm.generate(
+            model=main_model,
+            tokenizer=tokenizer,
+            prompt=prompt,
+            draft_model=draft_model,
+            num_draft_tokens=num_draft_tokens,
+            max_tokens=256,
+        )

--- a/tests/benchmark_speculative_decoding.py
+++ b/tests/benchmark_speculative_decoding.py
@@ -1,12 +1,13 @@
 import mlx_lm
 
-main_model, tokenizer = mlx_lm.load("mlx-community/Qwen2.5-Coder-32B-Instruct-3bit")
+MAIN_MODEL = "mlx-community/Qwen2.5-Coder-32B-Instruct-3bit"
+main_model, tokenizer = mlx_lm.load(MAIN_MODEL)
 
 prompt = "Write a Python program to sum up the Fibonacci series"
 messages = [{"role": "user", "content": prompt}]
 prompt = tokenizer.apply_chat_template(messages, add_generation_prompt=True)
 
-print(f"\n Autoregression")
+print(f"\nAutoregression: {MAIN_MODEL}")
 mlx_lm.generate(
     model=main_model,
     tokenizer=tokenizer,
@@ -21,7 +22,7 @@ DRAFT_MODELS = [
 ]
 
 for DM in DRAFT_MODELS:
-    print(f"\n Draft Model: {DM}")
+    print(f"\nDraft Model: {DM}")
     draft_model, _ = mlx_lm.load(DM)
     assert draft_model
 


### PR DESCRIPTION
This PR is only for reproducing the problem that speculative does not accelerate the inference of model Qwen 2.5 32B 3bit.  It is **not** indent to merge.

```shell
python tests/benchmark_speculative_decoding.py  | tee /tmp/logg
```

Copying numbers from the output file `/tmp/logg` into a spreadsheet gave us the following:

<img width="900" alt="Screenshot 2025-04-02 at 11 19 39 PM" src="https://github.com/user-attachments/assets/1a8979c0-3376-4f1e-bfe1-c9eb5fb1e384" />

