### PR TITLE
fix / improve dsv3

### DIFF
--- a/mlx_lm/convert.py
+++ b/mlx_lm/convert.py
@@ -102,7 +102,13 @@ def convert(
 
     weights = dict(tree_flatten(model.parameters()))
     dtype = getattr(mx, dtype)
-    weights = {k: v.astype(dtype) for k, v in weights.items()}
+    if hasattr(model, "cast_predicate"):
+        cast_predicate = model.cast_predicate()
+    else:
+        cast_predicate = lambda _: True
+    weights = {
+        k: v.astype(dtype) if cast_predicate(k) else v for k, v in weights.items()
+    }
 
     if quantize and dequantize:
         raise ValueError("Choose either quantize or dequantize, not both.")

--- a/mlx_lm/examples/pipeline_generate.py
+++ b/mlx_lm/examples/pipeline_generate.py
@@ -5,8 +5,7 @@ Run with:
 
 ```
 mlx.launch \
- --hostfile /path/to/hosts.txt \
- --backend mpi \
+ --hostfile /path/to/hosts.json \
  /path/to/pipeline_generate.py \
  --prompt "hello world"
 ```
@@ -19,6 +18,9 @@ https://ml-explore.github.io/mlx/build/html/usage/distributed.html).
 
 import argparse
 import json
+
+# Needed for 8 bit model
+import resource
 from pathlib import Path
 
 import mlx.core as mx
@@ -27,6 +29,10 @@ from mlx.utils import tree_flatten
 
 from mlx_lm import load, stream_generate
 from mlx_lm.utils import load_model, load_tokenizer
+
+soft_limit = 2048
+ard_limit = 4096
+resource.setrlimit(resource.RLIMIT_NOFILE, (soft_limit, hard_limit))
 
 
 def download(repo: str, allow_patterns: list[str]) -> Path:
@@ -49,7 +55,7 @@ def shard_and_load(repo):
     # which weights we need
     model, _ = load_model(model_path, lazy=True, strict=False)
 
-    group = mx.distributed.init(backend="mpi")
+    group = mx.distributed.init()
     rank = group.rank()
     model.model.pipeline(group)
 
@@ -98,7 +104,7 @@ if __name__ == "__main__":
     )
     args = parser.parse_args()
 
-    group = mx.distributed.init(backend="mpi")
+    group = mx.distributed.init()
     rank = group.rank()
 
     def rprint(*args, **kwargs):

--- a/mlx_lm/examples/pipeline_generate.py
+++ b/mlx_lm/examples/pipeline_generate.py
@@ -18,8 +18,6 @@ https://ml-explore.github.io/mlx/build/html/usage/distributed.html).
 
 import argparse
 import json
-
-# Needed for 8 bit model
 import resource
 from pathlib import Path
 
@@ -30,9 +28,8 @@ from mlx.utils import tree_flatten
 from mlx_lm import load, stream_generate
 from mlx_lm.utils import load_model, load_tokenizer
 
-soft_limit = 2048
-ard_limit = 4096
-resource.setrlimit(resource.RLIMIT_NOFILE, (soft_limit, hard_limit))
+# Needed for 8 bit model
+resource.setrlimit(resource.RLIMIT_NOFILE, (2048, 4096))
 
 
 def download(repo: str, allow_patterns: list[str]) -> Path:

--- a/mlx_lm/models/deepseek_v3.py
+++ b/mlx_lm/models/deepseek_v3.py
@@ -97,9 +97,7 @@ class DeepseekV3YarnRotaryEmbedding(nn.Module):
             scaling_factor, mscale_all_dim
         )
         freq_extra = base ** (mx.arange(0, dim, 2, dtype=mx.float32) / dim)
-        freq_inter = scaling_factor * base ** (
-            mx.arange(0, dim, 2, dtype=mx.float32) / dim
-        )
+        freq_inter = scaling_factor * freq_extra
         low, high = yarn_find_correction_range(
             beta_fast,
             beta_slow,
@@ -157,7 +155,7 @@ class DeepseekV3Attention(nn.Module):
             self.q_a_proj = nn.Linear(
                 self.hidden_size, self.q_lora_rank, bias=config.attention_bias
             )
-            self.q_a_layernorm = nn.RMSNorm(self.q_lora_rank)
+            self.q_a_layernorm = nn.RMSNorm(self.q_lora_rank, eps=1e-6)
             self.q_b_proj = nn.Linear(
                 self.q_lora_rank, self.num_heads * self.q_head_dim, bias=False
             )
@@ -167,7 +165,7 @@ class DeepseekV3Attention(nn.Module):
             self.kv_lora_rank + self.qk_rope_head_dim,
             bias=config.attention_bias,
         )
-        self.kv_a_layernorm = nn.RMSNorm(self.kv_lora_rank)
+        self.kv_a_layernorm = nn.RMSNorm(self.kv_lora_rank, eps=1e-6)
         self.kv_b_proj = nn.Linear(
             self.kv_lora_rank,
             self.num_heads
@@ -291,6 +289,7 @@ def group_expert_select(
 
     k = top_k
     scores = mx.sigmoid(gates.astype(mx.float32))
+    orig_scores = scores
     scores = scores + e_score_correction_bias
     scores = mx.unflatten(scores, axis=-1, shape=(n_group, -1))
     group_scores = mx.topk(scores, 2, axis=-1).sum(axis=-1, keepdims=True)
@@ -301,9 +300,9 @@ def group_expert_select(
 
     k = top_k
     inds = mx.argpartition(-scores, kth=k - 1, axis=-1)[..., :k]
-    scores = mx.take_along_axis(scores, inds, axis=-1)
+    scores = mx.take_along_axis(orig_scores, inds, axis=-1)
     if top_k > 1 and norm_topk_prob:
-        denominator = scores.sum(axis=-1, keepdims=True) + 1e-20
+        denominator = scores.sum(axis=-1, keepdims=True)
         scores = scores / denominator
     scores = scores * routed_scaling_factor
 
@@ -437,8 +436,6 @@ class DeepseekV3Model(nn.Module):
 
         pipeline_rank = self.pipeline_rank
         pipeline_size = self.pipeline_size
-        # Hack to avoid time-outs during prompt-processing
-        dist_stream = mx.cpu if h.shape[1] > 1 else mx.gpu
         if mask is None:
             mask = create_attention_mask(h, cache)
 
@@ -448,19 +445,17 @@ class DeepseekV3Model(nn.Module):
         # Receive from the previous process in the pipeline
 
         if pipeline_rank < pipeline_size - 1:
-            h = mx.distributed.recv_like(h, (pipeline_rank + 1), stream=dist_stream)
+            h = mx.distributed.recv_like(h, (pipeline_rank + 1))
 
         for i in range(self.num_layers):
             h = self.layers[self.start_idx + i](h, mask, cache[i])
 
         # Send to the next process in the pipeline
         if pipeline_rank != 0:
-            h = mx.distributed.send(
-                h, (pipeline_rank - 1) % pipeline_size, stream=dist_stream
-            )
+            h = mx.distributed.send(h, (pipeline_rank - 1) % pipeline_size)
 
         # Broadcast h while keeping it in the graph
-        h = mx.distributed.all_gather(h, stream=dist_stream)[: h.shape[0]]
+        h = mx.distributed.all_gather(h)[: h.shape[0]]
 
         return self.norm(h)
 
@@ -484,6 +479,7 @@ class Model(nn.Module):
 
     def sanitize(self, weights):
         def dequant(weight, scale_inv):
+            dtype = weight.dtype
             bs = 128  # block size
             m, n = weight.shape
             pad_bottom = (-m) % bs
@@ -492,11 +488,10 @@ class Model(nn.Module):
             weight = weight.reshape(
                 ((m + pad_bottom) // bs, bs, (n + pad_side) // bs, bs)
             )
-            scale_inv = scale_inv.astype(weight.dtype)
             weight = (weight * scale_inv[:, None, :, None]).reshape(
                 m + pad_bottom, n + pad_side
             )
-            return weight[:m, :n]
+            return weight[:m, :n].astype(dtype)
 
         # Dequantize
         new_weights = {}

--- a/mlx_lm/models/deepseek_v3.py
+++ b/mlx_lm/models/deepseek_v3.py
@@ -528,3 +528,9 @@ class Model(nn.Module):
     @property
     def layers(self):
         return self.model.layers[self.model.start_idx : self.model.end_idx]
+
+    def cast_predicate(self):
+        def predicate(k):
+            return "e_score_correction_bias" not in k
+
+        return predicate


### PR DESCRIPTION
3 days later...

Several things in this PR

- The big fix is not using the bias shifted scores to weight the expert hidden states but using the original scores instead
- Some precision improvements to DSV3
  - When dequanting from the original do it in fp32 since the scales are in fp32 and then down cast (rather than down cast the scales and then multiply). This matches how the DSV3 dequant kernel works and should give results closer to the original.
  - Use the right epsilon for some RMSNorms
  - Keep the expert score bias in fp32. Casting them to bf16 is quite destructive. And since this computation is done in fp32 anyway there is no perf issue. Adds a mechanism to let a model indicate which keys should not be cast.
  - Fix the pipeline parallel dsv3