### PR TITLE
Move from `python -m mlx_lm.generate` to `python -m mlx_lm generate`

### DIFF
--- a/mlx_lm/__main__.py
+++ b/mlx_lm/__main__.py
@@ -4,7 +4,18 @@ import importlib
 import sys
 
 if __name__ == "__main__":
-    subcommands = {"convert"}
+    subcommands = {
+        "cache_prompt",
+        "chat",
+        "convert",
+        "evaluate",
+        "fuse",
+        "generate",
+        "lora",
+        "merge",
+        "server",
+        "manage",
+    }
     if len(sys.argv) < 2:
         raise ValueError(f"CLI requires a subcommand in {subcommands}")
     subcommand = sys.argv.pop(1)

--- a/mlx_lm/cache_prompt.py
+++ b/mlx_lm/cache_prompt.py
@@ -159,4 +159,8 @@ def main():
 
 
 if __name__ == "__main__":
+    print(
+        "Calling `python -m mlx_lm.cache_prompt...` directly is deprecated."
+        " Use `mlx_lm.cache_prompt...` or `python -m mlx_lm cache_prompt ...` instead."
+    )
     main()

--- a/mlx_lm/chat.py
+++ b/mlx_lm/chat.py
@@ -106,4 +106,8 @@ def main():
 
 
 if __name__ == "__main__":
+    print(
+        "Calling `python -m mlx_lm.chat...` directly is deprecated."
+        " Use `mlx_lm.chat...` or `python -m mlx_lm chat ...` instead."
+    )
     main()

--- a/mlx_lm/fuse.py
+++ b/mlx_lm/fuse.py
@@ -127,4 +127,8 @@ def main() -> None:
 
 
 if __name__ == "__main__":
+    print(
+        "Calling `python -m mlx_lm.fuse...` directly is deprecated."
+        " Use `mlx_lm.fuse...` or `python -m mlx_lm fuse ...` instead."
+    )
     main()

--- a/mlx_lm/lora.py
+++ b/mlx_lm/lora.py
@@ -330,4 +330,8 @@ def main():
 
 
 if __name__ == "__main__":
+    print(
+        "Calling `python -m mlx_lm.lora...` directly is deprecated."
+        " Use `mlx_lm.lora...` or `python -m mlx_lm lora ...` instead."
+    )
     main()

--- a/mlx_lm/manage.py
+++ b/mlx_lm/manage.py
@@ -136,4 +136,8 @@ def main():
 
 
 if __name__ == "__main__":
+    print(
+        "Calling `python -m mlx_lm.manage...` directly is deprecated."
+        " Use `mlx_lm.manage...` or `python -m mlx_lm manage ...` instead."
+    )
     main()

--- a/mlx_lm/merge.py
+++ b/mlx_lm/merge.py
@@ -169,4 +169,8 @@ def main():
 
 
 if __name__ == "__main__":
+    print(
+        "Calling `python -m mlx_lm.merge...` directly is deprecated."
+        " Use `mlx_lm.merge...` or `python -m mlx_lm merge ...` instead."
+    )
     main()

--- a/mlx_lm/server.py
+++ b/mlx_lm/server.py
@@ -792,4 +792,8 @@ def main():
 
 
 if __name__ == "__main__":
+    print(
+        "Calling `python -m mlx_lm.server...` directly is deprecated."
+        " Use `mlx_lm.server...` or `python -m mlx_lm server ...` instead."
+    )
     main()


### PR DESCRIPTION
We had done the move and added the deprecation notice but the commands weren't available in `mlx_lm/__main__.py`. Added all of them and more deprecation notices.