### PR TITLE
Remove vision_config from llama4 and from model conversion

### DIFF
--- a/mlx_lm/models/llama4.py
+++ b/mlx_lm/models/llama4.py
@@ -40,19 +40,12 @@ class TextArgs(BaseModelArgs):
 
 
 @dataclass
-class VisionArgs(BaseModelArgs):
-    model_type: str
-
-
-@dataclass
 class ModelArgs(BaseModelArgs):
     text_config: Union[TextArgs, dict]
-    vision_config: Union[VisionArgs, dict]
     model_type: str
 
     def __post_init__(self):
         self.text_config = TextArgs.from_dict(self.text_config)
-        self.vision_config = VisionArgs.from_dict(self.vision_config)
 
 
 class Attention(nn.Module):

--- a/mlx_lm/utils.py
+++ b/mlx_lm/utils.py
@@ -483,6 +483,7 @@ def save_config(
     """
     # Clean unused keys
     config.pop("_name_or_path", None)
+    config.pop("vision_config", None)
 
     # sort the config for better readability
     config = dict(sorted(config.items()))


### PR DESCRIPTION
Remove vision_config from llama4 since it's unused, so it shouldn't be a requirement for loading a model

Also, remove vision_config from the model conversion script so that it's easier for MLX users to see if the model was converted with vision enabled