### PR TITLE
Support AWQ Quantization

### DIFF
--- a/mlx_lm/AWQ.md
+++ b/mlx_lm/AWQ.md
@@ -1,0 +1,44 @@
+# AWQ
+
+MLX LM supports Activation-aware Weight Quantization (AWQ)[^1]. AWQ uses the
+activations of the model on a representative dataset to tune the quantization
+parameters.
+
+Use `mlx_lm.awq` to run AWQ on a given model. For example:
+```
+mlx_lm.awq --model mistralai/Mistral-7B-Instruct-v0.3
+```
+
+The script can take a while to run depending on the model size and the number
+of samples. Once it's finished, the model will be saved in the current
+directory under `mlx_model`.
+
+For a full list of options run:
+
+```bash
+mlx_lm.awq --help
+```
+
+You can specify the quantization precision and group size, the number of
+samples to use, the save path, and more. 
+
+Once the script finishes, you can evaluate the quality of the model on
+downstream tasks using `mlx_lm.evaluate`. For example:
+
+```bash
+mlx_lm.evaluate \
+    --model mlx_model \
+    --tasks winogrande boolq arc_challenge arc_easy hellaswag openbookqa piqa social_iqa                      
+```
+
+To upload the AWQ model to the Hugging Face Hub, run:
+
+```bash
+mlx_lm.upload \
+    --model mlx_model \
+    --upload-repo mlx-community/Mistral-7B-Instruct-v0.3-3bit-AWQ
+```
+
+[^1]: Refer to the [paper](https://arxiv.org/abs/2306.00978)
+and [github repository](https://github.com/mit-han-lab/llm-awq) for more
+details.

--- a/mlx_lm/__main__.py
+++ b/mlx_lm/__main__.py
@@ -5,6 +5,7 @@ import sys
 
 if __name__ == "__main__":
     subcommands = {
+        "awq",
         "cache_prompt",
         "chat",
         "convert",
@@ -15,6 +16,7 @@ if __name__ == "__main__":
         "merge",
         "server",
         "manage",
+        "upload",
     }
     if len(sys.argv) < 2:
         raise ValueError(f"CLI requires a subcommand in {subcommands}")

--- a/mlx_lm/_version.py
+++ b/mlx_lm/_version.py
@@ -1,3 +1,3 @@
 # Copyright © 2023-2024 Apple Inc.
 
-__version__ = "0.23.1"
+__version__ = "0.23.2"

--- a/mlx_lm/awq.py
+++ b/mlx_lm/awq.py
@@ -1,0 +1,439 @@
+# Learned quantization using AWQ:
+
+# References:
+# AWQ
+# https://arxiv.org/abs/2306.00978
+# https://github.com/mit-han-lab/llm-awq
+
+import argparse
+import glob
+import shutil
+from pathlib import Path
+from typing import Callable
+
+import mlx.core as mx
+import mlx.nn as nn
+import numpy as np
+from datasets import Dataset, load_dataset
+from mlx.utils import tree_flatten, tree_map_with_path
+from mlx_lm.models.base import create_attention_mask
+from mlx_lm.tokenizer_utils import TokenizerWrapper
+from mlx_lm.utils import fetch_from_hub, get_model_path, save_config, save_weights
+from tqdm import tqdm
+
+
+def mse(x, y):
+    return ((x - y).astype(mx.float32)) ** 2
+
+
+def run_layer(layer: nn.Module, x: mx.array, batch_size: int = 32, **kwargs):
+    y = []
+    for i in range(0, x.shape[0], batch_size):
+        y.append(layer(x[i : i + batch_size], **kwargs))
+        mx.eval(y)
+    y = mx.concatenate(y, axis=0)
+    return y
+
+
+def dist_split(x: mx.array, group: mx.distributed.Group):
+    B = x.shape[0]
+    N = group.size()
+    assert B % N == 0
+    r = group.rank()
+    local_B = (B + N - 1) // N
+    return x[r * local_B : (r + 1) * local_B]
+
+
+def search_best_scale(
+    layers: list[nn.Module],
+    x: mx.array,
+    quantize_func: Callable,
+    block: nn.Module | None = None,
+    layer_kwargs: dict | None = None,
+    n_grid: int = 20,
+):
+    group = mx.distributed.init() if mx.distributed.is_available() else None
+    layer_kwargs = layer_kwargs or {}
+
+    block = block or layers[0]
+    out = block(x, **layer_kwargs)
+
+    x_max = x.abs().mean(axis=(0, 1))
+
+    best_error = float("inf")
+    best_scales = None
+
+    weights = tree_flatten(block.parameters())
+
+    for ratio in tqdm(range(n_grid)):
+        ratio = ratio * 1 / n_grid
+        scales = mx.maximum(x_max**ratio, 1e-4).reshape(-1)
+        scales = scales / (scales.max() * scales.min()).sqrt()
+        for layer in layers:
+            layer.weight = quantize_func(layer.weight * scales) / scales
+
+        out_q = run_layer(block, x, **layer_kwargs)
+        loss = mse(out, out_q).sum()
+        if group is not None:
+            loss = mx.distributed.all_sum(loss, stream=mx.cpu) / group.size()
+        loss /= out.size
+        mx.eval(loss)
+        is_best = loss < best_error
+        if is_best:
+            best_error = loss
+            best_scales = scales
+
+        # reload the original weights
+        block.load_weights(weights)
+
+    best_scales = best_scales.reshape(-1)
+    mx.eval(best_scales)
+    return best_scales
+
+
+def apply_scale(prev_op, layers, scales):
+    # Apply the scales to the layers
+    if isinstance(prev_op, nn.Linear):
+        assert len(layers) == 1
+        prev_op.weight = prev_op.weight / scales[:, mx.newaxis]
+        if hasattr(prev_op, "bias"):
+            prev_op.bias = prev_op.bias / scales
+        layers[0].weight = layers[0].weight * scales[mx.newaxis]
+    elif isinstance(prev_op, (nn.LayerNorm, nn.RMSNorm)):
+        prev_op.weight = prev_op.weight / scales
+        if hasattr(prev_op, "bias"):
+            prev_op.bias = prev_op.bias / scales
+        for layer in layers:
+            layer.weight = layer.weight * scales
+    else:
+        raise NotImplementedError(f"Could not apply scale to prev_op: {prev_op}")
+
+
+def scale_block(
+    block, input_feat, quantize_func: Callable, layer_kwargs: dict | None = None
+):
+    layers = [
+        block.self_attn.q_proj,
+        block.self_attn.k_proj,
+        block.self_attn.v_proj,
+    ]
+    scales = search_best_scale(
+        layers=layers,
+        block=block.self_attn,
+        x=input_feat["q_proj"],
+        quantize_func=quantize_func,
+        layer_kwargs=layer_kwargs,
+    )
+    apply_scale(block.input_layernorm, layers, scales)
+    for name in ["q_proj", "k_proj", "v_proj"]:
+        input_feat[name] = input_feat[name] / scales
+
+    layers = [
+        block.mlp.gate_proj,
+        block.mlp.up_proj,
+    ]
+    scales = search_best_scale(
+        block=block.mlp,
+        layers=layers,
+        x=input_feat["gate_proj"],
+        quantize_func=quantize_func,
+    )
+    mlp_norm = getattr(
+        block, "pre_feedforward_layernorm", block.post_attention_layernorm
+    )
+    apply_scale(mlp_norm, layers, scales)
+    for name in ["gate_proj", "up_proj"]:
+        input_feat[name] = input_feat[name] / scales
+
+    layers = [block.mlp.down_proj]
+    scales = search_best_scale(
+        layers=layers,
+        x=input_feat["down_proj"],
+        quantize_func=quantize_func,
+    )
+    apply_scale(block.mlp.up_proj, layers, scales)
+    input_feat["down_proj"] = input_feat["down_proj"] / scales
+
+
+def search_best_clip(
+    w: mx.array,
+    x: mx.array,
+    quantize_func: Callable,
+    group_size: int,
+    n_grid: int = 20,
+    max_shrink: float = 0.5,
+    subsample: int = 4,
+    batch_size: int = 64,
+):
+    group = mx.distributed.init() if mx.distributed.is_available() else None
+
+    x = x[:, ::subsample]
+    x = x.reshape(*x.shape[:-1], -1, group_size)
+
+    w_all = w
+    w_max_all = []
+    w_min_all = []
+
+    for b in range(0, w.shape[0], batch_size):
+        w = w_all[b : b + batch_size]
+
+        group_shape = (w.shape[0], w.shape[-1] // group_size)
+        best_error = mx.full(group_shape, float("inf"))
+        best_w_max = mx.zeros((*group_shape, 1), dtype=x.dtype)
+        best_w_min = mx.zeros((*group_shape, 1), dtype=x.dtype)
+
+        w_shape = w.shape
+
+        w = w.reshape(*w.shape[:-1], -1, group_size)
+        out = mx.einsum("btdg,odg->btod", x, w)
+
+        for i in range(int(max_shrink * n_grid)):
+            p = 1 - i / n_grid
+            w_max = p * w.max(axis=-1, keepdims=True)
+            w_min = p * w.min(axis=-1, keepdims=True)
+            w_m = mx.clip(w, w_min, w_max).reshape(w_shape)
+
+            w_q = quantize_func(w_m)
+
+            w_q = w_q.reshape(*w_q.shape[:-1], -1, group_size)
+            out_q = mx.einsum("btdg,odg->btod", x, w_q)
+
+            # Take the mean across the input batch
+            loss = mse(out, out_q).sum(axis=(0, 1))
+            if group is not None:
+                loss = mx.distributed.all_sum(loss, stream=mx.cpu) / group.size()
+            loss /= out.shape[0] * out.shape[1]
+            best_indices = loss < best_error
+            best_error = mx.where(best_indices, loss, best_error)
+            best_w_max = mx.where(best_indices[..., mx.newaxis], w_max, best_w_max)
+            best_w_min = mx.where(best_indices[..., mx.newaxis], w_min, best_w_min)
+            mx.eval(best_w_max, best_w_min, best_error)
+
+        w_max_all.append(best_w_max)
+        w_min_all.append(best_w_min)
+
+    best_w_max = mx.concatenate(w_max_all, axis=0)
+    best_w_min = mx.concatenate(w_min_all, axis=0)
+
+    w_r = w_all.reshape(*w_all.shape[:-1], -1, group_size)
+    best_w = mx.clip(w_r, best_w_min, best_w_max)
+    best_w = best_w.reshape(w_all.shape)
+
+    mx.eval(best_w)
+    return best_w
+
+
+def clip_block(
+    block: nn.Module,
+    input_feat: dict[str, mx.array],
+    quantize_func: Callable,
+    group_size: int,
+):
+
+    def apply_clip(path, module):
+        if (
+            isinstance(module, nn.Linear)
+            and "q_proj" not in path
+            and "k_proj" not in path
+        ):
+            name = path.split(".")[-1]
+            best_weight = search_best_clip(
+                module.weight,
+                input_feat[name],
+                quantize_func=quantize_func,
+                group_size=group_size,
+            )
+            module.weight = best_weight
+
+    tree_map_with_path(apply_clip, block.leaf_modules(), is_leaf=nn.Module.is_module)
+
+
+def awq_quantize(
+    model,
+    inputs: mx.array,
+    group_size: int = 64,
+    bits: int = 3,
+    embed_group_size: int = 32,
+    embed_bits: int = 4,
+):
+    group = mx.distributed.init() if mx.distributed.is_available() else None
+
+    def quantize_func(w):
+        wq = mx.quantize(w, bits=bits, group_size=group_size)
+        return mx.dequantize(*wq, bits=bits, group_size=group_size)
+
+    mask = create_attention_mask(inputs)
+
+    model.model.embed_tokens = model.model.embed_tokens.to_quantized(
+        group_size=embed_group_size, bits=embed_bits
+    )
+    inputs = model.model.embed_tokens(inputs)
+
+    input_feat = {}
+
+    def capture(path, module):
+        if not isinstance(module, nn.Linear):
+            return module
+
+        class Catcher(nn.Module):
+            def __call__(self, x: mx.array):
+                name = path.split(".")[-1]
+                input_feat[name] = x
+                return module(x)
+
+        return Catcher()
+
+    for i, layer in enumerate(model.model.layers):
+        import time
+
+        s = time.time()
+        print(f"Starting block {i}")
+
+        # capture the inputs to each layer
+        orig_leaves = layer.leaf_modules()
+        capture_leaves = tree_map_with_path(
+            capture, orig_leaves, is_leaf=nn.Module.is_module
+        )
+        layer.update_modules(capture_leaves)
+        outputs = run_layer(layer, inputs, mask=mask)
+        layer.update_modules(orig_leaves)
+        del capture_leaves
+
+        nn.quantize(layer, group_size=group_size, bits=bits)
+        outputs_q = run_layer(layer, inputs, mask=mask)
+        loss = mse(outputs, outputs_q).sum()
+        if group is not None:
+            loss = mx.distributed.all_sum(loss, stream=mx.cpu) / group.size()
+        loss /= outputs.size
+        print("Before Loss", loss, flush=True)
+        layer.update_modules(orig_leaves)
+        del orig_leaves
+
+        print("Scaling block", flush=True)
+        scale_block(
+            block=layer,
+            input_feat=input_feat,
+            quantize_func=quantize_func,
+            layer_kwargs={"mask": mask},
+        )
+
+        print("Clipping block", flush=True)
+        clip_block(
+            block=layer,
+            input_feat=input_feat,
+            quantize_func=quantize_func,
+            group_size=group_size,
+        )
+
+        nn.quantize(layer, group_size=group_size, bits=bits)
+        outputs_q = run_layer(layer, inputs, mask=mask)
+        loss = mse(outputs, outputs_q).sum()
+        if group is not None:
+            loss = mx.distributed.all_sum(loss, stream=mx.cpu) / group.size()
+        loss /= outputs.size
+        print("After Loss", loss, flush=True)
+
+        input_feat = {}
+        inputs = outputs
+
+        mx.eval(layer)
+        mx.metal.clear_cache()
+
+        e = time.time()
+        print("Loop time: ", e - s)
+
+    if hasattr(model, "lm_head"):
+        model.lm_head = model.lm_head.to_quantized(
+            group_size=embed_group_size, bits=embed_bits
+        )
+
+
+def load_wikitext(
+    tokenizer, num_samples: int = 32, sequence_length: int = 2048, split: str = "train"
+) -> mx.array:
+    dataset = load_dataset("Salesforce/wikitext", "wikitext-2-raw-v1", split=split)
+    texts = "\n\n".join(dataset["text"])
+    tokens = tokenizer.encode(texts, return_tensors="mlx")[0]
+
+    # Select random chunks
+    starts = mx.random.randint(
+        0, len(tokens) - sequence_length - 1, shape=(num_samples, 1)
+    )
+    data = tokens[starts + mx.arange(sequence_length)]
+    if tokenizer.bos_token_id:
+        data = mx.concatenate(
+            [mx.full((*data.shape[:2], 1), tokenizer.bos_token_id), data], axis=-1
+        )
+    return data
+
+
+def save_model(
+    model: nn.Module,
+    tokenizer: TokenizerWrapper,
+    config,
+    model_path: Path,
+    mlx_path: str,
+):
+    weights = dict(tree_flatten(model.parameters()))
+
+    mlx_path = Path(mlx_path)
+    save_weights(mlx_path, weights, donate_weights=True)
+
+    py_files = glob.glob(str(model_path / "*.py"))
+    for file in py_files:
+        shutil.copy(file, mlx_path)
+
+    tokenizer.save_pretrained(mlx_path)
+
+    config["quantization"] = {"group_size": 64, "bits": 4}
+
+    def update_config(path, module):
+        if hasattr(module, "bits"):
+            config["quantization"][path] = {
+                "group_size": module.group_size,
+                "bits": module.bits,
+            }
+        else:
+            config["quantization"][path] = False
+
+    tree_map_with_path(update_config, model.leaf_modules(), is_leaf=nn.Module.is_module)
+
+    save_config(config, config_path=mlx_path / "config.json")
+
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        "--model", "-m", default="mlx-community/Qwen2.5-7B-Instruct-bf16"
+    )
+    parser.add_argument("--mlx-path", default="mlx_model")
+    parser.add_argument("--bits", type=int, default=3)
+    parser.add_argument("--group-size", type=int, default=64)
+    parser.add_argument("--num-samples", type=int, default=32)
+    parser.add_argument("--sequence-length", type=int, default=2048)
+    parser.add_argument("--seed", type=int, default=123)
+    args = parser.parse_args()
+
+    group = mx.distributed.init() if mx.distributed.is_available() else None
+
+    num_samples = args.num_samples
+    if group is not None and num_samples % group.size() > 0:
+        num_samples += group.size() - num_samples % group.size()
+
+    mx.random.seed(args.seed)
+
+    model_path = get_model_path(args.model, revision=None)
+    model, config, tokenizer = fetch_from_hub(model_path, lazy=True)
+
+    calibration_data = load_wikitext(tokenizer, args.num_samples, args.sequence_length)
+
+    if group is not None:
+        calibration_data = dist_split(calibration_data, group)
+
+    # awq_quantize(model, calibration_data, bits=args.bits, group_size=args.group_size)
+
+    save_model(model, tokenizer, config, model_path, args.mlx_path)
+
+
+if __name__ == "__main__":
+    main()

--- a/mlx_lm/awq.py
+++ b/mlx_lm/awq.py
@@ -430,7 +430,7 @@ def main():
     if group is not None:
         calibration_data = dist_split(calibration_data, group)
 
-    # awq_quantize(model, calibration_data, bits=args.bits, group_size=args.group_size)
+    awq_quantize(model, calibration_data, bits=args.bits, group_size=args.group_size)
 
     save_model(model, tokenizer, config, model_path, args.mlx_path)
 

--- a/mlx_lm/awq.py
+++ b/mlx_lm/awq.py
@@ -1,35 +1,62 @@
-# Learned quantization using AWQ:
+# Learned quantization using AWQ
 
 # References:
-# AWQ
 # https://arxiv.org/abs/2306.00978
 # https://github.com/mit-han-lab/llm-awq
 
 import argparse
 import glob
 import shutil
+from dataclasses import dataclass
 from pathlib import Path
 from typing import Callable
 
 import mlx.core as mx
 import mlx.nn as nn
-import numpy as np
-from datasets import Dataset, load_dataset
-from mlx.utils import tree_flatten, tree_map_with_path
-from mlx_lm.models.base import create_attention_mask
-from mlx_lm.tokenizer_utils import TokenizerWrapper
-from mlx_lm.utils import fetch_from_hub, get_model_path, save_config, save_weights
+from datasets import load_dataset
+from mlx.utils import tree_flatten, tree_map, tree_map_with_path
 from tqdm import tqdm
+
+from mlx_lm.models.base import create_attention_mask
+from mlx_lm.models.switch_layers import SwitchLinear
+from mlx_lm.tokenizer_utils import TokenizerWrapper
+from mlx_lm.utils import (
+    MODEL_REMAPPING,
+    fetch_from_hub,
+    get_model_path,
+    save_config,
+    save_weights,
+)
+
+SUPPORTED_MODEL_TYPES = {
+    "llama",
+    "llama4",
+    "deepseek_v3",
+    "qwen2",
+    "gemma3",
+    "gemma3_text" "gemma2",
+}
 
 
 def mse(x, y):
     return ((x - y).astype(mx.float32)) ** 2
 
 
-def run_layer(layer: nn.Module, x: mx.array, batch_size: int = 32, **kwargs):
+def run_layer(
+    layer: nn.Module,
+    x: mx.array,
+    indices: mx.array | None = None,
+    batch_size: int = 32,
+    **kwargs,
+):
     y = []
     for i in range(0, x.shape[0], batch_size):
-        y.append(layer(x[i : i + batch_size], **kwargs))
+        if indices is not None:
+            y.append(
+                layer(x[i : i + batch_size], indices[i : i + batch_size], **kwargs)
+            )
+        else:
+            y.append(layer(x[i : i + batch_size], **kwargs))
         mx.eval(y)
     y = mx.concatenate(y, axis=0)
     return y
@@ -46,14 +73,18 @@ def dist_split(x: mx.array, group: mx.distributed.Group):
 
 def search_best_scale(
     layers: list[nn.Module],
-    x: mx.array,
     quantize_func: Callable,
     block: nn.Module | None = None,
     layer_kwargs: dict | None = None,
     n_grid: int = 20,
 ):
-    group = mx.distributed.init() if mx.distributed.is_available() else None
+    group = mx.distributed.init()
+
     layer_kwargs = layer_kwargs or {}
+
+    x = layers[0].input_feat
+    if (indices := layers[0].indices) is not None:
+        layer_kwargs["indices"] = indices
 
     block = block or layers[0]
     out = block(x, **layer_kwargs)
@@ -65,7 +96,9 @@ def search_best_scale(
 
     weights = tree_flatten(block.parameters())
 
-    for ratio in tqdm(range(n_grid)):
+    # Search across different scaling ratios
+    # and take the best loss.
+    for ratio in range(n_grid):
         ratio = ratio * 1 / n_grid
         scales = mx.maximum(x_max**ratio, 1e-4).reshape(-1)
         scales = scales / (scales.max() * scales.min()).sqrt()
@@ -92,8 +125,8 @@ def search_best_scale(
 
 
 def apply_scale(prev_op, layers, scales):
-    # Apply the scales to the layers
-    if isinstance(prev_op, nn.Linear):
+    # Fuse the scales into the previous op
+    if isinstance(prev_op, (nn.Linear, SwitchLinear)):
         assert len(layers) == 1
         prev_op.weight = prev_op.weight / scales[:, mx.newaxis]
         if hasattr(prev_op, "bias"):
@@ -105,59 +138,102 @@ def apply_scale(prev_op, layers, scales):
             prev_op.bias = prev_op.bias / scales
         for layer in layers:
             layer.weight = layer.weight * scales
+    elif prev_op.__class__.__name__ == "RMSNorm":  # For gemma models
+        prev_op.weight = (1.0 + prev_op.weight) / scales - 1.0
+        for layer in layers:
+            layer.weight = layer.weight * scales
     else:
         raise NotImplementedError(f"Could not apply scale to prev_op: {prev_op}")
 
+    for layer in layers:
+        layer.input_feat = layer.input_feat / scales
+
+
+@dataclass
+class LayerConfig:
+    prev_op: nn.Module
+    layers: list[nn.Module]
+    block: nn.Module | None = None
+    layer_kwargs: dict | None = None
+
 
 def scale_block(
-    block, input_feat, quantize_func: Callable, layer_kwargs: dict | None = None
+    block: nn.Module, mask: mx.array, quantize_func: Callable, n_grid: int = 20
 ):
-    layers = [
-        block.self_attn.q_proj,
-        block.self_attn.k_proj,
-        block.self_attn.v_proj,
-    ]
-    scales = search_best_scale(
-        layers=layers,
-        block=block.self_attn,
-        x=input_feat["q_proj"],
-        quantize_func=quantize_func,
-        layer_kwargs=layer_kwargs,
-    )
-    apply_scale(block.input_layernorm, layers, scales)
-    for name in ["q_proj", "k_proj", "v_proj"]:
-        input_feat[name] = input_feat[name] / scales
-
-    layers = [
-        block.mlp.gate_proj,
-        block.mlp.up_proj,
-    ]
-    scales = search_best_scale(
-        block=block.mlp,
-        layers=layers,
-        x=input_feat["gate_proj"],
-        quantize_func=quantize_func,
-    )
+    # Layers which have the same inputs (within an elementwise multiplication)
+    # can be scaled together.
     mlp_norm = getattr(
         block, "pre_feedforward_layernorm", block.post_attention_layernorm
     )
-    apply_scale(mlp_norm, layers, scales)
-    for name in ["gate_proj", "up_proj"]:
-        input_feat[name] = input_feat[name] / scales
-
-    layers = [block.mlp.down_proj]
-    scales = search_best_scale(
-        layers=layers,
-        x=input_feat["down_proj"],
-        quantize_func=quantize_func,
-    )
-    apply_scale(block.mlp.up_proj, layers, scales)
-    input_feat["down_proj"] = input_feat["down_proj"] / scales
+    config = [
+        LayerConfig(
+            block=block.self_attn,
+            prev_op=block.input_layernorm,
+            layers=[
+                block.self_attn.q_proj,
+                block.self_attn.k_proj,
+                block.self_attn.v_proj,
+            ],
+            layer_kwargs={"mask": mask},
+        )
+    ]
+    # Llama 4 MOE layer
+    if hasattr(block, "feed_forward") and block.is_moe_layer:
+        config += [
+            LayerConfig(
+                block=block.feed_forward,
+                prev_op=block.post_attention_layernorm,
+                layers=[
+                    block.feed_forward.shared_expert.gate_proj,
+                    block.feed_forward.shared_expert.up_proj,
+                    block.feed_forward.experts.gate_proj,
+                    block.feed_forward.experts.up_proj,
+                    block.feed_forward.router,
+                ],
+            ),
+            LayerConfig(
+                prev_op=block.feed_forward.experts.up_proj,
+                layers=[
+                    block.feed_forward.experts.down_proj,
+                ],
+            ),
+            LayerConfig(
+                prev_op=block.feed_forward.shared_expert.up_proj,
+                layers=[
+                    block.feed_forward.shared_expert.down_proj,
+                ],
+            ),
+        ]
+    else:
+        config += [
+            LayerConfig(
+                block=block.mlp,
+                prev_op=mlp_norm,
+                layers=[
+                    block.mlp.gate_proj,
+                    block.mlp.up_proj,
+                ],
+            ),
+            LayerConfig(
+                prev_op=block.mlp.up_proj,
+                layers=[
+                    block.mlp.down_proj,
+                ],
+            ),
+        ]
+    for conf in config:
+        scales = search_best_scale(
+            layers=conf.layers,
+            block=conf.block,
+            layer_kwargs=conf.layer_kwargs,
+            quantize_func=quantize_func,
+            n_grid=n_grid,
+        )
+        apply_scale(conf.prev_op, conf.layers, scales)
 
 
 def search_best_clip(
-    w: mx.array,
-    x: mx.array,
+    module: nn.Module,
     quantize_func: Callable,
     group_size: int,
     n_grid: int = 20,
@@ -165,7 +241,10 @@ def search_best_clip(
     subsample: int = 4,
     batch_size: int = 64,
 ):
-    group = mx.distributed.init() if mx.distributed.is_available() else None
+    group = mx.distributed.init()
+
+    x = module.input_feat
+    w = module.weight
 
     x = x[:, ::subsample]
     x = x.reshape(*x.shape[:-1], -1, group_size)
@@ -174,6 +253,7 @@ def search_best_clip(
     w_max_all = []
     w_min_all = []
 
+    # batch across W to save memory
     for b in range(0, w.shape[0], batch_size):
         w = w_all[b : b + batch_size]
 
@@ -187,6 +267,7 @@ def search_best_clip(
         w = w.reshape(*w.shape[:-1], -1, group_size)
         out = mx.einsum("btdg,odg->btod", x, w)
 
+        # try a range of clips and pick the one with the smallest loss
         for i in range(int(max_shrink * n_grid)):
             p = 1 - i / n_grid
             w_max = p * w.max(axis=-1, keepdims=True)
@@ -224,10 +305,7 @@ def search_best_clip(
 
 
 def clip_block(
-    block: nn.Module,
-    input_feat: dict[str, mx.array],
-    quantize_func: Callable,
-    group_size: int,
+    block: nn.Module, quantize_func: Callable, group_size: int, n_grid: int = 20
 ):
 
     def apply_clip(path, module):
@@ -236,12 +314,11 @@ def clip_block(
             and "q_proj" not in path
             and "k_proj" not in path
         ):
-            name = path.split(".")[-1]
             best_weight = search_best_clip(
-                module.weight,
-                input_feat[name],
+                module,
                 quantize_func=quantize_func,
                 group_size=group_size,
+                n_grid=n_grid,
             )
             module.weight = best_weight
 
@@ -255,8 +332,9 @@ def awq_quantize(
     bits: int = 3,
     embed_group_size: int = 32,
     embed_bits: int = 4,
+    n_grid: int = 20,
 ):
-    group = mx.distributed.init() if mx.distributed.is_available() else None
+    group = mx.distributed.init()
 
     def quantize_func(w):
         wq = mx.quantize(w, bits=bits, group_size=group_size)
@@ -269,78 +347,83 @@ def awq_quantize(
     )
     inputs = model.model.embed_tokens(inputs)
 
-    input_feat = {}
-
-    def capture(path, module):
-        if not isinstance(module, nn.Linear):
+    def capture(module):
+        if not isinstance(module, (nn.Linear, SwitchLinear)):
             return module
 
         class Catcher(nn.Module):
-            def __call__(self, x: mx.array):
-                name = path.split(".")[-1]
-                input_feat[name] = x
-                return module(x)
+            def __call__(self, x: mx.array, *args, **kwargs):
+                # Store the input features on the original modules.
+                if hasattr(module, "input_feat"):
+                    module.input_feat = mx.concatenate([module.input_feat, x], axis=0)
+                else:
+                    module.input_feat = x
+
+                # Also store the MOE indices if applicabale
+                module.indices = None
+                if isinstance(module, SwitchLinear):
+                    indices = args[0]
+                    if module.indices is not None:
+                        module.indices = mx.concatenate(
+                            [module.indices, indices], axis=0
+                        )
+                    else:
+                        module.indices = indices
+
+                return module(x, *args, **kwargs)
 
         return Catcher()
 
-    for i, layer in enumerate(model.model.layers):
-        import time
-
-        s = time.time()
-        print(f"Starting block {i}")
-
-        # capture the inputs to each layer
-        orig_leaves = layer.leaf_modules()
-        capture_leaves = tree_map_with_path(
-            capture, orig_leaves, is_leaf=nn.Module.is_module
-        )
-        layer.update_modules(capture_leaves)
-        outputs = run_layer(layer, inputs, mask=mask)
-        layer.update_modules(orig_leaves)
+    for block in tqdm(model.model.layers):
+        # Capture the input features for each of the layers in the transformer block
+        orig_leaves = block.leaf_modules()
+        capture_leaves = tree_map(capture, orig_leaves, is_leaf=nn.Module.is_module)
+        block.update_modules(capture_leaves)
+        outputs = run_layer(block, inputs, mask=mask)
+        block.update_modules(orig_leaves)
         del capture_leaves
 
-        nn.quantize(layer, group_size=group_size, bits=bits)
-        outputs_q = run_layer(layer, inputs, mask=mask)
-        loss = mse(outputs, outputs_q).sum()
+        # Quantize the block without AWQ to obtain a reference loss
+        nn.quantize(block, group_size=group_size, bits=bits)
+        outputs_q = run_layer(block, inputs, mask=mask)
+        before_loss = mse(outputs, outputs_q).sum()
         if group is not None:
-            loss = mx.distributed.all_sum(loss, stream=mx.cpu) / group.size()
-        loss /= outputs.size
-        print("Before Loss", loss, flush=True)
-        layer.update_modules(orig_leaves)
+            before_loss = (
+                mx.distributed.all_sum(before_loss, stream=mx.cpu) / group.size()
+            )
+        before_loss /= outputs.size
+        block.update_modules(orig_leaves)
         del orig_leaves
 
-        print("Scaling block", flush=True)
         scale_block(
-            block=layer,
-            input_feat=input_feat,
+            block=block,
+            mask=mask,
             quantize_func=quantize_func,
-            layer_kwargs={"mask": mask},
+            n_grid=n_grid,
         )
 
-        print("Clipping block", flush=True)
         clip_block(
-            block=layer,
-            input_feat=input_feat,
+            block=block,
             quantize_func=quantize_func,
             group_size=group_size,
+            n_grid=n_grid,
         )
 
-        nn.quantize(layer, group_size=group_size, bits=bits)
-        outputs_q = run_layer(layer, inputs, mask=mask)
-        loss = mse(outputs, outputs_q).sum()
+        # Quantize the scaled and clipped block
+        nn.quantize(block, group_size=group_size, bits=bits)
+        outputs_q = run_layer(block, inputs, mask=mask)
+        after_loss = mse(outputs, outputs_q).sum()
         if group is not None:
-            loss = mx.distributed.all_sum(loss, stream=mx.cpu) / group.size()
-        loss /= outputs.size
-        print("After Loss", loss, flush=True)
+            after_loss = (
+                mx.distributed.all_sum(after_loss, stream=mx.cpu) / group.size()
+            )
+        after_loss /= outputs.size
+        tqdm.write(f"Loss reduction: {after_loss / before_loss}")
 
-        input_feat = {}
         inputs = outputs
 
-        mx.eval(layer)
+        mx.eval(block)
         mx.metal.clear_cache()
-
-        e = time.time()
-        print("Loop time: ", e - s)
 
     if hasattr(model, "lm_head"):
         model.lm_head = model.lm_head.to_quantized(
@@ -362,7 +445,7 @@ def load_wikitext(
     data = tokens[starts + mx.arange(sequence_length)]
     if tokenizer.bos_token_id:
         data = mx.concatenate(
-            [mx.full((*data.shape[:2], 1), tokenizer.bos_token_id), data], axis=-1
+            [mx.full((*data.shape[:1], 1), tokenizer.bos_token_id), data], axis=-1
         )
     return data
 
@@ -409,12 +492,15 @@ def main():
     parser.add_argument("--mlx-path", default="mlx_model")
     parser.add_argument("--bits", type=int, default=3)
     parser.add_argument("--group-size", type=int, default=64)
+    parser.add_argument("--embed-bits", type=int, default=4)
+    parser.add_argument("--embed-group-size", type=int, default=32)
     parser.add_argument("--num-samples", type=int, default=32)
     parser.add_argument("--sequence-length", type=int, default=2048)
+    parser.add_argument("--n-grid", type=int, default=10)
     parser.add_argument("--seed", type=int, default=123)
     args = parser.parse_args()
 
-    group = mx.distributed.init() if mx.distributed.is_available() else None
+    group = mx.distributed.init()
 
     num_samples = args.num_samples
     if group is not None and num_samples % group.size() > 0:
@@ -425,12 +511,27 @@ def main():
     model_path = get_model_path(args.model, revision=None)
     model, config, tokenizer = fetch_from_hub(model_path, lazy=True)
 
+    model_type = config["model_type"]
+    model_type = MODEL_REMAPPING.get(model_type, model_type)
+    if model_type not in SUPPORTED_MODEL_TYPES:
+        raise NotImplementedError(f"AWQ support for {config['model_type']} models NYI.")
+
     calibration_data = load_wikitext(tokenizer, args.num_samples, args.sequence_length)
 
     if group is not None:
         calibration_data = dist_split(calibration_data, group)
 
-    awq_quantize(model, calibration_data, bits=args.bits, group_size=args.group_size)
+    # For Gemma3 vision/text models
+    language_model = getattr(model, "language_model", model)
+    awq_quantize(
+        language_model,
+        calibration_data,
+        bits=args.bits,
+        group_size=args.group_size,
+        embed_bits=args.embed_bits,
+        embed_group_size=args.embed_group_size,
+        n_grid=args.n_grid,
+    )
 
     save_model(model, tokenizer, config, model_path, args.mlx_path)
 

--- a/mlx_lm/awq.py
+++ b/mlx_lm/awq.py
@@ -31,10 +31,10 @@ from mlx_lm.utils import (
 SUPPORTED_MODEL_TYPES = {
     "llama",
     "llama4",
-    "deepseek_v3",
     "qwen2",
     "gemma3",
-    "gemma3_text" "gemma2",
+    "gemma3_text",
+    "gemma2",
 }
 
 
@@ -468,6 +468,7 @@ def save_model(
 
     tokenizer.save_pretrained(mlx_path)
 
+    # dummy
     config["quantization"] = {"group_size": 64, "bits": 4}
 
     def update_config(path, module):

--- a/mlx_lm/awq.py
+++ b/mlx_lm/awq.py
@@ -1,9 +1,4 @@
 # Copyright © 2025 Apple Inc.
-# Learned quantization using AWQ
-
-# References:
-# https://arxiv.org/abs/2306.00978
-# https://github.com/mit-han-lab/llm-awq
 
 import argparse
 import copy

--- a/mlx_lm/awq.py
+++ b/mlx_lm/awq.py
@@ -209,7 +209,7 @@ def search_best_scale(
     layer_kwargs = layer_kwargs or {}
 
     x = layers[0].input_feat
-    if (indices := layers[0].indices) is not None:
+    if (indices := getattr(layers[0], "indices", None)) is not None:
         layer_kwargs["indices"] = indices
 
     block = block or layers[0]
@@ -433,10 +433,9 @@ def awq_quantize(
                     module.input_feat = x
 
                 # Also store the MOE indices if applicabale
-                module.indices = None
                 if isinstance(module, SwitchLinear):
                     indices = args[0]
-                    if module.indices is not None:
+                    if hasattr(module, "indices"):
                         module.indices = mx.concatenate(
                             [module.indices, indices], axis=0
                         )

--- a/mlx_lm/convert.py
+++ b/mlx_lm/convert.py
@@ -11,6 +11,7 @@ import mlx.nn as nn
 from mlx.utils import tree_flatten
 
 from .utils import (
+    create_model_card,
     dequantize_model,
     fetch_from_hub,
     get_model_path,
@@ -151,8 +152,10 @@ def convert(
 
     save_config(config, config_path=mlx_path / "config.json")
 
+    create_model_card(mlx_path, hf_path)
+
     if upload_repo is not None:
-        upload_to_hub(mlx_path, upload_repo, hf_path)
+        upload_to_hub(mlx_path, upload_repo)
 
 
 def configure_parser() -> argparse.ArgumentParser:

--- a/mlx_lm/upload.py
+++ b/mlx_lm/upload.py
@@ -1,0 +1,22 @@
+# Copyright © 2025 Apple Inc.
+
+import argparse
+
+from .utils import upload_to_hub
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="Upload a model to the Hugging Face Hub"
+    )
+
+    parser.add_argument(
+        "--path", type=str, default="mlx_model", help="Path to the MLX model."
+    )
+    parser.add_argument(
+        "--upload-repo",
+        help="The Hugging Face repo to upload the model to.",
+        type=str,
+    )
+    args = parser.parse_args()
+    upload_to_hub(args.path, args.upload_repo)

--- a/setup.py
+++ b/setup.py
@@ -32,6 +32,7 @@ setup(
     },
     entry_points={
         "console_scripts": [
+            "mlx_lm.awq = mlx_lm.awq:main",
             "mlx_lm.cache_prompt = mlx_lm.cache_prompt:main",
             "mlx_lm.chat = mlx_lm.chat:main",
             "mlx_lm.convert = mlx_lm.convert:main",

--- a/setup.py
+++ b/setup.py
@@ -43,6 +43,7 @@ setup(
             "mlx_lm.merge = mlx_lm.merge:main",
             "mlx_lm.server = mlx_lm.server:main",
             "mlx_lm.manage = mlx_lm.manage:main",
+            "mlx_lm.upload = mlx_lm.upload:main",
         ]
     },
 )


### PR DESCRIPTION
Adds a command to use [AWQ](https://arxiv.org/abs/2306.00978) to quantize a model.

AWQ uses a calibration dataset to scale and clip `nn.Linear` layers, resulting in more accurate quantization. This is currently hard-coded to wiki text but should be easy to customize in the script.

Currently we support a subset of the model types in mlx-lm: Llama, Qwen and Gemma3. I prioritized the most popular according to the HF [mlx-community](https://huggingface.co/mlx-community?sort_models=downloads#models).

# Performance

Since the scales and clips are fused into the previous layer, the resulting model runs at exactly the same tokens per second as the normally quantized model.

# Quality
Quality benchmarks are run on 8 zero shot `lm_eval` tasks using `mlx_lm.evaluate`:
```
winogrande boolq arc_challenge arc_easy hellaswag openbookqa piqa social_iqa
```

`n-grid=20` `num-samples=256`

Scores are a percentage of average bf16 performance across the 8 tasks.
For all quants, embedding/lm_head layers are quantized with 4 bits, 32 group size.

## Qwen 2.5 7B

| Quant | % of bf16 |
| --- | --- |
| bf16 |  100.0 |
| 3 bit AWQ | 96.9 |
| 3 bit | 92.4 |

## Llama 3.2 1B
| Quant | % of bf16 |
| --- | --- |
| bf16 |  100.0 |
| 4 bit AWQ | 99.0 |
| 4 bit | 97.7 |
| 3 bit AWQ | 94.2 |
| 3 bit | 87.4 |

## Gemma 3 1B
| Quant | % of bf16 |
| --- | --- |
| bf16 |  100.0 |
| 4 bit AWQ | 98.4 |
| 4 bit | 96.1 |

# Quantization Time
AWQ is much more expensive at quantization time than our affine quants. A few examples:

M1 Max, 1B model, `--n-grid 10 --num-samples 32`:  15 minutes

M2 Ultra, 7B model, `--n-grid 20 --num-samples 256`: 3 hours

The script supports distributed execution which linearly speeds up the run time.

In practice I have seen more samples result in better task performance (as shown in the original paper), but I haven't done a comprehensive ablation.

# MOE
There's experimental MOE support in the script. I ran a few tests with MOE models and didn't see much improvement in the downstream task performance. It's possible there a bug or maybe MOE models require many more samples since all the experts need to be taken into account by a single scale.