### PR TITLE
Fix GPT2 Incremental Generation by Correctly Applying Position Embeddings and Offsets

### DIFF
--- a/mlx_lm/models/gpt2.py
+++ b/mlx_lm/models/gpt2.py
@@ -137,7 +137,7 @@ class GPT2Model(nn.Module):
         if cache is not None and len(cache) > 0 and cache[0] is not None:
             offset = cache[0].offset
 
-        position_ids = mx.array(np.arange(offset, offset + L))
+        position_ids = mx.arange(offset, offset + L)
         hidden_states += self.wpe(position_ids)
 
         if mask is None:

--- a/mlx_lm/models/gpt2.py
+++ b/mlx_lm/models/gpt2.py
@@ -1,7 +1,7 @@
 # Copyright © 2023-2024 Apple Inc.
 
 from dataclasses import dataclass
-from typing import Any, Dict, Optional, Tuple, Union
+from typing import Any, Optional
 
 import mlx.core as mx
 import mlx.nn as nn
@@ -133,14 +133,15 @@ class GPT2Model(nn.Module):
 
         hidden_states = self.wte(inputs)
 
-        mask = None
-        if hidden_states.shape[1] > 1:
+        offset = 0
+        if cache is not None and len(cache) > 0 and cache[0] is not None:
+            offset = cache[0].offset
 
-            position_ids = mx.array(np.arange(L))
-            hidden_states += self.wpe(position_ids)
+        position_ids = mx.array(np.arange(offset, offset + L))
+        hidden_states += self.wpe(position_ids)
 
-            if mask is None:
-                mask = create_attention_mask(hidden_states, cache)
+        if mask is None:
+            mask = create_attention_mask(hidden_states, cache)
 
         if cache is None:
             cache = [None] * len(self.h)


### PR DESCRIPTION
This PR fixes two main issues in the current GPT2 implementation code that caused incorrect generation with caching. An interesting observation is the `gpt2-xl` model seems to be less dependent on positional embeddings to generate correct output; however, the smaller models tend to generate garbage with incorrect positional embeddings applied.

Specifically, the current model implementation:

1. Skips position embeddings when the input length is one (if hidden_states.shape[1] > 1:).
2. Always starts position embeddings at zero for new tokens, ignoring previously generated tokens already in the KV cache.

As a result, single‐token forward passes fail to maintain correct positions, leading to distorted or repetitive outputs.

Changes:

1.	Always Apply Position Embeddings
Removed the condition that prevented adding position embeddings for single‐token inputs. Now, position embeddings are added for every input token, regardless of length.
2.	Offset Position Indices by Cache Length
Determined how many tokens were already processed by reading cache[0].offset (or similar) and offsetting new tokens’ position IDs accordingly. For example, if 50 tokens have been generated so far, the next token will be placed at position 50, not 0.
3.	Consistent Masking
If no attention mask is provided, the code now unconditionally creates a causal mask to ensure the model attends only to past and present tokens.

With these fixes the implementation now has output identical to the HF Transformers implementation:

```
(.venv) ~/work/repos/third-party/ml-explore/mlx-lm $ python -m mlx_lm generate --model openai-community/gpt2 --prompt "Hello, my name is" --max-tokens 100
Fetching 14 files: 100%|███████████████████████████████████| 14/14 [00:00<00:00, 40246.92it/s]
==========
John. I'm a writer, and I'm a writer. I'm a writer. I'm a writer. I'm a writer. I'm a writer. I'm a writer. I'm a writer. I'm a writer. I'm a writer. I'm a writer. I'm a writer. I'm a writer. I'm a writer. I'm a writer. I'm a writer. I'm a writer. I'm a writer. I'm a writer. I'm
==========
Prompt: 5 tokens, 379.540 tokens-per-sec
Generation: 100 tokens, 390.990 tokens-per-sec
Peak memory: 0.552 GB
```

Without fixes:
```
(.venv) ~/work/repos/third-party/ml-explore/mlx-lm $ python -m mlx_lm generate --model openai-community/gpt2 --prompt "Hello, my name is" --max-tokens 100
Fetching 14 files: 100%|██████████████████████████████████| 14/14 [00:00<00:00, 145707.83it/s]
==========
John.
I'm John John John John John John John John John John John John John John John John John John John John John John John John John John John John John John John John John John John John John John John John John John John John John John John John John John John John John John John John John John John John John John John John John John John John John John John John John John John John John John John John John John John John John John John John John John John John John John John
==========
Prompt: 5 tokens, 380.650 tokens-per-sec
Generation: 100 tokens, 387.713 tokens-per-sec
Peak memory: 0.554 GB
```
