### PR TITLE
Feature/resumable lora with metadata

### DIFF
--- a/mlx_lm/tuner/trainer.py
+++ b/mlx_lm/tuner/trainer.py
@@ -10,6 +10,7 @@ from typing import List, Optional, Tuple
 
 import mlx.core as mx
 import mlx.nn as nn
+import mlx.optimizers as optim
 import numpy as np
 from mlx.nn.utils import average_gradients
 from mlx.utils import tree_flatten
@@ -337,28 +338,10 @@ def train(
             steps = 0
             train_time = 0
 
-        # Save adapter weights
+        # Save adapter weights and optimizer state
         if it % args.steps_per_save == 0 and rank == 0:
-            adapter_weights = dict(tree_flatten(model.trainable_parameters()))
-
-            metadata = {
-                "iteration": str(it),
-                "trained_tokens": str(trained_tokens),
-                "loss": f"{train_loss:.6f}",
-            }
-
-            mx.save_safetensors(
-                str(args.adapter_file),
-                adapter_weights,
-                metadata=metadata,
-            )
-            checkpoint = (
-                Path(args.adapter_file).parent / f"{it:07d}_adapters.safetensors"
-            )
-            mx.save_safetensors(str(checkpoint), adapter_weights, metadata=metadata)
-            print(
-                f"Iter {it}: Saved adapter weights to "
-                f"{args.adapter_file} and {checkpoint}."
+            save_checkpoint(
+                model, optimizer, args.adapter_file, it, trained_tokens, train_loss
             )
 
     # Save final weights
@@ -371,3 +354,112 @@ def train(
         }
         mx.save_safetensors(str(args.adapter_file), adapter_weights, metadata=metadata)
         print(f"Saved final weights to {args.adapter_file}.")
+
+
+def save_checkpoint(model, optimizer, checkpoint_file, iteration, trained_tokens, loss):
+    """Save a checkpoint including model weights and optimizer state."""
+    adapter_weights = dict(tree_flatten(model.trainable_parameters()))
+    optimizer_state = dict(tree_flatten(optimizer.state))
+
+    # Extract optimizer configuration
+    optimizer_config = {
+        "step": str(optimizer_state.get("step", 0).item()),
+        "betas": str(optimizer.betas),
+        "eps": str(optimizer.eps),
+        "learning_rate": str(optimizer.learning_rate.item()),
+        "optimizer_type": type(optimizer).__name__,
+    }
+
+    # Add weight_decay only for AdamW
+    if isinstance(optimizer, optim.AdamW):
+        optimizer_config["weight_decay"] = str(optimizer.weight_decay)
+
+    # For Adam/AdamW, save the estimates
+    if isinstance(optimizer, (optim.Adam, optim.AdamW)):
+
+        optimizer_config.update(
+            {
+                "m": str(
+                    {k: v.tolist() for k, v in optimizer_state.get("m", {}).items()}
+                ),
+                "v": str(
+                    {k: v.tolist() for k, v in optimizer_state.get("v", {}).items()}
+                ),
+            }
+        )
+
+    metadata = {
+        "iteration": str(iteration),
+        "trained_tokens": str(trained_tokens),
+        "loss": f"{loss:.6f}",
+        "optimizer": str(optimizer_config),
+    }
+
+    # Save main checkpoint
+    mx.save_safetensors(str(checkpoint_file), adapter_weights, metadata=metadata)
+
+    # Save numbered checkpoint
+    checkpoint = Path(checkpoint_file).parent / f"{iteration:07d}_adapters.safetensors"
+    mx.save_safetensors(str(checkpoint), adapter_weights, metadata=metadata)
+
+    print(f"Saved adapter weights to {checkpoint_file} and {checkpoint}")
+
+
+def load_checkpoint(model, optimizer, checkpoint_file):
+    """Load a checkpoint and return the start iteration."""
+    start_iteration = 1
+    if checkpoint_file is None:
+        return start_iteration
+
+    checkpoint_path = Path(checkpoint_file)
+    if checkpoint_path.is_dir():
+        safetensor_files = sorted(
+            checkpoint_path.glob("*_adapters.safetensors"),
+            key=lambda f: int(f.name.split("_")[0]),
+            reverse=True,
+        )
+        if not safetensor_files:
+            raise ValueError("No adapter files found to resume from.")
+        checkpoint_file = str(safetensor_files[0])
+        print(f"Auto-resuming from latest adapter file: {checkpoint_file}")
+    else:
+        checkpoint_file = str(checkpoint_path)
+
+    weights, metadata = mx.load(checkpoint_file, return_metadata=True)
+    model.load_weights(checkpoint_file, strict=False)
+
+    if metadata:
+        if "iteration" in metadata:
+            start_iteration = int(metadata["iteration"]) + 1
+            print(f"Continuing from iteration {start_iteration}")
+
+        if "optimizer" in metadata:
+
+            optimizer_config = eval(metadata["optimizer"])
+
+            # Restore optimizer state
+            if isinstance(optimizer, (optim.Adam, optim.AdamW)):
+
+                m = eval(optimizer_config["m"])
+                v = eval(optimizer_config["v"])
+                m = {k: mx.array(v) for k, v in m.items()}
+                v = {k: mx.array(v) for k, v in v.items()}
+                optimizer.state["m"] = m
+                optimizer.state["v"] = v
+                optimizer.state["step"] = mx.array(int(optimizer_config["step"]))
+
+                # Restore optimizer parameters
+                optimizer.betas = eval(optimizer_config["betas"])
+                optimizer.eps = float(optimizer_config["eps"])
+                optimizer.learning_rate = float(optimizer_config["learning_rate"])
+
+                # Restore weight_decay only for AdamW
+                if (
+                    isinstance(optimizer, optim.AdamW)
+                    and "weight_decay" in optimizer_config
+                ):
+                    optimizer.weight_decay = float(optimizer_config["weight_decay"])
+
+                print("Restored optimizer state from checkpoint")
+
+    return start_iteration

--- a/tests/test_lora_resume.py
+++ b/tests/test_lora_resume.py
@@ -1,16 +1,13 @@
-import os
-import shutil
+import tempfile
+import unittest
 from pathlib import Path
 
-import mlx.core as mx
 import mlx.nn as nn
 import mlx.optimizers as optim
-import numpy as np
-import pytest
 from safetensors.numpy import safe_open
 
-from mlx_lm.tuner.datasets import CacheDataset
-from mlx_lm.tuner.trainer import TrainingArgs, train
+from mlx_lm.tuner.datasets import TextDataset
+from mlx_lm.tuner.trainer import TrainingArgs, load_checkpoint, save_checkpoint, train
 
 # ---------------------
 # Mock Components
@@ -42,47 +39,36 @@ class MockModel(nn.Module):
     def eval(self):
         pass
 
-
-class DummyDataset:
-    def __getitem__(self, idx):
-        return [i % 100 for i in range(32)]
-
-    def __len__(self):
-        return 1000
+    def load_weights(self, weights_file, strict=True):
+        pass
 
 
 class DummyTokenizer:
-    def __call__(self, texts):
-        return [[i % 100 for i, _ in enumerate(text.split())] for text in texts]
+    def __init__(self):
+        self.eos_token_id = 3
+        self.vocab_size = 128
+
+    def encode(self, text):
+        return [1, 2, 3] * 10
+
+    def decode(self, tokens):
+        return "dummy text"
 
 
-# ---------------------
-# Training Runner
-# ---------------------
+class DummyDataset(TextDataset):
+    def __init__(self, num_samples=100):
+        self._data = [{"text": f"dummy text {i}"} for i in range(num_samples)]
+        self.tokenizer = DummyTokenizer()
+        self.text_key = "text"
 
+    def __len__(self):
+        return len(self._data)
 
-def run_training(iters, adapter_file, resume_from=None):
-    model = MockModel()
-    dataset = DummyDataset()
-    train_set = CacheDataset(dataset)
-    val_set = CacheDataset(dataset)
-    tokenizer = DummyTokenizer()
-    optimizer = optim.Adam(learning_rate=1e-4)
+    def __getitem__(self, idx):
+        return self._data[idx]
 
-    args = TrainingArgs(
-        iters=iters,
-        batch_size=16,
-        val_batches=2,
-        steps_per_report=5,
-        steps_per_save=5,
-        adapter_file=adapter_file,
-        max_seq_length=64,
-    )
-
-    if resume_from:
-        model.load_weights(resume_from, strict=False)
-
-    train(model, tokenizer, optimizer, train_set, val_set, args=args)
+    def process(self, item):
+        return self.tokenizer.encode(item[self.text_key])
 
 
 # ---------------------
@@ -90,26 +76,158 @@ def run_training(iters, adapter_file, resume_from=None):
 # ---------------------
 
 
-@pytest.mark.order(1)
-def test_adapter_resume_and_metadata(tmp_path):
-    adapter_dir = tmp_path / "adapters"
-    adapter_dir.mkdir(parents=True, exist_ok=True)
+class TestLoraResume(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.test_dir_fid = tempfile.TemporaryDirectory()
+        cls.test_dir = cls.test_dir_fid.name
+        cls.adapter_dir = Path(cls.test_dir) / "adapters"
+        cls.adapter_dir.mkdir(parents=True, exist_ok=True)
 
-    # Step 1: Train for 5 iters
-    adapter_file = adapter_dir / "adapters.safetensors"
-    run_training(iters=5, adapter_file=adapter_file)
+    @classmethod
+    def tearDownClass(cls):
+        cls.test_dir_fid.cleanup()
 
-    assert (adapter_dir / "0000005_adapters.safetensors").exists()
+    def setUp(self):
+        # Create fresh model and datasets for each test
+        self.model = MockModel()
+        self.dataset = DummyDataset()
+        self.train_set = self.dataset
+        self.val_set = self.dataset
+        self.tokenizer = DummyTokenizer()
+        self.optimizer = optim.Adam(learning_rate=1e-4)
 
-    # Step 2: Resume for 5 more iters (should end at 10)
-    resume_file = adapter_dir / "0000005_adapters.safetensors"
-    run_training(iters=10, adapter_file=adapter_file, resume_from=resume_file)
+    def get_training_args(self, iters, adapter_file):
+        return TrainingArgs(
+            iters=iters,
+            batch_size=16,
+            val_batches=2,
+            steps_per_report=5,
+            steps_per_save=5,
+            adapter_file=adapter_file,
+            max_seq_length=64,
+        )
 
-    final_file = adapter_dir / "0000010_adapters.safetensors"
-    assert final_file.exists()
+    def test_initial_training(self):
+        """Test the initial training phase without resuming."""
+        adapter_file = self.adapter_dir / "adapters.safetensors"
+        args = self.get_training_args(iters=5, adapter_file=adapter_file)
 
-    # Step 3: Check metadata
-    with safe_open(str(final_file), framework="numpy") as f:
-        metadata = f.metadata()
-        assert "step" in metadata
-        assert metadata["step"] == "10"
+        train(
+            self.model,
+            self.tokenizer,
+            self.optimizer,
+            self.train_set,
+            self.val_set,
+            args=args,
+        )
+
+        # Verify checkpoint files were created
+        self.assertTrue((self.adapter_dir / "0000005_adapters.safetensors").exists())
+        self.assertTrue(adapter_file.exists())
+
+    def test_resume_training(self):
+        """Test resuming training from a checkpoint."""
+        adapter_file = self.adapter_dir / "adapters.safetensors"
+
+        # First training phase
+        args = self.get_training_args(iters=5, adapter_file=adapter_file)
+        train(
+            self.model,
+            self.tokenizer,
+            self.optimizer,
+            self.train_set,
+            self.val_set,
+            args=args,
+        )
+
+        # Resume training
+        resume_file = self.adapter_dir / "0000005_adapters.safetensors"
+        start_iteration = load_checkpoint(self.model, self.optimizer, resume_file)
+
+        args = self.get_training_args(iters=10, adapter_file=adapter_file)
+        train(
+            self.model,
+            self.tokenizer,
+            self.optimizer,
+            self.train_set,
+            self.val_set,
+            args=args,
+            start_step=start_iteration,
+        )
+
+        # Verify final checkpoint exists
+        final_file = self.adapter_dir / "0000010_adapters.safetensors"
+        self.assertTrue(final_file.exists())
+
+    def test_checkpoint_metadata(self):
+        """Test that checkpoint metadata is correctly saved and loaded."""
+        adapter_file = self.adapter_dir / "adapters.safetensors"
+        args = self.get_training_args(iters=5, adapter_file=adapter_file)
+
+        train(
+            self.model,
+            self.tokenizer,
+            self.optimizer,
+            self.train_set,
+            self.val_set,
+            args=args,
+        )
+
+        checkpoint_file = self.adapter_dir / "0000005_adapters.safetensors"
+        with safe_open(str(checkpoint_file), framework="numpy") as f:
+            metadata = f.metadata()
+
+            # Verify required metadata fields
+            self.assertIn("iteration", metadata)
+            self.assertEqual(metadata["iteration"], "5")
+            self.assertIn("optimizer", metadata)
+
+            # Verify optimizer state
+            optimizer_config = metadata["optimizer"]
+            self.assertIn("learning_rate", optimizer_config)
+            self.assertIn("step", optimizer_config)
+            self.assertIn("m", optimizer_config)
+            self.assertIn("v", optimizer_config)
+
+    def test_save_checkpoint(self):
+        """Test that save_checkpoint correctly saves model weights and metadata."""
+        # Create a test checkpoint
+        checkpoint_file = self.adapter_dir / "test_checkpoint.safetensors"
+
+        # Save checkpoint
+        save_checkpoint(
+            model=self.model,
+            optimizer=self.optimizer,
+            checkpoint_file=checkpoint_file,
+            iteration=1,
+            trained_tokens=100,
+            loss=0.5,
+        )
+
+        # Verify checkpoint was created
+        self.assertTrue(checkpoint_file.exists())
+
+        # Verify checkpoint contents
+        with safe_open(str(checkpoint_file), framework="numpy") as f:
+            metadata = f.metadata()
+
+            # Check metadata fields
+            self.assertIn("iteration", metadata)
+            self.assertEqual(metadata["iteration"], "1")
+            self.assertIn("trained_tokens", metadata)
+            self.assertEqual(metadata["trained_tokens"], "100")
+            self.assertIn("loss", metadata)
+            self.assertEqual(metadata["loss"], "0.500000")
+            self.assertIn("optimizer", metadata)
+
+            # Verify optimizer state
+            optimizer_config = metadata["optimizer"]
+            self.assertIn("learning_rate", optimizer_config)
+            self.assertIn("step", optimizer_config)
+            self.assertIn("m", optimizer_config)
+            self.assertIn("v", optimizer_config)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_lora_resume.py
+++ b/tests/test_lora_resume.py
@@ -1,0 +1,115 @@
+import os
+import shutil
+from pathlib import Path
+
+import mlx.core as mx
+import mlx.nn as nn
+import mlx.optimizers as optim
+import numpy as np
+import pytest
+from safetensors.numpy import safe_open
+
+from mlx_lm.tuner.datasets import CacheDataset
+from mlx_lm.tuner.trainer import TrainingArgs, train
+
+# ---------------------
+# Mock Components
+# ---------------------
+
+
+class MockModel(nn.Module):
+    def __init__(self, vocab_size=128, hidden_size=32):
+        super().__init__()
+        self.embed = nn.Embedding(vocab_size, hidden_size)
+        self.layers = [nn.Linear(hidden_size, hidden_size) for _ in range(2)]
+        self.out = nn.Linear(hidden_size, vocab_size)
+
+    def __call__(self, x):
+        x = self.embed(x)
+        for layer in self.layers:
+            x = layer(x)
+        return self.out(x)
+
+    def freeze(self):
+        pass
+
+    def unfreeze(self):
+        pass
+
+    def train(self):
+        pass
+
+    def eval(self):
+        pass
+
+
+class DummyDataset:
+    def __getitem__(self, idx):
+        return [i % 100 for i in range(32)]
+
+    def __len__(self):
+        return 1000
+
+
+class DummyTokenizer:
+    def __call__(self, texts):
+        return [[i % 100 for i, _ in enumerate(text.split())] for text in texts]
+
+
+# ---------------------
+# Training Runner
+# ---------------------
+
+
+def run_training(iters, adapter_file, resume_from=None):
+    model = MockModel()
+    dataset = DummyDataset()
+    train_set = CacheDataset(dataset)
+    val_set = CacheDataset(dataset)
+    tokenizer = DummyTokenizer()
+    optimizer = optim.Adam(learning_rate=1e-4)
+
+    args = TrainingArgs(
+        iters=iters,
+        batch_size=16,
+        val_batches=2,
+        steps_per_report=5,
+        steps_per_save=5,
+        adapter_file=adapter_file,
+        max_seq_length=64,
+    )
+
+    if resume_from:
+        model.load_weights(resume_from, strict=False)
+
+    train(model, tokenizer, optimizer, train_set, val_set, args=args)
+
+
+# ---------------------
+# Test Case
+# ---------------------
+
+
+@pytest.mark.order(1)
+def test_adapter_resume_and_metadata(tmp_path):
+    adapter_dir = tmp_path / "adapters"
+    adapter_dir.mkdir(parents=True, exist_ok=True)
+
+    # Step 1: Train for 5 iters
+    adapter_file = adapter_dir / "adapters.safetensors"
+    run_training(iters=5, adapter_file=adapter_file)
+
+    assert (adapter_dir / "0000005_adapters.safetensors").exists()
+
+    # Step 2: Resume for 5 more iters (should end at 10)
+    resume_file = adapter_dir / "0000005_adapters.safetensors"
+    run_training(iters=10, adapter_file=adapter_file, resume_from=resume_file)
+
+    final_file = adapter_dir / "0000010_adapters.safetensors"
+    assert final_file.exists()
+
+    # Step 3: Check metadata
+    with safe_open(str(final_file), framework="numpy") as f:
+        metadata = f.metadata()
+        assert "step" in metadata
+        assert metadata["step"] == "10"


### PR DESCRIPTION
Summary
-------

This pull request introduces resumable LoRA fine-tuning for mlx-lm, motivated by real-world issues encountered during training. When training was interrupted due to Out-Of-Memory (OOM) errors on macOS Metal, there was previously no way to resume progress. Training would always restart from iteration 1, overwriting adapter files leaving us back at square one.

This change adds:

*   The ability to resume training from the most recent adapter checkpoint (--resume-adapter-file)
*   Metadata saved in adapter .safetensors files to track the training iteration
*   Optimizer state saved and restored so training resumes accurately. 
*   Test coverage to validate resume behavior, metadata integrity, and optimizer state

Changes
-------

*   train\_model() and train() updated to track iteration count
*   trainer.py saves the current training step  and optimizer state in adapter metadata
*   On resume, the --resume-adapter-file checkpoint is loaded and the iteration count and optimizer state are restored
*   Filenames of the form 000XXXX\_adapters.safetensors continue correctly from the last step
    
*   Added test script test\_lora\_resume.py that tests saving and resuming from iteration and optimizer metadata
        

Why this is needed
------------------

Without resume functionality, training interruptions due to memory limits or system crashes result in wasted compute time and no way to continue training. This update provides robust continuation support while maintaining compatibility with existing workflows.

Test Plan
---------

*   Manual testing with --resume-adapter-file on interrupted training
*   Automated test test\_lora\_resume.py validates end-to-end resume behavior