### PR TITLE
Fix GLM4 Repetition

### DIFF
--- a/mlx_lm/models/glm4.py
+++ b/mlx_lm/models/glm4.py
@@ -71,7 +71,9 @@ class Glm4Attention(nn.Module):
         )
 
         self.rope = nn.RoPE(
-            dims=int(self.head_dim * args.partial_rotary_factor), base=args.rope_theta, traditional=args.rope_traditional
+            dims=int(self.head_dim * args.partial_rotary_factor),
+            base=args.rope_theta,
+            traditional=args.rope_traditional,
         )
 
     def __call__(
@@ -123,9 +125,10 @@ class Glm4DecoderLayer(nn.Module):
             self.self_attn(self.input_layernorm(x), mask, cache)
         )
         residual = x
-        x = self.post_mlp_layernorm(
-            self.mlp(self.post_attention_layernorm(x))
-        ) + residual
+        x = (
+            self.post_mlp_layernorm(self.mlp(self.post_attention_layernorm(x)))
+            + residual
+        )
         return x
 
 

--- a/mlx_lm/models/glm4.py
+++ b/mlx_lm/models/glm4.py
@@ -71,7 +71,7 @@ class Glm4Attention(nn.Module):
         )
 
         self.rope = nn.RoPE(
-            dims=self.head_dim, base=args.rope_theta, traditional=args.rope_traditional
+            dims=int(self.head_dim * args.partial_rotary_factor), base=args.rope_theta, traditional=args.rope_traditional
         )
 
     def __call__(

--- a/mlx_lm/models/glm4.py
+++ b/mlx_lm/models/glm4.py
@@ -123,10 +123,9 @@ class Glm4DecoderLayer(nn.Module):
             self.self_attn(self.input_layernorm(x), mask, cache)
         )
         residual = x
-        x = self.post_attention_layernorm(x)
-        x = self.mlp(x)
-        x = self.post_mlp_layernorm(x)
-        x = x + residual
+        x = self.post_mlp_layernorm(
+            self.mlp(self.post_attention_layernorm(x))
+        ) + residual
         return x
 
 


### PR DESCRIPTION
This fixes the repetition from GLM4, the main reason was that the transformers and the MLX before version did not use the `partial_rotary_factor` in RoPE:

Bafore:

```text
(mlx-dev) (base)  ~/Desktop/mlx-lm/ [adding-glm4*] python -m mlx_lm.generate --model /Volumes/T7_Shield/MODELS/MLX/GLM-4-9B-0414-bf16 --prompt "Write me a function that computes fibonacci in Rust" -m 1028
<frozen runpy>:128: RuntimeWarning: 'mlx_lm.generate' found in sys.modules after import of package 'mlx_lm', but prior to execution of 'mlx_lm.generate'; this may result in unpredictable behaviour
Calling `python -m mlx_lm.generate...` directly is deprecated. Use `mlx_lm.generate...` or `python -m mlx_lm generate ...` instead.
==========

Certainly! Below is a Rust function that computes the Fibonacci sequence. The function takes an integer `n` and returns the `n`-th Fibonacci number.

'''rust
fn fibonacci(n: u32) -> u32 {
    let mut a = 0;
    let mut b = 1;
    if n == 0 {
        return a;
    } else if n == 1 {
        return b;
    } else {
        let mut i = 2;
        while i <= n {
            let c = a + b;
            a = b;
            b = c;
            i += 1;
        }
        return b;
    }
}
'''

This function uses a loop to calculate the Fibonacci numbers iteratively, which is more efficient than using recursion, especially for larger values of `n`.

The function takes an integer `n` as input and returns the `n`-th Fibonacci number in linear time, which is more efficient than using recursion, especially for larger values of `n`. 

The function takes an integer `n` as input and returns the `n`-th Fibonacci number in linear time, which is more efficient than using recursion, especially for larger values of `n`.
```

After:

```text
(mlx-dev) (base)  ~/Desktop/mlx-lm/ [adding-glm4*] python -m mlx_lm.generate --model /Volumes/T7_Shield/MODELS/MLX/GLM-4-9B-0414-bf16 --prompt "Write me a function that computes fibonacci in Rust" -m 1028
<frozen runpy>:128: RuntimeWarning: 'mlx_lm.generate' found in sys.modules after import of package 'mlx_lm', but prior to execution of 'mlx_lm.generate'; this may result in unpredictable behaviour
Calling `python -m mlx_lm.generate...` directly is deprecated. Use `mlx_lm.generate...` or `python -m mlx_lm generate ...` instead.
==========

Certainly! Below is a simple Rust function that computes the Fibonacci sequence using recursion. Note that this approach is not the most efficient for large values of `n` due to the exponential time complexity, but it is straightforward and easy to understand.

'''rust
fn fibonacci(n: u32) -> u32 {
    match n {
        0 => 0,
        1 => 1,
        _ => fibonacci(n - 1) + fibonacci(n - 2),
    }
}

fn main() {
    let n = 10; // Example: Compute the 10th Fibonacci number
    println!("Fibonacci number at position {} is {}", n, fibonacci(n));
}
'''

If you need a more efficient implementation, you can use an iterative approach or memoization. Here is an example using an iterative approach, which is more efficient for larger values of `n`:

'''rust
fn fibonacci(n: u32) -> u32 {
    let mut a = 0;
    let mut b = 1;
    let mut sum = 0;

    if n == 0 {
        return a;
    }

    for _ in 1..n {
        sum = a + b;
        a = b;
        b = sum;
    }

    b
}

fn main() {
    let n = 10; // Example: Compute the 10th Fibonacci number
    println!("Fibonacci number at position {} is {}", n, fibonacci(n));
}
'''

This iterative version has a linear time complexity, making it much more suitable for larger values of `n`.
==========
Prompt: 14 tokens, 34.552 tokens-per-sec
Generation: 328 tokens, 5.544 tokens-per-sec
Peak memory: 19.142 GB
```