### PR TITLE
fix llama4 cache

### DIFF
--- a/mlx_lm/cache_prompt.py
+++ b/mlx_lm/cache_prompt.py
@@ -148,7 +148,7 @@ def main():
         pass
 
     print()
-    print(f"Peak memory: {mx.metal.get_peak_memory() / 1e9:.3f} GB")
+    print(f"Peak memory: {mx.get_peak_memory() / 1e9:.3f} GB")
 
     print("Saving...")
     metadata = {}

--- a/mlx_lm/models/cache.py
+++ b/mlx_lm/models/cache.py
@@ -447,9 +447,9 @@ class ChunkedKVCache(KVCache):
     def maybe_trim_front(self):
         # Maintain the cache below the chunk size
         if self.keys is not None and self.keys.shape[2] >= self.chunk_size:
-            self.keys = self.keys[..., self.chunk_size :, :]
-            self.values = self.values[..., self.chunk_size :, :]
-            self.start_position += self.chunk_size
+            self.start_position += self.keys.shape[2] - self.chunk_size
+            self.keys = self.keys[..., -self.chunk_size :, :]
+            self.values = self.values[..., -self.chunk_size :, :]
 
     def update_and_fetch(self, keys, values):
         prev = self.offset - self.start_position


### PR DESCRIPTION
Closes https://github.com/ml-explore/mlx-lm/issues/103

@Blaizzy another good thing for you to use in mlx-vlm from mlx-lm are the cache routines. E.g. you'll get the bug fix here if you use them.