### PR TITLE
Adding support for XTC (eXclude Top Choice) 

### DIFF
--- a/mlx_lm/chat.py
+++ b/mlx_lm/chat.py
@@ -12,6 +12,8 @@ from .utils import load
 
 DEFAULT_TEMP = 0.0
 DEFAULT_TOP_P = 1.0
+DEFAULT_XTC_PROBABILITY = 0.0
+DEFAULT_XTC_THRESHOLD = 0.0
 DEFAULT_SEED = None
 DEFAULT_MAX_TOKENS = 256
 DEFAULT_MODEL = "mlx-community/Llama-3.2-3B-Instruct-4bit"
@@ -36,6 +38,18 @@ def setup_arg_parser():
     )
     parser.add_argument(
         "--top-p", type=float, default=DEFAULT_TOP_P, help="Sampling top-p"
+    )
+    parser.add_argument(
+        "--xtc-probability",
+        type=float,
+        default=DEFAULT_XTC_PROBABILITY,
+        help="Probability of XTC sampling to happen each next token",
+    )
+    parser.add_argument(
+        "--xtc-threshold",
+        type=float,
+        default=0.0,
+        help="Thresold the probs of each next token candidate to be sampled by XTC",
     )
     parser.add_argument(
         "--seed",
@@ -93,12 +107,21 @@ def main():
             continue
         messages = [{"role": "user", "content": query}]
         prompt = tokenizer.apply_chat_template(messages, add_generation_prompt=True)
+        special_token_ids = [id for id in tokenizer.eos_token_ids] + tokenizer.encode(
+            "\n"
+        )
         for response in stream_generate(
             model,
             tokenizer,
             prompt,
             max_tokens=args.max_tokens,
-            sampler=make_sampler(args.temp, args.top_p),
+            sampler=make_sampler(
+                args.temp,
+                args.top_p,
+                xtc_threshold=args.xtc_threshold,
+                xtc_probability=args.xtc_probability,
+                special_tokens_ids=special_token_ids,
+            ),
             prompt_cache=prompt_cache,
         ):
             print(response.text, flush=True, end="")

--- a/mlx_lm/chat.py
+++ b/mlx_lm/chat.py
@@ -107,9 +107,6 @@ def main():
             continue
         messages = [{"role": "user", "content": query}]
         prompt = tokenizer.apply_chat_template(messages, add_generation_prompt=True)
-        special_token_ids = [id for id in tokenizer.eos_token_ids] + tokenizer.encode(
-            "\n"
-        )
         for response in stream_generate(
             model,
             tokenizer,
@@ -120,7 +117,9 @@ def main():
                 args.top_p,
                 xtc_threshold=args.xtc_threshold,
                 xtc_probability=args.xtc_probability,
-                special_tokens_ids=special_token_ids,
+                xtc_special_tokens=(
+                    tokenizer.encode("\n") + list(tokenizer.eos_token_ids)
+                ),
             ),
             prompt_cache=prompt_cache,
         ):

--- a/mlx_lm/generate.py
+++ b/mlx_lm/generate.py
@@ -820,7 +820,6 @@ def main():
             raise ValueError("Draft model tokenizer does not match model tokenizer.")
     else:
         draft_model = None
-    special_tokens_ids = [id for id in tokenizer.eos_token_ids] + tokenizer.encode("\n")
     sampler = make_sampler(
         args.temp,
         args.top_p,
@@ -828,7 +827,7 @@ def main():
         args.min_tokens_to_keep,
         xtc_probability=args.xtc_probability,
         xtc_threshold=args.xtc_threshold,
-        special_tokens_ids=special_tokens_ids,
+        xtc_special_tokens=tokenizer.encode("\n") + list(tokenizer.eos_token_ids),
     )
     response = generate(
         model,

--- a/mlx_lm/generate.py
+++ b/mlx_lm/generate.py
@@ -38,6 +38,8 @@ DEFAULT_MAX_TOKENS = 100
 DEFAULT_TEMP = 0.0
 DEFAULT_TOP_P = 1.0
 DEFAULT_MIN_P = 0.0
+DEFAULT_XTC_PROBABILITY = 0.0
+DEFAULT_XTC_THRESHOLD = 0.0
 DEFAULT_MIN_TOKENS_TO_KEEP = 1
 DEFAULT_SEED = None
 DEFAULT_MODEL = "mlx-community/Llama-3.2-3B-Instruct-4bit"
@@ -103,6 +105,18 @@ def setup_arg_parser():
     )
     parser.add_argument(
         "--min-p", type=float, default=DEFAULT_MIN_P, help="Sampling min-p"
+    )
+    parser.add_argument(
+        "--xtc-probability",
+        type=float,
+        default=DEFAULT_XTC_PROBABILITY,
+        help="Probability of XTC sampling to happen each next token",
+    )
+    parser.add_argument(
+        "--xtc-threshold",
+        type=float,
+        default=0.0,
+        help="Thresold the probs of each next token candidate to be sampled by XTC",
     )
     parser.add_argument(
         "--min-tokens-to-keep",
@@ -806,7 +820,16 @@ def main():
             raise ValueError("Draft model tokenizer does not match model tokenizer.")
     else:
         draft_model = None
-    sampler = make_sampler(args.temp, args.top_p, args.min_p, args.min_tokens_to_keep)
+    special_tokens_ids = [id for id in tokenizer.eos_token_ids] + tokenizer.encode("\n")
+    sampler = make_sampler(
+        args.temp,
+        args.top_p,
+        args.min_p,
+        args.min_tokens_to_keep,
+        xtc_probability=args.xtc_probability,
+        xtc_threshold=args.xtc_threshold,
+        special_tokens_ids=special_tokens_ids,
+    )
     response = generate(
         model,
         tokenizer,

--- a/mlx_lm/sample_utils.py
+++ b/mlx_lm/sample_utils.py
@@ -307,9 +307,11 @@ def make_xtc(
         )
         # Like in the original implementation, we exclude EOS/newline characters from being
         # removed by XTC sampling
-        for stop_ids in special_tokens_ids:
-            if indices_to_remove[:, stop_ids].any():
-                return logits
+        special_tokens_mask = mx.zeros(indices_to_remove.shape[1], getattr(mx, "bool_"))
+        special_tokens_mask[special_tokens_ids] = True
+        indices_to_remove = mx.logical_and(
+            indices_to_remove, mx.logical_not(special_tokens_mask)
+        )
 
         logits_edited = mx.where(indices_to_remove, -float("inf"), logits)
 

--- a/mlx_lm/sample_utils.py
+++ b/mlx_lm/sample_utils.py
@@ -261,21 +261,14 @@ def apply_xtc(
     probs = mx.softmax(logits, -1)
 
     mask = probs > mx.where(probs > xtc_threshold, probs, mx.inf).min()
-    mask_xtc_skip = mx.array(False)
     if special_tokens_ids:
-        special_ids_arr = mx.array(special_tokens_ids)
-        mask_xtc_skip  = mx.any(mask[..., special_ids_arr])
-
-    mask = mx.logical_and(mask,mx.logical_not(mask_xtc_skip))
-
+        mask[..., special_tokens_ids] = False
 
     return mx.where(
         mx.random.uniform(0, 1) > xtc_probability,
         logits,
         mx.where(mask, -mx.inf, logits),
-        )
-
-
+    )
 
 
 @partial(mx.compile, inputs=mx.random.state, outputs=mx.random.state)

--- a/mlx_lm/sample_utils.py
+++ b/mlx_lm/sample_utils.py
@@ -257,9 +257,7 @@ def apply_xtc(
             f"`probability` has to be a float in the [0, 1] interval, but is {xtc_probability}"
         )
 
-    # Converting logits to probs then get sorted probs
     probs = mx.softmax(logits, -1)
-
     mask = probs > mx.where(probs > xtc_threshold, probs, mx.inf).min()
     if special_tokens_ids:
         mask[..., special_tokens_ids] = False

--- a/mlx_lm/server.py
+++ b/mlx_lm/server.py
@@ -366,11 +366,11 @@ class APIHandler(BaseHTTPRequestHandler):
                 raise ValueError("logit_bias must be a dict of int to float")
         if not (
             isinstance(self.xtc_probability, float)
-            and 0.00 < self.xtc_probability <= 1.00
+            and 0.00 <= self.xtc_probability <= 1.00
         ):
             raise ValueError(f"xtc_probability must be a float between 0.00 and 1.00")
         if not (
-            isinstance(self.xtc_threshold, float) and 0.00 < self.xtc_threshold <= 0.50
+            isinstance(self.xtc_threshold, float) and 0.00 <= self.xtc_threshold <= 0.50
         ):
             raise ValueError(f"xtc_threshold must be a float between 0.00 and 0.5")
         if not isinstance(self.requested_model, str):

--- a/mlx_lm/server.py
+++ b/mlx_lm/server.py
@@ -527,6 +527,7 @@ class APIHandler(BaseHTTPRequestHandler):
             self.repetition_context_size,
             self.xtc_probability,
             self.xtc_threshold,
+            [self.tokenizer.eos_token_id, self.tokenizer.encode("\n")[-1]],
         )
         for gen_response in stream_generate(
             model=self.model,

--- a/mlx_lm/server.py
+++ b/mlx_lm/server.py
@@ -524,7 +524,7 @@ class APIHandler(BaseHTTPRequestHandler):
             top_p=self.top_p,
             xtc_probability=self.xtc_probability,
             xtc_threshold=self.xtc_threshold,
-            special_tokens_ids=[
+            xtc_special_tokens=[
                 self.tokenizer.eos_token_id,
                 self.tokenizer.encode("\n"),
             ],

--- a/tests/test_sample_utils.py
+++ b/tests/test_sample_utils.py
@@ -95,9 +95,9 @@ class TestSampleUtils(unittest.TestCase):
         )
 
     def test_apply_xtc(self):
-        probs = mx.array([0.4, 0.3, 0.15, 0.15])[None]
 
         # XTC should discard only the first probability
+        probs = mx.array([0.4, 0.3, 0.15, 0.15])[None]
         logprobs = mx.log(probs)
         new_logits = apply_xtc(logprobs, 1, 0.2, [100])
         new_probs = mx.softmax(new_logits.squeeze())
@@ -105,12 +105,16 @@ class TestSampleUtils(unittest.TestCase):
         self.assertEqual(new_probs_rounded, [0, 0.5, 0.25, 0.25])
 
         # All but the two last probs, which are the last ones above the threshold, should be discarded
+        probs = mx.array([0.4, 0.3, 0.15, 0.15])[None]
+        logprobs = mx.log(probs)
         new_logits = apply_xtc(logprobs, 1, 0.15, [100])
         new_probs = mx.softmax(new_logits.squeeze())
         new_probs_rounded = [round(p, 4) for p in new_probs.tolist()]
         self.assertEqual(new_probs_rounded, [0.0, 0.0, 0.5, 0.5])
 
         # If XTC probability = 0, the probs shouldn't change
+        probs = mx.array([0.4, 0.3, 0.15, 0.15])[None]
+        logprobs = mx.log(probs)
         new_logits = apply_xtc(logprobs, 0.00, 0.2, [100])
         new_probs = mx.softmax(new_logits.squeeze())
         new_probs_rounded = [round(p, 4) for p in new_probs.tolist()]

--- a/tests/test_sample_utils.py
+++ b/tests/test_sample_utils.py
@@ -104,11 +104,11 @@ class TestSampleUtils(unittest.TestCase):
         new_probs_rounded = [round(p, 4) for p in new_probs.tolist()]
         self.assertEqual(new_probs_rounded, [0, 0.5, 0.25, 0.25])
 
-        # All but the last prob, which is the last one above the threshold, should be discarded
+        # All but the two last probs, which are the last ones above the threshold, should be discarded
         new_logits = apply_xtc(logprobs, 1, 0.15, [100])
         new_probs = mx.softmax(new_logits.squeeze())
         new_probs_rounded = [round(p, 4) for p in new_probs.tolist()]
-        self.assertEqual(new_probs_rounded, [0, 0, 0, 1])
+        self.assertEqual(new_probs_rounded, [0.0, 0.0, 0.5, 0.5])
 
         # If XTC probability = 0, the probs shouldn't change
         new_logits = apply_xtc(logprobs, 0.00, 0.2, [100])


### PR DESCRIPTION
XTC (eXclude Top Choice) is a widely used logit processor in the storytelling community in LLM, by removing the most likely tokens from consideration, thus allowing more creativity into the generations. This PR adds XTC support by adapting the text-generation-webui's implementation of the sampler creator p-e-w  to mlx_lm. 

Because it's implemented as a logit processor, it's for now only usable in mlx_lm.server, as mlx_lm.generate doesn't implement them (unless I missed something). I didn't really know if it was intended or not, so I didn't push the generate modifications I did in local.

Since it's my first real open-source contribution, it's certainly not perfect, so I'm open to any improvement suggestions ! 



