### PR TITLE
Try and scan only mlx compatible LLMs

### DIFF
--- a/mlx_lm/_version.py
+++ b/mlx_lm/_version.py
@@ -1,3 +1,3 @@
 # Copyright © 2023-2024 Apple Inc.
 
-__version__ = "0.23.0"
+__version__ = "0.23.1"

--- a/mlx_lm/server.py
+++ b/mlx_lm/server.py
@@ -680,10 +680,18 @@ class APIHandler(BaseHTTPRequestHandler):
         self._set_completion_headers(200)
         self.end_headers()
 
+        files = ["config.json", "model.safetensors.index.json", "tokenizer_config.json"]
+
+        def probably_mlx_lm(repo):
+            if repo.repo_type != "model":
+                return False
+            file_names = {f.file_path.name for f in repo.refs["main"].files}
+            return all(f in file_names for f in files)
+
         # Scan the cache directory for downloaded mlx models
         hf_cache_info = scan_cache_dir()
         downloaded_models = [
-            repo for repo in hf_cache_info.repos if "mlx" in repo.repo_id
+            repo for repo in hf_cache_info.repos if probably_mlx_lm(repo)
         ]
 
         # Create a list of available models


### PR DESCRIPTION
For clients which use the models endpoint of mlx-lm.server it helps to try and only find LLMs to avoid cluttering the list with useless/incompatible repo ids.