### PR TITLE
Add top-k sampling switch to the generate CLI

### DIFF
--- a/mlx_lm/generate.py
+++ b/mlx_lm/generate.py
@@ -38,6 +38,7 @@ DEFAULT_MAX_TOKENS = 100
 DEFAULT_TEMP = 0.0
 DEFAULT_TOP_P = 1.0
 DEFAULT_MIN_P = 0.0
+DEFAULT_TOP_K = 0
 DEFAULT_XTC_PROBABILITY = 0.0
 DEFAULT_XTC_THRESHOLD = 0.0
 DEFAULT_MIN_TOKENS_TO_KEEP = 1
@@ -105,6 +106,9 @@ def setup_arg_parser():
     )
     parser.add_argument(
         "--min-p", type=float, default=DEFAULT_MIN_P, help="Sampling min-p"
+    )
+    parser.add_argument(
+        "--top-k", type=int, default=DEFAULT_TOP_K, help="Sampling top-k"
     )
     parser.add_argument(
         "--xtc-probability",
@@ -825,6 +829,7 @@ def main():
         args.top_p,
         args.min_p,
         args.min_tokens_to_keep,
+        top_k=args.top_k,
         xtc_probability=args.xtc_probability,
         xtc_threshold=args.xtc_threshold,
         xtc_special_tokens=tokenizer.encode("\n") + list(tokenizer.eos_token_ids),

--- a/mlx_lm/sample_utils.py
+++ b/mlx_lm/sample_utils.py
@@ -12,7 +12,7 @@ def make_sampler(
     top_p: float = 0.0,
     min_p: float = 0.0,
     min_tokens_to_keep: int = 1,
-    top_k: int = -1,
+    top_k: int = 0,
     xtc_probability: float = 0.0,
     xtc_threshold: float = 0.0,
     xtc_special_tokens: List[int] = [],


### PR DESCRIPTION
Add a `--top-k` parameter to the `mlx_lm generate` CLI tool. Also, update the default `make_sampler` top-k parameter to `0`, to be consistent across the code base.