### PR TITLE
Distilled weight quantization

### DIFF
--- a/mlx_lm/LEARNED_QUANTS.md
+++ b/mlx_lm/LEARNED_QUANTS.md
@@ -5,9 +5,9 @@ To reduce the quality loss from quantization MLX LM has two options:
 - Distilled Weight Quantization (DWQ)
 - Activation-aware Weight Quantization (AWQ)[^1].
 
-Both DWQ and AWQ use a example dataset to tune parameters of the model. DWQ
+Both DWQ and AWQ use an example dataset to tune parameters of the model. DWQ
 fine-tunes non-quantized parameters (including quantization scales and biases)
-using the un-quanized model as a teacher. AWQ scales and clips the weights
+using the non-quantized model as a teacher. AWQ scales and clips the weights
 prior to quantization. The scaling and clipping values are found with a grid
 search minimizing the distance from the quantized hidden activations to the
 non-quantized hidden activations
@@ -15,7 +15,7 @@ non-quantized hidden activations
 To get started, first install the requirements:
 
 ```
-pip install mlx-lm[awq]
+pip install mlx-lm[lwq]
 ```
 
 ### DWQ
@@ -24,6 +24,20 @@ Use `mlx_lm.dwq` to run DWQ on a given model. For example:
 
 ```bash
 mlx_lm.dwq --model mistralai/Mistral-7B-Instruct-v0.3
+```
+
+Some important options, along with their default values are:
+
+- `--mlx-path mlx_model`: The location to save the DWQ model.
+- `--bits 4`: Precision of the quantization.
+- `--num-samples 1024`: Number of samples to use. Using more samples can lead to
+  better results but takes longer.
+- `--batch-size 8`: Use a smaller batch size to reduce the memory footprint.
+
+For a full list of options run:
+
+```bash
+mlx_lm.dwq --help
 ```
 
 ### AWQ 
@@ -52,13 +66,10 @@ For a full list of options run:
 mlx_lm.awq --help
 ```
 
-You can specify the quantization precision and group size, the number of
-samples to use, the save path, and more. 
-
 ### Evaluate
 
-Once the script finishes, you can evaluate the quality of the model on
-downstream tasks using `mlx_lm.evaluate`. For example:
+Once the training script finishes, you can evaluate the quality of the model
+on downstream tasks using `mlx_lm.evaluate`. For example:
 
 ```bash
 mlx_lm.evaluate \
@@ -68,7 +79,8 @@ mlx_lm.evaluate \
 
 ### Upload to Hugging Face
 
-To upload the quantized model to the Hugging Face Hub, run:
+Use `mlx_lm.upload` to upload the quantized model to the Hugging Face Hub. For
+example:
 
 ```bash
 mlx_lm.upload \

--- a/mlx_lm/LEARNED_QUANTS.md
+++ b/mlx_lm/LEARNED_QUANTS.md
@@ -1,8 +1,16 @@
-# AWQ
+# Learned Quantization 
 
-MLX LM supports Activation-aware Weight Quantization (AWQ)[^1]. AWQ uses the
-activations of the model on a representative dataset to tune the quantization
-parameters.
+To reduce the quality loss from quantization MLX LM has two options:
+
+- Distilled Weight Quantization (DWQ)
+- Activation-aware Weight Quantization (AWQ)[^1].
+
+Both DWQ and AWQ use a example dataset to tune parameters of the model. DWQ
+fine-tunes non-quantized parameters (including quantization scales and biases)
+using the un-quanized model as a teacher. AWQ scales and clips the weights
+prior to quantization. The scaling and clipping values are found with a grid
+search minimizing the distance from the quantized hidden activations to the
+non-quantized hidden activations
 
 To get started, first install the requirements:
 
@@ -10,9 +18,19 @@ To get started, first install the requirements:
 pip install mlx-lm[awq]
 ```
 
+### DWQ
+
+Use `mlx_lm.dwq` to run DWQ on a given model. For example:
+
+```bash
+mlx_lm.dwq --model mistralai/Mistral-7B-Instruct-v0.3
+```
+
+### AWQ 
+
 Use `mlx_lm.awq` to run AWQ on a given model. For example:
 
-```
+```bash
 mlx_lm.awq --model mistralai/Mistral-7B-Instruct-v0.3
 ```
 
@@ -37,6 +55,8 @@ mlx_lm.awq --help
 You can specify the quantization precision and group size, the number of
 samples to use, the save path, and more. 
 
+### Evaluate
+
 Once the script finishes, you can evaluate the quality of the model on
 downstream tasks using `mlx_lm.evaluate`. For example:
 
@@ -46,12 +66,14 @@ mlx_lm.evaluate \
     --tasks winogrande boolq arc_challenge arc_easy hellaswag openbookqa piqa social_iqa                     
 ```
 
-To upload the AWQ model to the Hugging Face Hub, run:
+### Upload to Hugging Face
+
+To upload the quantized model to the Hugging Face Hub, run:
 
 ```bash
 mlx_lm.upload \
     --path mlx_model \
-    --upload-repo mlx-community/Mistral-7B-Instruct-v0.3-4bit-AWQ
+    --upload-repo mlx-community/Mistral-7B-Instruct-v0.3-3bit-DWQ
 ```
 
 [^1]: Refer to the [paper](https://arxiv.org/abs/2306.00978)

--- a/mlx_lm/__main__.py
+++ b/mlx_lm/__main__.py
@@ -6,6 +6,7 @@ import sys
 if __name__ == "__main__":
     subcommands = {
         "awq",
+        "dwq",
         "cache_prompt",
         "chat",
         "convert",

--- a/mlx_lm/awq.py
+++ b/mlx_lm/awq.py
@@ -182,8 +182,10 @@ def run_layer(
 
 
 def dist_split(x: mx.array, group: mx.distributed.Group):
-    B = x.shape[0]
     N = group.size()
+    if N == 1:
+        return x
+    B = x.shape[0]
     assert B % N == 0
     r = group.rank()
     local_B = (B + N - 1) // N
@@ -570,8 +572,7 @@ def main():
 
     calibration_data = load_wikitext(tokenizer, args.num_samples, args.sequence_length)
 
-    if group is not None:
-        calibration_data = dist_split(calibration_data, group)
+    calibration_data = dist_split(calibration_data, group)
 
     awq_quantize(
         model,

--- a/mlx_lm/dwq.py
+++ b/mlx_lm/dwq.py
@@ -164,7 +164,10 @@ def main():
     parser.add_argument("--learning-rate", type=float, default=1e-5)
     parser.add_argument("--batch-size", type=int, default=8)
     parser.add_argument(
-        "--temperature", type=int, default=0.5, help="Temperature scaling for the loss."
+        "--temperature",
+        type=float,
+        default=0.5,
+        help="Temperature scaling for the loss.",
     )
     args = parser.parse_args()
 

--- a/mlx_lm/dwq.py
+++ b/mlx_lm/dwq.py
@@ -1,0 +1,180 @@
+# Copyright © 2025 Apple Inc.
+
+import argparse
+import copy
+import glob
+import shutil
+from pathlib import Path
+
+import mlx.core as mx
+import mlx.nn as nn
+import mlx.optimizers as optimizers
+from datasets import load_dataset
+from mlx.utils import tree_flatten, tree_map
+
+from mlx_lm.tokenizer_utils import TokenizerWrapper
+from mlx_lm.tuner.utils import print_trainable_parameters
+from mlx_lm.utils import (
+    create_model_card,
+    fetch_from_hub,
+    get_model_path,
+    quantize_model,
+    save_config,
+    save_weights,
+)
+
+
+def dist_split(x: mx.array, group: mx.distributed.Group):
+    B = x.shape[0]
+    N = group.size()
+    assert B % N == 0
+    r = group.rank()
+    local_B = (B + N - 1) // N
+    return x[r * local_B : (r + 1) * local_B]
+
+
+def dwq_quantize(
+    model,
+    q_model,
+    opt,
+    inputs: mx.array,
+    group_size: int = 64,
+    bits: int = 3,
+    batch_size: int = 2,
+    dtype: mx.Dtype = mx.bfloat16,
+):
+    group = mx.distributed.init()
+    q_model.freeze()
+    q_model.unfreeze(keys=["scales", "biases"])
+    print_trainable_parameters(q_model)
+
+    def log_norm(x):
+        return x - mx.logsumexp(x, axis=-1, keepdims=True)
+
+    def loss_fn(params, x, targets):
+        q_model.update(tree_map(lambda x: x.astype(dtype), params))
+        logits = q_model(x).astype(mx.float32)
+        return nn.losses.kl_div_loss(log_norm(logits), targets, reduction="mean")
+
+    # TODO distributed support
+    def step(inputs, targets, params):
+        loss, grads = mx.value_and_grad(loss_fn)(params, inputs, targets)
+        params = opt.apply_gradients(grads, params)
+        return loss, params
+
+    # Accumulate learned weights in higher precision
+    params = tree_map(
+        lambda x: x.astype(mx.float32),
+        q_model.trainable_parameters(),
+    )
+
+    losses = []
+    it = 1
+    for i in range(0, inputs.shape[0], batch_size):
+        batch = inputs[i : i + batch_size]
+        targets = log_norm(model(batch).astype(mx.float32))
+        mx.eval(targets)
+        loss, params = step(batch, targets, params)
+        mx.eval(loss, params)
+        losses.append(loss.item())
+        print(f"Iter: {it}, Loss: {loss.item():.3f}")
+        if (it + 1) % 10 == 0:
+            loss_avg = sum(losses) / len(losses)
+            print(f"Average Loss {loss_avg:.3f}")
+            losses = []
+        it += 1
+    q_model.update(tree_map(lambda x: x.astype(dtype), params))
+
+
+def load_wikitext(
+    tokenizer, num_samples: int = 32, sequence_length: int = 2048, split: str = "train"
+) -> mx.array:
+    dataset = load_dataset("Salesforce/wikitext", "wikitext-2-raw-v1", split=split)
+    texts = "\n\n".join(dataset["text"])
+    tokens = tokenizer.encode(texts, return_tensors="mlx")[0]
+
+    # Select random chunks
+    starts = mx.random.randint(
+        0, len(tokens) - sequence_length - 1, shape=(num_samples, 1)
+    )
+    return tokens[starts + mx.arange(sequence_length)]
+
+
+def save_model(
+    model: nn.Module,
+    tokenizer: TokenizerWrapper,
+    config,
+    model_path: Path,
+    mlx_path: str,
+    hf_path: str,
+):
+    weights = dict(tree_flatten(model.parameters()))
+
+    mlx_path = Path(mlx_path)
+    save_weights(mlx_path, weights, donate_weights=True)
+
+    py_files = glob.glob(str(model_path / "*.py"))
+    for file in py_files:
+        shutil.copy(file, mlx_path)
+
+    tokenizer.save_pretrained(mlx_path)
+
+    save_config(config, config_path=mlx_path / "config.json")
+    create_model_card(mlx_path, hf_path)
+
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        "--model", "-m", default="mlx-community/Qwen2.5-7B-Instruct-bf16"
+    )
+    parser.add_argument("--mlx-path", default="mlx_model")
+    parser.add_argument("--bits", type=int, default=4)
+    parser.add_argument("--group-size", type=int, default=64)
+    parser.add_argument("--num-samples", type=int, default=32)
+    parser.add_argument("--sequence-length", type=int, default=2048)
+    parser.add_argument("--seed", type=int, default=123)
+    parser.add_argument("--learning-rate", type=float, default=1e-5)
+    parser.add_argument("--batch-size", type=float, default=8)
+    args = parser.parse_args()
+
+    group = mx.distributed.init()
+
+    num_samples = args.num_samples
+    if group is not None and num_samples % group.size() > 0:
+        num_samples += group.size() - num_samples % group.size()
+
+    mx.random.seed(args.seed)
+
+    model_path = get_model_path(args.model, revision=None)
+    model, config, tokenizer = fetch_from_hub(model_path, lazy=True)
+
+    calibration_data = load_wikitext(tokenizer, args.num_samples, args.sequence_length)
+
+    if group is not None:
+        calibration_data = dist_split(calibration_data, group)
+
+    q_model = copy.deepcopy(model)
+    tree_flatten(q_model.parameters())
+    _, config = quantize_model(
+        q_model,
+        config,
+        q_group_size=args.group_size,
+        q_bits=args.bits,
+    )
+
+    opt = optimizers.SGD(learning_rate=args.learning_rate)
+    dwq_quantize(
+        model,
+        q_model,
+        opt,
+        calibration_data,
+        bits=args.bits,
+        group_size=args.group_size,
+        batch_size=args.batch_size,
+    )
+    save_model(q_model, tokenizer, config, model_path, args.mlx_path, args.model)
+
+
+if __name__ == "__main__":
+    main()

--- a/mlx_lm/lora.py
+++ b/mlx_lm/lora.py
@@ -13,7 +13,6 @@ import mlx.optimizers as optim
 import numpy as np
 import yaml
 
-from .tokenizer_utils import TokenizerWrapper
 from .tuner.datasets import load_dataset
 from .tuner.trainer import TrainingArgs, TrainingCallback, evaluate, train
 from .tuner.utils import (
@@ -187,7 +186,6 @@ def build_parser():
 def train_model(
     args,
     model: nn.Module,
-    tokenizer: TokenizerWrapper,
     train_set,
     valid_set,
     training_callback: TrainingCallback = None,
@@ -258,7 +256,6 @@ def train_model(
     # Train model
     train(
         model=model,
-        tokenizer=tokenizer,
         args=training_args,
         optimizer=opt,
         train_dataset=train_set,
@@ -267,11 +264,10 @@ def train_model(
     )
 
 
-def evaluate_model(args, model: nn.Module, tokenizer: TokenizerWrapper, test_set):
+def evaluate_model(args, model: nn.Module, test_set):
     test_loss = evaluate(
         model=model,
         dataset=test_set,
-        tokenizer=tokenizer,
         batch_size=args.batch_size,
         num_batches=args.test_batches,
         max_seq_length=args.max_seq_length,
@@ -298,13 +294,13 @@ def run(args, training_callback: TrainingCallback = None):
 
     elif args.train:
         print("Training")
-        train_model(args, model, tokenizer, train_set, valid_set, training_callback)
+        train_model(args, model, train_set, valid_set, training_callback)
     else:
         raise ValueError("Must provide at least one of --train or --test")
 
     if args.test:
         print("Testing")
-        evaluate_model(args, model, tokenizer, test_set)
+        evaluate_model(args, model, test_set)
 
 
 def main():

--- a/mlx_lm/models/switch_layers.py
+++ b/mlx_lm/models/switch_layers.py
@@ -143,7 +143,7 @@ class SwitchGLU(nn.Module):
         input_dims: int,
         hidden_dims: int,
         num_experts: int,
-        activation=nn.silu,
+        activation=nn.SiLU(),
         bias: bool = False,
     ):
         super().__init__()
@@ -184,7 +184,7 @@ class SwitchMLP(nn.Module):
         input_dims: int,
         hidden_dims: int,
         num_experts: int,
-        activation=nn.gelu_approx,
+        activation=nn.GELU(approx="precise"),
         bias: bool = False,
     ):
         super().__init__()

--- a/mlx_lm/tuner/trainer.py
+++ b/mlx_lm/tuner/trainer.py
@@ -85,7 +85,6 @@ def default_loss(model, batch, lengths):
 
 def iterate_batches(
     dataset,
-    tokenizer,
     batch_size,
     max_seq_length,
     train=False,
@@ -153,7 +152,6 @@ def iterate_batches(
 def evaluate(
     model,
     dataset,
-    tokenizer,
     batch_size,
     num_batches,
     max_seq_length=2048,
@@ -170,7 +168,6 @@ def evaluate(
         index_iterator,
         iterate_batches(
             dataset=dataset,
-            tokenizer=tokenizer,
             batch_size=batch_size,
             max_seq_length=max_seq_length,
         ),
@@ -199,7 +196,6 @@ class TrainingCallback:
 
 def train(
     model,
-    tokenizer,
     optimizer,
     train_dataset,
     val_dataset,
@@ -250,7 +246,6 @@ def train(
         range(1, args.iters + 1),
         iterate_batches(
             dataset=train_dataset,
-            tokenizer=tokenizer,
             batch_size=args.batch_size,
             max_seq_length=args.max_seq_length,
             train=True,
@@ -265,7 +260,6 @@ def train(
                 model=model,
                 dataset=val_dataset,
                 loss=loss,
-                tokenizer=tokenizer,
                 batch_size=args.batch_size,
                 num_batches=args.val_batches,
                 max_seq_length=args.max_seq_length,

--- a/setup.py
+++ b/setup.py
@@ -29,8 +29,7 @@ setup(
     extras_require={
         "test": ["datasets"],
         "evaluate": ["lm-eval", "tqdm"],
-        "awq": ["datasets"],
-        "dwq": ["datasets"],
+        "lwq": ["datasets"],
     },
     entry_points={
         "console_scripts": [

--- a/setup.py
+++ b/setup.py
@@ -30,10 +30,12 @@ setup(
         "test": ["datasets"],
         "evaluate": ["lm-eval", "tqdm"],
         "awq": ["datasets"],
+        "dwq": ["datasets"],
     },
     entry_points={
         "console_scripts": [
             "mlx_lm.awq = mlx_lm.awq:main",
+            "mlx_lm.dwq = mlx_lm.dwq:main",
             "mlx_lm.cache_prompt = mlx_lm.cache_prompt:main",
             "mlx_lm.chat = mlx_lm.chat:main",
             "mlx_lm.convert = mlx_lm.convert:main",

--- a/tests/test_finetune.py
+++ b/tests/test_finetune.py
@@ -365,7 +365,6 @@ class TestScheduleConfig(unittest.TestCase):
     def test_evaluate_calls(self):
         mock_model = MagicMock()
         mock_dataset = MagicMock()
-        mock_tokenizer = MagicMock()
         mock_default_loss = MagicMock()
         mock_iterate_batches = MagicMock()
 
@@ -388,7 +387,6 @@ class TestScheduleConfig(unittest.TestCase):
             evaluate(
                 model=mock_model,
                 dataset=mock_dataset,
-                tokenizer=mock_tokenizer,
                 batch_size=2,
                 num_batches=2,
                 max_seq_length=2048,
@@ -398,7 +396,6 @@ class TestScheduleConfig(unittest.TestCase):
 
         mock_iterate_batches.assert_called_once_with(
             dataset=mock_dataset,
-            tokenizer=mock_tokenizer,
             batch_size=2,
             max_seq_length=2048,
         )
@@ -407,7 +404,6 @@ class TestScheduleConfig(unittest.TestCase):
     def test_evaluate_infinite_batches(self):
         mock_model = MagicMock()
         mock_dataset = MagicMock()
-        mock_tokenizer = MagicMock()
         mock_default_loss = MagicMock()
         mock_iterate_batches = MagicMock()
 
@@ -427,7 +423,6 @@ class TestScheduleConfig(unittest.TestCase):
             evaluate(
                 model=mock_model,
                 dataset=mock_dataset,
-                tokenizer=mock_tokenizer,
                 batch_size=2,
                 num_batches=-1,
                 max_seq_length=2048,
@@ -437,7 +432,6 @@ class TestScheduleConfig(unittest.TestCase):
 
         mock_iterate_batches.assert_called_once_with(
             dataset=mock_dataset,
-            tokenizer=mock_tokenizer,
             batch_size=2,
             max_seq_length=2048,
         )


### PR DESCRIPTION
Relies on https://github.com/ml-explore/mlx/pull/2129

```
mlx_lm.dwq --model hf/repo
```

This learns the quantization `scales` and `biases` parameters using gradient descent and a KL loss on the unquantized model outputs. Hence "distilled" weight quantization (DWQ).

One perk of this over AWQ is it works out of the box with any model in mlx-lm and any quantized layer (embedding, swtich, linear, etc). So much more general and the code is much simpler.

Some results on Llama 3.2 1B (not all done yet)

Model | Average accuracy
------ | -------
fp16 | 47.95 
Q4 | 46.21
Q4 DWQ, 256 samples |  47.27
Q4 DWQ, 512 samples |  47.57
Q3 | 39.87
Q3 DWQ, 256 samples | 44.65
Q3 DWQ, 512 samples | 44.99
Q3 DWQ, 1024 samples | 45.14

Eval done with:

```
mlx_lm.evaluate --model mlx_model  --tasks winogrande boolq arc_challenge arc_easy hellaswag openbookqa piqa social_iqa
```