### PR TITLE
Added flag --limit-to-loaded-model to cli and limit request to list…

### DIFF
--- a/mlx_lm/SERVER.md
+++ b/mlx_lm/SERVER.md
@@ -137,8 +137,8 @@ list contains the following fields:
 - `id`: The Hugging Face repo id.
 - `created`: A time-stamp representing the model creation time.
 
-You can now restrict a server to respond only with the specific model that was loaded during startup by using the `--limit-to-loaded-model` flag. This feature allows you to run multiple MLX LM servers on the same machine. This remove s the lazy loading from the mlx
-.
+One can restrict a server to respond only with the specific model that was loaded during startup by using the `--limit-to-loaded-model` flag. This feature allows you to run multiple MLX LM servers on the same machine. This remove s the lazy loading from mlx and thus fixing endpoints to one given model.
+
 For example, you can simultaneously run:
 
 `python -m mlx_lm.server --model mlx-community/Qwen3-4B-4bit --host 0.0.0.0 --port 8000 --limit-to-loaded-model`
@@ -147,4 +147,4 @@ and
 
 `python -m mlx_lm.server --model mlx-community/Qwen3-30B-A3B-8bit --host 0.0.0.0 --port 8001 --limit-to-loaded-model`
 
-This flag is also helpful when connecting open-webui to the correct endpoint as users switch between models, and you can specify a smaller model for the interface.RetryClaude can make mistakes. Please double-check responses.
+This flag is also helpful when connecting open-webui to the correct endpoint as users switch between models, and you can specify a smaller model for the interface.

--- a/mlx_lm/SERVER.md
+++ b/mlx_lm/SERVER.md
@@ -137,14 +137,18 @@ list contains the following fields:
 - `id`: The Hugging Face repo id.
 - `created`: A time-stamp representing the model creation time.
 
-One can restrict a server to respond only with the specific model that was loaded during startup by using the `--limit-to-loaded-model` flag. This feature allows you to run multiple MLX LM servers on the same machine. This remove s the lazy loading from mlx and thus fixing endpoints to one given model.
+One can restrict a server to respond only with the specific model that was loaded during startup by using the `--limit-to-loaded-model` flag. This feature allows you to run multiple mlx-lm servers on the same machine. This remove s the lazy loading from mlx yet fixes one endpoints to one given model.
 
 For example, you can simultaneously run:
 
-`python -m mlx_lm.server --model mlx-community/Qwen3-4B-4bit --host 0.0.0.0 --port 8000 --limit-to-loaded-model`
+```shell
+python -m mlx_lm.server --model mlx-community/Qwen3-4B-4bit --host 0.0.0.0 --port 8000 --limit-to-loaded-model
+```
 
 and
 
-`python -m mlx_lm.server --model mlx-community/Qwen3-30B-A3B-8bit --host 0.0.0.0 --port 8001 --limit-to-loaded-model`
+```shell
+python -m mlx_lm.server --model mlx-community/Qwen3-30B-A3B-8bit --host 0.0.0.0 --port 8001 --limit-to-loaded-model
+```
 
 This flag is also helpful when connecting open-webui to the correct endpoint as users switch between models, and you can specify a smaller model for the interface.

--- a/mlx_lm/SERVER.md
+++ b/mlx_lm/SERVER.md
@@ -136,3 +136,15 @@ list contains the following fields:
 
 - `id`: The Hugging Face repo id.
 - `created`: A time-stamp representing the model creation time.
+
+You can now restrict a server to respond only with the specific model that was loaded during startup by using the `--limit-to-loaded-model` flag. This feature allows you to run multiple MLX LM servers on the same machine. This remove s the lazy loading from the mlx
+.
+For example, you can simultaneously run:
+
+`python -m mlx_lm.server --model mlx-community/Qwen3-4B-4bit --host 0.0.0.0 --port 8000 --limit-to-loaded-model`
+
+and
+
+`python -m mlx_lm.server --model mlx-community/Qwen3-30B-A3B-8bit --host 0.0.0.0 --port 8001 --limit-to-loaded-model`
+
+This flag is also helpful when connecting open-webui to the correct endpoint as users switch between models, and you can specify a smaller model for the interface.RetryClaude can make mistakes. Please double-check responses.

--- a/mlx_lm/server.py
+++ b/mlx_lm/server.py
@@ -801,14 +801,20 @@ class APIHandler(BaseHTTPRequestHandler):
         ]
 
         # Create a list of available models
-        models = [
-            {
-                "id": repo.repo_id,
-                "object": "model",
-                "created": self.created,
-            }
-            for repo in downloaded_models
-        ]
+        models = []
+        for repo in downloaded_models:
+            if (
+                self.model_provider.cli_args.limit_to_loaded_model
+                and self.model_provider.cli_args.model != repo.repo_id
+            ):
+                continue
+            models.append(
+                {
+                    "id": repo.repo_id,
+                    "object": "model",
+                    "created": self.created,
+                }
+            )
 
         response = {"object": "list", "data": models}
 
@@ -901,6 +907,11 @@ def main():
         "--use-default-chat-template",
         action="store_true",
         help="Use the default chat template",
+    )
+    parser.add_argument(
+        "--limit-to-loaded-model",
+        action="store_true",
+        help="/v1/models requests will only list loaded model.",
     )
     args = parser.parse_args()
 


### PR DESCRIPTION
… only loaded model. This will provide possibility to launch multiple servers on same host and each instance can stick to its loaded model instead of lazy loading other available models