### PR TITLE
DWQ extra activation penalty

### DIFF
--- a/mlx_lm/LEARNED_QUANTS.md
+++ b/mlx_lm/LEARNED_QUANTS.md
@@ -40,6 +40,33 @@ For a full list of options run:
 mlx_lm.dwq --help
 ```
 
+#### Tips
+
+- DWQ works best distilling to lower precision, anywhere from 2-bit to 4-bit
+  models.
+- Distilling 16-bit precision to 8-bit and even 6-bit often doesn't work well.
+  The loss starts out so low that it's difficult to reduce further.
+- Decreasing the quantization group size (e.g. `--group-size 32`) doubles the
+  number of tunable parameters and can work much better.
+- If the loss is oscillating and not going down consistently, try reducing the
+  learning rate. If it is decreasing but slowly, try increasing the learning
+  rate.
+- As a rule of thumb, lower precision can benefit from a higher learning rate
+  since the loss starts out higher. Conversely, higher precision needs a lower
+  learning rate.
+
+
+#### Memory Use
+
+A few options to reduce memory use for DWQ:
+
+- Distill from an 8-bit model instead of a 16-bit model. The 8-bit
+  models are usually as good as 16-bit precision models.
+- Use a shorter maximum sequence length. The default is 2048. Using
+  `--max-seq-length 512` reduces the memory and still gets good results.
+- Use a smaller batch size, e.g. `--batch-size 1`
+
+
 ### AWQ 
 
 Use `mlx_lm.awq` to run AWQ on a given model. For example:

--- a/mlx_lm/dwq.py
+++ b/mlx_lm/dwq.py
@@ -118,6 +118,7 @@ def dwq_quantize(
     for it, (batch, lengths) in enumerate(
         iterate_batches(data, batch_size, max_seq_length)
     ):
+        batch = batch[:, :-1]
         targets, extra_targets = forward(model, batch)
         mx.eval(targets, extra_targets)
         loss, ntoks, params = step(batch, targets, extra_targets, lengths, params)
@@ -197,7 +198,7 @@ def main():
         default=1024,
         help="Number of samples to use for training.",
     )
-    parser.add_argument("--max-seq-length", type=int, default=2048)
+    parser.add_argument("--max-seq-length", type=int, default=2049)
     parser.add_argument("--seed", type=int, default=123)
     parser.add_argument("--learning-rate", type=float, default=1e-6)
     parser.add_argument("--batch-size", type=int, default=4)

--- a/mlx_lm/dwq.py
+++ b/mlx_lm/dwq.py
@@ -45,7 +45,7 @@ def dwq_quantize(
     data,
     batch_size: int = 2,
     max_seq_length: int = 2048,
-    temperature: float = 1.0,
+    temperature: float = 0.5,
     activation_layer_step: float = 0.25,
     activation_loss_weight: float = 1e-1,
     dtype: mx.Dtype = mx.bfloat16,
@@ -210,7 +210,7 @@ def main():
     parser.add_argument(
         "--temperature",
         type=float,
-        default=1.0,
+        default=0.5,
         help="Temperature scaling for the loss.",
     )
     args = parser.parse_args()

--- a/mlx_lm/tuner/trainer.py
+++ b/mlx_lm/tuner/trainer.py
@@ -93,7 +93,7 @@ def iterate_batches(
     if isinstance(dataset, CacheDataset):
         len_fn = lambda idx: dataset.itemlen(idx)
     else:
-        len_fn = lambda idx: len(dataset[idx])
+        len_fn = lambda idx: dataset[idx][1]
     idx = sorted(range(len(dataset)), key=len_fn)
     if len(dataset) < batch_size:
         raise ValueError(


### PR DESCRIPTION
Depends on #148 

Adds a penalty between the hidden states of the student and the teacher:
- The penalty uses L1 (L2 was too sensitive to large values).
- Defaults to use 4 layers equally spaced
- Loss is `kl_loss + activation_weight * activation_loss`
- Updates some default values which work better

New results on 2200 MMLU questions look pretty good for Gemma3 and Qwen3 4b models:

<img width="511" alt="Screenshot 2025-05-07 at 7 45 10 AM" src="https://github.com/user-attachments/assets/89cfebc0-a825-4cd2-8c9c-8899bd5b2e82" />

