### PR TITLE
Add search strategy

### DIFF
--- a/mlx_lm/generate.py
+++ b/mlx_lm/generate.py
@@ -297,7 +297,7 @@ class SearchStrategy(ABC):
         prompt_cache: List[Any],
         quantize_cache_fn: Callable[[Any], None],
         total_prompt_tokens: int,
-    ) -> Generator[Tuple[mx.array, mx.array], None, None]:
+    ) -> Generator[Tuple[int, mx.array], None, None]:
         """
         Generates a sequence of tokens from the model.
 
@@ -308,7 +308,7 @@ class SearchStrategy(ABC):
             total_prompt_tokens (int): The total number of tokens in the prompt.
 
         Yields:
-            Tuple[mx.array, mx.array]: A token and a vector of log probabilities.
+            Tuple[int, mx.array]: A token and a vector of log probabilities.
         """
         pass
 
@@ -328,7 +328,7 @@ def generate_step(
     quantized_kv_start: int = 0,
     prompt_progress_callback: Optional[Callable[[int, int], None]] = None,
     search_strategy: Optional[SearchStrategy] = None,
-) -> Generator[Tuple[mx.array, mx.array], None, None]:
+) -> Generator[Tuple[int, mx.array], None, None]:
     """
     A generator producing token ids based on the given prompt from the model.
 
@@ -358,7 +358,7 @@ def generate_step(
             `LinearSearch`.
 
     Yields:
-        Tuple[mx.array, mx.array]: One token and a vector of log probabilities.
+        Tuple[int, mx.array]: One token and a vector of log probabilities.
     """
 
     y = prompt

--- a/mlx_lm/generate.py
+++ b/mlx_lm/generate.py
@@ -293,27 +293,20 @@ class SearchStrategy(ABC):
     @abstractmethod
     def generate(
         self,
-        prompt: mx.array,
+        y: mx.array,
         prompt_cache: List[Any],
         quantize_cache_fn: Callable[[Any], None],
         total_prompt_tokens: int,
-        prompt_progress_callback: Callable[[int, int], None],
     ) -> Generator[Tuple[int, mx.array], None, None]:
         """
         Generates a sequence of tokens from the model.
 
         Args:
-            prompt (mx.array): The prompt to use for generation. Note: this may not be the
-                complete prompt if some of it has been cached in the `prompt_cache`.
-            prompt_cache (List[Any]): The prompt cache. This is normally updated when the model
-                is called to generate new tokens.
-            quantize_cache_fn (Callable[[Any], None]): A function to quantize the cache. This
-                should be called when the cache has been updated (by the model).
-            total_prompt_tokens (int): The total number of tokens in the prompt. This should
-                be passed to the `prompt_progress_callback` when the prompt has been processed.
-            prompt_progress_callback (Callable[int, int]): A call-back which takes the
-               prompt tokens processed so far and the total number of prompt tokens.
-               This should be called when the prompt has been processed.
+            y (mx.array): The next token sequence.
+            prompt_cache (List[Any]): The prompt cache.
+            quantize_cache_fn (Callable[[Any], None]): A function to quantize the cache.
+            total_prompt_tokens (int): The total number of tokens in the prompt.
+
         Yields:
             Tuple[int, mx.array]: A token and a vector of log probabilities.
         """
@@ -334,6 +327,7 @@ def generate_step(
     kv_group_size: int = 64,
     quantized_kv_start: int = 0,
     prompt_progress_callback: Optional[Callable[[int, int], None]] = None,
+    search_strategy: Optional[SearchStrategy] = None,
 ) -> Generator[Tuple[int, mx.array], None, None]:
     """
     A generator producing token ids based on the given prompt from the model.
@@ -360,72 +354,14 @@ def generate_step(
            when ``kv_bits`` is non-None. Default: ``0``.
         prompt_progress_callback (Callable[int, int]): A call-back which takes the
            prompt tokens processed so far and the total number of prompt tokens.
-
-    Yields:
-        Tuple[int, mx.array]: One token and a vector of log probabilities.
-    """
-    sampler = sampler or (lambda x: mx.argmax(x, axis=-1))
-    prompt_progress_callback = prompt_progress_callback or (lambda *_: None)
-    search_strategy = LinearSearch(
-        model=model,
-        sampler=sampler,
-        logits_processors=logits_processors,
-        max_tokens=max_tokens,
-    )
-    return generate_with_search(
-        prompt=prompt,
-        model=model,
-        search_strategy=search_strategy,
-        max_kv_size=max_kv_size,
-        prompt_cache=prompt_cache,
-        prefill_step_size=prefill_step_size,
-        kv_bits=kv_bits,
-        kv_group_size=kv_group_size,
-        quantized_kv_start=quantized_kv_start,
-        prompt_progress_callback=prompt_progress_callback,
-    )
-
-
-def generate_with_search(
-    prompt: mx.array,
-    model: nn.Module,
-    search_strategy: SearchStrategy,
-    *,
-    max_kv_size: Optional[int] = None,
-    prompt_cache: Optional[Any] = None,
-    prefill_step_size: int = 2048,
-    kv_bits: Optional[int] = None,
-    kv_group_size: int = 64,
-    quantized_kv_start: int = 0,
-    prompt_progress_callback: Optional[Callable[[int, int], None]] = None,
-) -> Generator[Tuple[int, mx.array], None, None]:
-    """
-    A generator producing token ids based on the given prompt and search strategy from the model.
-
-    Args:
-        prompt (mx.array): The input prompt.
-        model (nn.Module): The model to use for generation.
-        search_strategy (SearchStrategy): The search strategy to use.
-        max_kv_size (int, optional): Maximum size of the key-value cache. Old
-          entries (except the first 4 tokens) will be overwritten.
-        prompt_cache (List[Any], optional): A pre-computed prompt cache. Note, if
-          provided, the cache will be updated in place.
-        prefill_step_size (int): Step size for processing the prompt.
-        kv_bits (int, optional): Number of bits to use for KV cache quantization.
-          None implies no cache quantization. Default: ``None``.
-        kv_group_size (int): Group size for KV cache quantization. Default: ``64``.
-        quantized_kv_start (int): Step to begin using a quantized KV cache.
-           when ``kv_bits`` is non-None. Default: ``0``.
-        prompt_progress_callback (Callable[int, int]): A call-back which takes the
-           prompt tokens processed so far and the total number of prompt tokens.
+        search_strategy (SearchStrategy): The search strategy to use. This defaults to
+            `LinearSearch`.
 
     Yields:
         Tuple[int, mx.array]: One token and a vector of log probabilities.
     """
 
     y = prompt
-
-    prompt_progress_callback = prompt_progress_callback or (lambda *_: None)
 
     # Create the KV cache for generation
     if prompt_cache is None:
@@ -436,12 +372,16 @@ def generate_with_search(
     elif len(prompt_cache) != len(model.layers):
         raise ValueError("Wrong number of layers in the prompt cache.")
 
+    prompt_progress_callback = prompt_progress_callback or (lambda *_: None)
+
     quantize_cache_fn = functools.partial(
         maybe_quantize_kv_cache,
         quantized_kv_start=quantized_kv_start,
         kv_group_size=kv_group_size,
         kv_bits=kv_bits,
     )
+
+    sampler = sampler or (lambda x: mx.argmax(x, axis=-1))
 
     with mx.stream(generation_stream):
         total_prompt_tokens = y.size
@@ -455,12 +395,20 @@ def generate_with_search(
             y = y[prefill_step_size:]
             mx.clear_cache()
 
+    if search_strategy is None:
+        search_strategy = LinearSearch(
+            model=model,
+            sampler=sampler,
+            logits_processors=logits_processors,
+            max_tokens=max_tokens,
+            prompt_progress_callback=prompt_progress_callback,
+        )
+
     return search_strategy.generate(
-        prompt=y,
+        y=y,
         prompt_cache=prompt_cache,
         quantize_cache_fn=quantize_cache_fn,
         total_prompt_tokens=total_prompt_tokens,
-        prompt_progress_callback=prompt_progress_callback,
     )
 
 
@@ -476,19 +424,20 @@ class LinearSearch(SearchStrategy):
         sampler: Callable[[mx.array], mx.array],
         logits_processors: List[Callable[[mx.array, mx.array], mx.array]],
         max_tokens: int,
+        prompt_progress_callback: Callable[[int, int], None],
     ):
         self._model = model
         self._sampler = sampler
         self._logits_processors = logits_processors
         self._max_tokens = max_tokens
+        self._prompt_progress_callback = prompt_progress_callback
 
     def generate(
         self,
-        prompt: mx.array,
+        y: mx.array,
         prompt_cache: List[Any],
         quantize_cache_fn: Callable[[Any], None],
         total_prompt_tokens: int,
-        prompt_progress_callback: Callable[[int, int], None],
     ) -> Generator[Tuple[mx.array, mx.array], None, None]:
         tokens = None
 
@@ -510,23 +459,23 @@ class LinearSearch(SearchStrategy):
                 y = self._sampler(logprobs)
                 return y, logprobs.squeeze(0)
 
-        prompt, logprobs = _step(prompt)
+        y, logprobs = _step(y)
 
-        mx.async_eval(prompt, logprobs)
+        mx.async_eval(y, logprobs)
         n = 0
         while True:
             if n != self._max_tokens:
-                next_y, next_logprobs = _step(prompt)
+                next_y, next_logprobs = _step(y)
                 mx.async_eval(next_y, next_logprobs)
             if n == 0:
-                mx.eval(prompt)
-                prompt_progress_callback(total_prompt_tokens, total_prompt_tokens)
+                mx.eval(y)
+                self._prompt_progress_callback(total_prompt_tokens, total_prompt_tokens)
             if n == self._max_tokens:
                 break
-            yield prompt.item(), logprobs
+            yield y.item(), logprobs
             if n % 256 == 0:
                 mx.clear_cache()
-            prompt, logprobs = next_y, next_logprobs
+            y, logprobs = next_y, next_logprobs
             n += 1
 
 


### PR DESCRIPTION
This is a proposal for adding a "search strategy" to token generation. This enables different strategies for selecting generated tokens. For example, see this (not tested) [ prototype of beam search](https://github.com/nfergu/mlx-lm/pull/2) that is based on this.

I have left the interface of `generate_step` unchanged by defaulting to a "linear search" strategy, which does the same thing as before. In addition, there is a new function called `generate_with_search` which accepts a `SearchStrategy` implementation, which allows other strategies to be used. I haven't plumbed `generate_with_search` into the main `stream_generate` but perhaps it should be? 

There's perhaps some tidy up to be done, but I thought I'd get this out for feedback before I did too much more on it.

Let me know what you think. Happy to make changes. One alternative to this PR would be that search strategies would duplicate the code that is currently in `generate_with_search` within the `SearchStrategy` implementation itself. Or we  refactor the code that is currently in `generate_with_search` into a helper function that search strategies would call. If you think either of those are nicer approaches I'll close this PR.