### PR TITLE
Performance regression when reusing trainer with gradient checkpointing

### DIFF
--- a/mlx_lm/convert.py
+++ b/mlx_lm/convert.py
@@ -113,6 +113,7 @@ def convert(
 
     print("[INFO] Loading")
     model_path = get_model_path(hf_path, revision=revision)
+    print("[INFO] Model path:", model_path)
     model, config, tokenizer = fetch_from_hub(model_path, lazy=True)
 
     if isinstance(quant_predicate, str):

--- a/mlx_lm/models/rope_utils.py
+++ b/mlx_lm/models/rope_utils.py
@@ -176,6 +176,7 @@ def initialize_rope(
         return YarnRoPE(
             dims=dims,
             max_position_embeddings=max_position_embeddings,
+            scaling_factor=scaling_factor,
             traditional=traditional,
             base=base,
             **rope_kwargs,

--- a/mlx_lm/utils.py
+++ b/mlx_lm/utils.py
@@ -254,7 +254,7 @@ def load(
     """
     model_path = get_model_path(path_or_hf_repo)
 
-    model, config = load_model(model_path, lazy)
+    model, config = load_model(model_path, lazy, model_config=model_config)
     if adapter_path is not None:
         model = load_adapters(model, adapter_path)
         model.eval()


### PR DESCRIPTION
When repeatedly calling train() with activated gradient checkpointing (e.g. for HPO) the __call__ method would recursively be mapped to a checkpointed fn, which led to a performance decrease on each iterative run. 
This can be fixed by restoring the original __call__ method after training finishes.