### PR TITLE
Add ability to define default parameters for server in a settings file

### DIFF
--- a/mlx_lm/SERVER.md
+++ b/mlx_lm/SERVER.md
@@ -137,7 +137,8 @@ example above `"max_tokens": 256` would be applied to even the
 `mlx-community/Qwen2.5-Coder-32B-Instruct-8bit` model if it would not have
 `"max_tokens": 16384` written under its own key.
 
-You have to restart the server for any changes in this file to take effect!
+Any changes in this file take effect for any subsequent requests without a need to
+restart the server.
 
 
 ### Response Fields

--- a/mlx_lm/SERVER.md
+++ b/mlx_lm/SERVER.md
@@ -92,6 +92,53 @@ curl localhost:8080/v1/chat/completions \
 - `num_draft_tokens`: (Optional) The number of draft tokens the draft model
   should predict at once. Defaults to `3`.
 
+#### Custom defaults
+You can set custom defaults for the server by `~/.mlx_lm.settings.json` in
+your home directory. In this file you can specify a different default value
+for all the request fields listed above.
+
+```json
+{
+  "server": {
+    "parameters": {
+      "default": {
+        "max_tokens": 256
+      }
+    }
+  }
+}
+```
+This will set the default `max_tokens` to `256` for all requests, which does not
+contain `max_tokens` in the request body.
+
+The default values can be overridden on a per-model basis as well. For example to
+force speculative decoding for the `mlx-community/Qwen2.5-Coder-32B-Instruct-8bit`,
+this can be added:
+
+```json
+{
+  "server": {
+    "parameters": {
+      "default": {
+        "max_tokens": 256
+      },
+      "mlx-community/Qwen2.5-Coder-32B-Instruct-8bit": {
+        "max_tokens": 16384,
+        "draft_model": "mlx-community/Qwen2.5-Coder-1.5B-Instruct-8bit"
+      }
+    }
+  }
+}
+```
+
+Please note that the parameters under the `default` key are used for event the named
+models, if the named model does not have a default for the same parameter. So in the
+example above `"max_tokens": 256` would be applied to even the
+`mlx-community/Qwen2.5-Coder-32B-Instruct-8bit` model if it would not have
+`"max_tokens": 16384` written under its own key.
+
+You have to restart the server for any changes in this file to take effect!
+
 
 ### Response Fields
 

--- a/mlx_lm/utils.py
+++ b/mlx_lm/utils.py
@@ -574,17 +574,11 @@ def get_settings(
     """
     settings_path = os.path.expanduser(settings_path)
 
-    if not hasattr(get_settings, "_settings_cache"):
-        get_settings._settings_cache = {}
+    try:
+        with open(settings_path, "r") as f:
+            settings = json.load(f)
+            logging.debug(f"Loaded settings from: {settings_path}")
+    except FileNotFoundError:
+        settings = {}
 
-    if settings_path not in get_settings._settings_cache:
-        try:
-            with open(settings_path, "r") as f:
-                get_settings._settings_cache[settings_path] = json.load(f)
-                logging.debug(
-                    f"Loaded settings from {settings_path}: {get_settings._settings_cache[settings_path]}"
-                )
-        except FileNotFoundError:
-            get_settings._settings_cache[settings_path] = {}
-
-    return get_settings._settings_cache[settings_path].get(key, default)
+    return settings.get(key, default)

--- a/mlx_lm/utils.py
+++ b/mlx_lm/utils.py
@@ -554,3 +554,37 @@ def common_prefix_len(list1, list2):
     # No mismatch found within the bounds of the shorter list,
     # so the common prefix length is the length of the shorter list.
     return min_len
+
+
+def get_settings(
+    key: str,
+    default: Optional[Any] = None,
+    settings_path: Union[str, Path] = "~/.mlx_lm.settings.json",
+) -> Any:
+    """
+    Get a setting value from the settings file.
+
+    Args:
+        key (str): The key of the setting to retrieve.
+        default (Any, optional): The default value to return if the key is not found.
+        settings_path (Union[str, Path], optional): The path to the settings file.
+
+    Returns:
+        Any: The value of the setting or the default value if not found.
+    """
+    settings_path = os.path.expanduser(settings_path)
+
+    if not hasattr(get_settings, "_settings_cache"):
+        get_settings._settings_cache = {}
+
+    if settings_path not in get_settings._settings_cache:
+        try:
+            with open(settings_path, "r") as f:
+                get_settings._settings_cache[settings_path] = json.load(f)
+                logging.debug(
+                    f"Loaded settings from {settings_path}: {get_settings._settings_cache[settings_path]}"
+                )
+        except FileNotFoundError:
+            get_settings._settings_cache[settings_path] = {}
+
+    return get_settings._settings_cache[settings_path].get(key, default)

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -4,11 +4,12 @@ import http
 import json
 import threading
 import unittest
+from unittest.mock import patch
 
 import requests
 
 from mlx_lm.server import APIHandler
-from mlx_lm.utils import load
+from mlx_lm.utils import get_settings, load
 
 
 class DummyModelProvider:
@@ -54,6 +55,9 @@ class TestServer(unittest.TestCase):
         cls.server_thread = threading.Thread(target=cls.httpd.serve_forever)
         cls.server_thread.daemon = True
         cls.server_thread.start()
+        # Prevent user settings from being loaded and interfere with test runs
+        cls.get_settings_patcher = patch("mlx_lm.server.get_settings", return_value={})
+        cls.mock_get_settings = cls.get_settings_patcher.start()
 
     @classmethod
     def tearDownClass(cls):

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -115,14 +115,14 @@ class TestUtils(unittest.TestCase):
             "default_value",
         )
 
-        # Test caching
-        # Modify the file to check if the cache is used
+        # Test refresh
+        # Modify the file to check if the change is picked up
         with open(settings_path, "w") as f:
             json.dump({"setting1": "new_value1"}, f)
 
         # The cached value should still be the old one
         self.assertEqual(
-            utils.get_settings("setting1", settings_path=settings_path), "value1"
+            utils.get_settings("setting1", settings_path=settings_path), "new_value1"
         )
 
 


### PR DESCRIPTION
Same as #131 was, but I closed that because I accidentally opened that from my main,which is obviously is a mess.

When using `mlx_lm.server` to play with models locally, it can become a huge time waster to research and figure out how the parameters can be set for each tool that connects to the API. Some tools have nice UI to add arbitrary body parameters, some tools only have some common parameters on the UI, and need setting these in config files, and some tools does not allow adding custom body parameters at all, in which case one has to write and use a utility proxy to sit between the client and the server to modify the request. This is a huge time waster and also makes it hard to maintain all these configurations over various tools.

Here the key idea is that while some parameters may worth changing per client or even per request, some should be configurable as defaults for all requests. One such thing for me is proper `draft_model` for each of my installed models, which can easily 2x the generation speed. This should be a one time set and forget thing, regardless of what client will consume the server after.

For this reason, I've implemented a config file to sit in the user's home folder where the parameters can be preset for all requests.

In the config file I put everything under the main key of `server` thinking that maybe in the future other modules could utilize the same file as well. Also, under server I put everything under `parameters`, so other settings can be added later for the `server` module too.

One thing I am quite indecisive about is how the file should be read. First I made it only read the file once, and reuse the same value until server restart, but it makes fiddling with the file really tedious, to always restart the server, and since the settings are only loaded once per request I think it is better to load it every time. But this also means if other modules start to use the same `get_settings()` call, they must make sure the result is handled properly to avoid repeated reading of the settings file e.g. inside a loop or so.

Let me know what do you think!