### PR TITLE
Do not pass empty tools array to the tokenizer

### DIFF
--- a/mlx_lm/server.py
+++ b/mlx_lm/server.py
@@ -744,7 +744,7 @@ class APIHandler(BaseHTTPRequestHandler):
             process_message_content(messages)
             prompt = self.tokenizer.apply_chat_template(
                 messages,
-                body.get("tools", None),
+                body.get("tools") if body.get("tools") else None,
                 add_generation_prompt=True,
             )
         else:

--- a/mlx_lm/server.py
+++ b/mlx_lm/server.py
@@ -744,7 +744,7 @@ class APIHandler(BaseHTTPRequestHandler):
             process_message_content(messages)
             prompt = self.tokenizer.apply_chat_template(
                 messages,
-                body.get("tools") if body.get("tools") else None,
+                body.get("tools") or None,
                 add_generation_prompt=True,
             )
         else:


### PR DESCRIPTION
I've been fighting with an issue that my models started to hallucinate tool calls and respond in JSON strings when an empty models array was passed in the request body.

Indeed the [official API documentation](https://platform.openai.com/docs/api-reference/chat/create#chat-create-tools) does not say what should an empty array mean. But I think logically it should mean no tools, and no tools should not behave different based on if it was indicated by a missing parameter or an empty array.

This caused me issues when I tried to use MLX-LM with an agent tool (if interested I can say, but don't want to put unsolicited ads in here), which interprets the API in away that the `tools` property is always present in the body, but if there are no tools, it is an empty array.

The problem it causes that my llama models started to hallucinate tools when prompted with an empty array responding in fictive JSON tool calls.

One can argue that API consumers should not pass empty `tools` array, if there are no tools defined, but the real openai models respond just fine to such calls, so even thought the documentation does not explicitly says, the way for mlx-lm server to be closest to the real openai API is to handle empty array the same way as none.