### PR TITLE
Allow to use mistral3 model type for lora

### DIFF
--- a/mlx_lm/tuner/utils.py
+++ b/mlx_lm/tuner/utils.py
@@ -79,6 +79,7 @@ def linear_to_lora_layers(
         keys = set(keys)
     elif model.model_type in [
         "mistral",
+        "mistral3",
         "llama",
         "phi",
         "mixtral",


### PR DESCRIPTION
This complete request  [#166](https://github.com/ml-explore/mlx-lm/issues/136) to be able to use Mistral3 during lora.
Without this change, mlx_vlm.lora was aborted with message "Lora does not support mistral3" 