### PR TITLE
Don't hide exception with wrong message when HF model isn't found

### DIFF
--- a/mlx_lm/convert.py
+++ b/mlx_lm/convert.py
@@ -130,7 +130,12 @@ def convert(
         else:
             cast_predicate = lambda _: True
         weights = {
-            k: v.astype(dtype) if cast_predicate(k) else v for k, v in weights.items()
+            k: (
+                v.astype(dtype)
+                if cast_predicate(k) and mx.issubdtype(v.dtype, mx.floating)
+                else v
+            )
+            for k, v in weights.items()
         }
 
     if quantize and dequantize:

--- a/mlx_lm/utils.py
+++ b/mlx_lm/utils.py
@@ -443,6 +443,8 @@ def quantize_model(
     Returns:
         Tuple: Tuple containing quantized weights and config.
     """
+    if "quantization" in config:
+        raise ValueError("Cannot quantize already quantized model")
     quantized_config = copy.deepcopy(config)
     quantized_config["quantization"] = {"group_size": q_group_size, "bits": q_bits}
 

--- a/mlx_lm/utils.py
+++ b/mlx_lm/utils.py
@@ -25,8 +25,6 @@ import mlx.nn as nn
 if os.getenv("MLXLM_USE_MODELSCOPE", "False").lower() == "true":
     try:
         from modelscope import snapshot_download
-
-        requests.exceptions.HTTPError
     except ImportError:
         raise ImportError(
             "Please run `pip install modelscope` to activate the ModelScope."
@@ -50,12 +48,6 @@ MODEL_REMAPPING = {
 }
 
 MAX_FILE_SIZE_GB = 5
-
-
-class ModelNotFoundError(Exception):
-    def __init__(self, message):
-        self.message = message
-        super().__init__(self.message)
 
 
 def _get_classes(config: dict):

--- a/mlx_lm/utils.py
+++ b/mlx_lm/utils.py
@@ -25,6 +25,8 @@ import mlx.nn as nn
 if os.getenv("MLXLM_USE_MODELSCOPE", "False").lower() == "true":
     try:
         from modelscope import snapshot_download
+
+        requests.exceptions.HTTPError
     except ImportError:
         raise ImportError(
             "Please run `pip install modelscope` to activate the ModelScope."
@@ -104,31 +106,22 @@ def get_model_path(path_or_hf_repo: str, revision: Optional[str] = None) -> Path
     model_path = Path(path_or_hf_repo)
 
     if not model_path.exists():
-        try:
-            model_path = Path(
-                snapshot_download(
-                    path_or_hf_repo,
-                    revision=revision,
-                    allow_patterns=[
-                        "*.json",
-                        "*.safetensors",
-                        "*.py",
-                        "tokenizer.model",
-                        "*.tiktoken",
-                        "tiktoken.model",
-                        "*.txt",
-                        "*.jsonl",
-                    ],
-                )
+        model_path = Path(
+            snapshot_download(
+                path_or_hf_repo,
+                revision=revision,
+                allow_patterns=[
+                    "*.json",
+                    "*.safetensors",
+                    "*.py",
+                    "tokenizer.model",
+                    "*.tiktoken",
+                    "tiktoken.model",
+                    "*.txt",
+                    "*.jsonl",
+                ],
             )
-        except:
-            raise ModelNotFoundError(
-                f"Model not found for path or HF repo: {path_or_hf_repo}.\n"
-                "Please make sure you specified the local path or Hugging Face"
-                " repo id correctly.\nIf you are trying to access a private or"
-                " gated Hugging Face repo, make sure you are authenticated:\n"
-                "https://huggingface.co/docs/huggingface_hub/en/guides/cli#huggingface-cli-login"
-            ) from None
+        )
     return model_path
 
 

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -77,7 +77,7 @@ class TestUtils(unittest.TestCase):
     def test_convert(self):
         mlx_path = os.path.join(self.test_dir, "mlx_model")
 
-        convert(HF_MODEL_PATH, mlx_path=mlx_path, quantize=True)
+        convert(HF_MODEL_PATH, mlx_path=mlx_path, quantize=False)
         model, _ = utils.load(mlx_path)
         self.assertTrue(isinstance(model.layers[0].mlp.up_proj, nn.QuantizedLinear))
         self.assertTrue(isinstance(model.layers[-1].mlp.up_proj, nn.QuantizedLinear))
@@ -87,8 +87,8 @@ class TestUtils(unittest.TestCase):
         convert(HF_MODEL_PATH, mlx_path=mlx_path, dtype="bfloat16")
         model, _ = utils.load(mlx_path)
 
-        self.assertEqual(model.layers[0].mlp.up_proj.weight.dtype, mx.bfloat16)
-        self.assertEqual(model.layers[-1].mlp.up_proj.weight.dtype, mx.bfloat16)
+        self.assertEqual(model.layers[0].mlp.up_proj.scales.dtype, mx.bfloat16)
+        self.assertEqual(model.layers[-1].mlp.up_proj.scales.dtype, mx.bfloat16)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
As title.. 

The default HF exception when the repository isn't found is fine.. I'm not sure why we catch and re-raise a custom exception.

Also in cases where you run out of disk space or the download fails for a different reason we were hiding that with the wrong model not found message.