### PR TITLE
Add input_embeddings input to generate_step, Gemma 3, Qwen 2

### DIFF
--- a/mlx_lm/generate.py
+++ b/mlx_lm/generate.py
@@ -326,7 +326,7 @@ def generate_step(
         prompt_progress_callback (Callable[int, int]): A call-back which takes the
            prompt tokens processed so far and the total number of prompt tokens.
         input_embeddings (mx.array, optional): Input embeddings to use in place of
-           prompt tokens, if provided. Default: ``None``.
+           prompt tokens. Default: ``None``.
 
     Yields:
         Tuple[mx.array, mx.array]: One token and a vector of log probabilities.

--- a/mlx_lm/generate.py
+++ b/mlx_lm/generate.py
@@ -325,14 +325,19 @@ def generate_step(
            when ``kv_bits`` is non-None. Default: ``0``.
         prompt_progress_callback (Callable[int, int]): A call-back which takes the
            prompt tokens processed so far and the total number of prompt tokens.
-       input_embeddings (mx.array, optional): Input embeddings to use in place of
+        input_embeddings (mx.array, optional): Input embeddings to use in place of
            prompt tokens, if provided. Default: ``None``.
 
     Yields:
         Tuple[mx.array, mx.array]: One token and a vector of log probabilities.
     """
-    if input_embeddings is not None and not does_model_support_input_embeddings(model):
-        raise ValueError("Model does not support input embeddings.")
+    if input_embeddings is not None:
+        if not does_model_support_input_embeddings(model):
+            raise ValueError("Model does not support input embeddings.")
+        if len(prompt) != 0:
+            raise ValueError(
+                "If using input embeddings, prompt tokens must be an empty array."
+            )
 
     tokens = None
 
@@ -356,27 +361,22 @@ def generate_step(
 
     sampler = sampler or (lambda x: mx.argmax(x, axis=-1))
 
-    def _step(token_ids=None, embeddings=None):
+    def _model_call(y):
+        if y.ndim == 3:
+            return model(None, cache=prompt_cache, input_embeddings=y)
+        else:
+            return model(y, cache=prompt_cache)
+
+    def _step(y):
         nonlocal tokens
 
         with mx.stream(generation_stream):
-            if embeddings is not None:
-                logits = model(
-                    None, cache=prompt_cache, input_embeddings=embeddings[None]
-                )
-            elif token_ids is not None:
-                logits = model(token_ids[None], cache=prompt_cache)
-            else:
-                raise ValueError(
-                    "Either token_ids or embeddings must be provided to _step."
-                )
+            logits = _model_call(y[None])
 
             logits = logits[:, -1, :]
 
-            if logits_processors and token_ids is not None:
-                tokens = (
-                    mx.concat([tokens, token_ids]) if tokens is not None else token_ids
-                )
+            if logits_processors and input_embeddings is None:
+                tokens = mx.concat([tokens, y]) if tokens is not None else y
                 for processor in logits_processors:
                     logits = processor(tokens, logits)
 
@@ -393,14 +393,7 @@ def generate_step(
         total_prompt_tokens = y.shape[0]
         prompt_processed_tokens = 0
         while y.shape[0] > prefill_step_size:
-            if using_embeddings:
-                model(
-                    None,
-                    cache=prompt_cache,
-                    input_embeddings=y[:prefill_step_size][None],
-                )
-            else:
-                model(y[:prefill_step_size][None], cache=prompt_cache)
+            _model_call(y[:prefill_step_size][None])
             quantize_cache_fn(prompt_cache)
             mx.eval([c.state for c in prompt_cache])
             prompt_progress_callback(prompt_processed_tokens, total_prompt_tokens)
@@ -408,13 +401,13 @@ def generate_step(
             y = y[prefill_step_size:]
             mx.clear_cache()
 
-        y, logprobs = _step(embeddings=y) if using_embeddings else _step(token_ids=y)
+        y, logprobs = _step(y)
 
     mx.async_eval(y, logprobs)
     n = 0
     while True:
         if n != max_tokens:
-            next_y, next_logprobs = _step(token_ids=y)
+            next_y, next_logprobs = _step(y)
             mx.async_eval(next_y, next_logprobs)
         if n == 0:
             mx.eval(y)

--- a/mlx_lm/models/gemma3.py
+++ b/mlx_lm/models/gemma3.py
@@ -41,8 +41,11 @@ class Model(nn.Module):
         inputs: mx.array,
         cache=None,
         mask: Optional[mx.array] = None,
+        input_embeddings: Optional[mx.array] = None,
     ):
-        return self.language_model(inputs, cache=cache, mask=mask)
+        return self.language_model(
+            inputs, cache=cache, mask=mask, input_embeddings=input_embeddings
+        )
 
     def sanitize(self, weights):
         weights = tree_unflatten(list(weights.items()))

--- a/mlx_lm/models/gemma3_text.py
+++ b/mlx_lm/models/gemma3_text.py
@@ -175,9 +175,12 @@ class Gemma3Model(nn.Module):
         inputs: mx.array,
         mask: mx.array = None,
         cache=None,
+        input_embeddings: Optional[mx.array] = None,
     ):
-
-        h = self.embed_tokens(inputs)
+        if input_embeddings is not None:
+            h = input_embeddings
+        else:
+            h = self.embed_tokens(inputs)
         h *= mx.array(self.args.hidden_size**0.5, mx.bfloat16).astype(h.dtype)
 
         if cache is None:
@@ -218,8 +221,9 @@ class Model(nn.Module):
         inputs: mx.array,
         cache=None,
         mask: Optional[mx.array] = None,
+        input_embeddings: Optional[mx.array] = None,
     ):
-        out = self.model(inputs, mask, cache)
+        out = self.model(inputs, mask, cache, input_embeddings)
         out = self.lm_head(out)
         return out
 

--- a/mlx_lm/models/qwen2.py
+++ b/mlx_lm/models/qwen2.py
@@ -137,8 +137,12 @@ class Qwen2Model(nn.Module):
         inputs: mx.array,
         mask: mx.array = None,
         cache=None,
+        input_embeddings: Optional[mx.array] = None,
     ):
-        h = self.embed_tokens(inputs)
+        if input_embeddings is not None:
+            h = input_embeddings
+        else:
+            h = self.embed_tokens(inputs)
 
         if mask is None:
             mask = create_attention_mask(h, cache)
@@ -166,8 +170,9 @@ class Model(nn.Module):
         inputs: mx.array,
         mask: mx.array = None,
         cache=None,
+        input_embeddings: Optional[mx.array] = None,
     ):
-        out = self.model(inputs, mask, cache)
+        out = self.model(inputs, mask, cache, input_embeddings)
         if self.args.tie_word_embeddings:
             out = self.model.embed_tokens.as_linear(out)
         else:

--- a/mlx_lm/utils.py
+++ b/mlx_lm/utils.py
@@ -3,6 +3,7 @@
 import copy
 import glob
 import importlib
+import inspect
 import json
 import logging
 import os
@@ -541,3 +542,18 @@ def common_prefix_len(list1, list2):
     # No mismatch found within the bounds of the shorter list,
     # so the common prefix length is the length of the shorter list.
     return min_len
+
+
+def does_model_support_input_embeddings(model: nn.Module) -> bool:
+    """
+    Check if the model supports input_embeddings in its call signature.
+    Args:
+        model (nn.Module): The model to check.
+    Returns:
+        bool: True if the model supports input_embeddings, False otherwise.
+    """
+    try:
+        signature = inspect.signature(model.__call__)
+        return "input_embeddings" in signature.parameters
+    except (ValueError, TypeError):
+        return False

--- a/tests/test_generate.py
+++ b/tests/test_generate.py
@@ -90,6 +90,67 @@ class TestGenerate(unittest.TestCase):
         # from the target model, and last two should be drafts
         self.assertEqual(drafted, [True, True, False, True, True])
 
+    def test_stream_generate_input_embeddings(self):
+        sampler = make_sampler(temp=0.0)  # determinate sampler
+
+        # get prompt embeddings
+        messages = [{"role": "user", "content": "Say 'TEST' and nothing else"}]
+        prompt = self.tokenizer.apply_chat_template(
+            messages, add_generation_prompt=True
+        )
+        prompt_embeddings = self.model.model.embed_tokens(prompt)
+
+        response = ""
+        for generation_result in stream_generate(
+            model=self.model,
+            tokenizer=self.tokenizer,
+            prompt=[],  # no prompt tokens passed
+            max_tokens=5,
+            sampler=sampler,
+            input_embeddings=prompt_embeddings,
+        ):
+            response += generation_result.text
+
+        self.assertEqual("TEST", response)
+
+    def test_stream_generate_input_embeddings_prefill(self):
+        sampler = make_sampler(temp=0.0)  # determinate sampler
+
+        # get prompt embeddings
+        messages = [{"role": "user", "content": "Say 'TEST' and nothing else"}]
+        prompt = self.tokenizer.apply_chat_template(
+            messages, add_generation_prompt=True
+        )
+        prompt_embeddings = self.model.model.embed_tokens(prompt)
+
+        # setup prompt progress callback to track batched prefill
+        num_prompt_processing_callbacks = 0
+
+        def progress_callback(processed: int, total: int) -> None:
+            nonlocal num_prompt_processing_callbacks
+            num_prompt_processing_callbacks += 1
+
+        # generate
+        prefill_step_size = 5
+        response = ""
+        for generation_result in stream_generate(
+            model=self.model,
+            tokenizer=self.tokenizer,
+            prompt=[],  # no prompt tokens passed
+            max_tokens=5,
+            sampler=sampler,
+            input_embeddings=prompt_embeddings,
+            prefill_step_size=prefill_step_size,
+            prompt_progress_callback=progress_callback,
+        ):
+            response += generation_result.text
+
+        self.assertEqual("TEST", response)
+        num_embeddings = prompt_embeddings.shape[0]
+        self.assertEqual(
+            num_embeddings / prefill_step_size, num_prompt_processing_callbacks
+        )
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
### Overview

Enables `input_embeddings` to be used instead of `prompt`. This allows for prompt enrichment such as injecting image embeddings for models like Gemma3 and Qwen2/2.5VL.

I originally was only going to pipe this for Gemma3, but since `mlx-community/Qwen1.5-0.5B-Chat-4bit` (Qwen2 arch) is the current text model used for testing, I added `input_embeddings` to the Qwen2 model as well. This should eventually prove useful to be able to run Qwen2/2.5VL with image embeddings as input.

### Testing
- test_generate.py test for `stream_generate` with input embeddings
- test_generate.py test for `stream_generate` with input embeddings, with `prefill_step_size` < number of embeddings
```
matt@Matts-MacBook-Pro [10:35:14] [~/Workspace/forks/mlx-lm] [input-embeddings-gemma3]
-> % python -m unittest tests/test_generate.py   
Fetching 9 files: 100%|█████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 9/9 [00:00<00:00, 134337.14it/s]
Fetching 9 files: 100%|██████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 9/9 [00:00<00:00, 21423.80it/s]
.
----------------------------------------------------------------------
Ran 6 tests in 0.793s
```
- POC confirmation of the ability to compute Gemma3 image embeddings outside of `stream_generate`, then send them in with correct understanding of the image by the text model.