### PR TITLE
fix upload to hub usage

### DIFF
--- a/mlx_lm/fuse.py
+++ b/mlx_lm/fuse.py
@@ -115,7 +115,7 @@ def main() -> None:
             raise ValueError(
                 "Must provide original Hugging Face repo to upload local model."
             )
-        upload_to_hub(args.save_path, args.upload_repo, hf_path)
+        upload_to_hub(args.save_path, args.upload_repo)
 
 
 if __name__ == "__main__":

--- a/mlx_lm/merge.py
+++ b/mlx_lm/merge.py
@@ -159,7 +159,7 @@ def merge(
     save_config(config, config_path=mlx_path / "config.json")
 
     if upload_repo is not None:
-        upload_to_hub(mlx_path, upload_repo, base_hf_path)
+        upload_to_hub(mlx_path, upload_repo)
 
 
 def main():


### PR DESCRIPTION
Refer the implementation, fix the incorrect usage in fuse and merge

```
def upload_to_hub(path: str, upload_repo: str):
    """
    Uploads the model to Hugging Face hub.

    Args:
        path (str): Local path to the model.
        upload_repo (str): Name of the HF repo to upload to.
    """
```