### PR TITLE
Fix URL for LoRA Data in Error Message

### DIFF
--- a/mlx_lm/tuner/datasets.py
+++ b/mlx_lm/tuner/datasets.py
@@ -180,7 +180,7 @@ def create_dataset(
     else:
         raise ValueError(
             "Unsupported data format, check the supported formats here:\n"
-            "https://github.com/ml-explore/mlx-examples/blob/main/llms/mlx_lm/LORA.md#data."
+            "https://github.com/ml-explore/mlx-lm/blob/main/mlx_lm/LORA.md#Data."
         )
 
 


### PR DESCRIPTION
Updating the error for incorrect LoRA training data to point to the correct page instead of 404.