### PR TITLE
DWQ updates

### DIFF
--- a/mlx_lm/dwq.py
+++ b/mlx_lm/dwq.py
@@ -80,7 +80,7 @@ def dwq_quantize(
         q_model.update(tree_map(lambda x: x.astype(dtype), params))
         logprobs, q_extra_targets = forward(q_model, x)
         losses = nn.losses.kl_div_loss(logprobs, targets, reduction="none")
-        mask = mx.arange(targets.shape[1]) < lengths[:, 1:]
+        mask = mx.arange(1, 1 + targets.shape[1]) < lengths[:, 1:]
         ntoks = mask.sum()
         kl_loss = (mask * losses).sum() / ntoks
         act_loss = mx.stack(
@@ -183,7 +183,7 @@ def main():
     parser.add_argument(
         "--num-samples",
         type=int,
-        default=1024,
+        default=2048,
         help="Number of samples to use for training.",
     )
     parser.add_argument("--max-seq-length", type=int, default=2049)

--- a/mlx_lm/dwq.py
+++ b/mlx_lm/dwq.py
@@ -156,7 +156,12 @@ def load_data(tokenizer, data_path: str, num_samples: int, max_seq_length: int):
     )
     dataset = load_dataset(args, tokenizer)[0]
     perm = np.random.permutation(len(dataset))[:num_samples].tolist()
-    return [dataset.process(dataset[i])[:max_seq_length] for i in perm]
+
+    def process(idx):
+        tokens, offset = dataset.process(dataset[idx])
+        return (tokens[:max_seq_length], offset)
+
+    return [process(i) for i in perm]
 
 
 def main():

--- a/mlx_lm/tuner/datasets.py
+++ b/mlx_lm/tuner/datasets.py
@@ -25,7 +25,7 @@ class TextDataset:
         d = self.tokenizer.encode(d[self.text_key])
         if d[-1] != self.tokenizer.eos_token_id:
             d.append(self.tokenizer.eos_token_id)
-        return d
+        return (d, 0)
 
     def __getitem__(self, idx: int):
         return self._data[idx]
@@ -61,7 +61,7 @@ class ChatDataset:
             offset = len(self.tokenizer.apply_chat_template(messages, tools=tools))
             return (tokens, offset)
         else:
-            return tokens
+            return (tokens, 0)
 
     def __getitem__(self, idx: int):
         return self._data[idx]
@@ -106,7 +106,7 @@ class CompletionsDataset:
             )
             return (tokens, offset)
 
-        return tokens
+        return (tokens, 0)
 
     def __getitem__(self, idx: int):
         return self._data[idx]

--- a/mlx_lm/tuner/trainer.py
+++ b/mlx_lm/tuner/trainer.py
@@ -92,7 +92,7 @@ def iterate_batches(
     if isinstance(dataset, CacheDataset):
         len_fn = lambda idx: dataset.itemlen(idx)
     else:
-        len_fn = lambda idx: dataset[idx][1]
+        len_fn = lambda idx: len(dataset[idx][0])
     idx = sorted(range(len(dataset)), key=len_fn)
     if len(dataset) < batch_size:
         raise ValueError(


### PR DESCRIPTION
- Fix sorting for regular datasets
- Better logging for DWQ training
- Tune parameters to improve performance (TODO share some results)

Perplexity for Qwen3 0.6B Base

Model | Perplexity
----- | ------
Base model | 9.97
Q4 32 | 11.92 |
Q4 64 | 12.58 |
Q4 32 DWQ original | 11.37
Q4 64 DWQ original | 11.91
Q4 32 DWQ new | 10.87
Q4 64 DWQ new | 11.24

The new DWQ also includes training on more samples. I didn't put all the changes here.. but most of the updates led to incremental improvements.

As you can see the perplexity is still not matched to the base model. Training longer helps but it's diminishing returns. The benchmark here is particularly diverse and high ppl.. on other benchmarks the gap from DWQ to the full precision model can be quite a bit smaller.
