### PR TITLE
Fix chat templates

### DIFF
--- a/mlx_lm/server.py
+++ b/mlx_lm/server.py
@@ -653,7 +653,7 @@ class APIHandler(BaseHTTPRequestHandler):
         ):
             segment = gen_response.text
             text += segment
-            logging.debug(text)
+            logging.debug(segment)
             token = gen_response.token
             logprobs = gen_response.logprobs
             tokens.append(token)

--- a/mlx_lm/utils.py
+++ b/mlx_lm/utils.py
@@ -112,6 +112,7 @@ def get_model_path(path_or_hf_repo: str, revision: Optional[str] = None) -> Path
                     "tiktoken.model",
                     "*.txt",
                     "*.jsonl",
+                    "*.jinja",
                 ],
             )
         )


### PR DESCRIPTION
HF is changing how they store chat templates into a `chat_template.jinja`. So for newer models we need this otherwise the chat template is missed.

Also piggy-backed a minor nit to server logging to make it more readable