### PR TITLE
Remove sentencepiece dependencies

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 mlx>=0.25.0
 numpy
-transformers[sentencepiece]>=4.39.3
+transformers>=4.39.3
 protobuf
 pyyaml
 jinja2


### PR DESCRIPTION
Temporary fix while waiting for the new version release of sentencepiece that supports Python 3.13 on macOS environment.