### PR TITLE
Fix `IndexError` in `NaiveStreamingDetokenizer`

### DIFF
--- a/mlx_lm/tokenizer_utils.py
+++ b/mlx_lm/tokenizer_utils.py
@@ -91,6 +91,7 @@ class NaiveStreamingDetokenizer(StreamingDetokenizer):
             self._current_text = self._tokenizer.decode(self._current_tokens)
             if (
                 self._tokenizer.clean_up_tokenization_spaces
+                and len(self._current_text) > 0
                 and self._current_text[-1] == " "
             ):
                 self._current_text = self._current_text[:-1]


### PR DESCRIPTION
## Description
Fixed an IndexError that occurs in the `NaiveStreamingDetokenizer` class's `text` property when trying to access the last character of an empty string. Added a length check before accessing `self._current_text[-1]`.

## Problem
When the tokenizer tries to clean up tokenization spaces, it attempts to check if the current text ends with a space without first verifying that there is any text to check. This causes an IndexError when `self._current_text` is empty.

## Solution
Added a length check `len(self._current_text) > 0` before attempting to access the last character.