### PR TITLE
Pipe input_embeddings through mistral3 model_type

### DIFF
--- a/mlx_lm/models/mistral3.py
+++ b/mlx_lm/models/mistral3.py
@@ -32,8 +32,11 @@ class Model(nn.Module):
         inputs: mx.array,
         cache=None,
         mask: Optional[mx.array] = None,
+        input_embeddings: Optional[mx.array] = None,
     ):
-        return self.language_model(inputs, cache=cache, mask=mask)
+        return self.language_model(
+            inputs, cache=cache, mask=mask, input_embeddings=input_embeddings
+        )
 
     def sanitize(self, weights):
         weights = tree_unflatten(list(weights.items()))


### PR DESCRIPTION
This PR extends @mattjcly's PR #181 to optionally pipe `input_embeddings` through the `mistral3` model to the underlying `llama` model. This enables sending image embeddings to mistral3 as discussed in our [blog post](https://lmstudio.ai/blog/unified-mlx-engine).