### PR TITLE
Allow prompt and input_embeddings

### DIFF
--- a/mlx_lm/generate.py
+++ b/mlx_lm/generate.py
@@ -363,7 +363,7 @@ def generate_step(
 
     sampler = sampler or (lambda x: mx.argmax(x, axis=-1))
 
-    def _model_call(input_tokens: mx.array, input_embeddings: mx.array | None):
+    def _model_call(input_tokens: mx.array, input_embeddings: Optional[mx.array]):
         if input_embeddings is not None:
             return model(
                 input_tokens, cache=prompt_cache, input_embeddings=input_embeddings

--- a/mlx_lm/generate.py
+++ b/mlx_lm/generate.py
@@ -406,7 +406,7 @@ def generate_step(
         prompt_processed_tokens = 0
         while total_prompt_tokens - prompt_processed_tokens > prefill_step_size:
             _model_call(
-                input_tokens=(prompt[:prefill_step_size][None]),
+                input_tokens=prompt[:prefill_step_size][None],
                 input_embeddings=(
                     input_embeddings[:prefill_step_size][None]
                     if input_embeddings is not None

--- a/mlx_lm/generate.py
+++ b/mlx_lm/generate.py
@@ -330,7 +330,7 @@ def generate_step(
         prompt_progress_callback (Callable[int, int]): A call-back which takes the
            prompt tokens processed so far and the total number of prompt tokens.
         input_embeddings (mx.array, optional): Input embeddings to use in place of
-           prompt tokens. Default: ``None``.
+           or in conjunction with prompt tokens. Default: ``None``.
 
     Yields:
         Tuple[mx.array, mx.array]: One token and a vector of log probabilities.
@@ -338,9 +338,9 @@ def generate_step(
     if input_embeddings is not None:
         if not does_model_support_input_embeddings(model):
             raise ValueError("Model does not support input embeddings.")
-        if len(prompt) != 0:
+        elif len(prompt) != 0 and prompt.shape[0] != input_embeddings.shape[0]:
             raise ValueError(
-                "If using input embeddings, prompt tokens must be an empty array."
+                "If using input embeddings, the sequence length must match that of the prompt."
             )
 
     tokens = None
@@ -363,47 +363,71 @@ def generate_step(
 
     sampler = sampler or (lambda x: mx.argmax(x, axis=-1))
 
-    def _model_call(y):
-        if y.ndim == 3:
-            return model(None, cache=prompt_cache, input_embeddings=y)
+    def _model_call(input_tokens: mx.array, input_embeddings: mx.array | None):
+        if input_embeddings is not None:
+            return model(
+                input_tokens, cache=prompt_cache, input_embeddings=input_embeddings
+            )
         else:
-            return model(y, cache=prompt_cache)
+            return model(input_tokens, cache=prompt_cache)
 
-    def _step(y):
+    def _step(input_tokens: mx.array, input_embeddings: Optional[mx.array] = None):
         nonlocal tokens
 
         with mx.stream(generation_stream):
-            logits = _model_call(y[None])
+            logits = _model_call(
+                input_tokens=input_tokens[None],
+                input_embeddings=(
+                    input_embeddings[None] if input_embeddings is not None else None
+                ),
+            )
 
             logits = logits[:, -1, :]
 
-            if logits_processors and input_embeddings is None:
-                tokens = mx.concat([tokens, y]) if tokens is not None else y
+            if logits_processors and len(input_tokens) > 0:
+                tokens = (
+                    mx.concat([tokens, input_tokens])
+                    if tokens is not None
+                    else input_tokens
+                )
                 for processor in logits_processors:
                     logits = processor(tokens, logits)
 
             quantize_cache_fn(prompt_cache)
 
             logprobs = logits - mx.logsumexp(logits, keepdims=True)
-            y = sampler(logprobs)
-            return y, logprobs.squeeze(0)
+            sampled = sampler(logprobs)
+            return sampled, logprobs.squeeze(0)
 
-    using_embeddings = input_embeddings is not None
-
-    y = input_embeddings if using_embeddings else prompt
     with mx.stream(generation_stream):
-        total_prompt_tokens = y.shape[0]
+        total_prompt_tokens = (
+            prompt.shape[0] if len(prompt) > 0 else input_embeddings.shape[0]
+        )
         prompt_processed_tokens = 0
-        while y.shape[0] > prefill_step_size:
-            _model_call(y[:prefill_step_size][None])
+        while total_prompt_tokens - prompt_processed_tokens > prefill_step_size:
+            _model_call(
+                input_tokens=(
+                    prompt[:prefill_step_size][None] if len(prompt) > 0 else prompt
+                ),
+                input_embeddings=(
+                    input_embeddings[:prefill_step_size][None]
+                    if input_embeddings is not None
+                    else None
+                ),
+            )
             quantize_cache_fn(prompt_cache)
             mx.eval([c.state for c in prompt_cache])
             prompt_progress_callback(prompt_processed_tokens, total_prompt_tokens)
             prompt_processed_tokens += prefill_step_size
-            y = y[prefill_step_size:]
+            prompt = prompt[prefill_step_size:]
+            input_embeddings = (
+                input_embeddings[prefill_step_size:]
+                if input_embeddings is not None
+                else input_embeddings
+            )
             mx.clear_cache()
 
-        y, logprobs = _step(y)
+        y, logprobs = _step(input_tokens=prompt, input_embeddings=input_embeddings)
 
     mx.async_eval(y, logprobs)
     n = 0

--- a/tests/test_generate.py
+++ b/tests/test_generate.py
@@ -104,7 +104,7 @@ class TestGenerate(unittest.TestCase):
         for generation_result in stream_generate(
             model=self.model,
             tokenizer=self.tokenizer,
-            prompt=[],  # no prompt tokens passed
+            prompt=prompt,
             max_tokens=5,
             sampler=sampler,
             input_embeddings=prompt_embeddings,
@@ -136,7 +136,7 @@ class TestGenerate(unittest.TestCase):
         for generation_result in stream_generate(
             model=self.model,
             tokenizer=self.tokenizer,
-            prompt=[],  # no prompt tokens passed
+            prompt=prompt,
             max_tokens=5,
             sampler=sampler,
             input_embeddings=prompt_embeddings,


### PR DESCRIPTION
The [mlx-engine](https://github.com/lmstudio-ai/mlx-engine) [unified architecture](https://lmstudio.ai/blog/unified-mlx-engine) uses mlx-vlm to compute token and image embeddings, then passes those to mlx-lm for generation. Currently, "unified" models only pass those embeddings and not the input token IDs.

The Gemma3n implementation requires token IDs even when passing input embeddings directly, as they are needed to compute the Per Layer Embeddings.

This PR modifies the `generate_step` function to allow for just `prompt`, just `input_embeddings`, or both as input. These are then piped through to the underlying model calls. None of this is specific to Gemma3n, so it can be re-used by other models that require the same inputs.