### PR TITLE
Feat: add falcon-e support for bitnet models

### DIFF
--- a/mlx_lm/models/bitlinear_layers.py
+++ b/mlx_lm/models/bitlinear_layers.py
@@ -9,8 +9,7 @@ from mlx.nn.layers.quantized import QuantizedLinear
 def bitnet_quantize(model, modules_to_not_convert=None, invert_weight_scales: bool = False):
     quantize_layers = []
     for name, module in model.named_modules():     
-        if modules_to_not_convert is None:
-            modules_to_not_convert = []
+        modules_to_not_convert = modules_to_not_convert or []
 
         # Replace nn.Linear layers, but skip 'lm_head'
         if name not in modules_to_not_convert and isinstance(module, nn.Linear):

--- a/mlx_lm/models/bitlinear_layers.py
+++ b/mlx_lm/models/bitlinear_layers.py
@@ -2,30 +2,35 @@
 
 import mlx.core as mx
 import mlx.nn as nn
-from mlx.utils import tree_unflatten
 from mlx.nn.layers.quantized import QuantizedLinear
+from mlx.utils import tree_flatten, tree_unflatten
 
 
 def bitnet_quantize(model, quantization_config: dict):
     quantize_layers = []
-    modules_to_not_convert = quantization_config.get("modules_to_not_convert") or []
-    invert_weight_scales = quantization_config.get("linear_class", "") != "autobitlinear"
+    modules_to_not_convert = quantization_config.get("modules_to_not_convert", [])
+    invert_weight_scales = (
+        quantization_config.get("linear_class", "") != "autobitlinear"
+    )
 
-    for name, module in model.named_modules():     
+    for name, module in tree_flatten(model.leaf_modules(), is_leaf=nn.Module.is_module):
 
         # Replace nn.Linear layers, but skip any layer from the `modules_to_not_convert` list
         if name not in modules_to_not_convert and isinstance(module, nn.Linear):
             old_weight = module.weight
             out_features, in_features = old_weight.shape
             bias = "bias" in module
-            # Create a new instance of the custom linear layer
-            new_layer = BitLinear(in_features, out_features, bias=bias, invert_weight_scales=invert_weight_scales)
-
-            # Replace the layer in the model
+            new_layer = BitLinear(
+                in_features,
+                out_features,
+                bias=bias,
+                invert_weight_scales=invert_weight_scales,
+            )
             quantize_layers.append((name, new_layer))
     if len(quantize_layers) > 0:
         model.update_modules(tree_unflatten(quantize_layers))
     return model
+
 
 def make_bitlinear_kernel():
     """

--- a/mlx_lm/models/bitlinear_layers.py
+++ b/mlx_lm/models/bitlinear_layers.py
@@ -6,12 +6,14 @@ from mlx.utils import tree_unflatten
 from mlx.nn.layers.quantized import QuantizedLinear
 
 
-def bitnet_quantize(model, modules_to_not_convert=None, invert_weight_scales: bool = False):
+def bitnet_quantize(model, quantization_config: dict):
     quantize_layers = []
-    for name, module in model.named_modules():     
-        modules_to_not_convert = modules_to_not_convert or []
+    modules_to_not_convert = quantization_config.get("modules_to_not_convert") or []
+    invert_weight_scales = quantization_config.get("linear_class", "") != "autobitlinear"
 
-        # Replace nn.Linear layers, but skip 'lm_head'
+    for name, module in model.named_modules():     
+
+        # Replace nn.Linear layers, but skip any layer from the `modules_to_not_convert` list
         if name not in modules_to_not_convert and isinstance(module, nn.Linear):
             old_weight = module.weight
             out_features, in_features = old_weight.shape

--- a/mlx_lm/models/bitnet.py
+++ b/mlx_lm/models/bitnet.py
@@ -112,7 +112,7 @@ class MLP(nn.Module):
         self.gate_proj = BitLinear(dim, hidden_dim, bias=mlp_bias)
         self.down_proj = BitLinear(hidden_dim, dim, bias=mlp_bias)
         self.up_proj = BitLinear(dim, hidden_dim, bias=mlp_bias)
-        
+
         self.ffn_sub_norm = nn.RMSNorm(args.intermediate_size, eps=args.rms_norm_eps)
 
     def __call__(self, x) -> mx.array:

--- a/mlx_lm/models/bitnet.py
+++ b/mlx_lm/models/bitnet.py
@@ -40,6 +40,8 @@ class Attention(nn.Module):
         dim = args.hidden_size
         self.n_heads = n_heads = args.num_attention_heads
         self.n_kv_heads = n_kv_heads = args.num_key_value_heads
+        # `autobitliner` is the new bitnet class from HF transformers that do not invert the weight scales
+        # and adds an extra norm layer after attention
         self.use_bitnet_norm = args.quantization_config.get("linear_class", "") == "autobitlinear"
 
         self.head_dim = head_dim = args.head_dim or args.hidden_size // n_heads
@@ -108,6 +110,8 @@ class MLP(nn.Module):
 
         dim = args.hidden_size
         hidden_dim = args.intermediate_size
+        # `autobitliner` is the new bitnet class from HF transformers that do not invert the weight scales
+        # and adds an extra norm layer after attention
         self.use_bitnet_norm = args.quantization_config.get("linear_class", "") == "autobitlinear"
         if hasattr(args, "mlp_bias"):
             mlp_bias = args.mlp_bias

--- a/mlx_lm/models/bitnet.py
+++ b/mlx_lm/models/bitnet.py
@@ -30,7 +30,6 @@ class ModelArgs(BaseModelArgs):
     rope_traditional: bool = False
     rope_scaling: Optional[Dict[str, Union[float, str]]] = None
     tie_word_embeddings: bool = True
-    quantization_config: dict = None
 
 
 class Attention(nn.Module):
@@ -40,19 +39,16 @@ class Attention(nn.Module):
         dim = args.hidden_size
         self.n_heads = n_heads = args.num_attention_heads
         self.n_kv_heads = n_kv_heads = args.num_key_value_heads
-        # `autobitliner` is the new bitnet class from HF transformers that do not invert the weight scales
-        # and adds an extra norm layer after attention
-        self.use_bitnet_norm = args.quantization_config.get("linear_class", "") == "autobitlinear"
 
         self.head_dim = head_dim = args.head_dim or args.hidden_size // n_heads
 
         self.scale = head_dim**-0.5
         attention_bias = args.attention_bias
 
-        self.q_proj = BitLinear(dim, n_heads * head_dim, bias=attention_bias, invert_weight_scales=not self.use_bitnet_norm)
-        self.k_proj = BitLinear(dim, n_kv_heads * head_dim, bias=attention_bias, invert_weight_scales=not self.use_bitnet_norm)
-        self.v_proj = BitLinear(dim, n_kv_heads * head_dim, bias=attention_bias, invert_weight_scales=not self.use_bitnet_norm)
-        self.o_proj = BitLinear(n_heads * head_dim, dim, bias=attention_bias, invert_weight_scales=not self.use_bitnet_norm)
+        self.q_proj = BitLinear(dim, n_heads * head_dim, bias=attention_bias)
+        self.k_proj = BitLinear(dim, n_kv_heads * head_dim, bias=attention_bias)
+        self.v_proj = BitLinear(dim, n_kv_heads * head_dim, bias=attention_bias)
+        self.o_proj = BitLinear(n_heads * head_dim, dim, bias=attention_bias)
 
         self.rope = initialize_rope(
             self.head_dim,
@@ -61,8 +57,7 @@ class Attention(nn.Module):
             args.rope_scaling,
             args.max_position_embeddings,
         )
-        if self.use_bitnet_norm:
-            self.attn_sub_norm = nn.RMSNorm(args.hidden_size, eps=args.rms_norm_eps)
+        self.attn_sub_norm = nn.RMSNorm(args.hidden_size, eps=args.rms_norm_eps)
 
     def __call__(
         self,
@@ -92,8 +87,7 @@ class Attention(nn.Module):
         )
 
         output = output.transpose(0, 2, 1, 3).reshape(B, L, -1)
-        if self.use_bitnet_norm:
-            output = self.attn_sub_norm(output)
+        output = self.attn_sub_norm(output)
         output = self.o_proj(output)
 
         return output
@@ -110,26 +104,20 @@ class MLP(nn.Module):
 
         dim = args.hidden_size
         hidden_dim = args.intermediate_size
-        # `autobitliner` is the new bitnet class from HF transformers that do not invert the weight scales
-        # and adds an extra norm layer after attention
-        self.use_bitnet_norm = args.quantization_config.get("linear_class", "") == "autobitlinear"
         if hasattr(args, "mlp_bias"):
             mlp_bias = args.mlp_bias
         else:
             mlp_bias = False
 
-        self.gate_proj = BitLinear(dim, hidden_dim, bias=mlp_bias, invert_weight_scales=not self.use_bitnet_norm)
-        self.down_proj = BitLinear(hidden_dim, dim, bias=mlp_bias, invert_weight_scales=not self.use_bitnet_norm)
-        self.up_proj = BitLinear(dim, hidden_dim, bias=mlp_bias, invert_weight_scales=not self.use_bitnet_norm)
-        if self.use_bitnet_norm:
-            self.ffn_sub_norm = nn.RMSNorm(args.intermediate_size, eps=args.rms_norm_eps)
+        self.gate_proj = BitLinear(dim, hidden_dim, bias=mlp_bias)
+        self.down_proj = BitLinear(hidden_dim, dim, bias=mlp_bias)
+        self.up_proj = BitLinear(dim, hidden_dim, bias=mlp_bias)
+        
+        self.ffn_sub_norm = nn.RMSNorm(args.intermediate_size, eps=args.rms_norm_eps)
 
     def __call__(self, x) -> mx.array:
-        if self.use_bitnet_norm:
-            x = relu2(self.gate_proj(x)) * self.up_proj(x)
-            x = self.ffn_sub_norm(x)
-        else:
-            x = nn.silu(self.gate_proj(x)) * self.up_proj(x)
+        x = relu2(self.gate_proj(x)) * self.up_proj(x)
+        x = self.ffn_sub_norm(x)
         x = self.down_proj(x)
         return x
 

--- a/mlx_lm/models/bitnet.py
+++ b/mlx_lm/models/bitnet.py
@@ -30,6 +30,7 @@ class ModelArgs(BaseModelArgs):
     rope_traditional: bool = False
     rope_scaling: Optional[Dict[str, Union[float, str]]] = None
     tie_word_embeddings: bool = True
+    quantization_config: dict = None
 
 
 class Attention(nn.Module):
@@ -39,16 +40,17 @@ class Attention(nn.Module):
         dim = args.hidden_size
         self.n_heads = n_heads = args.num_attention_heads
         self.n_kv_heads = n_kv_heads = args.num_key_value_heads
+        self.use_bitnet_norm = args.quantization_config.get("linear_class", "") == "autobitlinear"
 
         self.head_dim = head_dim = args.head_dim or args.hidden_size // n_heads
 
         self.scale = head_dim**-0.5
         attention_bias = args.attention_bias
 
-        self.q_proj = BitLinear(dim, n_heads * head_dim, bias=attention_bias)
-        self.k_proj = BitLinear(dim, n_kv_heads * head_dim, bias=attention_bias)
-        self.v_proj = BitLinear(dim, n_kv_heads * head_dim, bias=attention_bias)
-        self.o_proj = BitLinear(n_heads * head_dim, dim, bias=attention_bias)
+        self.q_proj = BitLinear(dim, n_heads * head_dim, bias=attention_bias, invert_weight_scales=not self.use_bitnet_norm)
+        self.k_proj = BitLinear(dim, n_kv_heads * head_dim, bias=attention_bias, invert_weight_scales=not self.use_bitnet_norm)
+        self.v_proj = BitLinear(dim, n_kv_heads * head_dim, bias=attention_bias, invert_weight_scales=not self.use_bitnet_norm)
+        self.o_proj = BitLinear(n_heads * head_dim, dim, bias=attention_bias, invert_weight_scales=not self.use_bitnet_norm)
 
         self.rope = initialize_rope(
             self.head_dim,
@@ -57,7 +59,8 @@ class Attention(nn.Module):
             args.rope_scaling,
             args.max_position_embeddings,
         )
-        self.attn_sub_norm = nn.RMSNorm(args.hidden_size, eps=args.rms_norm_eps)
+        if self.use_bitnet_norm:
+            self.attn_sub_norm = nn.RMSNorm(args.hidden_size, eps=args.rms_norm_eps)
 
     def __call__(
         self,
@@ -87,7 +90,8 @@ class Attention(nn.Module):
         )
 
         output = output.transpose(0, 2, 1, 3).reshape(B, L, -1)
-        output = self.attn_sub_norm(output)
+        if self.use_bitnet_norm:
+            output = self.attn_sub_norm(output)
         output = self.o_proj(output)
 
         return output
@@ -104,19 +108,24 @@ class MLP(nn.Module):
 
         dim = args.hidden_size
         hidden_dim = args.intermediate_size
+        self.use_bitnet_norm = args.quantization_config.get("linear_class", "") == "autobitlinear"
         if hasattr(args, "mlp_bias"):
             mlp_bias = args.mlp_bias
         else:
             mlp_bias = False
 
-        self.gate_proj = BitLinear(dim, hidden_dim, bias=mlp_bias)
-        self.down_proj = BitLinear(hidden_dim, dim, bias=mlp_bias)
-        self.up_proj = BitLinear(dim, hidden_dim, bias=mlp_bias)
-        self.ffn_sub_norm = nn.RMSNorm(args.intermediate_size, eps=args.rms_norm_eps)
+        self.gate_proj = BitLinear(dim, hidden_dim, bias=mlp_bias, invert_weight_scales=not self.use_bitnet_norm)
+        self.down_proj = BitLinear(hidden_dim, dim, bias=mlp_bias, invert_weight_scales=not self.use_bitnet_norm)
+        self.up_proj = BitLinear(dim, hidden_dim, bias=mlp_bias, invert_weight_scales=not self.use_bitnet_norm)
+        if self.use_bitnet_norm:
+            self.ffn_sub_norm = nn.RMSNorm(args.intermediate_size, eps=args.rms_norm_eps)
 
     def __call__(self, x) -> mx.array:
-        x = relu2(self.gate_proj(x)) * self.up_proj(x)
-        x = self.ffn_sub_norm(x)
+        if self.use_bitnet_norm:
+            x = relu2(self.gate_proj(x)) * self.up_proj(x)
+            x = self.ffn_sub_norm(x)
+        else:
+            x = nn.silu(self.gate_proj(x)) * self.up_proj(x)
         x = self.down_proj(x)
         return x
 

--- a/mlx_lm/utils.py
+++ b/mlx_lm/utils.py
@@ -207,14 +207,10 @@ def load_model(
     elif (quantization_config := config.get("quantization_config", None)) is not None:
         # Handle legacy quantization config
         quantization_method = quantization_config.get("quant_method")
-        if quantization_method == "bitnet" and config.get("model_type") != "bitnet":
+        if quantization_method == "bitnet":
             from .models.bitlinear_layers import bitnet_quantize
 
-            model = bitnet_quantize(
-                model, 
-                quantization_config.get("modules_to_not_convert", None),
-                invert_weight_scales= quantization_config.get("linear_class", "") != "autobitlinear"
-            )
+            model = bitnet_quantize(model, quantization_config)
 
     model.load_weights(list(weights.items()), strict=strict)
 

--- a/mlx_lm/utils.py
+++ b/mlx_lm/utils.py
@@ -164,7 +164,6 @@ def load_model(
     config = load_config(model_path)
     config.update(model_config)
 
-
     weight_files = glob.glob(str(model_path / "model*.safetensors"))
 
     if not weight_files:
@@ -204,13 +203,15 @@ def load_model(
             bits=quantization["bits"],
             class_predicate=class_predicate,
         )
-    elif (quantization_config := config.get("quantization_config", None)) is not None:
+    elif quantization_config := config.get("quantization_config", False):
         # Handle legacy quantization config
-        quantization_method = quantization_config.get("quant_method")
-        if quantization_method == "bitnet":
+        quant_method = quantization_config["quant_method"]
+        if quant_method == "bitnet":
             from .models.bitlinear_layers import bitnet_quantize
 
             model = bitnet_quantize(model, quantization_config)
+        else:
+            raise ValueError(f"Unsupported quantization method {quant_method}")
 
     model.load_weights(list(weights.items()), strict=strict)
 


### PR DESCRIPTION
Follow up PR to: #219 - this is an alternative approach to support llama-compatible bitnet models such as Falcon-E or Falcon3-1.58bit series. 
The trick is to check inside the config if the attribute `quantization_config` exists, and check if the bitnet class used is the old (without norm and with invert scales), or the new one (with norm and without invert weight scales)

Confirmed that both Falcon-E and Microsoft bitnet works with this PR

<img width="1699" alt="Screenshot 2025-07-03 at 8 28 42 AM" src="https://github.com/user-attachments/assets/f8248ca4-6964-451f-9597-eea324bed4a2" />

<img width="1699" alt="Screenshot 2025-07-03 at 8 29 04 AM" src="https://github.com/user-attachments/assets/552718d5-ccfd-465b-9674-13907e2c36ed" />

@awni @Blaizzy @angeloskath 