### PR TITLE
Parse JSON arguments when OpenAI tool calling

### DIFF
--- a/mlx_lm/examples/openai_tool_use.py
+++ b/mlx_lm/examples/openai_tool_use.py
@@ -52,7 +52,7 @@ response = client.chat.completions.create(
 
 # Call the function
 function = response.choices[0].message.tool_calls[0].function
-tool_result = functions[function.name](**function.arguments)
+tool_result = functions[function.name](**json.loads(function.arguments))
 
 # Put the result of the function in the messages and generate the final
 # response:


### PR DESCRIPTION
The tool call Function argument is a string instead of dict. So it must be parsed as a JSON before being used with the function.