### PR TITLE
Allow generation without README

### DIFF
--- a/mlx_lm/utils.py
+++ b/mlx_lm/utils.py
@@ -116,8 +116,12 @@ def get_model_path(path_or_hf_repo: str, revision: Optional[str] = None) -> Path
 
         from huggingface_hub import ModelCard
 
-        card = ModelCard.load(model_path / "README.md")
-        hf_path = card.data.base_model
+        card_path = model_path / "README.md"
+        if card_path.is_file():
+            card = ModelCard.load(card_path)
+            hf_path = card.data.base_model
+        else:
+            hf_path = None
     return model_path, hf_path
 
 


### PR DESCRIPTION
A recent commit ([e8c2cfce](https://github.com/ml-explore/mlx-lm/commit/e8c2cfce6a3c039136c14fdfe9a5a279a811db56)) introduced a new requirement that a `README.md` must be present to load a model. This PR modifies `get_model_path` to return `None` for hf_path if the model card is not present in the local model path.