### PR TITLE
KL loss and memory improvements for DWQ and dynamic quant

### DIFF
--- a/mlx_lm/models/switch_layers.py
+++ b/mlx_lm/models/switch_layers.py
@@ -53,12 +53,6 @@ class QuantizedSwitchLinear(nn.Module):
         # Freeze this model's parameters
         self.freeze()
 
-    def unfreeze(self, *args, **kwargs):
-        """Wrap unfreeze so that we unfreeze any layers we might contain but
-        our parameters will remain frozen."""
-        super().unfreeze(*args, **kwargs)
-        self.freeze(recurse=False)
-
     @property
     def input_dims(self):
         return self.scales.shape[2] * self.group_size

--- a/mlx_lm/quant/dynamic_quant.py
+++ b/mlx_lm/quant/dynamic_quant.py
@@ -11,6 +11,8 @@ import numpy as np
 from mlx.utils import tree_flatten, tree_map, tree_unflatten
 from tqdm import tqdm
 
+from mlx_lm.tuner.losses import kl_div_loss
+from mlx_lm.tuner.trainer import grad_checkpoint
 from mlx_lm.quant.utils import load_data
 from mlx_lm.utils import (
     compute_bits_per_weight,
@@ -42,17 +44,17 @@ def estimate_sensitivities(
     low_group_size,
     high_bits,
     high_group_size,
+    batch_size: int = 4,
+    gradient_accum_dtype: mx.Dtype = mx.float32,
+    gradient_checkpoint: bool = False,
 ):
-    batch_size = 4
-    layers = tree_flatten(model.leaf_modules(), is_leaf=nn.Module.is_module)
-    layers = {k: l for k, l in layers if hasattr(l, "to_quantized")}
-
-    q_model = copy.deepcopy(model)
-
     def qdq(w, bits, group_size):
         w, s, b = mx.quantize(w, bits=bits, group_size=group_size)
         return mx.dequantize(w, scales=s, biases=b, bits=bits, group_size=group_size)
 
+    layers = tree_flatten(model.leaf_modules(), is_leaf=nn.Module.is_module)
+    layers = {k: l for k, l in layers if hasattr(l, "to_quantized")}
+    q_model = copy.deepcopy(model)
     q_layers = copy.deepcopy(layers)
     for l in q_layers.values():
         l.weight = qdq(l.weight, low_bits, low_group_size)
@@ -62,25 +64,27 @@ def estimate_sensitivities(
     q_model.freeze()
     q_model.update_modules(tree_unflatten(list(q_layers.items())))
 
-    def log_norm(x):
-        x = x.astype(mx.float32)
-        return x - mx.logsumexp(x, axis=-1, keepdims=True)
-
     def loss_fn(batch, targets):
-        logprobs = log_norm(q_model(batch))
-        return nn.losses.kl_div_loss(logprobs, targets, reduction="mean")
+        return kl_div_loss(q_model(batch), targets).mean()
 
-    grad_accum = tree_map(lambda x: mx.zeros(x.shape), q_model.trainable_parameters())
+    if gradient_checkpoint:
+        grad_checkpoint(q_model.layers[0])
+
+    grad_accum = tree_map(
+        lambda x: mx.zeros(x.shape, dtype=gradient_accum_dtype),
+        q_model.trainable_parameters()
+    )
     for e, s in tqdm(
         enumerate(range(0, len(data), batch_size)),
         total=len(data) // batch_size,
         desc="Estimating sensitivities",
     ):
         batch = data[s : s + batch_size]
-        targets = log_norm(model(batch))
+        targets = model(batch)
         mx.eval(targets)
         _, grads = nn.value_and_grad(q_model, loss_fn)(batch, targets)
         grad_accum = tree_map(lambda x, y: x + y, grad_accum, grads)
+        del grads
         mx.eval(grad_accum)
 
     def compute_sensitivity(gradient, low_q_weight, original_weight):
@@ -169,7 +173,17 @@ def main():
         action="store_true",
         help="Compute the perplexity of the base and quantized models.",
     )
-
+    parser.add_argument(
+        "--grad-checkpoint",
+        action="store_true",
+        help="Use gradient checkpointing to reduce memory use.",
+    )
+    parser.add_argument(
+        "--accumulation-dtype",
+        default="float32",
+        choices=["float32", "bfloat16"],
+        help="What type to use to accumulate the gradients for the sensitivities"
+    )
     args = parser.parse_args()
 
     group = mx.distributed.init()
@@ -186,6 +200,8 @@ def main():
             args.low_group_size,
             args.high_bits,
             args.high_group_size,
+            gradient_accum_dtype=getattr(mx, args.accumulation_dtype),
+            gradient_checkpoint=args.grad_checkpoint,
         )
         model_name = args.model.replace("/", "_")
         with open(f"{model_name}_sensitivities.json", "w") as fid:
@@ -241,6 +257,7 @@ def main():
         config,
         hf_repo=hf_repo,
     )
+    print(f"Peak memory used: {mx.get_peak_memory() / 1000**3:.3f}GB")
 
 
 if __name__ == "__main__":

--- a/mlx_lm/quant/dynamic_quant.py
+++ b/mlx_lm/quant/dynamic_quant.py
@@ -11,9 +11,9 @@ import numpy as np
 from mlx.utils import tree_flatten, tree_map, tree_unflatten
 from tqdm import tqdm
 
+from mlx_lm.quant.utils import load_data
 from mlx_lm.tuner.losses import kl_div_loss
 from mlx_lm.tuner.trainer import grad_checkpoint
-from mlx_lm.quant.utils import load_data
 from mlx_lm.utils import (
     compute_bits_per_weight,
     fetch_from_hub,
@@ -72,7 +72,7 @@ def estimate_sensitivities(
 
     grad_accum = tree_map(
         lambda x: mx.zeros(x.shape, dtype=gradient_accum_dtype),
-        q_model.trainable_parameters()
+        q_model.trainable_parameters(),
     )
     for e, s in tqdm(
         enumerate(range(0, len(data), batch_size)),
@@ -182,7 +182,7 @@ def main():
         "--accumulation-dtype",
         default="float32",
         choices=["float32", "bfloat16"],
-        help="What type to use to accumulate the gradients for the sensitivities"
+        help="What type to use to accumulate the gradients for the sensitivities",
     )
     args = parser.parse_args()
 

--- a/mlx_lm/tuner/losses.py
+++ b/mlx_lm/tuner/losses.py
@@ -1,0 +1,378 @@
+# Copyright © 2025 Apple Inc.
+
+import mlx.core as mx
+import mlx.nn as nn
+
+
+def _make_kl_forward_kernel():
+    source = """
+    constexpr int M = 4;
+    constexpr int block = 1024 * M;
+    constexpr int full_blocks = V / block;
+    constexpr int extra = V - full_blocks * block;
+
+    threadgroup float shared[32 * 2];
+
+    uint out_idx = threadgroup_position_in_grid.y;
+    uint simd_lane_id = thread_index_in_simdgroup;
+    uint simd_group_id = simdgroup_index_in_threadgroup;
+
+    logits_q += out_idx * V;
+    logits_p += out_idx * V;
+    out += out_idx;
+
+    float lse_q_minus_p;
+    float lse_p;
+
+    {
+        float max_q = -1e30;
+        float max_p = -1e30;
+        float sum_exp_q = 0;
+        float sum_exp_p = 0;
+
+        int offset = thread_index_in_threadgroup * M;
+        for (int i = 0; i < full_blocks; i++) {
+            // Read and update q and p
+            float vals_q[M];
+            float vals_p[M];
+            for (int j=0; j<M; j++) {
+                vals_q[j] = logits_q[offset + j];
+                vals_p[j] = logits_p[offset + j];
+            }
+            float prev_max_q = max_q;
+            float prev_max_p = max_p;
+            for (int j=0; j<M; j++) {
+                max_q = max(max_q, vals_q[j]);
+                max_p = max(max_p, vals_p[j]);
+            }
+            sum_exp_q *= metal::fast::exp(prev_max_q - max_q);
+            sum_exp_p *= metal::fast::exp(prev_max_p - max_p);
+            for (int j=0; j<M; j++) {
+                sum_exp_q += metal::fast::exp(vals_q[j] - max_q);
+                sum_exp_p += metal::fast::exp(vals_p[j] - max_p);
+            }
+
+            // Move to the next block
+            offset += block;
+        }
+        if (extra > 0) {
+            // Read and update q and p
+            float vals_q[M];
+            float vals_p[M];
+            for (int j=0; j < M; j++) {
+                vals_q[j] = (offset + j < V) ? logits_q[offset + j] : -1e30;
+                vals_p[j] = (offset + j < V) ? logits_p[offset + j] : -1e30;
+            }
+            float prev_max_q = max_q;
+            float prev_max_p = max_p;
+            for (int j=0; j<M; j++) {
+                max_q = max(max_q, vals_q[j]);
+                max_p = max(max_p, vals_p[j]);
+            }
+            sum_exp_q *= metal::fast::exp(prev_max_q - max_q);
+            sum_exp_p *= metal::fast::exp(prev_max_p - max_p);
+            for (int j=0; j<M; j++) {
+                sum_exp_q += metal::fast::exp(vals_q[j] - max_q);
+                sum_exp_p += metal::fast::exp(vals_p[j] - max_p);
+            }
+        }
+
+        // Share the maxs across the threadgroup
+        float prev_max_q = max_q;
+        float prev_max_p = max_p;
+        max_q = simd_max(max_q);
+        max_p = simd_max(max_p);
+        if (simd_lane_id == 0) {
+            shared[simd_group_id * 2 + 0] = max_q;
+            shared[simd_group_id * 2 + 1] = max_p;
+        }
+        threadgroup_barrier(mem_flags::mem_threadgroup);
+        max_q = shared[simd_lane_id * 2 + 0];
+        max_p = shared[simd_lane_id * 2 + 1];
+        max_q = simd_max(max_q);
+        max_p = simd_max(max_p);
+
+        // Share the sum_exp across the threadgroup
+        sum_exp_q *= metal::fast::exp(prev_max_q - max_q);
+        sum_exp_p *= metal::fast::exp(prev_max_p - max_p);
+        sum_exp_q = simd_sum(sum_exp_q);
+        sum_exp_p = simd_sum(sum_exp_p);
+        if (simd_lane_id == 0) {
+            shared[simd_group_id * 2 + 0] = sum_exp_q;
+            shared[simd_group_id * 2 + 1] = sum_exp_p;
+        }
+        threadgroup_barrier(mem_flags::mem_threadgroup);
+        sum_exp_q = shared[simd_lane_id * 2 + 0];
+        sum_exp_p = shared[simd_lane_id * 2 + 1];
+        sum_exp_q = simd_sum(sum_exp_q);
+        sum_exp_p = simd_sum(sum_exp_p);
+
+        lse_p = max_p + metal::fast::log(sum_exp_p);
+        lse_q_minus_p = max_q + metal::fast::log(sum_exp_q) - lse_p;
+    }
+
+    threadgroup_barrier(mem_flags::mem_none);
+
+    {
+        float kl = 0;
+
+        int offset = thread_index_in_threadgroup * M;
+        for (int i = 0; i < full_blocks; i++) {
+            // Read and add to the kl
+            float vals_q[M];
+            float vals_p[M];
+            for (int j=0; j<M; j++) {
+                vals_q[j] = logits_q[offset + j];
+                vals_p[j] = logits_p[offset + j];
+            }
+
+            for (int j=0; j<M; j++) {
+                kl += metal::fast::exp(vals_p[j] - lse_p) * (vals_p[j] - vals_q[j] + lse_q_minus_p);
+            }
+
+            // Move to the next block
+            offset += block;
+        }
+        if (extra > 0) {
+            float vals_q[M];
+            float vals_p[M];
+            for (int j=0; j<M; j++) {
+                vals_q[j] = (offset + j < V) ? logits_q[offset + j] : -1e30;
+                vals_p[j] = (offset + j < V) ? logits_p[offset + j] : -1e30;
+            }
+
+            for (int j=0; j<M; j++) {
+                kl += metal::fast::exp(vals_p[j] - lse_p) * (vals_p[j] - vals_q[j] + lse_q_minus_p);
+            }
+        }
+
+        // Add the kl across the threadgroup
+        kl = simd_sum(kl);
+        if (simd_lane_id == 0) {
+            shared[simd_group_id] = kl;
+        }
+        threadgroup_barrier(mem_flags::mem_none);
+        kl = shared[simd_lane_id];
+        kl = simd_sum(kl);
+
+        if (thread_index_in_threadgroup == 0) {
+            out[0] = static_cast<T>(kl);
+        }
+    }
+    """
+
+    return mx.fast.metal_kernel(
+        name="kl_forward",
+        input_names=["logits_q", "logits_p"],
+        output_names=["out"],
+        source=source,
+        ensure_row_contiguous=True,
+    )
+
+
+def _make_kl_backward_kernel():
+    source = """
+    constexpr int M = 4;
+    constexpr int block = 1024 * M;
+    constexpr int full_blocks = V / block;
+    constexpr int extra = V - full_blocks * block;
+
+    threadgroup float shared[32 * 2];
+
+    uint out_idx = threadgroup_position_in_grid.y;
+    uint simd_lane_id = thread_index_in_simdgroup;
+    uint simd_group_id = simdgroup_index_in_threadgroup;
+
+    logits_q += out_idx * V;
+    logits_p += out_idx * V;
+    out += out_idx * V;
+    cotan += out_idx;
+
+    float lse_q;
+    float lse_p;
+
+    {
+        float max_q = -1e30;
+        float max_p = -1e30;
+        float sum_exp_q = 0;
+        float sum_exp_p = 0;
+
+        int offset = thread_index_in_threadgroup * M;
+        for (int i = 0; i < full_blocks; i++) {
+            // Read and update q and p
+            float vals_q[M];
+            float vals_p[M];
+            for (int j=0; j<M; j++) {
+                vals_q[j] = logits_q[offset + j];
+                vals_p[j] = logits_p[offset + j];
+            }
+            float prev_max_q = max_q;
+            float prev_max_p = max_p;
+            for (int j=0; j<M; j++) {
+                max_q = max(max_q, vals_q[j]);
+                max_p = max(max_p, vals_p[j]);
+            }
+            sum_exp_q *= metal::fast::exp(prev_max_q - max_q);
+            sum_exp_p *= metal::fast::exp(prev_max_p - max_p);
+            for (int j=0; j<M; j++) {
+                sum_exp_q += metal::fast::exp(vals_q[j] - max_q);
+                sum_exp_p += metal::fast::exp(vals_p[j] - max_p);
+            }
+
+            // Move to the next block
+            offset += block;
+        }
+        if (extra > 0) {
+            // Read and update q and p
+            float vals_q[M];
+            float vals_p[M];
+            for (int j=0; j < M; j++) {
+                vals_q[j] = (offset + j < V) ? logits_q[offset + j] : -1e30;
+                vals_p[j] = (offset + j < V) ? logits_p[offset + j] : -1e30;
+            }
+            float prev_max_q = max_q;
+            float prev_max_p = max_p;
+            for (int j=0; j<M; j++) {
+                max_q = max(max_q, vals_q[j]);
+                max_p = max(max_p, vals_p[j]);
+            }
+            sum_exp_q *= metal::fast::exp(prev_max_q - max_q);
+            sum_exp_p *= metal::fast::exp(prev_max_p - max_p);
+            for (int j=0; j<M; j++) {
+                sum_exp_q += metal::fast::exp(vals_q[j] - max_q);
+                sum_exp_p += metal::fast::exp(vals_p[j] - max_p);
+            }
+        }
+
+        // Share the maxs across the threadgroup
+        float prev_max_q = max_q;
+        float prev_max_p = max_p;
+        max_q = simd_max(max_q);
+        max_p = simd_max(max_p);
+        if (simd_lane_id == 0) {
+            shared[simd_group_id * 2 + 0] = max_q;
+            shared[simd_group_id * 2 + 1] = max_p;
+        }
+        threadgroup_barrier(mem_flags::mem_threadgroup);
+        max_q = shared[simd_lane_id * 2 + 0];
+        max_p = shared[simd_lane_id * 2 + 1];
+        max_q = simd_max(max_q);
+        max_p = simd_max(max_p);
+
+        // Share the sum_exp across the threadgroup
+        sum_exp_q *= metal::fast::exp(prev_max_q - max_q);
+        sum_exp_p *= metal::fast::exp(prev_max_p - max_p);
+        sum_exp_q = simd_sum(sum_exp_q);
+        sum_exp_p = simd_sum(sum_exp_p);
+        if (simd_lane_id == 0) {
+            shared[simd_group_id * 2 + 0] = sum_exp_q;
+            shared[simd_group_id * 2 + 1] = sum_exp_p;
+        }
+        threadgroup_barrier(mem_flags::mem_threadgroup);
+        sum_exp_q = shared[simd_lane_id * 2 + 0];
+        sum_exp_p = shared[simd_lane_id * 2 + 1];
+        sum_exp_q = simd_sum(sum_exp_q);
+        sum_exp_p = simd_sum(sum_exp_p);
+
+        lse_p = max_p + metal::fast::log(sum_exp_p);
+        lse_q = max_q + metal::fast::log(sum_exp_q);
+    }
+
+    threadgroup_barrier(mem_flags::mem_none);
+
+    {
+        float kl = 0;
+        float c = cotan[0];
+
+        int offset = thread_index_in_threadgroup * M;
+        for (int i = 0; i < full_blocks; i++) {
+            // Read and add to the kl
+            float vals_q[M];
+            float vals_p[M];
+            for (int j=0; j<M; j++) {
+                vals_q[j] = logits_q[offset + j];
+                vals_p[j] = logits_p[offset + j];
+            }
+
+            for (int j=0; j<M; j++) {
+                out[offset + j] = static_cast<T>(
+                    c * (metal::fast::exp(vals_q[j] - lse_q) - metal::fast::exp(vals_p[j] - lse_p)));
+            }
+
+            // Move to the next block
+            offset += block;
+        }
+        if (extra > 0) {
+            float vals_q[M];
+            float vals_p[M];
+            for (int j=0; j<M; j++) {
+                vals_q[j] = (offset + j < V) ? logits_q[offset + j] : -1e30;
+                vals_p[j] = (offset + j < V) ? logits_p[offset + j] : -1e30;
+            }
+
+            for (int j=0; j<M; j++) {
+                if (offset + j < V) {
+                    out[offset + j] = static_cast<T>(
+                        c * (metal::fast::exp(vals_q[j] - lse_q) - metal::fast::exp(vals_p[j] - lse_p)));
+                }
+            }
+        }
+    }
+    """
+
+    return mx.fast.metal_kernel(
+        name="kl_backward",
+        input_names=["logits_q", "logits_p", "cotan"],
+        output_names=["out"],
+        source=source,
+        ensure_row_contiguous=True,
+    )
+
+
+_kl_forward_kernel = _make_kl_forward_kernel()
+_kl_backward_kernel = _make_kl_backward_kernel()
+
+
+@mx.custom_function
+def _kl_div_loss(logits_q, logits_p):
+    n_outs = logits_q.size // logits_q.shape[-1]
+    dt = logits_q.dtype
+
+    return _kl_forward_kernel(
+        inputs=[logits_q, logits_p],
+        output_shapes=[logits_q.shape[:-1]],
+        output_dtypes=[dt],
+        template=[("T", dt), ("V", logits_q.shape[-1])],
+        grid=(1024, n_outs, 1),
+        threadgroup=(1024, 1, 1),
+    )[0]
+
+
+@kl_div_loss.vjp
+def _kl_div_loss(primals, cotangent, output):
+    logits_q, logits_p = primals
+    dt = logits_q.dtype
+
+    dp = mx.zeros_like(logits_p)
+    dq = _kl_backward_kernel(
+        inputs=[logits_q, logits_p, cotangent],
+        output_shapes=[logits_q.shape],
+        output_dtypes=[dt],
+        template=[("T", dt), ("V", logits_q.shape[-1])],
+        grid=(1024, cotangent.size, 1),
+        threadgroup=(1024, 1, 1),
+    )[0]
+
+    return dq, dp
+
+
+def kl_div_loss(logits_q, logits_p):
+    if mx.metal.is_available():
+        return _kl_div_loss(logits_q, logits_p)
+    else:
+        return nn.losses.kl_div_loss(
+            logits_q - mx.logsumexp(logits_q, axis=-1, keepdims=True),
+            logits_p - mx.logsumexp(logits_p, axis=-1, keepdims=True),
+            axis=-1,
+            reduction="none",
+        )

--- a/mlx_lm/tuner/losses.py
+++ b/mlx_lm/tuner/losses.py
@@ -348,7 +348,7 @@ def _kl_div_loss(logits_q, logits_p):
     )[0]
 
 
-@kl_div_loss.vjp
+@_kl_div_loss.vjp
 def _kl_div_loss(primals, cotangent, output):
     logits_q, logits_p = primals
     dt = logits_q.dtype


### PR DESCRIPTION
This uses https://github.com/ml-explore/mlx/pull/2335 to train MoE DWQs and also adds a custom metal kernel for the KL loss which speeds it up a bit (it depends on how big of a fraction of the total cost it was) and saves quite a bit of memory especially for models with large vocabularies.

Dynamic quant for `Qwen3-0.6B-Base`
```
Before:                   43s and 17.9GB
After:                    40s and 11.4GB
After with checkpointing: 47s and 9GB
```

Dynamic quant for `Qwen3-8B`
```
Before:                   7m 37s and 91.6GB
After:                    7m 27s and 88.2GB
After with checkpointing: 8m 40s and 74.6GB
```

For DWQ we can now train properly the switch layers and with gradient checkpointing and the kl-loss we can use larger batch size so we get better utilization of the batch kernel. For example

DWQ of `Qwen3-30B-A3B`
```
Before:                     48M params and 113GB and 150 tps
After batch size 1:        954M params and 124GB and 115 tps
After batch size 8 & ckpt: 954M params and 115GB and 250 tps
```