### PR TITLE
Allow trust_remote_code in convert.py

### DIFF
--- a/mlx_lm/convert.py
+++ b/mlx_lm/convert.py
@@ -21,7 +21,6 @@ from .utils import (
 def mixed_quant_predicate_builder(
     recipe: str, model: nn.Module
 ) -> Callable[[str, nn.Module, dict], Union[bool, dict]]:
-
     high_bits = 6
     group_size = 64
 
@@ -96,6 +95,7 @@ def convert(
     quant_predicate: Optional[
         Union[Callable[[str, nn.Module, dict], Union[bool, dict]], str]
     ] = None,
+    trust_remote_code: bool = False,
 ):
     # Check the save path is empty
     if isinstance(mlx_path, str):
@@ -109,7 +109,9 @@ def convert(
 
     print("[INFO] Loading")
     model_path, hf_path = get_model_path(hf_path, revision=revision)
-    model, config, tokenizer = fetch_from_hub(model_path, lazy=True)
+    model, config, tokenizer = fetch_from_hub(
+        model_path, lazy=True, trust_remote_code=trust_remote_code
+    )
 
     if isinstance(quant_predicate, str):
         quant_predicate = mixed_quant_predicate_builder(quant_predicate, model)

--- a/mlx_lm/utils.py
+++ b/mlx_lm/utils.py
@@ -113,7 +113,6 @@ def get_model_path(path_or_hf_repo: str, revision: Optional[str] = None) -> Path
             )
         )
     else:
-
         from huggingface_hub import ModelCard
 
         card_path = model_path / "README.md"
@@ -267,11 +266,13 @@ def load(
 
 
 def fetch_from_hub(
-    model_path: Path, lazy: bool = False
+    model_path: Path, lazy: bool = False, trust_remote_code: bool = False
 ) -> Tuple[nn.Module, dict, PreTrainedTokenizer]:
     model, config = load_model(model_path, lazy)
     tokenizer = load_tokenizer(
-        model_path, eos_token_ids=config.get("eos_token_id", None)
+        model_path,
+        eos_token_ids=config.get("eos_token_id", None),
+        tokenizer_config_extra={"trust_remote_code": trust_remote_code},
     )
     return model, config, tokenizer
 


### PR DESCRIPTION
Some recent MoE models (Hunyuan, Ernie 4.5) have quants up on mlx-community that are incompatible with the code in `main` (even after reverting to the respective initial support commits). To create updated quants, one must use `convert.py`, but these models don't yet have native support in HF Transformers and so require `trust_remote_code=True` in `AutoTokenizer.from_pretrained` to load their custom model code. There isn't currently a way to pipe this kwarg in from the surface API in `convert.py`, so this PR adds that.

cc @awni