### PR TITLE
Fix gemma3n config load bug

### DIFF
--- a/mlx_lm/models/gemma3n.py
+++ b/mlx_lm/models/gemma3n.py
@@ -25,7 +25,6 @@ class TextConfig(BaseModelArgs):
     vocab_size: int
     num_key_value_heads: int
     num_kv_shared_layers: int
-    query_pre_attn_scalar: float
     vocab_size_per_layer_input: int
     sliding_window: int
     max_position_embeddings: int


### PR DESCRIPTION
The gemma3n pytorch weights were re-uploaded. The re-upload removed the `query_pre_attn_scalar` field from the config, and now conversions of that model do not load. To fix, remove the `query_pre_attn_scalar` config requirement, since it isn't being used anyway.

Ref:
https://huggingface.co/google/gemma-3n-E4B-it/commit/72639b6c011b3d1357b0777871e0cfba6cac5b04
https://huggingface.co/google/gemma-3n-E2B-it/commit/f5c5abb3bcbe5ab954b06dc6a9cb10ef07b02290
