### PR TITLE
Allow empty prompt with input_embeddings

### DIFF
--- a/mlx_lm/generate.py
+++ b/mlx_lm/generate.py
@@ -329,21 +329,25 @@ def generate_step(
            when ``kv_bits`` is non-None. Default: ``0``.
         prompt_progress_callback (Callable[int, int]): A call-back which takes the
            prompt tokens processed so far and the total number of prompt tokens.
-        input_embeddings (mx.array, optional): Input embeddings to use in conjunction
-           with prompt tokens. Default: ``None``.
+        input_embeddings (mx.array, optional): Input embeddings to use instead of or in
+          conjunction with prompt tokens. Default: ``None``.
 
     Yields:
         Tuple[mx.array, mx.array]: One token and a vector of log probabilities.
     """
-    if len(prompt) == 0:
-        raise ValueError("Prompt must be non-empty.")
     if input_embeddings is not None:
         if not does_model_support_input_embeddings(model):
             raise ValueError("Model does not support input embeddings.")
-        elif prompt.shape[0] != input_embeddings.shape[0]:
+        elif len(prompt) > 0 and len(prompt) != len(input_embeddings):
             raise ValueError(
-                "If using input embeddings, the sequence length must match that of the prompt."
+                f"When providing input_embeddings, their sequence length ({len(input_embeddings)}) "
+                f"must match the sequence length of the prompt ({len(prompt)}), or the "
+                "prompt must be empty."
             )
+    elif len(prompt) == 0:
+        raise ValueError(
+            "Either input_embeddings or prompt (or both) must be provided."
+        )
 
     tokens = None
 
@@ -386,7 +390,7 @@ def generate_step(
 
             logits = logits[:, -1, :]
 
-            if logits_processors:
+            if logits_processors and (tokens is not None or len(input_tokens) > 0):
                 tokens = (
                     mx.concat([tokens, input_tokens])
                     if tokens is not None
@@ -403,6 +407,9 @@ def generate_step(
 
     with mx.stream(generation_stream):
         total_prompt_tokens = prompt.shape[0]
+        total_prompt_tokens = (
+            len(input_embeddings) if input_embeddings is not None else len(prompt)
+        )
         prompt_processed_tokens = 0
         while total_prompt_tokens - prompt_processed_tokens > prefill_step_size:
             _model_call(

--- a/mlx_lm/generate.py
+++ b/mlx_lm/generate.py
@@ -390,7 +390,7 @@ def generate_step(
 
             logits = logits[:, -1, :]
 
-            if logits_processors and (tokens is not None or len(input_tokens) > 0):
+            if logits_processors and len(input_tokens) > 0:
                 tokens = (
                     mx.concat([tokens, input_tokens])
                     if tokens is not None
@@ -406,7 +406,6 @@ def generate_step(
             return sampled, logprobs.squeeze(0)
 
     with mx.stream(generation_stream):
-        total_prompt_tokens = prompt.shape[0]
         total_prompt_tokens = (
             len(input_embeddings) if input_embeddings is not None else len(prompt)
         )


### PR DESCRIPTION
This PR allows the following `generate_step` parameter combinations. Currently only 1 and 3 are allowed.

1. `len(prompt) > 0 and input_embeddings is None` i.e. prompt only
2. `len(prompt) == 0 and input_embeddings is not None` i.e. input embeddings only
3. `input_embeddings is not None and len(prompt) == len(input_embeddings)` i.e. sequence lengths match

This still provides a helpful check that sequence lengths match when both are provided, but allows for just `input_embeddings` to be provided when the underlying model implementation only requires one or the other.
