### PR TITLE
Update W&B logging crash in MLX-LM-LORA

### DIFF
--- a/mlx_lm/tuner/callbacks.py
+++ b/mlx_lm/tuner/callbacks.py
@@ -31,19 +31,20 @@ class WandBCallback(TrainingCallback):
             )
         self.wrapped_callback = wrapped_callback
         wandb.init(project=project_name, dir=log_dir, config=config)
-    
+
     def _convert_to_serializable(self, data: dict) -> dict:
-        return {
-            k: v.tolist() if hasattr(v, "tolist") else v
-            for k, v in data.items()
-        }
+        return {k: v.tolist() if hasattr(v, "tolist") else v for k, v in data.items()}
 
     def on_train_loss_report(self, train_info: dict):
-        wandb.log(self._convert_to_serializable(train_info), step=train_info.get("iteration"))
+        wandb.log(
+            self._convert_to_serializable(train_info), step=train_info.get("iteration")
+        )
         if self.wrapped_callback:
             self.wrapped_callback.on_train_loss_report(train_info)
 
     def on_val_loss_report(self, val_info: dict):
-        wandb.log(self._convert_to_serializable(val_info), step=val_info.get("iteration"))
+        wandb.log(
+            self._convert_to_serializable(val_info), step=val_info.get("iteration")
+        )
         if self.wrapped_callback:
             self.wrapped_callback.on_val_loss_report(val_info)

--- a/mlx_lm/tuner/callbacks.py
+++ b/mlx_lm/tuner/callbacks.py
@@ -34,7 +34,7 @@ class WandBCallback(TrainingCallback):
     
     def _convert_to_serializable(self, data: dict) -> dict:
         return {
-            k: (v.item() if hasattr(v, "item") else v.tolist() if hasattr(v, "tolist") else v)
+            k: v.tolist() if hasattr(v, "tolist") else v
             for k, v in data.items()
         }
 

--- a/mlx_lm/tuner/callbacks.py
+++ b/mlx_lm/tuner/callbacks.py
@@ -31,13 +31,19 @@ class WandBCallback(TrainingCallback):
             )
         self.wrapped_callback = wrapped_callback
         wandb.init(project=project_name, dir=log_dir, config=config)
+    
+    def _convert_to_serializable(self, data: dict) -> dict:
+        return {
+            k: (v.item() if hasattr(v, "item") else v.tolist() if hasattr(v, "tolist") else v)
+            for k, v in data.items()
+        }
 
     def on_train_loss_report(self, train_info: dict):
-        wandb.log(train_info, step=train_info.get("iteration"))
+        wandb.log(self._convert_to_serializable(train_info), step=train_info.get("iteration"))
         if self.wrapped_callback:
             self.wrapped_callback.on_train_loss_report(train_info)
 
     def on_val_loss_report(self, val_info: dict):
-        wandb.log(val_info, step=val_info.get("iteration"))
+        wandb.log(self._convert_to_serializable(val_info), step=val_info.get("iteration"))
         if self.wrapped_callback:
             self.wrapped_callback.on_val_loss_report(val_info)


### PR DESCRIPTION
Ensures all metrics are JSON-serializable by converting MX arrays before logging to wandb.
Avoids TypeError: Object of type array is not JSON serializable.