### PR TITLE
Add --trust-remote-code cli option

### DIFF
--- a/mlx_lm/chat.py
+++ b/mlx_lm/chat.py
@@ -29,6 +29,11 @@ def setup_arg_parser():
         default=DEFAULT_MODEL,
     )
     parser.add_argument(
+        "--trust-remote-code",
+        action="store_true",
+        help="Enable trusting remote code for tokenizer",
+    )
+    parser.add_argument(
         "--adapter-path",
         type=str,
         help="Optional path for the trained adapter weights and config.",
@@ -83,7 +88,7 @@ def main():
     model, tokenizer = load(
         args.model,
         adapter_path=args.adapter_path,
-        tokenizer_config={"trust_remote_code": True},
+        tokenizer_config={"trust_remote_code": True if args.trust_remote_code else None},
     )
 
     def print_help():

--- a/mlx_lm/generate.py
+++ b/mlx_lm/generate.py
@@ -64,6 +64,11 @@ def setup_arg_parser():
         default=None,
     )
     parser.add_argument(
+        "--trust-remote-code",
+        action="store_true",
+        help="Enable trusting remote code for tokenizer",
+    )
+    parser.add_argument(
         "--adapter-path",
         type=str,
         help="Optional path for the trained adapter weights and config.",
@@ -770,7 +775,7 @@ def main():
     tokenizer_config = (
         {} if not using_cache else json.loads(metadata["tokenizer_config"])
     )
-    tokenizer_config["trust_remote_code"] = True
+    tokenizer_config["trust_remote_code"] = True if args.trust_remote_code else None
 
     model_path = args.model
     if using_cache:


### PR DESCRIPTION
Some of the CLI scripts were missing the `--trust-remote-code` command line argument, and instead always passed true. This PR adds the argument and uses the same logic as other scripts like `mlx_lm.server`. Note that this change is not backwards compatible since the default has changed, but it matches the other scripts' defaults and also matches what the README states.