### PR TITLE
Initialize empty cache when cache=None for Gemma‑3n models

### DIFF
--- a/mlx_lm/_version.py
+++ b/mlx_lm/_version.py
@@ -1,3 +1,3 @@
 # Copyright © 2023-2025 Apple Inc.
 
-__version__ = "0.26.1"
+__version__ = "0.26.2"

--- a/mlx_lm/models/gemma3n.py
+++ b/mlx_lm/models/gemma3n.py
@@ -476,7 +476,7 @@ class LanguageModel(nn.Module):
         per_layer_inputs = self.project_per_layer_inputs(h, per_layer_inputs)
 
         if cache is None:
-            cache = [None] * len(self.layers)
+            cache = self.make_cache()
 
         if mask is None:
             full_mask = create_attention_mask(


### PR DESCRIPTION
Closes #322

When `cache=None`, Gemma-3n models produced incorrect outputs due to shared KV layers expecting initialized `Cache` objects but receiving `None` values.

This change ensures proper cache initialization even when no cache is provided by the user, fixing a critical inference bug that caused 27+ logit differences between cached and uncached forward passes.

```diff
- cache = [None] * len(self.layers)
+ cache = self.make_cache()
```

Sample output, when running the same script as in #322:

```
Logits without cache - yes: 16.125, no: 8.0
Logprobs without cache - yes: 0.0, no: -8.125
Probabilities without cache - yes: 1.0, no: 0.0002960447163786739

Logits with cache - yes: 15.25, no: 7.625
Logprobs with cache - yes: 0.0, no: -7.625
Probabilities with cache - yes: 1.0, no: 0.00048809527652338147
```

Before: Δ ≈ 27 logits (yes −12.2 → +15.25)
After:  Δ ≈ 0.9 logits (yes +16.125 → +15.25)
The former 27-logit swing is now < 1 logit, and the probabilities are stable between cached and uncached inference.

