### PR TITLE
Lora works with cuda backend

### DIFF
--- a/mlx_lm/LEARNED_QUANTS.md
+++ b/mlx_lm/LEARNED_QUANTS.md
@@ -22,7 +22,7 @@ quantized model can be further refined with DWQ.
 To get started, first install the requirements:
 
 ```
-pip install mlx-lm[quant]
+pip install "mlx-lm[train]"
 ```
 
 ### DWQ

--- a/mlx_lm/LORA.md
+++ b/mlx_lm/LORA.md
@@ -26,6 +26,12 @@ LoRA (QLoRA).[^qlora] LoRA fine-tuning works with the following model families:
 
 ## Run
 
+First, make sure you have the training dependenices installed:
+
+```shell
+pip install "mlx-lm[train]"
+```
+
 The main command is `mlx_lm.lora`. To see a full list of command-line options run:
 
 ```shell

--- a/mlx_lm/_version.py
+++ b/mlx_lm/_version.py
@@ -1,3 +1,3 @@
-# Copyright © 2023-2024 Apple Inc.
+# Copyright © 2023-2025 Apple Inc.
 
 __version__ = "0.26.0"

--- a/mlx_lm/generate.py
+++ b/mlx_lm/generate.py
@@ -218,31 +218,31 @@ def wired_limit(model: nn.Module, streams: Optional[List[mx.Stream]] = None):
         try:
             yield
         finally:
-            return
-
-    model_bytes = tree_reduce(
-        lambda acc, x: acc + x.nbytes if isinstance(x, mx.array) else acc, model, 0
-    )
-    max_rec_size = mx.metal.device_info()["max_recommended_working_set_size"]
-    if model_bytes > 0.9 * max_rec_size:
-        model_mb = model_bytes // 2**20
-        max_rec_mb = max_rec_size // 2**20
-        print(
-            f"[WARNING] Generating with a model that requires {model_mb} MB "
-            f"which is close to the maximum recommended size of {max_rec_mb} "
-            "MB. This can be slow. See the documentation for possible work-arounds: "
-            "https://github.com/ml-explore/mlx-lm/tree/main#large-models"
+            pass
+    else:
+        model_bytes = tree_reduce(
+            lambda acc, x: acc + x.nbytes if isinstance(x, mx.array) else acc, model, 0
         )
-    old_limit = mx.set_wired_limit(max_rec_size)
-    try:
-        yield
-    finally:
-        if streams is not None:
-            for s in streams:
-                mx.synchronize(s)
-        else:
-            mx.synchronize()
-        mx.set_wired_limit(old_limit)
+        max_rec_size = mx.metal.device_info()["max_recommended_working_set_size"]
+        if model_bytes > 0.9 * max_rec_size:
+            model_mb = model_bytes // 2**20
+            max_rec_mb = max_rec_size // 2**20
+            print(
+                f"[WARNING] Generating with a model that requires {model_mb} MB "
+                f"which is close to the maximum recommended size of {max_rec_mb} "
+                "MB. This can be slow. See the documentation for possible work-arounds: "
+                "https://github.com/ml-explore/mlx-lm/tree/main#large-models"
+            )
+        old_limit = mx.set_wired_limit(max_rec_size)
+        try:
+            yield
+        finally:
+            if streams is not None:
+                for s in streams:
+                    mx.synchronize(s)
+            else:
+                mx.synchronize()
+            mx.set_wired_limit(old_limit)
 
 
 @dataclass

--- a/mlx_lm/quant/dwq.py
+++ b/mlx_lm/quant/dwq.py
@@ -223,7 +223,7 @@ def main():
     )
 
     if args.quantized_model is not None:
-        q_model_path = get_model_path(args.quantized_model, revision=None)
+        q_model_path, _ = get_model_path(args.quantized_model, revision=None)
         q_model, config, _ = fetch_from_hub(
             q_model_path, lazy=True, trust_remote_code=True
         )

--- a/mlx_lm/tuner/trainer.py
+++ b/mlx_lm/tuner/trainer.py
@@ -197,7 +197,8 @@ def train(
     iterate_batches: callable = iterate_batches,
     training_callback: TrainingCallback = None,
 ):
-    mx.set_wired_limit(mx.metal.device_info()["max_recommended_working_set_size"])
+    if mx.metal.is_available():
+        mx.set_wired_limit(mx.metal.device_info()["max_recommended_working_set_size"])
     print(f"Starting training..., iters: {args.iters}")
     world = mx.distributed.init()
     world_size = world.size()

--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,7 @@ from _version import __version__
 setup(
     name="mlx-lm",
     version=__version__,
-    description="LLMs on Apple silicon with MLX and the Hugging Face Hub",
+    description="LLMs with MLX and the Hugging Face Hub",
     long_description=open("README.md", encoding="utf-8").read(),
     long_description_content_type="text/markdown",
     readme="README.md",
@@ -28,8 +28,8 @@ setup(
     python_requires=">=3.8",
     extras_require={
         "test": ["datasets"],
+        "train": ["datasets", "tqdm"],
         "evaluate": ["lm-eval", "tqdm"],
-        "quant": ["datasets", "tqdm"],
     },
     entry_points={
         "console_scripts": [


### PR DESCRIPTION
Pretty fast on an A100:

```
mlx_lm.lora --model meta-llama/Llama-3.2-3B-Instruct --data mlx-community/WikiSQL --train --iters 100
Loading pretrained model
Fetching 11 files: 100%|██████████████████████████████████████████████████████████████████████████████████████████████████| 11/11 [00:00<00:00, 101848.44it/s]
Loading datasets
Loading Hugging Face dataset mlx-community/WikiSQL.
Training
Trainable parameters: 0.041% (1.311M/3212.750M)
Starting training..., iters: 100
Calculating loss...: 100%|████████████████████████████████████████████████████████████████████████████████████████████████████| 25/25 [00:05<00:00,  4.75it/s]
Iter 1: Val loss 2.936, Val took 5.265s
Iter 10: Train loss 2.662, Learning Rate 1.000e-05, It/sec 0.490, Tokens/sec 161.374, Trained Tokens 3290, Peak mem 9.707 GB
Iter 20: Train loss 2.101, Learning Rate 1.000e-05, It/sec 13.913, Tokens/sec 4560.749, Trained Tokens 6568, Peak mem 10.588 GB
Iter 30: Train loss 1.781, Learning Rate 1.000e-05, It/sec 24.234, Tokens/sec 7514.985, Trained Tokens 9669, Peak mem 10.588 GB
Iter 40: Train loss 1.505, Learning Rate 1.000e-05, It/sec 25.674, Tokens/sec 8056.378, Trained Tokens 12807, Peak mem 10.588 GB
Iter 50: Train loss 1.585, Learning Rate 1.000e-05, It/sec 23.600, Tokens/sec 7889.451, Trained Tokens 16150, Peak mem 10.588 GB
Iter 60: Train loss 1.646, Learning Rate 1.000e-05, It/sec 25.317, Tokens/sec 7823.044, Trained Tokens 19240, Peak mem 10.588 GB
Iter 70: Train loss 1.428, Learning Rate 1.000e-05, It/sec 25.803, Tokens/sec 8037.607, Trained Tokens 22355, Peak mem 10.588 GB
Iter 80: Train loss 1.640, Learning Rate 1.000e-05, It/sec 25.953, Tokens/sec 7866.373, Trained Tokens 25386, Peak mem 10.588 GB
Iter 90: Train loss 1.519, Learning Rate 1.000e-05, It/sec 27.436, Tokens/sec 8949.772, Trained Tokens 28648, Peak mem 10.588 GB
Calculating loss...: 100%|████████████████████████████████████████████████████████████████████████████████████████████████████| 25/25 [00:00<00:00, 43.75it/s]
Iter 100: Val loss 1.534, Val took 0.575s
Iter 100: Train loss 1.591, Learning Rate 1.000e-05, It/sec 25.773, Tokens/sec 8133.829, Trained Tokens 31804, Peak mem 10.588 GB
Iter 100: Saved adapter weights to adapters/adapters.safetensors and adapters/0000100_adapters.safetensors.
Saved final weights to adapters/adapters.safetensors.
```