### PR TITLE
Resolve streaming last token error and correct total token usage

### DIFF
--- a/mlx_lm/server.py
+++ b/mlx_lm/server.py
@@ -487,15 +487,17 @@ class APIHandler(BaseHTTPRequestHandler):
             "choices": [
                 {
                     "index": 0,
-                    "logprobs": {
-                        "token_logprobs": token_logprobs,
-                        "top_logprobs": top_logprobs,
-                        "tokens": tokens,
-                    },
                     "finish_reason": finish_reason,
                 },
             ],
         }
+
+        if token_logprobs or top_logprobs or tokens:
+            response["choices"][0]["logprobs"] = {
+                "token_logprobs": token_logprobs,
+                "top_logprobs": top_logprobs,
+                "tokens": tokens,
+            }
 
         if not self.stream:
             if not (

--- a/mlx_lm/server.py
+++ b/mlx_lm/server.py
@@ -769,7 +769,12 @@ class APIHandler(BaseHTTPRequestHandler):
             self.wfile.write(f"data: {json.dumps(response)}\n\n".encode())
             self.wfile.flush()
             if self.stream_options is not None and self.stream_options["include_usage"]:
-                response = self.completion_usage_response(len(prompt), len(tokens))
+                original_prompt_length = (
+                    len(self.prompt_cache.tokens) - len(tokens) + len(prompt)
+                )
+                response = self.completion_usage_response(
+                    original_prompt_length, len(tokens)
+                )
                 self.wfile.write(f"data: {json.dumps(response)}\n\n".encode())
                 self.wfile.flush()
             self.wfile.write("data: [DONE]\n\n".encode())


### PR DESCRIPTION
# Purpose

This PR aims to improve LiteLLM compatibility by adhering more faithfully to the OpenAI API specification and addresses three key issues:

1.  **Last Token Error in Streaming**: Resolves an error where accessing an mlx-lm server via LiteLLM (proxy) with streaming enabled would cause the request to crash on the last token with the following error:
    ```
    JSON: TypeError: 'MockValSer' object cannot be converted to 'SchemaSerializer'
    ```
    This was improved by ensuring that an empty dictionary is not returned when `logprob` and `tokens` are not present.

2.  **Inaccurate Token Usage**: Corrects the token usage result, which previously only considered the very last prompt and response, leading to misinterpretation on the Roo Code interface.
    This was resolved by including the `prompt_cache` length in the token usage calculation.

3.  **Better JSON Parsing**: Enhanced error handling for invalid JSON in the request body. Previously, a `json.JSONDecodeError` would crash the process. Now, the server logs the error and returns an appropriate 400 Bad Request response to the client, handling both streaming and non-streaming contexts gracefully.

Per the contribution guide, `black` has been run on the code.

# Related Issues
- https://github.com/BerriAI/litellm/issues/9345