### PR TITLE
Allow per model quant config

### DIFF
--- a/mlx_lm/convert.py
+++ b/mlx_lm/convert.py
@@ -49,7 +49,6 @@ def mixed_quant_predicate_builder(
     def mixed_quant_predicate(
         path: str,
         module: nn.Module,
-        config: dict,
     ) -> Union[bool, dict]:
         """Implements mixed quantization predicates with similar choices to, for example, llama.cpp's Q4_K_M.
         Ref: https://github.com/ggerganov/llama.cpp/blob/917786f43d0f29b7c77a0c56767c0fa4df68b1c5/src/llama.cpp#L5265

--- a/mlx_lm/models/qwen3_moe.py
+++ b/mlx_lm/models/qwen3_moe.py
@@ -236,5 +236,14 @@ class Model(nn.Module):
         return weights
 
     @property
+    def quant_predicate(self):
+        def predicate(path, _):
+            if path.endswith("mlp.gate"):
+                return {"group_size": 64, "bits": 8}
+            return True
+
+        return predicate
+
+    @property
     def layers(self):
         return self.model.layers


### PR DESCRIPTION
Quantizing the gate for the MoE in higher precision makes a pretty large difference to KL and virtually no difference to bits-per-weight and run-time.