### PR TITLE
Add SSE keepalive to stop client disconnects during prompt processing

### DIFF
--- a/tests/test_keepalive.py
+++ b/tests/test_keepalive.py
@@ -1,0 +1,57 @@
+# Copyright © 2025 Apple Inc.
+
+import io
+import unittest
+from unittest.mock import Mock
+
+
+class TestKeepalive(unittest.TestCase):
+
+    def test_keepalive_callback(self):
+        """Test keepalive callback sends SSE comments and handles errors"""
+        # Mock handler
+        mock_wfile = io.BytesIO()
+        handler = Mock()
+        handler.wfile = mock_wfile
+
+        # Test callback logic (same as in server.py)
+        def keepalive_callback(processed_tokens, total_tokens):
+            if handler.stream:
+                try:
+                    handler.wfile.write(
+                        f": keepalive {processed_tokens}/{total_tokens}\n\n".encode()
+                    )
+                    handler.wfile.flush()
+                except (BrokenPipeError, ConnectionResetError, OSError):
+                    pass
+
+        # Test streaming enabled
+        handler.stream = True
+        keepalive_callback(1024, 4096)
+
+        output = mock_wfile.getvalue().decode("utf-8")
+        self.assertEqual(output, ": keepalive 1024/4096\n\n")
+
+        # Test streaming disabled
+        handler.stream = False
+        mock_wfile.seek(0)
+        mock_wfile.truncate(0)
+        keepalive_callback(2048, 4096)
+
+        output = mock_wfile.getvalue().decode("utf-8")
+        self.assertEqual(output, "")
+
+        # Test error handling
+        handler.stream = True
+        handler.wfile = Mock()
+        handler.wfile.write.side_effect = BrokenPipeError("Connection broken")
+
+        # Should not raise exception
+        try:
+            keepalive_callback(3072, 4096)
+        except Exception as e:
+            self.fail(f"Callback should handle BrokenPipeError: {e}")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
This PR adds a keepalive callback to send SSE comments during prompt processing, to prevent client timeouts.

When trying to process very large prompt in Cline/Kilocode etc, I was getting disconnected.

The changes here allowed me to run a Cline session that successfully waited 20 minutes for a >100k GLM Air session to resume, and then successfully went on to process over 3 million tokens over the course of the task.

I've attempted to add a test, but this change is obviously better tested with a real client using a medium/large model and context.

This is my first ever open source PR, so any advice on etiquette etc is appreciated. I wasn't sure if I should create an issue first or just directly submit the PR.