### PR TITLE
Allow mlx_lm.generate to create and save prompt cache

### DIFF
--- a/mlx_lm/generate.py
+++ b/mlx_lm/generate.py
@@ -808,8 +808,9 @@ def main():
                         "--kv-group-size does not match the kv cache loaded from --prompt-cache-file."
                     )
             cache_exists = True
-        except RuntimeError:
-            pass
+        except RuntimeError as e:
+            if not args.save_prompt_cache:
+                raise e
     elif args.save_prompt_cache:
         raise ValueError(
             "--save-prompt-cache flag set but --prompt-cache-file not provided."


### PR DESCRIPTION
Doing so makes it easy and straightforward to implement an iterative chatbot on the command line. Since making this change, I've been able to replace my usage of `mlx_lm.chat` with a shell script wrapper around  `mlx_lm.generate` which introduces functionality I find useful (such as multi-line input to chat, being able to inject shell output, etc).