### PR TITLE
remove comma and add muon

### DIFF
--- a/mlx_lm/lora.py
+++ b/mlx_lm/lora.py
@@ -109,7 +109,7 @@ def build_parser():
     parser.add_argument(
         "--optimizer",
         type=str,
-        choices=["adam", "adamw", "sgd", "adafactor"],
+        choices=["adam", "adamw", "muon", "sgd", "adafactor"],
         default=None,
         help="Optimizer to use for training: adam, adamw, sgd, or adafactor.",
     )
@@ -191,7 +191,7 @@ def build_parser():
         default=None,
         help=(
             "The 'wandb' argument is deprecated and will be removed in a future release. "
-            "Use 'report_to: wandb' and 'project_name' in the configuration instead.",
+            "Use 'report_to: wandb' and 'project_name' in the configuration instead."
         ),
     )
     parser.add_argument(


### PR DESCRIPTION
Before:

```text
Traceback (most recent call last):
  File "<frozen runpy>", line 198, in _run_module_as_main
  File "<frozen runpy>", line 88, in _run_code
  File "/Users/gokdenizgulmez/Desktop/mlx-lm/mlx_lm/lora.py", line 381, in <module>
    main()
  File "/Users/gokdenizgulmez/Desktop/mlx-lm/mlx_lm/lora.py", line 357, in main
    args = parser.parse_args()
           ^^^^^^^^^^^^^^^^^^^
  File "/opt/miniconda3/lib/python3.12/argparse.py", line 1904, in parse_args
    args, argv = self.parse_known_args(args, namespace)
                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/opt/miniconda3/lib/python3.12/argparse.py", line 1914, in parse_known_args
    return self._parse_known_args2(args, namespace, intermixed=False)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/opt/miniconda3/lib/python3.12/argparse.py", line 1943, in _parse_known_args2
    namespace, args = self._parse_known_args(args, namespace, intermixed)
                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/opt/miniconda3/lib/python3.12/argparse.py", line 2184, in _parse_known_args
    start_index = consume_optional(start_index)
                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/opt/miniconda3/lib/python3.12/argparse.py", line 2113, in consume_optional
    take_action(action, args, option_string)
  File "/opt/miniconda3/lib/python3.12/argparse.py", line 2018, in take_action
    action(self, namespace, argument_values, option_string)
  File "/opt/miniconda3/lib/python3.12/argparse.py", line 1148, in __call__
    parser.print_help()
  File "/opt/miniconda3/lib/python3.12/argparse.py", line 2621, in print_help
    self._print_message(self.format_help(), file)
                        ^^^^^^^^^^^^^^^^^^
  File "/opt/miniconda3/lib/python3.12/argparse.py", line 2605, in format_help
    return formatter.format_help()
           ^^^^^^^^^^^^^^^^^^^^^^^
  File "/opt/miniconda3/lib/python3.12/argparse.py", line 286, in format_help
    help = self._root_section.format_help()
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/opt/miniconda3/lib/python3.12/argparse.py", line 217, in format_help
    item_help = join([func(*args) for func, args in self.items])
                      ^^^^^^^^^^^
  File "/opt/miniconda3/lib/python3.12/argparse.py", line 217, in format_help
    item_help = join([func(*args) for func, args in self.items])
                      ^^^^^^^^^^^
  File "/opt/miniconda3/lib/python3.12/argparse.py", line 545, in _format_action
    if action.help and action.help.strip():
                       ^^^^^^^^^^^^^^^^^
AttributeError: 'tuple' object has no attribute 'strip'
```

after:

```text
usage: lora.py [-h] [--model MODEL] [--train] [--data DATA] [--fine-tune-type {lora,dora,full}] [--optimizer {adam,adamw,muon,sgd,adafactor}]
               [--mask-prompt] [--num-layers NUM_LAYERS] [--batch-size BATCH_SIZE] [--iters ITERS] [--val-batches VAL_BATCHES]
               [--learning-rate LEARNING_RATE] [--steps-per-report STEPS_PER_REPORT] [--steps-per-eval STEPS_PER_EVAL]
               [--resume-adapter-file RESUME_ADAPTER_FILE] [--adapter-path ADAPTER_PATH] [--save-every SAVE_EVERY] [--test]
               [--test-batches TEST_BATCHES] [--max-seq-length MAX_SEQ_LENGTH] [-c CONFIG] [--grad-checkpoint] [--wandb WANDB]
               [--report-to REPORT_TO] [--project-name PROJECT_NAME] [--seed SEED]

LoRA or QLoRA finetuning.

options:
  -h, --help            show this help message and exit
  --model MODEL         The path to the local model directory or Hugging Face repo.
  --train               Do training
  --data DATA           Directory with {train, valid, test}.jsonl files or the name of a Hugging Face dataset (e.g., 'mlx-community/wikisql')
  --fine-tune-type {lora,dora,full}
                        Type of fine-tuning to perform: lora, dora, or full.
  --optimizer {adam,adamw,muon,sgd,adafactor}
                        Optimizer to use for training: adam, adamw, sgd, or adafactor.
  --mask-prompt         Mask the prompt in the loss when training
  --num-layers NUM_LAYERS
                        Number of layers to fine-tune. Default is 16, use -1 for all.
  --batch-size BATCH_SIZE
                        Minibatch size.
  --iters ITERS         Iterations to train for.
  --val-batches VAL_BATCHES
                        Number of validation batches, -1 uses the entire validation set.
  --learning-rate LEARNING_RATE
                        Adam learning rate.
  --steps-per-report STEPS_PER_REPORT
                        Number of training steps between loss reporting.
  --steps-per-eval STEPS_PER_EVAL
                        Number of training steps between validations.
  --resume-adapter-file RESUME_ADAPTER_FILE
                        Load path to resume training from the given fine-tuned weights.
  --adapter-path ADAPTER_PATH
                        Save/load path for the fine-tuned weights.
  --save-every SAVE_EVERY
                        Save the model every N iterations.
  --test                Evaluate on the test set after training
  --test-batches TEST_BATCHES
                        Number of test set batches, -1 uses the entire test set.
  --max-seq-length MAX_SEQ_LENGTH
                        Maximum sequence length.
  -c CONFIG, --config CONFIG
                        A YAML configuration file with the training options
  --grad-checkpoint     Use gradient checkpointing to reduce memory use.
  --wandb WANDB         The 'wandb' argument is deprecated and will be removed in a future release. Use 'report_to: wandb' and 'project_name' in
                        the configuration instead.
  --report-to REPORT_TO
                        Services to report logs to ('wandb', 'swanlab', or 'wandb,swanlab').
  --project-name PROJECT_NAME
                        Project name for logging. Defaults to the name of the root directory.
  --seed SEED           The PRNG seed
```