### PR TITLE
Adding trust_remote_code=True for training

### DIFF
--- a/mlx_lm/lora.py
+++ b/mlx_lm/lora.py
@@ -330,7 +330,7 @@ def run(args, training_callback: TrainingCallback = None):
     )
 
     print("Loading pretrained model")
-    model, tokenizer = load(args.model)
+    model, tokenizer = load(args.model, tokenizer_config={"trust_remote_code": True})
 
     print("Loading datasets")
     train_set, valid_set, test_set = load_dataset(args, tokenizer)


### PR DESCRIPTION
to get rid of this when training:

```text
....
You can avoid this prompt in future by passing the argument `trust_remote_code=True`.

Do you wish to run the custom code? [y/N] y
```