### PR TITLE
Add Qwen2-VL model implementation

### DIFF
--- a/mlx_lm/_version.py
+++ b/mlx_lm/_version.py
@@ -1,3 +1,3 @@
 # Copyright © 2023-2025 Apple Inc.
 
-__version__ = "0.26.3"
+__version__ = "0.26.4"

--- a/mlx_lm/models/qwen2_vl.py
+++ b/mlx_lm/models/qwen2_vl.py
@@ -44,8 +44,16 @@ class Model(nn.Module):
     
     def sanitize(self, weights):
         weights = tree_unflatten(list(weights.items()))
+        weights.pop("visual", None)
         weights.pop("vision_tower", None)
-        return dict(tree_flatten(weights))
+        weights = dict(tree_flatten(weights))
+        
+        sanitized = {}
+        for key, value in weights.items():
+            if not key.startswith("language_model."):
+                key = "language_model." + key
+            sanitized[key] = value
+        return sanitized
     
     @property
     def layers(self):

--- a/mlx_lm/models/qwen2_vl.py
+++ b/mlx_lm/models/qwen2_vl.py
@@ -1,0 +1,52 @@
+# Copyright © 2025 Apple Inc.
+
+from dataclasses import dataclass
+from typing import Optional
+
+import mlx.core as mx
+import mlx.nn as nn
+from mlx.utils import tree_flatten, tree_unflatten
+
+from . import qwen2
+from .base import BaseModelArgs
+
+@dataclass
+class ModelArgs(BaseModelArgs):
+    model_type: str
+    text_config: dict
+
+    @classmethod
+    def from_dict(cls, params):
+        if "text_config" not in params:
+            return cls(
+                model_type=params["model_type"],
+                text_config=params
+            )
+        return cls(**params)
+
+class Model(nn.Module):
+    def __init__(self, args: ModelArgs):
+        super().__init__()
+        self.args = args
+        self.model_type = args.model_type
+        self.language_model = qwen2.Model(qwen2.ModelArgs.from_dict(args.text_config))
+    
+    def __call__(
+        self,
+        inputs: mx.array,
+        cache=None,
+        mask: Optional[mx.array] = None,
+        input_embeddings: Optional[mx.array] = None,
+    ):
+        return self.language_model(
+            inputs, cache=cache, mask=mask, input_embeddings=input_embeddings
+        )
+    
+    def sanitize(self, weights):
+        weights = tree_unflatten(list(weights.items()))
+        weights.pop("vision_tower", None)
+        return dict(tree_flatten(weights))
+    
+    @property
+    def layers(self):
+        return self.language_model.model.layers

--- a/mlx_lm/models/rope_utils.py
+++ b/mlx_lm/models/rope_utils.py
@@ -192,6 +192,90 @@ class YarnRoPE(nn.Module):
             freqs=self._freqs,
         )
 
+class MRoPE(nn.Module):   
+    def __init__(
+        self,
+        dims: int,
+        mrope_section: List[int],
+        traditional: bool = False,
+        base: float = 10000,
+        scale: float = 1.0,
+        max_position_embeddings: int = 2048,
+    ):
+        super().__init__()
+        self.dims = dims
+        self.traditional = traditional
+        self.base = base
+        self.scale = scale
+        self.mrope_section = mrope_section
+        
+        self._split_indices = mx.cumsum(mx.array(mrope_section) * 2)[:-1].tolist()
+        
+        self._inv_freq = 1.0 / (base ** (mx.arange(0, dims, 2, dtype=mx.float32) / dims))
+        
+        self.max_seq_len_cached = 0
+        self._cos_cached = None
+        self._sin_cached = None
+        self._update_cos_sin_cache(max_position_embeddings)
+    
+    def _update_cos_sin_cache(self, seq_len: int, device=None):
+        if seq_len <= self.max_seq_len_cached:
+            return
+        
+        self.max_seq_len_cached = seq_len
+        
+        positions = mx.arange(seq_len, dtype=mx.float32)
+        freqs = mx.outer(positions, self._inv_freq)
+        
+        emb = mx.concatenate([freqs, freqs], axis=-1)
+        
+        self._cos_cached = mx.cos(emb)
+        self._sin_cached = mx.sin(emb)
+    
+    def _rotate_half(self, x: mx.array) -> mx.array:
+        half_dim = x.shape[-1] // 2
+        x1, x2 = x[..., :half_dim], x[..., half_dim:]
+        return mx.concatenate([-x2, x1], axis=-1)
+    
+    def _apply_mrope_sections(self, cos: mx.array, sin: mx.array) -> tuple[mx.array, mx.array]:
+        cos_sections = mx.split(cos, self._split_indices, axis=-1)
+        sin_sections = mx.split(sin, self._split_indices, axis=-1)
+        
+        cos_reordered = mx.concatenate([sec[i % 3] for i, sec in enumerate(cos_sections)], axis=-1)
+        sin_reordered = mx.concatenate([sec[i % 3] for i, sec in enumerate(sin_sections)], axis=-1)
+        
+        cos_reordered = cos_reordered[:, None, :, :]
+        sin_reordered = sin_reordered[:, None, :, :]
+        
+        return cos_reordered, sin_reordered
+    
+    def __call__(self, x: mx.array, offset: int = 0) -> mx.array:
+        original_shape = x.shape
+        
+        if len(original_shape) == 3:
+            B, L, D = original_shape
+            x = x.reshape(B, 1, L, D)
+        
+        B, H, L, D = x.shape
+        
+        if offset + L > self.max_seq_len_cached:
+            self._update_cos_sin_cache(offset + L * 2)
+
+        position_ids = mx.arange(offset, offset + L, dtype=mx.int32)
+        position_ids = mx.broadcast_to(position_ids[None, None, :], (3, B, L))
+        
+        cos = self._cos_cached[position_ids]
+        sin = self._sin_cached[position_ids]
+        
+        cos, sin = self._apply_mrope_sections(cos, sin)
+        
+        x_rotated = x * cos + self._rotate_half(x) * sin
+        
+        if len(original_shape) == 3:
+            x_rotated = x_rotated.reshape(original_shape)
+        
+        return x_rotated
+
 
 def initialize_rope(
     dims,
@@ -251,6 +335,13 @@ def initialize_rope(
             short_factor=scaling_config["short_factor"],
             long_factor=scaling_config["long_factor"],
         )
-
+    elif rope_type == "mrope":
+        return MRoPE(
+            dims=dims,
+            traditional=traditional,
+            base=base,
+            max_position_embeddings=max_position_embeddings,
+            mrope_section=scaling_config["mrope_section"],
+        )
     else:
         raise ValueError(f"Unsupported RoPE type {rope_type}")

--- a/mlx_lm/models/rope_utils.py
+++ b/mlx_lm/models/rope_utils.py
@@ -193,76 +193,6 @@ class YarnRoPE(nn.Module):
         )
 
 
-class MRoPE(nn.Module):
-    def __init__(
-        self,
-        dims: int,
-        mrope_section: List[int],
-        base: float = 10000,
-        max_position_embeddings: int = 2048,
-    ):
-        super().__init__()
-        self._split_indices = mx.cumsum(mx.array(mrope_section) * 2)[:-1].tolist()
-        self._inv_freq = 1.0 / (
-            base ** (mx.arange(0, dims, 2, dtype=mx.float32) / dims)
-        )
-        self._cos_cached = None
-        self._sin_cached = None
-        self._set_cos_sin_cache(seq_len=max_position_embeddings)
-
-    def _set_cos_sin_cache(self, seq_len: int):
-        self.max_seq_len_cached = seq_len
-        t = mx.arange(self.max_seq_len_cached).astype(mx.float32)
-        freqs = mx.outer(t, self._inv_freq)
-        emb = mx.concatenate((freqs, freqs), axis=-1)
-        self._cos_cached = mx.cos(emb)
-        self._sin_cached = mx.sin(emb)
-
-    def _rotate_half(self, x: mx.array):
-        x1 = x[..., : x.shape[-1] // 2]
-        x2 = x[..., x.shape[-1] // 2 :]
-        return mx.concatenate([-x2, x1], axis=-1)
-
-    def _apply_mrope_sections(self, cos: mx.array, sin: mx.array):
-        cos_sections = mx.split(cos, self._split_indices, axis=-1)
-        sin_sections = mx.split(sin, self._split_indices, axis=-1)
-
-        cos_reordered = mx.concatenate(
-            [cos_sections[i % 3] for i in range(len(cos_sections))], axis=-1
-        )[None, None, :, :]
-        sin_reordered = mx.concatenate(
-            [sin_sections[i % 3] for i in range(len(sin_sections))], axis=-1
-        )[None, None, :, :]
-
-        return cos_reordered, sin_reordered
-
-    def __call__(
-        self,
-        x: mx.array,
-        offset: int = 0,
-        position_ids: Optional[mx.array] = None,
-    ):
-        B, _, L, _ = x.shape
-
-        if position_ids is None:
-            position_ids = mx.arange(offset, offset + L, dtype=mx.int32)
-        else:
-            position_ids = position_ids.astype(mx.int32)
-
-        seq_len = position_ids.max().item() + 1
-        if seq_len > self.max_seq_len_cached:
-            self._set_cos_sin_cache(seq_len=seq_len)
-
-        cos = self._cos_cached[position_ids]
-        sin = self._sin_cached[position_ids]
-
-        cos, sin = self._apply_mrope_sections(cos, sin)
-
-        x = (x * cos.astype(x.dtype)) + (self._rotate_half(x) * sin.astype(x.dtype))
-
-        return x
-
-
 def initialize_rope(
     dims,
     base,
@@ -322,11 +252,10 @@ def initialize_rope(
             long_factor=scaling_config["long_factor"],
         )
     elif rope_type == "mrope":
-        return MRoPE(
-            dims=dims,
-            base=base,
-            max_position_embeddings=max_position_embeddings,
-            mrope_section=scaling_config["mrope_section"],
-        )
+        mrope_section = scaling_config.get("mrope_section", [])
+        assert (
+            len(mrope_section) == 3
+        ), f"MRoPE currently only supports 3 sections, got {len(mrope_section)}."
+        return nn.RoPE(dims, traditional=traditional, base=base)
     else:
         raise ValueError(f"Unsupported RoPE type {rope_type}")

--- a/mlx_lm/models/rope_utils.py
+++ b/mlx_lm/models/rope_utils.py
@@ -249,7 +249,9 @@ class MRoPE(nn.Module):
         B, _, L, _ = x.shape
 
         if position_ids is None:
-            position_ids = mx.arange(offset, offset + L)
+            position_ids = mx.arange(offset, offset + L, dtype=mx.int32)
+        else:
+            position_ids = position_ids.astype(mx.int32)
 
         seq_len = position_ids.max().item() + 1
         if seq_len > self.max_seq_len_cached:
@@ -260,7 +262,7 @@ class MRoPE(nn.Module):
 
         cos, sin = self._apply_mrope_sections(cos, sin)
 
-        x = (x * cos) + (self._rotate_half(x) * sin)
+        x = (x * cos.astype(x.dtype)) + (self._rotate_half(x) * sin.astype(x.dtype))
 
         return x
 

--- a/mlx_lm/models/rope_utils.py
+++ b/mlx_lm/models/rope_utils.py
@@ -202,10 +202,6 @@ class MRoPE(nn.Module):
         max_position_embeddings: int = 2048,
     ):
         super().__init__()
-        self.dims = dims
-        self.mrope_section = mrope_section
-        self.base = base
-        self.max_position_embeddings = max_position_embeddings
         self._split_indices = mx.cumsum(mx.array(mrope_section) * 2)[:-1].tolist()
         self._inv_freq = 1.0 / (
             base ** (mx.arange(0, dims, 2, dtype=mx.float32) / dims)

--- a/mlx_lm/utils.py
+++ b/mlx_lm/utils.py
@@ -45,6 +45,7 @@ MODEL_REMAPPING = {
     "phi-msft": "phixtral",
     "falcon_mamba": "mamba",
     "kimi_k2": "deepseek_v3",
+    "qwen2_5_vl": "qwen2_vl",
 }
 
 MAX_FILE_SIZE_GB = 5


### PR DESCRIPTION
Adds the [Qwen2-VL](https://huggingface.co/collections/Qwen/qwen2-vl-66cee7455501d7126940800d) model family for text-only inference. Sibling of [lmstudio-ai/mlx-engine#215](https://github.com/lmstudio-ai/mlx-engine/pull/215).

Because Qwen2-VL and Qwen2.5-VL have the same language model implementation, the [Qwen2.5-VL](https://huggingface.co/collections/Qwen/qwen25-vl-6795ffac22b334a837c0f9a5) model family is supported and mapped to `qwen2_vl`.