### PR TITLE
fix sampling with small top k

### DIFF
--- a/mlx_lm/sample_utils.py
+++ b/mlx_lm/sample_utils.py
@@ -48,8 +48,6 @@ def make_sampler(
 
     # Create sampler chain
     sampling_methods = []
-    if top_k > 0:
-        sampling_methods.append(lambda x: apply_top_k(x, top_k))
     if top_p > 0 and top_p < 1.0:
         sampling_methods.append(lambda x: apply_top_p(x, top_p))
     if min_p != 0.0:
@@ -58,14 +56,15 @@ def make_sampler(
         sampling_methods.append(
             lambda x: apply_xtc(x, xtc_probability, xtc_threshold, xtc_special_tokens)
         )
+    if top_k > 0:
+        sampling_methods.append(lambda x: apply_top_k(x, top_k))
 
     # Apply the sampling methods
-    def sampler(logits):
+    def sampler(logprobs):
         for method in sampling_methods:
-            logits = method(logits)
-
+            logprobs = method(logprobs)
         # Return the sampled token
-        return categorical_sampling(logits, temp)
+        return categorical_sampling(logprobs, temp)
 
     return sampler
 


### PR DESCRIPTION
As pointed out by @neilmehta24 there is a bug for small `top_k` when using `top_p`, e.g.:

```
mlx_lm.generate --model mlx-community/Qwen3-4B-Thinking-2507-4bit --prompt "Tell me a story about Einstein" -m 1000 --top-k 1 --top-p 0.8 --temp 0.01
```

The bug is that `top_k` doesn't preserve the distribution.. and top_p assumes the cumulative sum is 1. If it's not 1 we can get a case where all the tokens are masked in top_p after top_k. 

The fix is simply to do top_k last.