### PR TITLE
Server now attempts to load models from local cache first

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -80,7 +80,7 @@ To determine the model layer names, we suggest either:
 To add LoRA support edit
 [`mlx_lm/tuner/utils.py`](https://github.com/ml-explore/mlx-lm/blob/main/mlx_lm/tuner/utils.py#L27-L60)
 
-Finally, add a test for the new modle type to the [model
+Finally, add a test for the new model type to the [model
 tests](https://github.com/ml-explore/mlx-lm/blob/main/tests/test_models.py).
 
 You can run the tests with:

--- a/mlx_lm/server.py
+++ b/mlx_lm/server.py
@@ -202,11 +202,15 @@ class ModelProvider:
                     adapter_path if adapter_path else self.cli_args.adapter_path
                 ),  # if the user doesn't change the model but adds an adapter path
                 tokenizer_config=tokenizer_config,
+                attempt_with_local_files=True,
             )
         else:
             self._validate_model_path(model_path)
             model, tokenizer = load(
-                model_path, adapter_path=adapter_path, tokenizer_config=tokenizer_config
+                model_path,
+                adapter_path=adapter_path,
+                tokenizer_config=tokenizer_config,
+                attempt_with_local_files=True,
             )
 
         if self.cli_args.use_default_chat_template:
@@ -230,12 +234,16 @@ class ModelProvider:
             draft_model_path == "default_model"
             and self.cli_args.draft_model is not None
         ):
-            self.draft_model, draft_tokenizer = load(self.cli_args.draft_model)
+            self.draft_model, draft_tokenizer = load(
+                self.cli_args.draft_model, attempt_with_local_files=True
+            )
             validate_draft_tokenizer(draft_tokenizer)
 
         elif draft_model_path is not None and draft_model_path != "default_model":
             self._validate_model_path(draft_model_path)
-            self.draft_model, draft_tokenizer = load(draft_model_path)
+            self.draft_model, draft_tokenizer = load(
+                draft_model_path, attempt_with_local_files=True
+            )
             validate_draft_tokenizer(draft_tokenizer)
         return self.model, self.tokenizer
 


### PR DESCRIPTION
### Summary

This PR improves the model loading behavior by enabling the server to first attempt loading models from the local Hugging Face cache before falling back to downloading them from the Hugging Face Hub. This change reduces unnecessary network requests and improves performance when models are already cached locally.

### Changes

1. **Enhanced `get_model_path` function**:
   - The function now checks if the model path exists locally.
   - If the path does not exist, it proceeds to download the model from Hugging Face.

2. **Updated `load` function**:
   - Added a new parameter `attempt_with_local_files` to control whether the server should attempt to load models from the local cache first.
   - When `attempt_with_local_files=True`, the function first tries to load the model using `local_files_only=True`.
   - If that fails with a `LocalEntryNotFoundError`, it falls back to downloading the model from Hugging Face.
   - When `attempt_with_local_files=False` (default), the behavior remains unchanged — always attempts to download from Hugging Face.

### Behavior

- **Before**: The server always made a `GET` request to Hugging Face when a model was loaded, even if it already existed locally.
- **After**: If `attempt_with_local_files=True`, the server will first check the local cache (`.cache/huggingface`) and attempt to load the model from there. If that fails, it falls back to downloading from Hugging Face.

### Example Usage

```python
# Load model from local cache if available, fallback to HF if not
model, tokenizer = load(\"meta-llama/Llama-3.2-1B\", attempt_with_local_files=True)
```
