### PR TITLE
Fix prompt cache corruption when generation is interrupted

### DIFF
--- a/mlx_lm/server.py
+++ b/mlx_lm/server.py
@@ -736,6 +736,7 @@ class APIHandler(BaseHTTPRequestHandler):
             token = gen_response.token
             logprobs = gen_response.logprobs
             tokens.append(token)
+            self.prompt_cache.tokens.append(token)
 
             if self.logprobs > 0:
                 sorted_indices = mx.argpartition(-logprobs, kth=self.logprobs - 1)
@@ -777,8 +778,6 @@ class APIHandler(BaseHTTPRequestHandler):
                     self.wfile.flush()
                     segment = ""
                     tool_calls = []
-
-        self.prompt_cache.tokens.extend(tokens)
 
         if gen_response.finish_reason is not None:
             finish_reason = gen_response.finish_reason


### PR DESCRIPTION
If you interrupt the connection to the server during generation a `BrokenPipeError` is raised which is not caught or handled. Due to the current code, `self.prompt_cache.cache` will have been updated (it gets updated with each token in `stream_generate`), but `self.prompt_cache.tokens` will not be updated. This PR changes the code to append the token to the `PromptCache` object earlier to mitigate the issue.

There is still a possibility that the `self.prompt_cache.cache` is corrupted with this fix, but the chance is minimized. Fixing the issue fully would likely require catching the exception, verifying that `self.prompt_cache.cache` is in a consistent state, then appending the tokens. I figured this was a reasonable initial fix for the issue. Maybe a follow-up PR can fix this more fully.