### PR TITLE
Fix mlx_lm.perplexity seed w/ np.random.seed to ensure determinism across runs

### DIFF
--- a/mlx_lm/perplexity.py
+++ b/mlx_lm/perplexity.py
@@ -135,6 +135,7 @@ def main():
     args = parser.parse_args()
 
     # Set random seed
+    np.random.seed(args.seed)
     mx.random.seed(args.seed)
 
     # Load model


### PR DESCRIPTION
As per: https://x.com/kernelpool/status/1961640338214588625

Numpy random seed was not set, multiple runs were not deterministic.