### PR TITLE
Allow fp8

### DIFF
--- a/mlx_lm/utils.py
+++ b/mlx_lm/utils.py
@@ -221,8 +221,6 @@ def load_model(
             config["quantization"] = quantization
             config["quantization_config"] = quantization
             _quantize(quantization)
-        else:
-            raise ValueError(f"Unknown quantization method {quant_method}.")
 
     model.load_weights(list(weights.items()), strict=strict)
 


### PR DESCRIPTION
This condition was breaking dequantization of fp8 quantized DSv3-style models (e.g. Kimi). Thanks to @ivanfioravanti for pointing out the issue.