### PR TITLE
fix(quantization): Parameterize hardcoded group_size in mixed_quant_predicate_builder

### DIFF
--- a/mlx_lm/convert.py
+++ b/mlx_lm/convert.py
@@ -19,10 +19,9 @@ from .utils import (
 
 
 def mixed_quant_predicate_builder(
-    recipe: str, model: nn.Module
+    recipe: str, model: nn.Module, group_size: int = 64
 ) -> Callable[[str, nn.Module, dict], Union[bool, dict]]:
     high_bits = 6
-    group_size = 64
 
     if recipe == "mixed_2_6":
         low_bits = 2
@@ -34,7 +33,7 @@ def mixed_quant_predicate_builder(
     elif recipe == "mixed_4_6":
         low_bits = 4
     else:
-        raise ValueError("Invalid quant recipe {recipe}")
+        raise ValueError(f"Invalid quant recipe {recipe}")
 
     down_keys = [k for k, _ in model.named_modules() if "down_proj" in k]
     if len(down_keys) == 0:
@@ -114,7 +113,9 @@ def convert(
     )
 
     if isinstance(quant_predicate, str):
-        quant_predicate = mixed_quant_predicate_builder(quant_predicate, model)
+        quant_predicate = mixed_quant_predicate_builder(
+            quant_predicate, model, q_group_size
+        )
 
     if dtype is None:
         dtype = config.get("torch_dtype", None)


### PR DESCRIPTION
### Description
This PR addresses a hardcoded value in the mixed quantization predicate builder by making `group_size` configurable. Previously, it was fixed at 64, limiting flexibility for users needing custom group sizes in quantization recipes (e.g., for different model architectures or performance tweaks).

### Changes
- Updated `mixed_quant_predicate_builder` signature to include `group_size: int = 64`.
- In the `convert` function, passed `q_group_size` to the builder when a string predicate (e.g., "mixed_2_6") is provided.
- No breaking changes; defaults preserve existing behavior.

### Testing
- Verified with sample models: Quantization works with default (64) and custom (e.g., 32) group sizes.
- No regressions in non-mixed quantization paths.

### Checklist
- [x] Code changes applied.
- [x] Tested locally.