### PR TITLE
Faster ssm

### DIFF
--- a/mlx_lm/models/granitemoehybrid.py
+++ b/mlx_lm/models/granitemoehybrid.py
@@ -138,9 +138,9 @@ class GraniteMoeHybridMamba2Mixer(nn.Module):
             batch_size, seq_len, self.num_heads, self.head_dim
         )
 
-        if cache is not None:
+        if cache is not None and cache[1] is not None:
             state = cache[1]
-        if state is None:
+        else:
             state = mx.zeros(
                 (batch_size, self.num_heads, self.head_dim, self.ssm_state_size),
                 hidden_states.dtype,

--- a/mlx_lm/models/granitemoehybrid.py
+++ b/mlx_lm/models/granitemoehybrid.py
@@ -9,6 +9,7 @@ import mlx.nn as nn
 from .base import BaseModelArgs, create_attention_mask, scaled_dot_product_attention
 from .cache import KVCache, MambaCache
 from .rope_utils import initialize_rope
+from .ssm import ssm_step, ssm_step_ops
 from .switch_layers import SwitchGLU
 
 
@@ -133,44 +134,33 @@ class GraniteMoeHybridMamba2Mixer(nn.Module):
     ) -> mx.array:
         batch_size, seq_len, _ = hidden_states.shape
 
-        dt = nn.softplus(dt + self.dt_bias)
-        dt = mx.clip(dt, self.time_step_limit[0], self.time_step_limit[1])
-
         hidden_states = hidden_states.reshape(
             batch_size, seq_len, self.num_heads, self.head_dim
         )
 
-        B = B.reshape(batch_size, seq_len, self.n_groups, self.ssm_state_size)
-        B = mx.repeat(B, self.heads_per_group, axis=2)
-        C = C.reshape(batch_size, seq_len, self.n_groups, self.ssm_state_size)
-        C = mx.repeat(C, self.heads_per_group, axis=2)
-
-        A = -mx.exp(self.A_log.astype(mx.float32)).astype(hidden_states.dtype)
-
-        if cache is not None and cache[1] is not None:
-            h = cache[1]
-        else:
-            h = mx.zeros(
+        if cache is not None:
+            state = cache[1]
+        if state is None:
+            state = mx.zeros(
                 (batch_size, self.num_heads, self.head_dim, self.ssm_state_size),
-                dtype=hidden_states.dtype,
+                hidden_states.dtype,
             )
 
-        outputs = []
-        for t in range(seq_len):
-            dt_t = dt[:, t, :]
-            dA = mx.exp(dt_t * A)[..., None, None]
-            dB = (dt_t[..., None] * B[:, t])[..., None, :]
-
-            h = dA * h + dB * hidden_states[:, t, :, :, None]
-            y_t = (h @ C[:, t, :, :, None]).squeeze(-1) + self.D[
-                :, None
-            ] * hidden_states[:, t]
-            outputs.append(y_t)
+        ssm_fn = ssm_step if seq_len == 1 else ssm_step_ops
+        y, state = ssm_fn(
+            hidden_states,
+            self.A_log,
+            B,
+            C,
+            self.D,
+            dt,
+            self.dt_bias,
+            state,
+            self.time_step_limit,
+        )
 
         if cache is not None:
-            cache[1] = h
-
-        y = mx.stack(outputs, axis=1)
+            cache[1] = state
         return y.reshape(batch_size, seq_len, self.intermediate_size)
 
     def __call__(

--- a/mlx_lm/models/ssm.py
+++ b/mlx_lm/models/ssm.py
@@ -1,0 +1,108 @@
+import mlx.core as mx
+import mlx.nn as nn
+
+
+@mx.compile
+def compute_dt(dt, dt_bias, time_step_limit):
+    dt = nn.softplus(dt + dt_bias)
+    return mx.clip(dt, time_step_limit[0], time_step_limit[1])
+
+
+def ssm_step_ops(
+    hidden_states: mx.array,
+    A_log: mx.array,
+    B: mx.array,
+    C: mx.array,
+    D: mx.array,
+    dt: mx.array,
+    dt_bias: mx.array,
+    state: mx.array,
+    time_step_limit=(0.001, 100.0),
+) -> mx.array:
+    batch_size, seq_len, num_heads, head_dim = hidden_states.shape
+    state_size = B.shape[-1]
+    dt = compute_dt(dt, dt_bias, time_step_limit)
+    A = -mx.exp(A_log.astype(mx.float32)).astype(hidden_states.dtype)
+    B = B.reshape(batch_size, seq_len, 1, state_size)
+    C = C.reshape(batch_size, seq_len, 1, state_size)
+    C = mx.repeat(C, num_heads, axis=2)
+    dA = mx.exp(dt * A)
+    dB = dt[..., None] * mx.repeat(B, num_heads, axis=2)
+    dB_h = dB[..., None, :] * hidden_states[..., None]
+    hs = []
+    for t in range(seq_len):
+        state = dA[:, t, :, None, None] * state + dB_h[:, t]
+        hs.append(state)
+    Dh = D[:, None] * hidden_states
+    y = (mx.stack(hs, axis=1) @ C[..., None]).squeeze(-1) + Dh
+    return y, state
+
+
+def make_ssm_kernel():
+    source = f"""
+        // TODO this needs a fix for batching
+        auto n = thread_position_in_grid.z;
+        constexpr int n_per_t = Ds / 32;
+
+        auto x = X + n * Dh;
+        out += n * Dh;
+        auto i_state = state_in + n * Dh * Ds;
+        auto o_state = state_out + n * Dh * Ds;
+
+        auto ds_idx = thread_position_in_threadgroup.x;
+        auto d_idx = thread_position_in_grid.y;
+
+        auto dt_ = static_cast<float>(dt[n]);
+        auto A = -fast::exp(static_cast<float>(A_log[n]));
+        auto dA = fast::exp(A * dt_);
+
+        float acc = 0.0;
+        auto x_ = static_cast<float>(x[d_idx]);
+
+        for (int i = 0; i < n_per_t; ++i) {{
+            auto s_idx = n_per_t * ds_idx + i;
+            auto idx = d_idx * Ds + s_idx;
+            auto dB_by_x = x_ * dt_ * static_cast<float>(B[s_idx]);
+            auto state = dA * i_state[idx] + dB_by_x;
+            o_state[idx] = static_cast<T>(state);
+            acc += state * C[s_idx];
+        }}
+        acc = simd_sum(acc);
+        if (thread_index_in_simdgroup == 0) {{
+            out[d_idx] = static_cast<T>(acc + x_ * D[n]);
+        }}
+    """
+    return mx.fast.metal_kernel(
+        name="ssm_kernel",
+        input_names=["X", "A_log", "B", "C", "D", "dt", "state_in"],
+        output_names=["out", "state_out"],
+        source=source,
+    )
+
+
+_ssm_kernel = make_ssm_kernel()
+
+
+def ssm_step(
+    hidden_states: mx.array,
+    A_log: mx.array,
+    B: mx.array,
+    C: mx.array,
+    D: mx.array,
+    dt: mx.array,
+    dt_bias: mx.array,
+    state: mx.array,
+    time_step_limit=(0.001, 100.0),
+):
+    input_type = hidden_states.dtype
+    n, _, h, d = hidden_states.shape
+    ds = B.shape[-1]
+    dt = compute_dt(dt, dt_bias, time_step_limit)
+    return _ssm_kernel(
+        inputs=[hidden_states, A_log, B, C, D, dt, state],
+        template=[("T", input_type), ("Dh", d), ("Ds", ds), ("H", h)],
+        grid=(32, d, h * n),
+        threadgroup=(32, 8, 1),
+        output_shapes=[(n, 1, h, d), state.shape],
+        output_dtypes=[input_type, input_type],
+    )

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -10,6 +10,7 @@ from mlx.utils import tree_map
 from mlx_lm.models import rope_utils
 from mlx_lm.models.base import create_causal_mask, scaled_dot_product_attention
 from mlx_lm.models.cache import KVCache, RotatingKVCache, make_prompt_cache
+from mlx_lm.models.ssm import ssm_step, ssm_step_ops
 
 
 class TestModels(unittest.TestCase):
@@ -1724,6 +1725,25 @@ class TestModels(unittest.TestCase):
                     config["vocab_size"],
                     config["num_hidden_layers"],
                 )
+
+    def test_ssm(self):
+        num_heads = 48
+        head_dim = 64
+        state_dim = 128
+
+        hidden_states = mx.random.normal(shape=(1, 1, num_heads, head_dim))
+        B = mx.random.normal(shape=(1, 1, state_dim))
+        C = mx.random.normal(shape=(1, 1, state_dim))
+        dt = mx.random.normal(shape=(1, 1, num_heads))
+        dt_bias = mx.random.normal(shape=(num_heads,))
+        A_log = mx.random.normal(shape=(num_heads,))
+        D = mx.random.normal(shape=(num_heads,))
+        state = mx.random.normal(shape=(1, num_heads, head_dim, state_dim))
+
+        out, out_state = ssm_step_ops(hidden_states, A_log, B, C, D, dt, dt_bias, state)
+        out_c, out_state_c = ssm_step(hidden_states, A_log, B, C, D, dt, dt_bias, state)
+        self.assertTrue(mx.allclose(out, out_c, atol=1e-4, rtol=1e-4))
+        self.assertTrue(mx.allclose(out_state, out_state_c, atol=1e-4, rtol=1e-4))
 
 
 if __name__ == "__main__":

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -1727,23 +1727,28 @@ class TestModels(unittest.TestCase):
                 )
 
     def test_ssm(self):
-        num_heads = 48
-        head_dim = 64
-        state_dim = 128
+        for batch_size in [1, 2]:
+            num_heads = 48
+            head_dim = 64
+            state_dim = 128
 
-        hidden_states = mx.random.normal(shape=(1, 1, num_heads, head_dim))
-        B = mx.random.normal(shape=(1, 1, state_dim))
-        C = mx.random.normal(shape=(1, 1, state_dim))
-        dt = mx.random.normal(shape=(1, 1, num_heads))
-        dt_bias = mx.random.normal(shape=(num_heads,))
-        A_log = mx.random.normal(shape=(num_heads,))
-        D = mx.random.normal(shape=(num_heads,))
-        state = mx.random.normal(shape=(1, num_heads, head_dim, state_dim))
+            hidden_states = mx.random.normal(shape=(batch_size, 1, num_heads, head_dim))
+            B = mx.random.normal(shape=(batch_size, 1, state_dim))
+            C = mx.random.normal(shape=(batch_size, 1, state_dim))
+            dt = mx.random.normal(shape=(batch_size, 1, num_heads))
+            dt_bias = mx.random.normal(shape=(num_heads,))
+            A_log = mx.random.normal(shape=(num_heads,))
+            D = mx.random.normal(shape=(num_heads,))
+            state = mx.random.normal(shape=(batch_size, num_heads, head_dim, state_dim))
 
-        out, out_state = ssm_step_ops(hidden_states, A_log, B, C, D, dt, dt_bias, state)
-        out_c, out_state_c = ssm_step(hidden_states, A_log, B, C, D, dt, dt_bias, state)
-        self.assertTrue(mx.allclose(out, out_c, atol=1e-4, rtol=1e-4))
-        self.assertTrue(mx.allclose(out_state, out_state_c, atol=1e-4, rtol=1e-4))
+            out, out_state = ssm_step_ops(
+                hidden_states, A_log, B, C, D, dt, dt_bias, state
+            )
+            out_c, out_state_c = ssm_step(
+                hidden_states, A_log, B, C, D, dt, dt_bias, state
+            )
+            self.assertTrue(mx.allclose(out, out_c, atol=1e-4, rtol=1e-4))
+            self.assertTrue(mx.allclose(out_state, out_state_c, atol=1e-4, rtol=1e-4))
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Adds a custom SSM kernel + some optimizations to SSM.

Since these are more common.. I think it's worth having a common + fast implementation that hybrid SSM models can use.

TODO:

- Use ssm step for other models where possible
- Possible speed up prompt processing using scan formulation instead of recurrent formulation.