### PR TITLE
Fix `TypeError: Model.__call__() got an unexpected keyword argument 'mask'` for qwen2_vl, mistral3

### DIFF
--- a/mlx_lm/models/mistral3.py
+++ b/mlx_lm/models/mistral3.py
@@ -31,11 +31,10 @@ class Model(nn.Module):
         self,
         inputs: mx.array,
         cache=None,
-        mask: Optional[mx.array] = None,
         input_embeddings: Optional[mx.array] = None,
     ):
         return self.language_model(
-            inputs, cache=cache, mask=mask, input_embeddings=input_embeddings
+            inputs, cache=cache, input_embeddings=input_embeddings
         )
 
     def sanitize(self, weights):

--- a/mlx_lm/models/qwen2_vl.py
+++ b/mlx_lm/models/qwen2_vl.py
@@ -34,11 +34,10 @@ class Model(nn.Module):
         self,
         inputs: mx.array,
         cache=None,
-        mask: Optional[mx.array] = None,
         input_embeddings: Optional[mx.array] = None,
     ):
         return self.language_model(
-            inputs, cache=cache, mask=mask, input_embeddings=input_embeddings
+            inputs, cache=cache, input_embeddings=input_embeddings
         )
 
     def sanitize(self, weights):


### PR DESCRIPTION
This PR fixes `TypeError: Model.__call__() got an unexpected keyword argument 'mask'`.

After recent changes, the underlying language models for `qwen2_vl` and `mistral3` do not accept `mask` as an argument.