### PR TITLE
Extends quantization predicate with config

### DIFF
--- a/mlx_lm/utils.py
+++ b/mlx_lm/utils.py
@@ -496,7 +496,7 @@ def quantize_model(
             return False
         bool_or_params = True
         if quant_predicate is not None:
-            bool_or_params = quant_predicate(path, module)
+            bool_or_params = quant_predicate(path, module, config)
         if isinstance(bool_or_params, dict):
             quantized_config["quantization"][path] = bool_or_params
         elif fine_grained_config and bool_or_params:


### PR DESCRIPTION
Adds config parameter to quantization predicate. (I didn't look at the blame for this code but it looks like this was just accidentally removed at some point.

```
python -m mlx_lm quant.dynamic_quant \
  --model robbiemu/MobileLLM-R1-950M-mlx-fp16 \
  --mlx-path ./mlx-q4-dyn-output \
  --target-bpw 4.5
  
[INFO] Quantized model with 5.003 bits per weight.
Peak memory used: 25.323GB

Fetching 8 files:
100%|██████████| 8/8 [00:00<00:00, 181375.31it/s]

Token indices sequence length is longer than the specified maximum sequence length for this model (110205 > 32768). Running this sequence through the model will result in indexing errors.

Estimating sensitivities:
100%|██████████| 53/53 [01:45<00:00, 1.96s/it]
sensitivities: 54it [01:48, 2.02s/it]

Fetching 8 files:
100%|██████████| 8/8 [00:00<00:00, 243148.06it/s]

Token indices sequence length is longer than the specified maximum sequence length for this model (110205 > 32768). Running this sequence through the model will result in indexing errors.
```

resolves #475 
