### PR TITLE
Make mixed quantization affect attention in DeepSeek V3, others

### DIFF
--- a/mlx_lm/convert.py
+++ b/mlx_lm/convert.py
@@ -63,7 +63,9 @@ def mixed_quant_predicate_builder(
             or index >= 7 * num_layers // 8
             or (index - num_layers // 8) % 3 == 2
         )
-        if "v_proj" in path and use_more_bits:
+        if (
+            "v_proj" in path or "v_a_proj" in path or "v_b_proj" in path
+        ) and use_more_bits:
             return {"group_size": group_size, "bits": high_bits}
         if "down_proj" in path and use_more_bits:
             return {"group_size": group_size, "bits": high_bits}


### PR DESCRIPTION
Please review this pull request with skepticism. It is intended as a question, "Is the current behavior intended, and if not should it be this instead?" accompanied by code.

Currently:

```python
def mixed_quant_predicate(
    path: str,
    module: nn.Module,
) -> Union[bool, dict]:
    """Implements mixed quantization predicates with similar choices to, for example, llama.cpp's Q4_K_M.
    Ref: https://github.com/ggerganov/llama.cpp/blob/917786f43d0f29b7c77a0c56767c0fa4df68b1c5/src/llama.cpp#L5265
    By Alex Barron: https://gist.github.com/barronalex/84addb8078be21969f1690c1454855f3
    """
    index = (
        int(path.split(".")[layer_location])
        if len(path.split(".")) > layer_location
        else 0
    )
    use_more_bits = (
        index < num_layers // 8
        or index >= 7 * num_layers // 8
        or (index - num_layers // 8) % 3 == 2
    )
    if "v_proj" in path and use_more_bits:
        return {"group_size": group_size, "bits": high_bits}
    if "down_proj" in path and use_more_bits:
        return {"group_size": group_size, "bits": high_bits}
    if "lm_head" in path:
        return {"group_size": group_size, "bits": high_bits}

    return {"group_size": group_size, "bits": low_bits}
```

For DeepSeek-V3.1-Terminus, there are no tensors with names containing "v_proj." There are however "(k)v_a_proj" and "(k)v_b_proj." Looking at the config.json from a mixed_4_6 quant generated by the current mlx_lm.convert:

| name                                        | group_size | bits |
|---------------------------------------------|------------|------|
| model.layers.0.self_attn.q_a_proj           | 64         | 4    |
| model.layers.0.self_attn.q_b_proj           | 64         | 4    |
| model.layers.0.self_attn.kv_a_proj_with_mqa | 64         | 4    |
| model.layers.0.self_attn.kv_b_proj          | 64         | 4    |
| model.layers.0.self_attn.o_proj             | 64         | 4    |
| model.layers.0.mlp.gate_proj                | 64         | 4    |
| model.layers.0.mlp.up_proj                  | 64         | 4    |
| model.layers.0.mlp.down_proj                | 64         | 6    |

Compare with the metadata of [a Q4_K_M GGUF for DeepSeek-V3.1-Terminus](https://huggingface.co/bartowski/deepseek-ai_DeepSeek-V3.1-Terminus-GGUF/tree/main/deepseek-ai_DeepSeek-V3.1-Terminus-Q4_K_M?show_file_info=deepseek-ai_DeepSeek-V3.1-Terminus-Q4_K_M%2Fdeepseek-ai_DeepSeek-V3.1-Terminus-Q4_K_M-00001-of-00011.gguf) (you can examine it on huggingface without downloading):

| name                        | shape           | precision |
|-----------------------------|-----------------|-----------|
| blk.0.attn_k_b.weight       | [128, 512, 128] | Q8_0      |
| blk.0.attn_kv_a_mqa.weight  | [7 168, 576]    | Q8_0      |
| blk.0.attn_kv_a_norm.weight | [512]           | F32       |
| blk.0.attn_norm.weight      | [7 168]         | F32       |
| blk.0.attn_q_a.weight       | [7 168, 1 536]  | Q6_K      |
| blk.0.attn_q_a_norm.weight  | [1 536]         | F32       |
| blk.0.attn_q_b.weight       | [1 536, 24 576] | Q5_K      |
| blk.0.attn_v_b.weight       | [512, 128, 128] | Q8_0      |
| blk.0.ffn_down.weight       | [18 432, 7 168] | Q6_K      |
| blk.0.ffn_gate.weight       | [7 168, 18 432] | Q4_K      |
| blk.0.ffn_norm.weight       | [7 168]         | F32       |
| blk.0.ffn_up.weight         | [7 168, 18 432] | Q4_K      |
| blk.0.attn_output.weight    | [16 384, 7 168] | Q5_K      |

The code change in this PR changes the reported bpw for `mlx_lm.convert --quantize --quant-predicate mixed_4_6 --hf-path deepseek-ai/DeepSeek-V3.1-Terminus ...` from 4.809 to 4.811, or from 403.41 GB to 403.57 GB as reported by the file system.