### PR TITLE
Fix: Correct weight masking for zero-computation experts in LongCat Flash MoE

### DIFF
--- a/mlx_lm/models/longcat_flash.py
+++ b/mlx_lm/models/longcat_flash.py
@@ -235,7 +235,7 @@ class LongcatFlashMoE(nn.Module):
 
         regular_outputs = self.switch_mlp(hidden_states, topk_indices)
 
-        weighted_outputs = regular_outputs * topk_weights[..., None]
+        weighted_outputs = regular_outputs * regular_weights[..., None]
 
         # Add identity expert contribution if needed
         assert self.zero_expert_type == "identity"


### PR DESCRIPTION
The MoE layer was incorrectly applying weights to regular expert outputs. Line 234 computed `regular_weights` (which zeros out contributions for tokens routed to identity experts) but line 238 mistakenly used `topk_weights` instead, causing tokens routed to identity experts to incorrectly receive contributions from both regular and identity expert paths. 

This fix uses `regular_weights` instead of `topk_weights` to ensure tokens are processed by either regular experts or identity experts.

Here is some before and after perplexity testing using [ppl.py](https://gist.github.com/N8python/fe048698e17fc430416d28d4689603dc)

**Test Configuration**

  - Sequence length: 512
  - Samples: 225
  - Batch size: 8

**Results**

  Before (without fix)

  | Model                   | Perplexity    | Memory (GB) | Tokens/sec |
  |-------------------------|---------------|-------------|------------|
  | LongCat-Flash-Chat-6bit | 4.186 ± 0.007 | 428.93      | 154        |
  | LongCat-Flash-Chat-5bit | 4.194 ± 0.007 | 363.67      | 170        |
  | LongCat-Flash-Chat-4bit | 4.304 ± 0.007 | 298.42      | 211        |
  | LongCat-Flash-Chat-3bit | 5.008 ± 0.007 | 233.16      | 269        |

  After (with fix)

  | Model                   | Perplexity    | Memory (GB) | Tokens/sec | Improvement |
  |-------------------------|---------------|-------------|------------|-------------|
  | LongCat-Flash-Chat-6bit | 3.811 ± 0.007 | 428.93      | 153        | -8.96%      |
  | LongCat-Flash-Chat-5bit | 3.837 ± 0.007 | 363.67      | 166        | -8.51%      |
  | LongCat-Flash-Chat-4bit | 3.921 ± 0.007 | 298.42      | 219        | -8.90%      |
  | LongCat-Flash-Chat-3bit | 4.362 ± 0.007 | 233.16      | 265        | -12.90%     |