### PR TITLE
Finish: Add early stopping for LoRA training (supersedes #331)

### DIFF
--- a/mlx_lm/LORA.md
+++ b/mlx_lm/LORA.md
@@ -82,6 +82,13 @@ You can specify the output location with `--adapter-path`.
 You can resume fine-tuning with an existing adapter with
 `--resume-adapter-file <path_to_adapters.safetensors>`.
 
+#### Early stopping
+
+Pass `--early-stopping` (or set `early_stopping: true` in a config file) to
+skip further training once the validation loss increases between evaluation
+checkpoints. This is useful when you want to avoid overfitting without manually
+monitoring the run.
+
 #### Logging
 
 You can log training metrics to Weights & Biases by passing a project name with

--- a/mlx_lm/examples/lora_config.yaml
+++ b/mlx_lm/examples/lora_config.yaml
@@ -67,6 +67,9 @@ max_seq_length: 2048
 # Use gradient checkpointing to reduce memory use.
 grad_checkpoint: false
 
+# Stop training when validation loss increases between evaluations.
+early_stopping: false
+
 # LoRA parameters can only be specified in a config file
 lora_parameters:
   # The layer keys to apply LoRA to.
@@ -89,4 +92,3 @@ lora_parameters:
 #  valid_split: "train[-100:]"
 #  prompt_feature: "text"
 #  completion_feature: "summary"
-

--- a/mlx_lm/lora.py
+++ b/mlx_lm/lora.py
@@ -67,6 +67,7 @@ CONFIG_DEFAULTS = {
     "max_seq_length": 2048,
     "config": None,
     "grad_checkpoint": False,
+    "early_stopping": False,
     "lr_schedule": None,
     "lora_parameters": {"rank": 8, "dropout": 0.0, "scale": 20.0},
     "mask_prompt": False,

--- a/mlx_lm/lora.py
+++ b/mlx_lm/lora.py
@@ -247,6 +247,7 @@ def train_model(
         adapter_file=adapter_file,
         max_seq_length=args.max_seq_length,
         grad_checkpoint=args.grad_checkpoint,
+        early_stopping=args.early_stopping,
     )
 
     # Initialize the selected optimizer

--- a/mlx_lm/lora.py
+++ b/mlx_lm/lora.py
@@ -188,6 +188,12 @@ def build_parser():
         default=None,
         help="WandB project name to report training metrics. Disabled if None.",
     )
+    parser.add_argument(
+        "--early-stopping",
+        help="Stop when the evaluation loss increases, and overfitting starts.",
+        action="store_true",
+    )
+
     parser.add_argument("--seed", type=int, help="The PRNG seed")
     return parser
 

--- a/mlx_lm/tuner/trainer.py
+++ b/mlx_lm/tuner/trainer.py
@@ -347,7 +347,7 @@ def train(
 
     # Save final weights
     if rank == 0:
-        if not args.early_stopping:  # if early stopping is not used, save the final weights, otherwise the last checkpoint is the best model
+        if not args.early_stopping or val_loss < last_validation_loss:
             adapter_weights = dict(tree_flatten(model.trainable_parameters()))
         mx.save_safetensors(str(args.adapter_file), adapter_weights)
         print(f"Saved final weights to {args.adapter_file}.")


### PR DESCRIPTION
This PR completes and extends the work started in #331 by @hansvdam to add an early-stopping mechanism for LoRA training runs. It wires the option through the public interfaces, documents how to use it, and sets a conservative default to keep existing workflows safe.

> Credit: This builds directly on #331. Co-authored-by lines are included in the PR.
Supersedes: #331

**What's new in this PR:**
* Addresses comments left in #331 
* Add `early_stopping: false` to `CONFIG_DEFAULTS`.
* Expose in `examples/lora_config.yaml` with a one-line description.
* Document flag in `LORA.md` and CLI as `--early-stopping`.

**Usage**

* YAML: `early_stopping: true`
* CLI: `... --eval-interval <n> --early-stopping`