### PR TITLE
Fix batching for models with nested cache structures

### DIFF
--- a/mlx_lm/models/cache.py
+++ b/mlx_lm/models/cache.py
@@ -655,8 +655,8 @@ class CacheList(_BaseCache):
         """
         In-place extend this cache with the other cache.
         """
-        for c in self.caches:
-            c.extend(other)
+        for c, o in zip(self.caches, other.caches):
+            c.extend(o)
 
 
 class BatchKVCache(_BaseCache):


### PR DESCRIPTION
This PR fixes a bug preventing batch generation from working with models that use CacheList for hybrid architectures (Falcon-H1, Baichuan-M1) or dual-cache designs (LongCat-Flash).

```
mlx_lm.benchmark --model /Volumes/WD_EXTRA/models/catalyst/LongCat-Flash-Chat-3bit -p 128 -g 128 -b 16
Running warmup..
Traceback (most recent call last):
  File "/Users/optimus/repo/mlx-lm/.venv/bin/mlx_lm.benchmark", line 7, in <module>
    sys.exit(main())
             ^^^^^^
  File "/Users/optimus/repo/mlx-lm/mlx_lm/benchmark.py", line 105, in main
    _bench()
  File "/Users/optimus/repo/mlx-lm/mlx_lm/benchmark.py", line 95, in batch_bench
    return batch_generate(
           ^^^^^^^^^^^^^^^
  File "/Users/optimus/repo/mlx-lm/mlx_lm/generate.py", line 1088, in batch_generate
    while responses := gen.next():
                       ^^^^^^^^^^
  File "/Users/optimus/repo/mlx-lm/mlx_lm/generate.py", line 1053, in next
    return self._next()
           ^^^^^^^^^^^^
  File "/Users/optimus/repo/mlx-lm/mlx_lm/generate.py", line 1005, in _next
    self.active_batch.extend(batch)
  File "/Users/optimus/repo/mlx-lm/mlx_lm/generate.py", line 855, in extend
    c.extend(o)
  File "/Users/optimus/repo/mlx-lm/mlx_lm/models/cache.py", line 659, in extend
    c.extend(other)
  File "/Users/optimus/repo/mlx-lm/mlx_lm/models/cache.py", line 763, in extend
    max_idx = max(self._idx, other._idx)
                             ^^^^^^^^^^
AttributeError: 'CacheList' object has no attribute '_idx'
```