### PR TITLE
Added gradient accumulation to training loop

### DIFF
--- a/mlx_lm/LORA.md
+++ b/mlx_lm/LORA.md
@@ -82,6 +82,10 @@ You can specify the output location with `--adapter-path`.
 You can resume fine-tuning with an existing adapter with
 `--resume-adapter-file <path_to_adapters.safetensors>`.
 
+If you need an effective batch size larger than what fits in memory, set
+`--gradient-accumulation-steps <N>` to accumulate gradients across `N`
+micro-batches before each optimizer update.
+
 #### Logging
 
 You can log training metrics to Weights & Biases using `--report-to wandb`, or

--- a/mlx_lm/examples/lora_config.yaml
+++ b/mlx_lm/examples/lora_config.yaml
@@ -47,6 +47,9 @@ steps_per_report: 10
 # Number of training steps between validations.
 steps_per_eval: 200
 
+# Number of micro-steps to accumulate before each optimizer update.
+gradient_accumulation_steps: 1
+
 # Load path to resume training with the given adapter weights.
 resume_adapter_file: null
 
@@ -90,4 +93,3 @@ lora_parameters:
 #  valid_split: "train[-100:]"
 #  prompt_feature: "text"
 #  completion_feature: "summary"
-

--- a/mlx_lm/lora.py
+++ b/mlx_lm/lora.py
@@ -68,6 +68,7 @@ CONFIG_DEFAULTS = {
     "max_seq_length": 2048,
     "config": None,
     "grad_checkpoint": False,
+    "gradient_accumulation_steps": 1,
     "lr_schedule": None,
     "lora_parameters": {"rank": 8, "dropout": 0.0, "scale": 20.0},
     "mask_prompt": False,
@@ -141,6 +142,11 @@ def build_parser():
         "--steps-per-eval",
         type=int,
         help="Number of training steps between validations.",
+    )
+    parser.add_argument(
+        "--gradient-accumulation-steps",
+        type=int,
+        help="Number of micro-steps to accumulate before each optimizer update.",
     )
     parser.add_argument(
         "--resume-adapter-file",
@@ -265,6 +271,7 @@ def train_model(
         adapter_file=adapter_file,
         max_seq_length=args.max_seq_length,
         grad_checkpoint=args.grad_checkpoint,
+        gradient_accumulation_steps=args.gradient_accumulation_steps,
     )
 
     # Initialize the selected optimizer


### PR DESCRIPTION
This adds `--gradient-accumulation-steps` to the trainer to match a core feature in Hugging Face Transformers. 

**Details:**
* New CLI flag: `--gradient-accumulation-steps` (default `1`, no behavior change).
* Accumulates micro-batch gradients and applies one optimizer update per window.

**Why:**
* Feature parity with HF Transformers.
* Enables larger effective batches on limited memory.