### PR TITLE
feat: Refactor granitemoehybrid to support dense and non-hybrid variants

### DIFF
--- a/mlx_lm/_version.py
+++ b/mlx_lm/_version.py
@@ -1,3 +1,3 @@
 # Copyright © 2023-2025 Apple Inc.
 
-__version__ = "0.28.1"
+__version__ = "0.28.2"

--- a/mlx_lm/models/granitemoehybrid.py
+++ b/mlx_lm/models/granitemoehybrid.py
@@ -417,9 +417,7 @@ class GraniteMoeHybridModel(nn.Module):
             else None
         )
         self.ssm_idx = (
-            args.layer_types.index("mamba")
-            if "mamba" in args.layer_types
-            else None
+            args.layer_types.index("mamba") if "mamba" in args.layer_types else None
         )
 
     def __call__(
@@ -492,7 +490,10 @@ class Model(nn.Module):
                 weights[k] = v.moveaxis(2, 1)
 
         # Handle MoE weight transformation to SwitchGLU format (only for MoE models)
-        if self.args.use_moe and "model.layers.0.block_sparse_moe.input_linear.weight" in weights:
+        if (
+            self.args.use_moe
+            and "model.layers.0.block_sparse_moe.input_linear.weight" in weights
+        ):
             for l in range(self.args.num_hidden_layers):
                 prefix = f"model.layers.{l}.block_sparse_moe"
 
@@ -510,7 +511,10 @@ class Model(nn.Module):
                 )
 
         # Handle dense MLP weight transformation (for dense models)
-        elif not self.args.use_moe and "model.layers.0.shared_mlp.input_linear.weight" in weights:
+        elif (
+            not self.args.use_moe
+            and "model.layers.0.shared_mlp.input_linear.weight" in weights
+        ):
             for l in range(self.args.num_hidden_layers):
                 prefix = f"model.layers.{l}.shared_mlp"
 

--- a/mlx_lm/models/granitemoehybrid.py
+++ b/mlx_lm/models/granitemoehybrid.py
@@ -20,6 +20,7 @@ from .switch_layers import SwitchGLU
 
 @dataclass
 class ModelArgs(BaseModelArgs):
+    # Required fields (no defaults)
     model_type: str
     vocab_size: int
     hidden_size: int
@@ -29,33 +30,41 @@ class ModelArgs(BaseModelArgs):
     num_attention_heads: int
     num_key_value_heads: int
     attention_bias: bool
-
-    # Scalar multipliers
     embedding_multiplier: float
     attention_multiplier: float
     logits_scaling: float
     residual_multiplier: float
-
-    # MoE parameters
-    num_local_experts: int
-    num_experts_per_tok: int
-    shared_intermediate_size: int
-
-    # Mamba parameters
-    mamba_n_heads: int
-    mamba_d_head: int
-    mamba_proj_bias: bool
-    mamba_d_state: int
-    mamba_d_conv: int
-    mamba_n_groups: int
-    mamba_conv_bias: bool
-
     layer_types: List[str]
     rms_norm_eps: float
     rope_theta: float
+
+    # Optional fields (with defaults)
+    # MoE parameters (optional for dense mode)
+    num_local_experts: Optional[int] = None
+    num_experts_per_tok: Optional[int] = None
+    shared_intermediate_size: Optional[int] = None
+
+    # Mamba parameters (optional for non-hybrid mode)
+    mamba_n_heads: Optional[int] = None
+    mamba_d_head: Optional[int] = None
+    mamba_proj_bias: Optional[bool] = None
+    mamba_d_state: Optional[int] = None
+    mamba_d_conv: Optional[int] = None
+    mamba_n_groups: Optional[int] = None
+    mamba_conv_bias: Optional[bool] = None
+
+    # Dense MLP parameters (for non-MoE mode)
+    mlp_bias: bool = False
+
+    # Other optional parameters
     position_embedding_type: str = "rope"
     tie_word_embeddings: bool = True
     time_step_limit: Tuple[float, float] = (0.001, 100.0)
+
+    # Mode flags - inferred from num_local_experts
+    @property
+    def use_moe(self) -> bool:
+        return self.num_local_experts is not None and self.num_local_experts > 0
 
 
 class GraniteMoeHybridRMSNormGated(nn.Module):
@@ -314,11 +323,27 @@ class GraniteMoeHybridSharedMLP(nn.Module):
         return self.output_linear(nn.silu(gate) * up)
 
 
+class GraniteMoeHybridMLP(nn.Module):
+    def __init__(self, args: ModelArgs):
+        super().__init__()
+        dim = args.hidden_size
+        hidden_dim = args.intermediate_size
+        mlp_bias = args.mlp_bias
+
+        self.gate_proj = nn.Linear(dim, hidden_dim, bias=mlp_bias)
+        self.down_proj = nn.Linear(hidden_dim, dim, bias=mlp_bias)
+        self.up_proj = nn.Linear(dim, hidden_dim, bias=mlp_bias)
+
+    def __call__(self, x) -> mx.array:
+        return self.down_proj(nn.silu(self.gate_proj(x)) * self.up_proj(x))
+
+
 class GraniteMoeHybridLayer(nn.Module):
     def __init__(self, args: ModelArgs, layer_type: str):
         super().__init__()
         self.layer_type = layer_type
         self.residual_multiplier = args.residual_multiplier
+        self.use_moe = args.use_moe
 
         self.input_layernorm = nn.RMSNorm(args.hidden_size, eps=args.rms_norm_eps)
 
@@ -329,8 +354,14 @@ class GraniteMoeHybridLayer(nn.Module):
         else:
             raise ValueError(f"Unknown layer type: {layer_type}")
 
-        self.shared_mlp = GraniteMoeHybridSharedMLP(args)
-        self.block_sparse_moe = GraniteMoeHybridMoE(args)
+        # MoE or dense MLP after attention/mamba
+        if self.use_moe:
+            self.shared_mlp = GraniteMoeHybridSharedMLP(args)
+            self.block_sparse_moe = GraniteMoeHybridMoE(args)
+        else:
+            # Dense MLP mode
+            self.mlp = GraniteMoeHybridMLP(args)
+
         self.post_attention_layernorm = nn.RMSNorm(
             args.hidden_size, eps=args.rms_norm_eps
         )
@@ -352,13 +383,16 @@ class GraniteMoeHybridLayer(nn.Module):
 
         hidden_states = residual + hidden_states * self.residual_multiplier
 
-        # Second block: MoE + shared_mlp
+        # Second block: MoE + shared_mlp OR dense MLP
         residual = hidden_states
         normed = self.post_attention_layernorm(hidden_states)
 
-        moe_out = self.block_sparse_moe(normed)
-        shared_out = self.shared_mlp(normed)
-        mlp_out = moe_out + shared_out
+        if self.use_moe:
+            moe_out = self.block_sparse_moe(normed)
+            shared_out = self.shared_mlp(normed)
+            mlp_out = moe_out + shared_out
+        else:
+            mlp_out = self.mlp(normed)
 
         hidden_states = residual + mlp_out * self.residual_multiplier
 
@@ -375,9 +409,20 @@ class GraniteMoeHybridModel(nn.Module):
         ]
         self.norm = nn.RMSNorm(args.hidden_size, eps=args.rms_norm_eps)
         self.embedding_multiplier = args.embedding_multiplier
-        self.fa_idx = args.layer_types.index("attention")
-        self.ssm_idx = args.layer_types.index("mamba")
+
+        # Handle hybrid vs non-hybrid mode
+        if "attention" in args.layer_types:
+            self.fa_idx = args.layer_types.index("attention")
+        else:
+            self.fa_idx = None
+
+        if "mamba" in args.layer_types:
+            self.ssm_idx = args.layer_types.index("mamba")
+        else:
+            self.ssm_idx = None
+
         self.layer_types = args.layer_types
+        self.is_hybrid = "mamba" in args.layer_types
 
     def __call__(
         self,
@@ -389,12 +434,22 @@ class GraniteMoeHybridModel(nn.Module):
         if cache is None:
             cache = [None] * len(self.layers)
 
-        attn_mask = create_attention_mask(hidden_states, cache[self.fa_idx])
-        mamba_mask = create_ssm_mask(hidden_states, cache[self.ssm_idx])
+        # Create masks based on what layer types exist
+        attn_mask = None
+        mamba_mask = None
 
-        cache_counter = 0
+        if self.fa_idx is not None:
+            attn_mask = create_attention_mask(hidden_states, cache[self.fa_idx])
+        if self.ssm_idx is not None:
+            mamba_mask = create_ssm_mask(hidden_states, cache[self.ssm_idx])
+
         for layer, c, layer_type in zip(self.layers, cache, self.layer_types):
-            mask = attn_mask if layer.layer_type == "attention" else mamba_mask
+            if layer.layer_type == "attention":
+                mask = attn_mask
+            elif layer.layer_type == "mamba":
+                mask = mamba_mask
+            else:
+                mask = None
             hidden_states = layer(hidden_states, mask=mask, cache=c)
 
         return self.norm(hidden_states)
@@ -435,6 +490,8 @@ class Model(nn.Module):
                 caches.append(MambaCache())
             elif layer.layer_type == "attention":
                 caches.append(KVCache())
+            else:
+                caches.append(None)
         return caches
 
     def sanitize(self, weights):
@@ -443,8 +500,8 @@ class Model(nn.Module):
             if "conv1d.weight" in k and v.shape[-1] != 1:
                 weights[k] = v.moveaxis(2, 1)
 
-        # Handle MoE weight transformation to SwitchGLU format
-        if "model.layers.0.block_sparse_moe.input_linear.weight" in weights:
+        # Handle MoE weight transformation to SwitchGLU format (only for MoE models)
+        if self.args.use_moe and "model.layers.0.block_sparse_moe.input_linear.weight" in weights:
             for l in range(self.args.num_hidden_layers):
                 prefix = f"model.layers.{l}.block_sparse_moe"
 
@@ -461,12 +518,28 @@ class Model(nn.Module):
                     f"{prefix}.output_linear.weight"
                 )
 
+        # Handle dense MLP weight transformation (for dense models)
+        elif not self.args.use_moe and "model.layers.0.shared_mlp.input_linear.weight" in weights:
+            for l in range(self.args.num_hidden_layers):
+                prefix = f"model.layers.{l}.shared_mlp"
+
+                # Transform shared_mlp weights to standard mlp weights
+                input_weight = weights.pop(f"{prefix}.input_linear.weight")
+                # Split into gate and up projections (each half)
+                gate_proj, up_proj = mx.split(input_weight, 2, axis=0)
+                weights[f"model.layers.{l}.mlp.gate_proj.weight"] = gate_proj
+                weights[f"model.layers.{l}.mlp.up_proj.weight"] = up_proj
+
+                weights[f"model.layers.{l}.mlp.down_proj.weight"] = weights.pop(
+                    f"{prefix}.output_linear.weight"
+                )
+
         return weights
 
     @property
     def quant_predicate(self):
         def predicate(path, _):
-            if path.endswith("router.layer"):
+            if self.args.use_moe and path.endswith("router.layer"):
                 return {"group_size": 64, "bits": 8}
             return True
 


### PR DESCRIPTION
## Description

This PR extends the `granitemoehybrid.py` model implementation to support "degenerate" cases of the architecture where a dense block is used in place of an MoE and/or all layers are attention layers (non-hybrid). There will be some models in the granite 4 family that require these cases.

## Notes

In order to get _any_ of these models to run locally on this branch, I also had to remove [this line](https://github.com/ml-explore/mlx-lm/blob/main/mlx_lm/models/base.py#L136). The version of `mlx` I have (installed with `pip install -e` from the tip of `main` / `bbf14239`) does not seem to support the `sinks` argument, though I do see it implemented [here](https://github.com/ml-explore/mlx/blob/bbf14239538c18a9f8a3d61f52ab0f29589410f0/python/src/fast.cpp#L237), so it's possible that something didn't get recompiled correctly. Either way, the addition of this flag forces the lower-bound on `mlx.core` up to a version that includes that in the function signature. This could be worked around to be backwards-compatible with either a runtime version check or a `try/except` that falls back to calling without `sinks`. Alternately, the signature with `sinks` could be called only if `sinks is not None`.

## Details

Written with Claude Code. Initial prompt:

---

I need to modify the model support implemented in `mlx_lm/models/granitemoehybrid.py` in two ways:

* Support optionally using a dense block in place of MoE. The dense block should look like `mlx_lm/models/granite.py` instead of `mlx_lm/models/granitemoe.py`.

* Support the case where there are no `mamba` layers (ie non-hybrid). This should devolve to exactly `granite.py` or `granitemoe.py` depending on whether the block after attention is dense or MoE.

You can test this using the following two models:

* Dense w/ hybrid: /Users/ghart/models/dmf_models/granite-4.0-h-micro-r250918a
* Dense w/ non-hybrid: /Users/ghart/models/dmf_models/granite-4.0-micro-r250918a

---

Signed-off-by: Gabe Goodhart <ghart@us.ibm.com>