### PR TITLE
GPT2 Batching Fix

### DIFF
--- a/mlx_lm/models/gpt2.py
+++ b/mlx_lm/models/gpt2.py
@@ -138,7 +138,9 @@ class GPT2Model(nn.Module):
         if cache[0] is not None:
             offset = cache[0].offset
 
-        position_ids = mx.arange(offset, offset + L)
+        offset = mx.array(offset)
+        position_ids = mx.arange(L) + offset[..., None]
+
         hidden_states += self.wpe(position_ids)
 
         mask = create_attention_mask(hidden_states, cache[0])

--- a/mlx_lm/models/gpt2.py
+++ b/mlx_lm/models/gpt2.py
@@ -1,4 +1,4 @@
-# Copyright © 2023-2024 Apple Inc.
+# Copyright © 2023 - 2024 Apple Inc.
 
 from dataclasses import dataclass
 from typing import Any, Optional


### PR DESCRIPTION
Modified GPT2 positional embedding computation to be compatible with the new batching functions. The original implementation assumes int offset, which fails with batching where offset is an 1D array of int offsets. Now it creates a 2D array for input to the positional embeddings regardless of whether offset is int or 1D array.
