### PR TITLE
Fix: Add __future__ annotations import to qwen3_next.py for Python 3.9 compatibility

### DIFF
--- a/mlx_lm/models/qwen3_next.py
+++ b/mlx_lm/models/qwen3_next.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 # Copyright © 2025 Apple Inc.
 
 from dataclasses import dataclass

--- a/mlx_lm/models/qwen3_next.py
+++ b/mlx_lm/models/qwen3_next.py
@@ -1,6 +1,6 @@
-from __future__ import annotations
-
 # Copyright © 2025 Apple Inc.
+
+from __future__ import annotations
 
 from dataclasses import dataclass
 from typing import Any, Dict, List, Optional, Tuple, Union


### PR DESCRIPTION
## Summary
Fixes Python 3.8/3.9 compatibility issue in `qwen3_next.py`.

## Problem
- `qwen3_next.py` uses `|` union syntax (line 60: `mx.array | None`)
- This syntax requires Python 3.10+ or `from __future__ import annotations`
- Package declares `python_requires>=3.8` but breaks on Python 3.9
- Affects macOS system Python (3.9.6, shipped with macOS 15 Sequoia)

## Root Cause
Missing `from __future__ import annotations` import at top of file.

## Solution
Add the missing import (2 lines: import + blank line before copyright).

## Testing
Verified on Python 3.9.6 (macOS 15.6.1):
```python
from mlx_lm.utils import _get_classes
config = {"model_type": "qwen3_next"}
model_class, args_class = _get_classes(config)
# ✅ Works after fix (was: TypeError before)
```

## Consistency
Other model files (e.g., `llama.py`) use `Optional[...]` syntax for Python 3.8+ compatibility. This fix brings `qwen3_next.py` in line with the declared package requirements while using modern syntax.

## Impact
- ✅ Maintains Python 3.8+ compatibility (as declared)
- ✅ Works on macOS system Python
- ✅ No code changes, only import addition
- ✅ Compatible with Python 3.10+ (no change in behavior)