### PR TITLE
Optimize Bailing MoE

### DIFF
--- a/mlx_lm/models/bailing_moe.py
+++ b/mlx_lm/models/bailing_moe.py
@@ -56,7 +56,9 @@ def swiglu(gate, up):
 
 @partial(mx.compile, shapeless=True)
 def aggregate_expert_outputs(expert_outputs, scores):
-    return (expert_outputs * scores[..., None]).sum(axis=-2).astype(expert_outputs.dtype)
+    return (
+        (expert_outputs * scores[..., None]).sum(axis=-2).astype(expert_outputs.dtype)
+    )
 
 
 class BailingMoeMLP(nn.Module):


### PR DESCRIPTION
# Description

This PR adds modest performance improvements (5-6%) to the Bailing MoE model implementation

- Add `@mx.compile` decorator to `group_expert_select` function
- Eliminate array copy in expert selection using negative `kth` in `argpartition`
- Add explicit `dtype` to scalar creation to avoid implicit conversions
- Add compiled `swiglu_fused` function to fuse MLP activation
- Add compiled `aggregate_expert_outputs` to fuse expert aggregation

Note that as context length grows, improvement reduces as attention becomes the bottleneck.
  
# Benchmarks

`mlx_lm.benchmark --model /Volumes/WD_EXTRA/models/catalyst/Ling-1T-3bit -p <n> -g 128`

## Prompt Processing Speed (tokens/sec)

| Context Length | Without PR | With PR | Improvement |
|----------------|------------|---------|-------------|
| 512 tokens     | 136.20     | 136.23  | +0.02%      |
| 1024 tokens    | 164.69     | 164.93  | +0.15%      |
| 2048 tokens    | 184.64     | 184.59  | -0.03%      |
| 4096 tokens    | 182.71     | 182.72  | +0.01%      |
| 8192 tokens    | 176.18     | 176.11  | -0.04%      |

## Generation Speed (tokens/sec)

| Context Length | Without PR | With PR | Improvement |
|----------------|------------|---------|-------------|
| 512 tokens     | 18.826     | 19.964  | +6.04% ✅    |
| 1024 tokens    | 18.435     | 19.398  | +5.22% ✅    |
| 2048 tokens    | 18.165     | 19.062  | +4.94% ✅    |
| 4096 tokens    | 17.618     | 18.513  | +5.08% ✅    |
| 8192 tokens    | 16.583     | 17.371  | +4.75% ✅    |

## Peak Memory Usage (GB)

| Context Length | Without PR | With PR | Improvement |
|----------------|------------|---------|-------------|
| 512 tokens     | 438.334    | 438.377 | -0.043      |
| 1024 tokens    | 438.870    | 439.048 | -0.178      |
| 2048 tokens    | 439.797    | 440.069 | -0.272      |
| 4096 tokens    | 442.734    | 443.006 | -0.272      |
| 8192 tokens    | 442.734    | 443.006 | -0.272      |

# Perplexity Testing

Model: inclusionAI/Ling-1T
Dataset: wikitext, 225 samples, batch_size=8, sequence_length=512

## Perplexity

| Quantization | Without PR      | With PR         | Change          |
|--------------|-----------------|-----------------|-----------------|
| 2-bit        | 6.490 ± 0.007   | 6.486 ± 0.007   | -0.004 ✅        |
| 3-bit        | 4.613 ± 0.007   | 4.611 ± 0.007   | -0.002 ✅        |

## Peak Memory (GB)

| Quantization | Without PR | With PR | Change  |
|--------------|------------|---------|---------|
| 2-bit        | 296.83     | 297.33  | +0.50   |
| 3-bit        | 413.19     | 413.70  | +0.51   |
