### PR TITLE
Add RWKV7

### DIFF
--- a/mlx_lm/models/rwkv7.py
+++ b/mlx_lm/models/rwkv7.py
@@ -1,3 +1,5 @@
+# Copyright © 2025 Apple Inc.
+
 from dataclasses import dataclass
 from functools import partial
 from typing import Optional

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -2080,6 +2080,19 @@ class TestModels(unittest.TestCase):
                 "swa_v_head_dim": 64,
                 "partial_rotary_factor": 0.5,
             },
+            {
+                "model_type": "rwkv7",
+                "vocab_size": 1000,
+                "hidden_size": 128,
+                "intermediate_size": 128,
+                "norm_eps": 1e-5,
+                "head_dim": 32,
+                "num_hidden_layers": 4,
+                "a_low_rank_dim": 16,
+                "v_low_rank_dim": 16,
+                "gate_low_rank_dim": 16,
+                "decay_low_rank_dim": 16,
+            },
         ]
         for config in test_configs:
             model_type = config["model_type"]


### PR DESCRIPTION
This PR adds support for RWKV-7 models.
example hf model for testing: https://huggingface.co/fla-hub/rwkv7-1.5B-g1a

```
(base) 
# molly @ mollydeMacBook-Pro in ~/mlx-lm on git:main x [22:42:49] C:1
$ mlx_lm.generate --model ~/rwkv7-2.9B-g1a -m 1024 -p "who is albert einstein" --trust-remote-code 
==========
>
Okay, the user is asking "who is albert einstein". Let me start by recalling what I know about Albert Einstein. He's a famous physicist, right? I remember he's known for the theory of relativity. There's the special theory and the general theory. Oh, and he's also known for the equation E=mc², which relates energy and mass.
Wait, he was born in Germany, but he moved to the United States later. I think he was a professor at Princeton University. He won the Nobel Prize in Physics, but I'm not sure for what. Maybe it was for his work on the photoelectric effect? That's related to quantum mechanics, but he's more famous for relativity.
He was a pacifist, but during World War II, he helped develop the atomic bomb. That's a bit controversial. He also had a theory about the universe expanding, which led to the Big Bang theory. Oh, and he was a great violinist too. He played the violin a lot.
He was a prolific writer, not just a scientist. He wrote essays and books. His name is often associated with genius and intelligence. He was a bit of a rebel, maybe? He had some unconventional ideas. Also, he was a humanist and spoke out against racism and war.
Wait, I should check if there's more to his contributions. He worked on the photoelectric effect, which is part of quantum theory. He also did work on the structure of atoms and molecules. Oh, and he was involved in the development of the atomic bomb, but he later regretted it.
He was a key figure in the development of modern physics. His theories changed how we understand space, time, and gravity. He was a pioneer in the field of relativity. He also contributed to the understanding of the universe's expansion and the Big Bang.
He was a humanitarian as well. He was involved in the civil rights movement and spoke out against racism. He was a member of the American Association for the Advancement of Science and the American Physical Society.
He died in 1955, but his legacy continues. His work is still studied and applied in various fields. He's considered one of the most influential scientists of the 20th century.
I should make sure to mention his contributions to physics, his humanitarian efforts, and his impact on society. Also, his personal life, like his marriage to Mileva Marić and his children. He was a complex person with many interests beyond science.
</think>
Albert Einstein (1879–1955) was a German-born theoretical physicist who is widely regarded as one of the most influential scientists of the 20th century. He is best known for his **theory of relativity**, which revolutionized our understanding of space, time, and gravity. Here are key aspects of his life and work:
### **Scientific Contributions**
1. **Theory of Relativity**:
   - **Special Relativity (1905)**: Introduced the famous equation **E=mc²**, linking energy (E) and mass (m), and showed that mass and energy are interchangeable.
   - **General Relativity (1915)**: Proposed that gravity is not a force but a curvature of spacetime caused by mass and energy. This theory explained phenomena like the bending of light by gravity and the expansion of the universe.
2. **Photoelectric Effect**:
   - Einstein won the **Nobel Prize in Physics (1921)** for explaining the photoelectric effect, which demonstrated the particle nature of light (photons).
3. **Atomic Theory**:
   - He contributed to the development of quantum mechanics and the understanding of atomic structure, though his work on the atomic bomb (during World War II) remains controversial.
### **Personal Life and Legacy**
- **Early Life**: Born in Ulm, Germany, Einstein showed an early aptitude for mathematics and physics. He later studied at the Swiss Federal Polytechnic in Zurich.
- **Career**: He worked as a patent clerk in Bern, Switzerland, before becoming a professor at the University of Zurich and later at Princeton University.
- **Humanitarianism**: Einstein was a vocal advocate for peace, civil rights, and social justice. He was a member of the **American Association for the Advancement of Science** and the **American Physical Society**.
- **Controversies**: His involvement in the atomic bomb project during World War II remains a subject of debate.
### **Impact**
Einstein’s work laid the foundation for modern physics and influenced fields like cosmology, quantum mechanics, and astrophysics. His ideas continue to shape scientific thought and inspire generations of scientists and thinkers.
He is often celebrated as a symbol of genius, curiosity, and the power of human intellect.<|rwkv_tokenizer_end_of_text|>
==========
Prompt: 15 tokens, 128.393 tokens-per-sec
Generation: 1024 tokens, 38.248 tokens-per-sec
Peak memory: 6.054 GB
```

Performance test (M4 Pro 16-core GPU):
```
$ mlx_lm.benchmark --model ~/rwkv7-2.9B-g1a --prompt-tokens 512 --generation-tokens 128 --num-trials 3
Running warmup..
Timing with prompt_tokens=512, generation_tokens=128, batch_size=1.
Trial 1:  prompt_tps=826.874, generation_tps=38.791, peak_memory=6.569
Trial 2:  prompt_tps=825.450, generation_tps=38.848, peak_memory=6.569
Trial 3:  prompt_tps=828.748, generation_tps=38.856, peak_memory=6.569
Averages: prompt_tps=827.024, generation_tps=38.831, peak_memory=6.569

$ mlx_lm.benchmark --model "meta-llama/Llama-3.2-3B-Instruct" --prompt-tokens 4096 --generation-tokens 128 --num-trials 3
Fetching 11 files: 100%|███████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 11/11 [00:00<00:00, 70871.50it/s]
Running warmup..
Timing with prompt_tokens=4096, generation_tokens=128, batch_size=1.
Trial 1:  prompt_tps=920.678, generation_tps=33.216, peak_memory=7.449
Trial 2:  prompt_tps=918.976, generation_tps=33.254, peak_memory=7.449
Trial 3:  prompt_tps=920.003, generation_tps=33.294, peak_memory=7.449
Averages: prompt_tps=919.886, generation_tps=33.255, peak_memory=7.449
```

The accuracy is checked upon the official implementation.
MLX fp16 LAMBADA eval (it's not fast on my m4pro macbook compared to that on rtx5090; 1600 samples with identical results should be enough):
```
### LAMBADA ######################################################################

100 ppl 3.98 acc 66.0
200 ppl 3.55 acc 69.5
300 ppl 3.61 acc 69.7
400 ppl 3.68 acc 70.5
500 ppl 3.59 acc 71.0
600 ppl 3.48 acc 71.7
700 ppl 3.5 acc 71.6
800 ppl 3.53 acc 71.6
900 ppl 3.55 acc 71.6
1000 ppl 3.55 acc 72.3
1100 ppl 3.53 acc 72.6
1200 ppl 3.51 acc 73.2
1300 ppl 3.48 acc 73.4
1400 ppl 3.54 acc 73.0
1500 ppl 3.49 acc 73.1
1600 ppl 3.42 acc 73.5
```
CUDA fp16 LAMBADA eval:
```
### LAMBADA ######################################################################

100 ppl 3.99 acc 66.0
200 ppl 3.55 acc 69.5
300 ppl 3.61 acc 69.7
400 ppl 3.68 acc 70.5
500 ppl 3.6 acc 71.0
600 ppl 3.49 acc 71.7
700 ppl 3.5 acc 71.6
800 ppl 3.54 acc 71.6
900 ppl 3.56 acc 71.6
1000 ppl 3.55 acc 72.3
1100 ppl 3.53 acc 72.6
1200 ppl 3.51 acc 73.2
1300 ppl 3.48 acc 73.4
1400 ppl 3.54 acc 73.0
1500 ppl 3.49 acc 73.1
1600 ppl 3.43 acc 73.5
1700 ppl 3.41 acc 73.5
1800 ppl 3.42 acc 73.4
1900 ppl 3.44 acc 73.2
2000 ppl 3.39 acc 73.4
2100 ppl 3.41 acc 73.5
2200 ppl 3.43 acc 73.4
2300 ppl 3.44 acc 73.3
2400 ppl 3.44 acc 73.3
2500 ppl 3.42 acc 73.4
2600 ppl 3.41 acc 73.3
2700 ppl 3.4 acc 73.4
2800 ppl 3.42 acc 73.2
2900 ppl 3.44 acc 73.0
3000 ppl 3.44 acc 73.0
3100 ppl 3.47 acc 73.1
3200 ppl 3.47 acc 73.1
3300 ppl 3.48 acc 72.9
3400 ppl 3.47 acc 73.0
3500 ppl 3.46 acc 73.1
3600 ppl 3.45 acc 73.2
3700 ppl 3.44 acc 73.2
3800 ppl 3.45 acc 73.2
3900 ppl 3.46 acc 73.4
4000 ppl 3.45 acc 73.4
4100 ppl 3.44 acc 73.3
4200 ppl 3.44 acc 73.5
4300 ppl 3.46 acc 73.3
4400 ppl 3.47 acc 73.4
4500 ppl 3.48 acc 73.3
4600 ppl 3.5 acc 73.2
4700 ppl 3.5 acc 73.2
4800 ppl 3.49 acc 73.3
4900 ppl 3.5 acc 73.3
5000 ppl 3.5 acc 73.2
5100 ppl 3.51 acc 73.1
5153 ppl 3.52 acc 73.0
```