### PR TITLE
Normalize scheduler/warmup step-like arguments by grad_accumulation_steps; warmup-only configuration, sane argument defaults and tests

### DIFF
--- a/tests/test_finetune.py
+++ b/tests/test_finetune.py
@@ -363,11 +363,24 @@ class TestScheduleConfig(unittest.TestCase):
         self.assertAlmostEqual(lr, 1e-6, delta=1e-7)
 
     def test_malformed_config(self):
-        config = {"warmup": 100}
-        self.assertRaises(KeyError, build_schedule, config)
-
         config = {"cosine_decay": None}
         self.assertRaises(KeyError, build_schedule, config)
+        # unknown scheduler name
+        self.assertRaises(KeyError, build_schedule, {"name": None, "arguments": [1e-5]})
+        self.assertRaises(
+            ValueError,
+            build_schedule,
+            {"name": "unknown_scheduler"},
+            learning_rate=1e-5,
+        )
+        # no initial lr provided
+        self.assertRaises(KeyError, build_schedule, {"name": "linear_schedule"})
+        # too many arguments provided
+        self.assertRaises(
+            ValueError,
+            build_schedule,
+            {"name": "linear_schedule", "arguments": [0.1, 0.0, 10, 0.5]},
+        )
 
     def test_evaluate_calls(self):
         mock_model = MagicMock()

--- a/tests/test_tuner_utils.py
+++ b/tests/test_tuner_utils.py
@@ -1,14 +1,16 @@
 # Copyright © 2024 Apple Inc.
 
+import math
 import sys
 import unittest
 from io import StringIO
 from unittest.mock import MagicMock
 
 import mlx.nn as nn
+import mlx.optimizers as opt
 
 from mlx_lm.tuner.lora import LoRALinear
-from mlx_lm.tuner.utils import print_trainable_parameters
+from mlx_lm.tuner.utils import build_schedule, print_trainable_parameters
 
 
 class TestTunerUtils(unittest.TestCase):
@@ -80,6 +82,61 @@ class TestTunerUtils(unittest.TestCase):
         expected_output = "Trainable parameters: 50.000% (3.000M/6.000M)\n"
         print_trainable_parameters(model)
         self.assertEqual(self.capturedOutput.getvalue(), expected_output)
+
+
+class TestScheduleArguments(unittest.TestCase):
+    def test_linear_schedule_argument_variants(self):
+        # Only start provided vs explicit end and steps
+        sched_a = build_schedule(
+            {"name": "linear_schedule", "arguments": [0.1]}, iters=10
+        )
+        sched_b = build_schedule(
+            {"name": "linear_schedule", "arguments": [0.1, 0.0, 10]}
+        )
+        for t in (0, 5, 10):
+            self.assertAlmostEqual(sched_a(t), sched_b(t), delta=1e-8)
+
+        # Start and end provided vs explicit steps
+        sched_c = build_schedule(
+            {"name": "linear_schedule", "arguments": [0.2, 0.05]}, iters=10
+        )
+        sched_d = build_schedule(
+            {"name": "linear_schedule", "arguments": [0.2, 0.05, 10]}
+        )
+        for t in (0, 5, 10):
+            self.assertAlmostEqual(sched_c(t), sched_d(t), delta=1e-8)
+
+        # Three-arg form matches MLX reference schedule across steps
+        sched_e = build_schedule(
+            {"name": "linear_schedule", "arguments": [0.3, 0.1, 5]}
+        )
+        ref_e = opt.schedulers.linear_schedule(0.3, 0.1, 5)
+        for t in (0, 1, 4, 5):
+            self.assertAlmostEqual(sched_e(t), ref_e(t), delta=1e-8)
+
+    def test_cosine_decay_with_grad_accum_conversion(self):
+        # decay_steps should be converted by grad_accumulation_steps; compare to an equivalent schedule
+        sched = build_schedule(
+            {"name": "cosine_decay", "arguments": [0.1, 20]}, grad_accumulation_steps=2
+        )
+        ref = build_schedule(
+            {"name": "cosine_decay", "arguments": [0.1, 10]}, grad_accumulation_steps=1
+        )
+        for t in (0, 5, 10):
+            self.assertAlmostEqual(sched(t), ref(t), delta=1e-6)
+
+    def test_step_decay_defaults_and_conversion(self):
+        # Only lr provided; step_size defaults to iters//10 converted; compare to explicit form
+        sched = build_schedule({"name": "step_decay", "arguments": [0.1]}, iters=100)
+        ref = build_schedule({"name": "step_decay", "arguments": [0.1, 0.5, 10]})
+        for t in (0, 10, 20, 30):
+            self.assertAlmostEqual(sched(t), ref(t), delta=1e-6)
+
+    def test_warmup_only_config(self):
+        config = {"warmup": 100}
+        lr_schedule = build_schedule(config, learning_rate=1e-5)
+        self.assertAlmostEqual(lr_schedule(0), 0.0, delta=1e-7)
+        self.assertAlmostEqual(lr_schedule(100), 1e-5, delta=1e-7)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
**Summary:**
- **Step-like arguments are converted by grad_accumulation_steps for consistency with configured training steps.**
  - e.g. A warmup of `100`, with gradient accumulation of `32` steps will now last for `100` steps instead of `100*32` steps.  This should be more intuitive for users.
- Missing scheduler name now falls back to `constant` when `warmup > 0`, making warmup-only configs simpler.
- If both name and warmup are missing, we raise `KeyError("name")` to surface misconfigurations early.
- Centralized learning rate validation and safer handling of variable argument lengths across schedulers.

**Grad accumulation normalization:**
- `warmup`: steps
- `linear_schedule`: steps
- `cosine_decay`: decay_steps
- `step_decay`: step_size
- Conversion: `effective_steps = ceil(config_steps / max(1, grad_accumulation_steps))`, with a minimum of 1.

**Tests:**
- Warmup-only config now validated in tests.
- Added tests for linear/cosine/step variants and grad-accum conversions; linear schedule comparisons use MLX reference.

**Behavioral notes:**
  - No change for valid, named schedulers.
  - Schedules without arguments fall back to sane defaults
  - Unknown names still raise `ValueError` as before.
  
**Minor improvements:**
  - Added `muon` to `--optimizer` help text
  - Changed `--learning-rate` help text from "Adam learning rate." to "Optimizer learning rate." since it applies to more than just Adam
  - Improved `lr_schedule` configuration discoverability and documentation
  
From:
  ```py
  "lr_schedule": None
  ```
To:
  ```py
  # name options: "cosine_decay", "linear_schedule", "exponential_decay", or "step_decay"
  # arguments match positional values for the corresponding mlx scheduler:
  # See: https://ml-explore.github.io/mlx/build/html/python/optimizers/schedulers.html
  "lr_schedule": {"name": None, "arguments": [], "warmup": 0, "warmup_init": 0.0},
  ```
  
  Added reference to config and docs where the scheduler is built:
  ```py
  # Initialize the selected optimizer
    lr = args.learning_rate
    if args.lr_schedule.get("name", None) or args.lr_schedule.get("warmup", 0) > 0:
        # See CONFIG_DEFAULTS["lr_schedule"] for the format
        # and https://ml-explore.github.io/mlx/build/html/python/optimizers/schedulers.html
        # for the available schedulers
        lr = build_schedule(
            args.lr_schedule,
            args.learning_rate,
            args.iters,
            args.grad_accumulation_steps,
        )
  ```
