### PR TITLE
Fixed typo in `load_adapters` that broke adapter loading

### DIFF
--- a/mlx_lm/utils.py
+++ b/mlx_lm/utils.py
@@ -237,7 +237,7 @@ def load_model(
     return model, config
 
 
-def load_adapeters(model: nn.Module, adapter_path: str) -> nn.Module:
+def load_adapters(model: nn.Module, adapter_path: str) -> nn.Module:
     from .tuner.utils import load_adapters as _load_adapters
 
     return _load_adapters(model, adapter_path)


### PR DESCRIPTION
Fixed typo in `load_adapters` that broke adapter loading after a regression in a recent commit.

The function was defined as `load_adapeters` but all references were expecting `load_adapters`

Simple fix, easy to miss, but important.