### PR TITLE
Fixed/improved behavior of the mask_prompt feature.

### DIFF
--- a/mlx_lm/tuner/datasets.py
+++ b/mlx_lm/tuner/datasets.py
@@ -8,34 +8,6 @@ from typing import Any, Dict, List
 from transformers import PreTrainedTokenizer
 
 
-def _apply_chat_template_safe(
-    tokenizer, messages, tools=None, add_generation_prompt=None
-):
-    try:
-        if add_generation_prompt is None:
-            # try with tools
-            return tokenizer.apply_chat_template(messages, tools=tools)
-        # try with tools and add_generation_prompt
-        return tokenizer.apply_chat_template(
-            messages, tools=tools, add_generation_prompt=add_generation_prompt
-        )
-    except (TypeError, AttributeError):
-        try:
-            if add_generation_prompt is None:
-                # try without tools
-                return tokenizer.apply_chat_template(messages)
-            # try without tools but with add_generation_prompt
-            return tokenizer.apply_chat_template(
-                messages, add_generation_prompt=add_generation_prompt
-            )
-        except (TypeError, AttributeError):
-            # if we still get an error, try without add_generation_prompt
-            if add_generation_prompt is not None:
-                return tokenizer.apply_chat_template(messages)
-            # propagate the original failure
-            raise
-
-
 class TextDataset:
     """
     Light-weight wrapper to hold a dataset.
@@ -67,7 +39,7 @@ class TextDataset:
 class ChatDataset:
     """
     A dataset for chat data in the format of {"messages": [...]}
-    https://platform.openai.com/docs/guides/fine-tuning/example-format
+    https://platform.openai.com/docs/guides/supervised-fine-tuning#formatting-your-data
     """
 
     def __init__(
@@ -85,13 +57,16 @@ class ChatDataset:
     def process(self, d):
         messages = d[self.chat_key]
         tools = d.get("tools", None)
-        tokens = _apply_chat_template_safe(self.tokenizer, messages, tools=tools)
+        tokens = self.tokenizer.apply_chat_template(messages, tools=tools)
         if self.mask_prompt:
-            messages = messages[:-1]
-            offset_tokens = _apply_chat_template_safe(
-                self.tokenizer, messages, tools=tools, add_generation_prompt=True
+            add_generation_prompt = messages[-1].get("role") == "assistant"
+            offset = len(
+                self.tokenizer.apply_chat_template(
+                    messages[:-1],
+                    tools=tools,
+                    add_generation_prompt=add_generation_prompt,
+                )
             )
-            offset = len(offset_tokens)
             return (tokens, offset)
         else:
             return (tokens, 0)
@@ -132,14 +107,11 @@ class CompletionsDataset:
         ]
         tokens = _apply_chat_template_safe(self.tokenizer, messages, tools=tools)
         if self.mask_prompt:
-            user_only = [{"role": "user", "content": d[self.prompt_key]}]
-            offset_tokens = _apply_chat_template_safe(
-                self.tokenizer,
-                user_only,
-                tools=tools,
-                add_generation_prompt=True,
+            offset = len(
+                self.tokenizer.apply_chat_template(
+                    messages[0], tools=tools, add_generation_prompt=True
+                )
             )
-            offset = len(offset_tokens)
             return (tokens, offset)
 
         return (tokens, 0)


### PR DESCRIPTION
Without setting `add_generation_prompt=True`, the model/assistant turn header can be included, which forces loss to be calculated over more than just the model's output that we care about.

Before:
```
<start_of_turn>model
model output...<end_of_turn>
```

After:
```
model output...<end_of_turn>
```

I also introduced `_apply_chat_template_safe` to centralize defensive calls to `apply_chat_template` to account for some environments that don't support tools (added defensive measures for `add_generation_prompt` too just in case).