### PR TITLE
Add gen options and CoT removal

### DIFF
--- a/mlx_lm/evaluate.py
+++ b/mlx_lm/evaluate.py
@@ -354,7 +354,7 @@ class MLXLM(LM):
         for e, (text, opt) in enumerate(zip(completions, options)):
             completions[e] = _rstrip_until(text, opt["until"])
             if self.tokenizer.has_thinking:
-                completions[e] = _lstrip(text, self.tokenizer.think_start)
+                completions[e] = _lstrip(text, self.tokenizer.think_end)
 
         # Gather the completions
         if group.size() > 1:


### PR DESCRIPTION
This is necessary to get good results with thinking models.

Using:

```
mlx_lm.evaluate --model Qwen/Qwen3-4B-Thinking-2507 --task mmlu_pro --max-tokens 16384 --temp 0.6 --top-k 20 --top-p 0.95
```

Now gets 72.5 which almost matches the reported 74.

For Qwen3 4B Instruct 2507 I get 70.03 which is slightly higher than the reported 69.6 with the following command:

```
mlx_lm.evaluate --model Qwen/Qwen3-4B-Thinking-2507 --task mmlu_pro --max-tokens 16384 --temp 0.8 --top-k 20 --top-p 0.8
```

I think it's partially due to the increas in max tokens from 2048 (the MMLU Pro default) and the correct sampling params.

The sampling parameters come from the generation config / are recommended sampling parameters of the model