### PR TITLE
Fix : mlx-server for chunked request (to support one-api, curl)

### DIFF
--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -7,6 +7,7 @@ import threading
 import unittest
 
 import requests
+import time
 
 from mlx_lm.server import APIHandler
 from mlx_lm.utils import load
@@ -68,6 +69,55 @@ class TestServer(unittest.TestCase):
         cls.httpd.shutdown()
         cls.httpd.server_close()
         cls.server_thread.join()
+
+    def test_handle_chunked_request(self):
+        url = f"http://localhost:{self.port}/v1/chat/completions"
+
+        post_data = {
+            "model": "default_model",
+            "prompt": "Once upon a time",
+            "max_tokens": 10,
+            "temperature": 0.0,
+            "stream": False,
+            "top_p": 1.0,
+        }
+
+        # chunked request
+        data_parts = [
+            b'{"model": "default_model", "messages": [{"role": "user", "content": "Once',
+            b' upon a times, Once upon ',
+            b'a time"}], "temperature": 0.8, "max_tokens": 1024, "stream": false}',
+        ]
+
+        max_length = 0
+        for part in data_parts:
+            max_length += len(part)
+
+        def data_generator():
+            for part in data_parts:
+                yield part
+                time.sleep(0.1)
+
+        try:
+            response = requests.post(
+                url,
+                data=data_generator(),
+                headers={
+                    "Transfer-Encoding": "chunked",
+                    "Content-Type": "application/json",
+                },
+            )
+            self.assertEqual(response.status_code, 200)
+        except requests.exceptions.RequestException:
+            self.assertTrue(False, "Chunked request failed")
+
+        response_body = json.loads(response.text)
+        self.assertIn("id", response_body)
+        self.assertIn("choices", response_body)
+        self.assertIn("usage", response_body) 
+
+        # Check that tokens were generated
+        self.assertTrue(response_body["usage"]["completion_tokens"] > 0)
 
     def test_handle_completions(self):
         url = f"http://localhost:{self.port}/v1/completions"


### PR DESCRIPTION
## Description

Since in an agentic environment, multiple requests, or chunked requests send from model router (one-api) for example, we found that the server codes have been broken without chunked request support.

With this feature people can handle chunked in an agentic LLM flow

#### Verification in an agentic envrionment, where multiple concurrent calls made

<img width="400" height="500" alt="mlx_test_img" src="https://github.com/user-attachments/assets/e618e380-a47d-4cec-987d-48f164f0c21a" />

## Handy Test

#### curl for model router

For whom may refer to this PR and require a quick test with curl:


###### Agentic Entry

Our agentic model router (model can be any models handled in model router to the real model behind):

```
curl -v http://localhost:3000/v1/chat/completions \
 -H "Authorization: Bearer sk-${YOUR_KEY}" \
 -H "Content-Type: application/json" \
 -d '{"model": "gpt-oss-120b-MXFP4-Q4", "message": [{"role": "user", "content": "Once upon a time"}], "temperature": 0.8, "max_tokens": 1024, "stream": false}'
```

to replace usual test entry (model name must be the real model name) :

```
curl -v http://localhost:5001/v1/chat/completions \
  -H "Content-Type: application/json" \
  -d '{"model": "gpt-oss-120b-MXFP4-Q4", "messages": [{"role": "user", "content": "Once upon a time"}], "temperature": 0.8, "max_tokens": 1024, "stream": true}'
```

Explanation : "http://localhost:3000/v1/chat/completions" is our model router to test various of models hosted in MacOS Studio:

It will automatically route models to the right services hosted by MLX (default to 5001)


###### The real request

```
echo -n '{"model": "gpt-oss-120b-MXFP4-Q4", "messages": [{"role": "user", "content": "Once upon a time"}], "temperature": 0.8, "max_tokens": 1024, "stream": true}' > payload.json

curl -v --request POST http://localhost:5001/v1/chat/completions \
  -H "Content-Type: application/json" \
  --data-binary @playload.json
```

###### simpler test

server:

> python -m mlx_lm.server --model "mlx-community/Qwen1.5-0.5B-Chat-4bit" --port 5001

client:

```
echo -n '{"model": "mlx-community/Qwen1.5-0.5B-Chat-4bit", "messages": [{"role": "user", "content": "Once upon a time"}], "temperature": 0.8, "max_tokens": 1024, "stream": false}' > payload.json

curl -v --request POST http://localhost:5001/v1/chat/completions \
  -H "Content-Type: application/json" \                                                         
  --data-binary @payload.json
```

## Unit Test

#### python

- test_server.py
  - test_handle_chunked_request
