### PR TITLE
Fix: Remove call to deleted method

### DIFF
--- a/mlx_lm/tuner/datasets.py
+++ b/mlx_lm/tuner/datasets.py
@@ -105,7 +105,7 @@ class CompletionsDataset:
             {"role": "user", "content": d[self.prompt_key]},
             {"role": "assistant", "content": d[self.completion_key]},
         ]
-        tokens = _apply_chat_template_safe(self.tokenizer, messages, tools=tools)
+        tokens = self.tokenizer.apply_chat_template(messages, tools=tools)
         if self.mask_prompt:
             offset = len(
                 self.tokenizer.apply_chat_template(


### PR DESCRIPTION
This PR fixes a runtime error introduced in  #584.

@awni It looks like `_apply_chat_template_safe` was removed in the followup commit, but a call to it was left in the `process` method of `CompletionsDataset`. This PR just removes that erroneous line.