### PR TITLE
Fix: JSON parse error handling: avoid referencing stream before init

### DIFF
--- a/mlx_lm/server.py
+++ b/mlx_lm/server.py
@@ -294,17 +294,10 @@ class APIHandler(BaseHTTPRequestHandler):
             self.body = json.loads(raw_body.decode())
         except json.JSONDecodeError as e:
             logging.error(f"JSONDecodeError: {e} - Raw body: {raw_body.decode()}")
-            # Set appropriate headers based on streaming requirement
-            if self.stream:
-                self._set_stream_headers(400)
-                self.wfile.write(
-                    f"data: {json.dumps({'error': f'Invalid JSON in request body: {e}'})}\n\n".encode()
-                )
-            else:
-                self._set_completion_headers(400)
-                self.wfile.write(
-                    json.dumps({"error": f"Invalid JSON in request body: {e}"}).encode()
-                )
+            self._set_completion_headers(400)
+            self.wfile.write(
+                json.dumps({"error": f"Invalid JSON in request body: {e}"}).encode()
+            )
             return
 
         indent = "\t"  # Backslashes can't be inside of f-strings


### PR DESCRIPTION
Fixes a bug where self.stream was referenced before being initialized when the request body fails to parse.

On JSONDecodeError, we now always return a non-stream JSON error response since streaming preference cannot be trusted without a parsed body.

This prevents potential exceptions during error handling.