### PR TITLE
Fix tool calling with openai server

### DIFF
--- a/mlx_lm/server.py
+++ b/mlx_lm/server.py
@@ -473,7 +473,7 @@ class APIHandler(BaseHTTPRequestHandler):
         top_logprobs = top_tokens or []
         tool_calls = tool_calls or []
 
-        def parse_function(tool_text):
+        def parse_function(idx, tool_text):
             tool_call = json.loads(tool_text.strip())
             return {
                 "function": {
@@ -481,7 +481,8 @@ class APIHandler(BaseHTTPRequestHandler):
                     "arguments": json.dumps(tool_call.get("arguments", "")),
                 },
                 "type": "function",
-                "id": None,
+                "id": str(uuid.uuid4()),
+                "index": idx,
             }
 
         # Static response
@@ -529,7 +530,10 @@ class APIHandler(BaseHTTPRequestHandler):
             choice[key_name] = {
                 "role": "assistant",
                 "content": text,
-                "tool_calls": [parse_function(tool_text) for tool_text in tool_calls],
+                "tool_calls": [
+                    parse_function(idx, tool_text)
+                    for idx, tool_text in enumerate(tool_calls)
+                ],
             }
         elif self.object_type == "text_completion":
             choice.update(text=text)


### PR DESCRIPTION
Tool calling is currently broken for the openai style server. The `index` is a required field. The `id` is optional, but most client apps rely on a tool_call_id to match results particularly when executing tools in parallel. 

Some unit tests were failing locally, but seemed completely unrelated.