### PR TITLE
Fix Byte Decoder Lookup for Esoteric Single-Characters 

### DIFF
--- a/mlx_lm/tokenizer_utils.py
+++ b/mlx_lm/tokenizer_utils.py
@@ -210,8 +210,7 @@ class BPEStreamingDetokenizer(StreamingDetokenizer):
         # For multi-byte utf-8 wait until they are complete
         # For single spaces wait until the next token to clean it if needed
         if not text.endswith("\ufffd") and not (
-            len(v) == 1
-            and self._byte_decoder.get(v[0]) == 32
+            len(v) == 1 and self._byte_decoder.get(v[0]) == 32
         ):
             self.text += self._maybe_trim_space(text)
             self._unflushed = ""


### PR DESCRIPTION
While working with the new [Baguettotron](https://huggingface.co/PleIAs/Baguettotron), I noticed it had a penchant for emitting strange characters like '→' or '●'. These characters would then cause the following error:

```
Traceback (most recent call last):
  File "/Users/natebreslow/Documents/mlx-lm/test.py", line 12, in <module>
    generate(model, tokenizer, prompt=prompt, verbose=True, max_tokens=8192, sampler=sampler, logits_processors=logits_processors)
  File "/Users/natebreslow/Documents/mlx-lm/mlx_lm/generate.py", line 759, in generate
    for response in stream_generate(model, tokenizer, prompt, **kwargs):
  File "/Users/natebreslow/Documents/mlx-lm/mlx_lm/generate.py", line 704, in stream_generate
    detokenizer.add_token(token)
  File "/Users/natebreslow/Documents/mlx-lm/mlx_lm/tokenizer_utils.py", line 213, in add_token
    len(v) == 1 and self._byte_decoder[v[0]] == 32
KeyError: '●'
```

The fix was simple - just make sure `v[0]` is in the _byte_decoder array:

```python
        if not text.endswith("\ufffd") and not (
            len(v) == 1
            and (v[0] in self._byte_decoder)
            and self._byte_decoder[v[0]] == 32
        ):
            self.text += self._maybe_trim_space(text)
            self._unflushed = ""
```

This eliminates the issue and allows Baguettotron to run unimpeded.