### PR TITLE
Fix input_embeddings prefill bug in generate_step

### DIFF
--- a/mlx_lm/generate.py
+++ b/mlx_lm/generate.py
@@ -418,7 +418,7 @@ def generate_step(
         prompt_processed_tokens = 0
         prompt_progress_callback(prompt_processed_tokens, total_prompt_tokens)
         while total_prompt_tokens - prompt_processed_tokens > 1:
-            remaining = (total_prompt_tokens - prompt_processed_tokens) - 1 
+            remaining = (total_prompt_tokens - prompt_processed_tokens) - 1
             n_to_process = min(prefill_step_size, remaining)
             _model_call(
                 input_tokens=prompt[:n_to_process][None],


### PR DESCRIPTION
### Problem
The prefill loop in `generate_step` incorrectly calculates the number of tokens to process when using `input_embeddings`. It only considers `prompt.size` instead of accounting for the actual input length, causing it to process 0 embeddings when the prompt is empty or small.

### Bug
```python
n_to_process = min(prefill_step_size, prompt.size - 1)
```

This fails when:
- `input_embeddings` is provided with an empty prompt (prompt.size = 0)
- The prompt is smaller than the embeddings sequence

### Fix
Calculate `n_to_process` based on the remaining tokens to process:

(Option 1)
```python
remaining = (total_prompt_tokens - prompt_processed_tokens) - 1
n_to_process = min(prefill_step_size, remaining)
```
(Option 2)
```python
current_size = len(input_embeddings) if input_embeddings is not None else prompt.size
n_to_process = min(prefill_step_size, current_size - 1)
```

This ensures the prefill loop correctly processes input embeddings regardless of prompt size, fixing the "Cannot infer the shape of an empty array" error in downstream multimodal models such as Voxtral in [mlx-audio](https://github.com/Blaizzy/mlx-audio/issues/271).
