### PR TITLE
Add sub 1bit streamk gemm

### DIFF
--- a/mlx_lm/models/sub_1bit_streamk_kernel.py
+++ b/mlx_lm/models/sub_1bit_streamk_kernel.py
@@ -88,7 +88,8 @@ def make_sub_1bit_streamk_kernel(**config):
 
                     if (offs_xq_m + m < M && k_start + k < K) {
                         regs = *((const device half4*)(x + (offs_xq_m + m) * stride_x_m + (k_start + k) * stride_x_k));
-                        
+
+                        #pragma unroll    
                         for (uint r=0; r < vec_size && k_start + k + r < K; r++) {
                             tile_xq[m][k + r] = regs[r];
                         }
@@ -110,6 +111,7 @@ def make_sub_1bit_streamk_kernel(**config):
                     if (offs_wq_n + n < N && (k_start / packed_size) + k < K / packed_size) {
                         regs = *((const device half4*)(packed_weights + (offs_wq_n + n) * stride_w_n + ((k_start / packed_size) + k) * stride_w_k));
 
+                        #pragma unroll
                         for (uint r=0; r < vec_size && (k_start / packed_size) + k + r < K / packed_size; r++) {
                             tile_wq[n][k + r] = as_type<uint16_t>(regs[r]);
                         }


### PR DESCRIPTION
## Description

This is from the latest paper where pervious 1-bit is packed with 2 bits, we prove sub-1 bit (0.7 ~ 0.8 bit) can also generate very good results and only 1 bit needed to pack weights.

Config:

Mlx : 0.29.3
Pytorch : 2.9
System : 
  - M4 Pro (20 metal 3 cores + 16 ANE cores), 
  - M3 Ultra (80 metal 3 cores + 32 ANE cores),

## Test

##### Simple Case

  <img width="433" height="158" alt="截屏2025-11-14 下午8 42 56" src="https://github.com/user-attachments/assets/1e864d31-21a6-455f-9029-0095cf0a6af7" />
  

We found apple's fp16 AccT has some precision problems hence fallback to fp32 datatype for accFrag.

##### Complex Case 

- Llama3 classic layout MxKxN = 4096 x 16384 x 4096
  - baseline :
    -  M4 Pro :
        <img width="552" height="231" alt="截屏2025-11-15 下午6 47 11" src="https://github.com/user-attachments/assets/3db49f5d-e24d-4141-ad2d-4aa168df256f" />
  - metal kernel vectorized loads
    - M4 Pro :
      <img width="552" height="231" alt="截屏2025-11-16 下午2 20 24" src="https://github.com/user-attachments/assets/5f5573d1-afd1-4b6c-8d1b-546029af097e" />
    - M3 Ultra (thanks the support from Apple team) :
      <img width="552" height="231" alt="mlx_test_img_2" src="https://github.com/user-attachments/assets/af6e1e85-714b-4126-9dad-988ae8d0e8ac" />  

  

##### TO DO LIST

[] Double Buffer
[] WASP
[WIP] ping-pong/interleave
[] Prefetch
[] Add a simple tunner
[x] streamk :
[x] splitk with atomic_fetch_add
[] SIMD_SUM_ACC, SIMD_ADD_MULTIPLY_ACC (to improve flops/bytes ratio)
[x] Faster unpack
[] Faster SIMD unpack
[] Memory interleave preprocessing
[x] vector load (64 bit)
[WIP] generalized N banks M (guess, 32 banks, 4 byte per bank) bit (64 bits vectorization size for Apple platform) swizzle strategy, e.g. BLOCK_SIZE_K=128*16 bits data, for 4 x 8 threads group configure 32x128 / (8x64) = 8 rows, at least BLOCK_SIZE_M=16 exists will gives 2-way conficts.


## Apple Metal Performance Ablation Study

Pending
