### PR TITLE
FIX: Add missing sentencepiece dependency for tokenizers

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -27,6 +27,7 @@ setup(
         f"mlx>={MIN_MLX_VERSION}; platform_system == 'Darwin'",
         "numpy",
         "transformers>=4.39.3",
+        "sentencepiece",
         "protobuf",
         "pyyaml",
         "jinja2",


### PR DESCRIPTION
I discovered that running models based on SentencePiece (like Mistral) causes a ValueError because the sentencepiece package is not a listed dependency.

This PR fixes the error by adding sentencepiece to the install_requires list in setup.py.

I've confirmed this resolves the issue by testing in a clean environment.

P.S. I have also noticed that test_js_div_loss is failing on the current main branch with a numerical precision error (AssertionError: array(False, dtype=bool) is not true). This appears to be an unrelated, pre-existing flaky test, so I've submitted my fix anyway.