### PR TITLE
Added TTFT logic into the existing flow

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,6 +29,7 @@ share/python-wheels/
 .installed.cfg
 *.egg
 MANIFEST
+*.txt
 
 # PyInstaller
 #  Usually these files are written by a python script from a template
@@ -137,3 +138,8 @@ dmypy.json
 
 # .DS_Store files
 .DS_Store
+prompt_files/llama3_p1_out512.txt
+benchmark2.py
+benchmarking.py
+mlx_lm/mlx-commands
+test_ttft_optimized.py

--- a/mlx_lm/benchmark.py
+++ b/mlx_lm/benchmark.py
@@ -103,7 +103,7 @@ def main():
     rprint("Running warmup..")
     _bench()
 
-    report_keys = ["prompt_tps", "generation_tps", "peak_memory"]
+    report_keys = ["prompt_tps", "ttft", "generation_tps", "peak_memory"]
     rprint(f"Timing with {prompt_tokens=}, {generation_tokens=}, {batch_size=}.")
     responses = []
     for i in range(args.num_trials):


### PR DESCRIPTION
The TTFT logic involves wrapping the token generator with a timer that tracks the time taken to generate the first token.
Along with the existing metrics, TTFT will also be printed like this:
Prompt: 2048 tokens, 475.326 tokens-per-sec
**Time to first token**: 4.309 sec
Generation: 128 tokens, 29.802 tokens-per-sec
Peak memory: 27.527 GB

Thanks!