### PR TITLE
add support for Trinity/AfMoE model

### DIFF
--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -1996,6 +1996,26 @@ class TestModels(unittest.TestCase):
                 "moe_intermediate_size": 128,
                 "kv_lora_rank": 8,
             },
+            {
+                "model_type": "afmoe",
+                "vocab_size": 1000,
+                "hidden_size": 128,
+                "num_hidden_layers": 4,
+                "num_attention_heads": 8,
+                "num_key_value_heads": 4,
+                "intermediate_size": 128,
+                "head_dim": 32,
+                "rope_theta": 100.0,
+                "layer_types": [
+                    "full_attention",
+                    "sliding_attention",
+                    "sliding_attention",
+                    "full_attention",
+                ],
+                "num_experts": 4,
+                "num_experts_per_tok": 2,
+                "moe_intermediate_size": 128,
+            },
         ]
         for config in test_configs:
             model_type = config["model_type"]


### PR DESCRIPTION
Closes #639 
- Implement AfMoE architecture with MoE (128 experts, 8 active per token)
- Dual normalization pattern (4 layer norms per decoder layer)
- Attention with Q/K normalization and learned sigmoid gating
- RoPE only for sliding window attention layers
- muP embedding scaling
- Shared experts support
- Custom quant_predicate for 4-bit quantization (keeps attention/embeddings at 8-bit)