### PR TITLE
Fix SuScaledRoPE

### DIFF
--- a/mlx_lm/models/rope_utils.py
+++ b/mlx_lm/models/rope_utils.py
@@ -43,18 +43,36 @@ class SuScaledRoPE(nn.Module):
             long_mscale (float, optional): Scale the input prior to embedding.
         """
         super().__init__()
-        freqs = base ** (mx.arange(0, dims, 2, dtype=mx.float32) / dims)
-        self._freqs = mx.array(long_factor, dtype=mx.float32) * freqs
         self.original_max_position_embeddings = original_max_position_embeddings
-        self.scale = long_mscale or math.sqrt(
-            1
-            + math.log(max_position_embeddings / original_max_position_embeddings)
-            / math.log(original_max_position_embeddings)
-        )
         self.dim = dims
 
+        freqs = base ** (mx.arange(0, dims, 2, dtype=mx.float32) / dims)
+        self._short_freqs = mx.array(short_factor, dtype=mx.float32) * freqs
+        self._long_freqs = mx.array(long_factor, dtype=mx.float32) * freqs
+
+        def default_scale(factor):
+            return math.sqrt(
+                1 + math.log(factor) / math.log(original_max_position_embeddings)
+            )
+
+        factor = max_position_embeddings / original_max_position_embeddings
+        self._short_scale = short_mscale or (
+            1.0 if factor <= 1.0 else default_scale(factor)
+        )
+        self._long_scale = long_mscale or (
+            1.0 if factor <= 1.0 else default_scale(factor)
+        )
+
     def __call__(self, x, offset: int = 0):
-        x[..., : self.dim] = self.scale * x[..., : self.dim]
+        seq_len = offset + x.shape[-2]
+        if seq_len > self.original_max_position_embeddings:
+            freqs = self._long_freqs
+            scale = self._long_scale
+        else:
+            freqs = self._short_freqs
+            scale = self._short_scale
+
+        x[..., : self.dim] = scale * x[..., : self.dim]
         return mx.fast.rope(
             x,
             self.dim,
@@ -62,7 +80,7 @@ class SuScaledRoPE(nn.Module):
             base=None,
             scale=1.0,
             offset=offset,
-            freqs=self._freqs,
+            freqs=freqs,
         )
 
 


### PR DESCRIPTION
I've fixed `SuScaledRoPE` to properly switch between short and long factors based on sequence length.

In the previous implementation:
- `short_factor` and `short_mscale` parameters were accepted but never used
- Long factors were always applied regardless of sequence length
- Non-1.0 scale was computed even when `factor <= 1.0`

This fix aligns the [transformers implementation](https://github.com/huggingface/transformers/blob/main/src/transformers/modeling_rope_utils.py#L394-L481).
