### PR TITLE
Add MiniMax M2 tool call parser support

### DIFF
--- a/mlx_lm/tokenizer_utils.py
+++ b/mlx_lm/tokenizer_utils.py
@@ -274,7 +274,10 @@ class TokenizerWrapper:
         self._tool_call_end = None
 
         THINK_TOKENS = [("<think>", "</think>")]
-        TOOL_CALL_TOKENS = [("<tool_call>", "</tool_call>")]
+        TOOL_CALL_TOKENS = [
+            ("<minimax:tool_call>", "</minimax:tool_call>"),
+            ("<tool_call>", "</tool_call>"),
+        ]
 
         vocab = tokenizer.get_vocab()
         for think_start, think_end in THINK_TOKENS:
@@ -282,12 +285,15 @@ class TokenizerWrapper:
                 self._think_start = think_start
                 self._think_end = think_end
                 break
-        if tokenizer.chat_template and '"tool"' in tokenizer.chat_template:
-            for tool_call_start, tool_call_end in TOOL_CALL_TOKENS:
-                if tool_call_start in vocab and tool_call_end in vocab:
-                    self._tool_call_start = tool_call_start
-                    self._tool_call_end = tool_call_end
-                    break
+        for tool_call_start, tool_call_end in TOOL_CALL_TOKENS:
+            if tool_call_start in vocab and tool_call_end in vocab:
+                self._tool_call_start = tool_call_start
+                self._tool_call_end = tool_call_end
+                break
+            elif tokenizer.chat_template and tool_call_start in tokenizer.chat_template:
+                self._tool_call_start = tool_call_start
+                self._tool_call_end = tool_call_end
+                break
 
     def add_eos_token(self, token: str):
         token_id = None

--- a/mlx_lm/tool_parsers/__init__.py
+++ b/mlx_lm/tool_parsers/__init__.py
@@ -1,0 +1,108 @@
+# Copyright © 2025 Apple Inc.
+
+import json
+import logging
+import uuid
+from typing import Any, Dict, List, Optional
+
+from .base import ToolParser, ToolCall, ExtractedToolCallInformation
+from .minimax_m2_tool_parser import MinimaxM2ToolParser
+
+TOOL_PARSERS = {
+    "minimax_m2": MinimaxM2ToolParser,
+}
+
+
+def parse_tool_calls_to_openai_format(
+    tool_text_list: List[str],
+    tool_parser: Optional[ToolParser] = None,
+) -> List[Dict[str, Any]]:
+    """
+    Parse tool call text strings and convert to OpenAI API format.
+
+    Args:
+        tool_text_list: List of raw tool call text strings
+        tool_parser: Optional parser to use (falls back to JSON parsing if None)
+
+    Returns:
+        List of tool calls in OpenAI format
+    """
+    parsed_calls = []
+    call_index = 0
+
+    for tool_text in tool_text_list:
+        if tool_parser is not None:
+            result = tool_parser.parse_tool_calls(tool_text)
+            for tc in result.tool_calls:
+                parsed_calls.append(tc.to_openai_format(index=call_index))
+                call_index += 1
+        else:
+            # Fallback JSON parsing for backward compatibility
+            try:
+                tool_call = json.loads(tool_text.strip())
+                parsed_calls.append({
+                    "index": call_index,
+                    "id": f"call_{uuid.uuid4().hex[:24]}",
+                    "type": "function",
+                    "function": {
+                        "name": tool_call.get("name"),
+                        "arguments": json.dumps(tool_call.get("arguments", "")),
+                    },
+                })
+                call_index += 1
+            except json.JSONDecodeError:
+                logging.warning(f"Failed to parse tool call: {tool_text}")
+
+    return parsed_calls
+
+
+def process_tool_call_arguments(message: Dict[str, Any]) -> None:
+    """
+    Process tool_calls in a message, converting arguments from JSON string to dict.
+
+    This is necessary because OpenAI API returns arguments as a JSON string,
+    but some chat templates expect it as a dict. Modifies message in place.
+
+    Args:
+        message: Message dict that may contain tool_calls
+    """
+    if "tool_calls" in message and message["tool_calls"]:
+        for tool_call in message["tool_calls"]:
+            if "function" in tool_call:
+                args = tool_call["function"].get("arguments")
+                if isinstance(args, str):
+                    try:
+                        tool_call["function"]["arguments"] = json.loads(args)
+                    except json.JSONDecodeError:
+                        pass
+
+
+def get_tool_parser(parser_name: str) -> ToolParser:
+    """
+    Get a tool parser by name.
+
+    Args:
+        parser_name: Name of the parser (e.g., "json", "minimax_m2")
+
+    Returns:
+        ToolParser instance
+    """
+    if parser_name not in TOOL_PARSERS:
+        raise ValueError(
+            f"Unknown tool parser: {parser_name}. "
+            f"Available parsers: {list(TOOL_PARSERS.keys())}"
+        )
+
+    return TOOL_PARSERS[parser_name]()
+
+
+__all__ = [
+    "ToolParser",
+    "ToolCall",
+    "ExtractedToolCallInformation",
+    "MinimaxM2ToolParser",
+    "get_tool_parser",
+    "parse_tool_calls_to_openai_format",
+    "process_tool_call_arguments",
+    "TOOL_PARSERS",
+]

--- a/mlx_lm/tool_parsers/base.py
+++ b/mlx_lm/tool_parsers/base.py
@@ -1,0 +1,206 @@
+# Copyright © 2025 Apple Inc.
+
+"""
+Base classes for tool call parsing.
+
+This module provides the abstract base class and data structures for parsing
+tool calls from model output. Different models use different formats for
+tool calls (e.g., JSON, XML), and this abstraction allows supporting multiple
+formats through a common interface.
+"""
+
+import json
+from abc import ABC, abstractmethod
+from dataclasses import dataclass, field
+from typing import Any, Dict, List, Optional, Tuple, Union
+
+
+@dataclass
+class ToolCall:
+    """
+    Represents a single tool/function call extracted from model output.
+
+    Attributes:
+        name: The name of the function to call
+        arguments: Dictionary of argument names to values
+        id: Optional unique identifier for the tool call
+    """
+
+    name: str
+    arguments: Dict[str, Any]
+    id: Optional[str] = None
+
+    def to_openai_format(self, index: int = 0) -> dict:
+        """
+        Convert to OpenAI API format.
+
+        Args:
+            index: The index of this tool call in the tool_calls array
+
+        Returns:
+            Dictionary in OpenAI's tool_calls format
+        """
+        import uuid
+
+        return {
+            "index": index,
+            "id": self.id or f"call_{uuid.uuid4().hex[:24]}",
+            "type": "function",
+            "function": {
+                "name": self.name,
+                "arguments": json.dumps(self.arguments)
+                if isinstance(self.arguments, dict)
+                else str(self.arguments),
+            },
+        }
+
+
+@dataclass
+class ExtractedToolCallInformation:
+    """
+    Contains the results of parsing tool calls from model output.
+
+    Attributes:
+        tool_calls: List of extracted tool calls
+        content: Any text content outside of tool calls
+        tools_called: Whether any tool calls were found
+    """
+
+    tool_calls: List[ToolCall] = field(default_factory=list)
+    content: str = ""
+    tools_called: bool = False
+
+
+class ToolParser(ABC):
+    """
+    Abstract base class for tool call parsers.
+
+    Each parser implementation handles a specific format for tool calls
+    (e.g., JSON wrapped in <tool_call> tags, MiniMax XML format, etc.)
+
+    Subclasses must implement:
+        - tool_call_start: The token/string that marks the start of a tool call
+        - tool_call_end: The token/string that marks the end of a tool call
+        - parse_tool_calls: Method to extract tool calls from accumulated text
+    """
+
+    @property
+    @abstractmethod
+    def tool_call_start(self) -> str:
+        """The token or string that marks the beginning of a tool call block."""
+        pass
+
+    @property
+    @abstractmethod
+    def tool_call_end(self) -> str:
+        """The token or string that marks the end of a tool call block."""
+        pass
+
+    @abstractmethod
+    def parse_tool_calls(
+        self, tool_call_text: str
+    ) -> ExtractedToolCallInformation:
+        """
+        Parse tool calls from the text between start and end markers.
+
+        Args:
+            tool_call_text: The text content between tool_call_start and
+                tool_call_end markers (exclusive of the markers themselves)
+
+        Returns:
+            ExtractedToolCallInformation containing parsed tool calls
+        """
+        pass
+
+    def extract_tool_calls_from_response(
+        self, full_response: str
+    ) -> Tuple[str, List[ToolCall]]:
+        """
+        Extract all tool calls from a complete model response.
+
+        This method finds all tool call blocks in the response, parses them,
+        and returns both the non-tool-call content and the extracted calls.
+
+        Args:
+            full_response: The complete model output text
+
+        Returns:
+            Tuple of (content_without_tool_calls, list_of_tool_calls)
+        """
+        tool_calls = []
+        content_parts = []
+        remaining = full_response
+
+        while True:
+            start_idx = remaining.find(self.tool_call_start)
+            if start_idx == -1:
+                content_parts.append(remaining)
+                break
+
+            # Add content before the tool call
+            content_parts.append(remaining[:start_idx])
+
+            # Find the end of the tool call
+            end_idx = remaining.find(
+                self.tool_call_end,
+                start_idx + len(self.tool_call_start)
+            )
+            if end_idx == -1:
+                # Incomplete tool call, treat as content
+                content_parts.append(remaining[start_idx:])
+                break
+
+            # Extract and parse the tool call content
+            tool_text = remaining[
+                start_idx + len(self.tool_call_start):end_idx
+            ]
+            result = self.parse_tool_calls(tool_text)
+            tool_calls.extend(result.tool_calls)
+
+            # Continue after the tool call
+            remaining = remaining[end_idx + len(self.tool_call_end):]
+
+        content = "".join(content_parts).strip()
+        return content, tool_calls
+
+    @staticmethod
+    def convert_value(value_str: str) -> Any:
+        """
+        Convert a string value to its appropriate Python type.
+
+        Attempts to parse as JSON first, then falls back to type inference.
+
+        Args:
+            value_str: String representation of the value
+
+        Returns:
+            Converted value (bool, int, float, list, dict, or str)
+        """
+        value_str = value_str.strip()
+
+        # Try JSON parsing first (handles arrays, objects, strings with quotes)
+        try:
+            return json.loads(value_str)
+        except json.JSONDecodeError:
+            pass
+
+        # Handle boolean
+        if value_str.lower() == "true":
+            return True
+        if value_str.lower() == "false":
+            return False
+
+        # Handle null/none
+        if value_str.lower() in ("null", "none"):
+            return None
+
+        # Handle numbers
+        try:
+            if "." in value_str:
+                return float(value_str)
+            return int(value_str)
+        except ValueError:
+            pass
+
+        # Return as string
+        return value_str

--- a/mlx_lm/tool_parsers/minimax_m2_tool_parser.py
+++ b/mlx_lm/tool_parsers/minimax_m2_tool_parser.py
@@ -1,0 +1,347 @@
+# Copyright © 2025 Apple Inc.
+
+"""
+MiniMax M2 XML-based tool call parser.
+
+This parser handles the XML format used by MiniMax M2 models for tool calls.
+MiniMax M2 uses a structured XML format instead of JSON for tool invocations.
+
+Expected format:
+    <minimax:tool_call>
+    <invoke name="function_name">
+    <parameter name="arg1">value1</parameter>
+    <parameter name="arg2">value2</parameter>
+    </invoke>
+    </minimax:tool_call>
+
+Multiple tool calls can be made in a single block:
+    <minimax:tool_call>
+    <invoke name="func1">
+    <parameter name="x">1</parameter>
+    </invoke>
+    <invoke name="func2">
+    <parameter name="y">2</parameter>
+    </invoke>
+    </minimax:tool_call>
+
+Parameter values support various types:
+    - Strings: <parameter name="query">search term</parameter>
+    - Numbers: <parameter name="count">42</parameter>
+    - Booleans: <parameter name="enabled">true</parameter>
+    - Arrays: <parameter name="tags">["a", "b", "c"]</parameter>
+    - Objects: <parameter name="config">{"key": "value"}</parameter>
+
+Reference: https://huggingface.co/MiniMaxAI/MiniMax-M2/blob/main/docs/tool_calling_guide.md
+"""
+
+import logging
+import re
+from typing import Any, Dict, List, Optional
+
+from .base import ExtractedToolCallInformation, ToolCall, ToolParser
+
+logger = logging.getLogger(__name__)
+
+
+class MinimaxM2ToolParser(ToolParser):
+    """
+    Parser for MiniMax M2 XML-formatted tool calls.
+
+    This parser extracts tool calls from MiniMax M2's XML format and converts
+    them to the standard ToolCall format compatible with OpenAI's API.
+    """
+
+    # Regex patterns for parsing XML structure
+    # Pattern to match complete <invoke name="...">...</invoke> blocks
+    INVOKE_PATTERN = re.compile(
+        r'<invoke\s+name\s*=\s*["\']([^"\']+)["\']\s*>(.*?)</invoke>',
+        re.DOTALL | re.IGNORECASE,
+    )
+
+    # Pattern to match <parameter name="...">...</parameter> elements
+    PARAMETER_PATTERN = re.compile(
+        r'<parameter\s+name\s*=\s*["\']([^"\']+)["\']\s*>(.*?)</parameter>',
+        re.DOTALL | re.IGNORECASE,
+    )
+
+    # Alternative pattern for self-closing parameters (rare but possible)
+    PARAMETER_SELF_CLOSING_PATTERN = re.compile(
+        r'<parameter\s+name\s*=\s*["\']([^"\']+)["\']\s*'
+        r'value\s*=\s*["\']([^"\']*)["\']'
+        r'\s*/?>',
+        re.IGNORECASE,
+    )
+
+    @property
+    def tool_call_start(self) -> str:
+        return "<minimax:tool_call>"
+
+    @property
+    def tool_call_end(self) -> str:
+        return "</minimax:tool_call>"
+
+    def parse_tool_calls(
+        self, tool_call_text: str
+    ) -> ExtractedToolCallInformation:
+        """
+        Parse MiniMax M2 XML-formatted tool calls.
+
+        Args:
+            tool_call_text: XML string containing tool call information
+                (content between <minimax:tool_call> tags)
+
+        Returns:
+            ExtractedToolCallInformation with parsed tool calls
+        """
+        tool_calls = []
+        text = tool_call_text.strip()
+
+        if not text:
+            return ExtractedToolCallInformation(
+                tool_calls=[],
+                content="",
+                tools_called=False,
+            )
+
+        # Find all <invoke> blocks
+        for invoke_match in self.INVOKE_PATTERN.finditer(text):
+            function_name = invoke_match.group(1).strip()
+            invoke_content = invoke_match.group(2)
+
+            # Parse parameters from the invoke block
+            arguments = self._parse_parameters(invoke_content)
+
+            tool_call = ToolCall(
+                name=function_name,
+                arguments=arguments,
+                id=None,
+            )
+            tool_calls.append(tool_call)
+
+        # If no invoke blocks found, try alternative parsing
+        if not tool_calls:
+            tool_calls = self._try_alternative_parsing(text)
+
+        return ExtractedToolCallInformation(
+            tool_calls=tool_calls,
+            content="",
+            tools_called=len(tool_calls) > 0,
+        )
+
+    def _parse_parameters(self, invoke_content: str) -> Dict[str, Any]:
+        """
+        Parse parameter elements from invoke block content.
+
+        Args:
+            invoke_content: Content inside an <invoke> block
+
+        Returns:
+            Dictionary of parameter names to converted values
+        """
+        arguments = {}
+
+        # Match standard <parameter name="...">value</parameter> format
+        for param_match in self.PARAMETER_PATTERN.finditer(invoke_content):
+            param_name = param_match.group(1).strip()
+            param_value_str = param_match.group(2).strip()
+
+            # Convert the string value to appropriate type
+            arguments[param_name] = self._convert_param_value(param_value_str)
+
+        # Also check for self-closing parameter format
+        for param_match in self.PARAMETER_SELF_CLOSING_PATTERN.finditer(
+            invoke_content
+        ):
+            param_name = param_match.group(1).strip()
+            param_value_str = param_match.group(2).strip()
+
+            if param_name not in arguments:  # Don't override existing
+                arguments[param_name] = self._convert_param_value(param_value_str)
+
+        return arguments
+
+    def _convert_param_value(self, value_str: str) -> Any:
+        """
+        Convert a parameter value string to its appropriate Python type.
+
+        MiniMax M2 supports various value types:
+        - Strings (plain text or quoted)
+        - Numbers (integers and floats)
+        - Booleans (true/false)
+        - JSON arrays
+        - JSON objects
+
+        Args:
+            value_str: The string value from the parameter element
+
+        Returns:
+            Converted Python value
+        """
+        return self.convert_value(value_str)
+
+    def _try_alternative_parsing(self, text: str) -> List[ToolCall]:
+        """
+        Try alternative parsing strategies for malformed XML.
+
+        This handles cases where the XML might be slightly malformed
+        or use non-standard formatting.
+
+        Args:
+            text: The tool call text that didn't match standard patterns
+
+        Returns:
+            List of parsed ToolCall objects (may be empty)
+        """
+        tool_calls = []
+
+        # Try to find function name using looser pattern
+        loose_invoke_pattern = re.compile(
+            r'<invoke[^>]*name\s*=\s*["\']?([^"\'>\s]+)["\']?[^>]*>(.*?)</invoke>',
+            re.DOTALL | re.IGNORECASE,
+        )
+
+        for match in loose_invoke_pattern.finditer(text):
+            function_name = match.group(1).strip()
+            content = match.group(2)
+
+            arguments = self._parse_parameters(content)
+
+            # If no parameters found with standard pattern, try looser matching
+            if not arguments:
+                arguments = self._parse_parameters_loose(content)
+
+            if function_name:
+                tool_calls.append(
+                    ToolCall(
+                        name=function_name,
+                        arguments=arguments,
+                        id=None,
+                    )
+                )
+
+        return tool_calls
+
+    def _parse_parameters_loose(self, content: str) -> Dict[str, Any]:
+        """
+        Parse parameters with a looser pattern for malformed XML.
+
+        Args:
+            content: Content that may contain parameters in non-standard format
+
+        Returns:
+            Dictionary of parameter names to values
+        """
+        arguments = {}
+
+        # Very loose pattern that might catch malformed parameters
+        loose_param_pattern = re.compile(
+            r'<parameter[^>]*name\s*=\s*["\']?([^"\'>\s]+)["\']?[^>]*>'
+            r'(.*?)'
+            r'</parameter>',
+            re.DOTALL | re.IGNORECASE,
+        )
+
+        for match in loose_param_pattern.finditer(content):
+            param_name = match.group(1).strip()
+            param_value = match.group(2).strip()
+            arguments[param_name] = self._convert_param_value(param_value)
+
+        return arguments
+
+
+class MinimaxM2StreamingState:
+    """
+    State tracker for streaming MiniMax M2 tool call parsing.
+
+    This class maintains state while incrementally parsing tool calls
+    during streaming generation. It tracks partial XML elements and
+    accumulates content until complete tool calls can be extracted.
+    """
+
+    def __init__(self):
+        self.reset()
+
+    def reset(self):
+        """Reset all streaming state."""
+        self.accumulated_text: str = ""
+        self.in_tool_call: bool = False
+        self.in_invoke: bool = False
+        self.in_parameter: bool = False
+        self.current_function_name: Optional[str] = None
+        self.current_param_name: Optional[str] = None
+        self.current_param_value: str = ""
+        self.accumulated_params: Dict[str, Any] = {}
+        self.pending_tool_calls: List[ToolCall] = []
+
+    def add_token(self, token_text: str) -> Optional[ToolCall]:
+        """
+        Process a new token and potentially return a complete tool call.
+
+        Args:
+            token_text: The text of the newly generated token
+
+        Returns:
+            A complete ToolCall if one was finished, None otherwise
+        """
+        self.accumulated_text += token_text
+
+        # Check for tool call boundaries
+        if "<minimax:tool_call>" in self.accumulated_text and not self.in_tool_call:
+            self.in_tool_call = True
+            idx = self.accumulated_text.find("<minimax:tool_call>")
+            self.accumulated_text = self.accumulated_text[
+                idx + len("<minimax:tool_call>"):
+            ]
+
+        if not self.in_tool_call:
+            return None
+
+        # Check for complete invoke blocks
+        completed_call = self._try_extract_complete_invoke()
+
+        # Check for end of tool call block
+        if "</minimax:tool_call>" in self.accumulated_text:
+            self.in_tool_call = False
+            idx = self.accumulated_text.find("</minimax:tool_call>")
+            self.accumulated_text = self.accumulated_text[
+                idx + len("</minimax:tool_call>"):
+            ]
+
+        return completed_call
+
+    def _try_extract_complete_invoke(self) -> Optional[ToolCall]:
+        """
+        Try to extract a complete invoke block from accumulated text.
+
+        Returns:
+            ToolCall if a complete invoke was found, None otherwise
+        """
+        parser = MinimaxM2ToolParser()
+        match = parser.INVOKE_PATTERN.search(self.accumulated_text)
+
+        if match:
+            function_name = match.group(1).strip()
+            invoke_content = match.group(2)
+            arguments = parser._parse_parameters(invoke_content)
+
+            # Remove the matched content
+            self.accumulated_text = self.accumulated_text[match.end():]
+
+            return ToolCall(
+                name=function_name,
+                arguments=arguments,
+                id=None,
+            )
+
+        return None
+
+    def get_pending_calls(self) -> List[ToolCall]:
+        """
+        Get and clear any pending complete tool calls.
+
+        Returns:
+            List of complete ToolCall objects
+        """
+        calls = self.pending_tool_calls
+        self.pending_tool_calls = []
+        return calls

--- a/tests/test_tool_parsers.py
+++ b/tests/test_tool_parsers.py
@@ -1,0 +1,209 @@
+# Copyright © 2025 Apple Inc.
+
+"""Tests for tool call parsers."""
+
+import unittest
+
+from mlx_lm.tool_parsers import (
+    MinimaxM2ToolParser,
+    ToolCall,
+    get_tool_parser,
+)
+
+
+class TestMinimaxM2ToolParser(unittest.TestCase):
+    """Tests for the MiniMax M2 XML tool call parser."""
+
+    def setUp(self):
+        self.parser = MinimaxM2ToolParser()
+
+    def test_tool_call_tokens(self):
+        """Test that the correct start/end tokens are defined."""
+        self.assertEqual(self.parser.tool_call_start, "<minimax:tool_call>")
+        self.assertEqual(self.parser.tool_call_end, "</minimax:tool_call>")
+
+    def test_parse_simple_tool_call(self):
+        """Test parsing a simple MiniMax XML tool call."""
+        tool_text = '''
+        <invoke name="get_weather">
+        <parameter name="location">Boston</parameter>
+        </invoke>
+        '''
+        result = self.parser.parse_tool_calls(tool_text)
+
+        self.assertTrue(result.tools_called)
+        self.assertEqual(len(result.tool_calls), 1)
+        self.assertEqual(result.tool_calls[0].name, "get_weather")
+        self.assertEqual(result.tool_calls[0].arguments, {"location": "Boston"})
+
+    def test_parse_multiple_parameters(self):
+        """Test parsing a tool call with multiple parameters."""
+        tool_text = '''
+        <invoke name="search_web">
+        <parameter name="query">machine learning</parameter>
+        <parameter name="max_results">10</parameter>
+        <parameter name="include_images">true</parameter>
+        </invoke>
+        '''
+        result = self.parser.parse_tool_calls(tool_text)
+
+        self.assertTrue(result.tools_called)
+        args = result.tool_calls[0].arguments
+        self.assertEqual(args["query"], "machine learning")
+        self.assertEqual(args["max_results"], 10)
+        self.assertEqual(args["include_images"], True)
+
+    def test_parse_multiple_invokes(self):
+        """Test parsing multiple invoke blocks."""
+        tool_text = '''
+        <invoke name="func1">
+        <parameter name="x">1</parameter>
+        </invoke>
+        <invoke name="func2">
+        <parameter name="y">2</parameter>
+        </invoke>
+        '''
+        result = self.parser.parse_tool_calls(tool_text)
+
+        self.assertTrue(result.tools_called)
+        self.assertEqual(len(result.tool_calls), 2)
+        self.assertEqual(result.tool_calls[0].name, "func1")
+        self.assertEqual(result.tool_calls[0].arguments, {"x": 1})
+        self.assertEqual(result.tool_calls[1].name, "func2")
+        self.assertEqual(result.tool_calls[1].arguments, {"y": 2})
+
+    def test_parse_json_array_parameter(self):
+        """Test parsing a parameter containing a JSON array."""
+        tool_text = '''
+        <invoke name="search">
+        <parameter name="tags">["tech", "ai", "ml"]</parameter>
+        </invoke>
+        '''
+        result = self.parser.parse_tool_calls(tool_text)
+
+        self.assertTrue(result.tools_called)
+        self.assertEqual(result.tool_calls[0].arguments["tags"], ["tech", "ai", "ml"])
+
+    def test_parse_json_object_parameter(self):
+        """Test parsing a parameter containing a JSON object."""
+        tool_text = '''
+        <invoke name="configure">
+        <parameter name="settings">{"theme": "dark", "fontSize": 14}</parameter>
+        </invoke>
+        '''
+        result = self.parser.parse_tool_calls(tool_text)
+
+        self.assertTrue(result.tools_called)
+        self.assertEqual(
+            result.tool_calls[0].arguments["settings"],
+            {"theme": "dark", "fontSize": 14}
+        )
+
+    def test_parse_empty_text(self):
+        """Test parsing empty text."""
+        result = self.parser.parse_tool_calls("")
+
+        self.assertFalse(result.tools_called)
+        self.assertEqual(len(result.tool_calls), 0)
+
+    def test_parse_with_single_quotes(self):
+        """Test parsing with single quotes in attribute."""
+        tool_text = '''
+        <invoke name='get_data'>
+        <parameter name='id'>123</parameter>
+        </invoke>
+        '''
+        result = self.parser.parse_tool_calls(tool_text)
+
+        self.assertTrue(result.tools_called)
+        self.assertEqual(result.tool_calls[0].name, "get_data")
+        self.assertEqual(result.tool_calls[0].arguments["id"], 123)
+
+    def test_to_openai_format(self):
+        """Test conversion to OpenAI format."""
+        tool_text = '''
+        <invoke name="test_func">
+        <parameter name="x">1</parameter>
+        </invoke>
+        '''
+        result = self.parser.parse_tool_calls(tool_text)
+
+        openai_format = result.tool_calls[0].to_openai_format()
+        self.assertEqual(openai_format["type"], "function")
+        self.assertEqual(openai_format["function"]["name"], "test_func")
+        self.assertEqual(openai_format["function"]["arguments"], '{"x": 1}')
+
+    def test_extract_from_full_response(self):
+        """Test extracting tool calls from a full model response."""
+        full_response = '''Let me search for that information.
+<minimax:tool_call>
+<invoke name="search_web">
+<parameter name="query">MLX framework</parameter>
+</invoke>
+</minimax:tool_call>
+I'll get back to you with the results.'''
+
+        content, tool_calls = self.parser.extract_tool_calls_from_response(
+            full_response
+        )
+
+        self.assertEqual(len(tool_calls), 1)
+        self.assertEqual(tool_calls[0].name, "search_web")
+        self.assertEqual(tool_calls[0].arguments, {"query": "MLX framework"})
+        self.assertIn("Let me search", content)
+        self.assertIn("get back to you", content)
+
+
+class TestGetToolParser(unittest.TestCase):
+    """Tests for the get_tool_parser factory function."""
+
+    def test_get_minimax_parser(self):
+        """Test getting the MiniMax parser by name."""
+        parser = get_tool_parser("minimax_m2")
+        self.assertIsInstance(parser, MinimaxM2ToolParser)
+
+    def test_invalid_parser_name(self):
+        """Test that invalid parser name raises ValueError."""
+        with self.assertRaises(ValueError):
+            get_tool_parser("invalid_parser")
+
+
+class TestToolCall(unittest.TestCase):
+    """Tests for the ToolCall dataclass."""
+
+    def test_to_openai_format_basic(self):
+        """Test basic OpenAI format conversion."""
+        tc = ToolCall(name="test", arguments={"a": 1})
+        result = tc.to_openai_format()
+
+        self.assertEqual(result["type"], "function")
+        self.assertEqual(result["function"]["name"], "test")
+        self.assertEqual(result["function"]["arguments"], '{"a": 1}')
+
+    def test_to_openai_format_with_id(self):
+        """Test OpenAI format conversion with ID."""
+        tc = ToolCall(name="test", arguments={}, id="call_123")
+        result = tc.to_openai_format()
+
+        self.assertEqual(result["id"], "call_123")
+
+    def test_to_openai_format_complex_arguments(self):
+        """Test OpenAI format with complex nested arguments."""
+        tc = ToolCall(
+            name="complex",
+            arguments={
+                "nested": {"deep": {"value": 42}},
+                "array": [1, 2, 3],
+                "mixed": [{"a": 1}, {"b": 2}]
+            }
+        )
+        result = tc.to_openai_format()
+
+        self.assertEqual(result["function"]["name"], "complex")
+        # Arguments should be JSON string
+        self.assertIn('"nested"', result["function"]["arguments"])
+        self.assertIn('"array"', result["function"]["arguments"])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

This PR adds support for MiniMax M2's XML-based tool calling format through a pluggable tool parser system.

### Background

While testing MiniMax-M2 locally with [OpenCode](https://github.com/opencode-ai/opencode) (an AI coding agent), I discovered that the model's tool calls were not being parsed correctly. MiniMax M2 uses a unique XML format for tool calls that differs from the standard JSON format used by other models like Qwen and Llama:

```xml
<minimax:tool_call>
<invoke name="function_name">
<parameter name="param1">value1</parameter>
<parameter name="param2">value2</parameter>
</invoke>
</minimax:tool_call>
```

The existing server implementation only supports JSON-formatted tool calls wrapped in `<tool_call>` tags, causing MiniMax's XML format to be passed through unparsed, which breaks agent workflows that depend on properly structured tool call responses.

### Changes

- **New `mlx_lm/tool_parsers/` module**: Pluggable architecture for tool call parsing
  - `base.py`: Abstract base class `ToolParser` with `ToolCall` and `ExtractedToolCallInformation` dataclasses
  - `minimax_m2_tool_parser.py`: XML parser for MiniMax M2's format using regex patterns
  - `__init__.py`: Factory function and helper utilities

- **New `--tool-call-parser` CLI flag**: Explicitly select the parser to use
  - Currently supports: `minimax_m2`
  - When not specified, uses original JSON parsing behavior (backward compatible)

- **Updated `tokenizer_utils.py`**: Added MiniMax tool call token detection (`<minimax:tool_call>`, `</minimax:tool_call>`)

- **Updated `server.py`**: Integration with the tool parser system
  - Uses selected parser for tool call extraction
  - Proper `finish_reason: "tool_calls"` handling per OpenAI spec
  - Converts tool call arguments format for chat templates

- **Comprehensive tests**: 15 tests for MiniMax parser functionality

### Usage

```bash
mlx_lm.server --model MiniMaxAI/MiniMax-M2 --tool-call-parser minimax_m2
```

### Test Plan

- [x] All existing server tests pass (13 tests)
- [x] New tool parser tests pass (15 tests)
- [x] Tested manually with MiniMax-M2 and OpenCode agent
- [x] Backward compatible - no flag uses original behavior