### PR TITLE
fix: server busy-waiting during idle request polling

### DIFF
--- a/mlx_lm/server.py
+++ b/mlx_lm/server.py
@@ -532,12 +532,15 @@ class ResponseGenerator:
 
         unprocessed_requests = []
 
-        def get_next_request():
+        def get_next_request(timeout=None):
             if unprocessed_requests:
                 return unprocessed_requests.pop()
             else:
                 try:
-                    return self.requests.get_nowait()
+                    if timeout is not None:
+                        return self.requests.get(timeout=timeout)
+                    else:
+                        return self.requests.get_nowait()
                 except QueueEmpty:
                     return None
 
@@ -549,7 +552,9 @@ class ResponseGenerator:
         while not self._stop:
             request = None
             if not drain_batch:
-                request = get_next_request()
+                # Use timeout when idle (no batch running) to avoid busy-waiting
+                timeout = 0.1 if batch_generator is None else None
+                request = get_next_request(timeout=timeout)
 
             # We got a request
             if request is not None:


### PR DESCRIPTION
# Issue
`mlx_lm serve` takes up 100% cpu (for a single core) and often ignore ctrl+c.

# Goal
Prevent 100% CPU spin-loop when server idle by adding 0.1s timeout to queue.get().

# Changes
- `get_next_request()` now accepts optional timeout param
- idle state (no batch running): use 0.1s timeout via queue.get(timeout=0.1)
- batch processing: use non-blocking get_nowait() (avoids latency impact)