### PR TITLE
fix: gpt-oss modules_to_not_convert

### DIFF
--- a/mlx_lm/utils.py
+++ b/mlx_lm/utils.py
@@ -592,7 +592,14 @@ def quantize_model(
     """
     quantized_config = copy.deepcopy(config)
 
-    quant_predicate = quant_predicate or getattr(model, "quant_predicate", None)
+    # Check for mode-specific predicate first (e.g., quant_predicate_mxfp4)
+    # This allows models to define different quantization strategies per mode
+    mode_specific_predicate = getattr(model, f"quant_predicate_{mode}", None)
+    quant_predicate = (
+        quant_predicate
+        or mode_specific_predicate
+        or getattr(model, "quant_predicate", None)
+    )
     quant_params = {"group_size": group_size, "bits": bits, "mode": mode}
     if "quantization" in quantized_config:
         # If the model is already partially quantized, return params so that


### PR DESCRIPTION
The current MLX conversion/quantization for gpt-oss models quantizes layers that OpenAI specifies should remain at full precision (modules_to_not_convert). This PR aligns MXFP4 quantization with OpenAI's specification, keeping attention, embeddings, routers, and lm_head at bfloat16 while MLP experts remain at MXFP4.

Models quantized with `--q-mode mxfp4` will be slightly larger than before, with potentially better output quality matching OpenAI's intended precision scheme.

# Support for MXFP4 conversion of gpt-oss fine-tunes

Loading unquantized bfloat16 gpt-oss fine-tunes fail. Fine-tunes of gpt-oss often convert to Huggingface safetensors format. Attempting to convert them would fail with errors like:

```
ValueError: Received 108 parameters not in model:
model.layers.0.mlp.experts.down_proj,
model.layers.0.mlp.experts.gate_proj,
...
```

## Root Cause

| Format | Tensor Names | Shape | Dim Order |
|--------|--------------|-------|-----------|
| MXFP4 | `gate_up_proj_blocks` | `(128, 5760, ...)` | `(experts, OUT, IN)` |
| Unquantized | `gate_up_proj` | `(128, 2880, 5760)` | `(experts, IN, OUT)` |

HuggingFace uses interleaved gate/up outputs ([modeling_gpt_oss.py](https://github.com/huggingface/transformers/blob/main/src/transformers/models/gpt_oss/modeling_gpt_oss.py)):
```python
gate, up = gate_up[..., ::2], gate_up[..., 1::2]
```

Unquantized weights needed: interleaved split + transpose to match `SwitchLinear`.

## Testing

| Model | Source | Result |
|-------|--------|--------|
| `openai/gpt-oss-120b` | MXFP4 (baseline) | Pass |
| `ArliAI/gpt-oss-120b-Derestricted` | ArliAI fine-tune | Pass |
| `ArliAI/gpt-oss-20b-Derestricted` | ArliAI fine-tune | Pass |
| `p-e-w/gpt-oss-20b-heretic` | Heretic fine-tune | Pass |
| Unit test | Synthetic tensors | Pass |

Tested across multiple independent fine-tunes on Huggingface and both model sizes (20b, 120b).

## Compatibility

- MXFP4 paths unchanged (guarded by `_blocks`/`_scales` checks)
- Early return if already sanitized
- Unit test added: `test_gpt_oss_sanitize_hf`

## MXFP4 Quantization Alignment

Added mode-specific quantization predicates to match OpenAI's intended MXFP4 scheme.

### Changes to `utils.py`

Added support for mode-specific predicates to help avoid quantizing layers not intended for quantization with mxfp4  (e.g., `quant_predicate_mxfp4`).

### modules_to_not_convert support in `gpt_oss.py`

Added `quant_predicate_mxfp4` property matching OpenAI's `modules_to_not_convert`:

| Component | OpenAI MXFP4 | Our Implementation |
|-----------|--------------|-------------------|
| `model.layers.*.self_attn` | Full precision | Full precision |
| `model.layers.*.mlp.router` | Full precision | Full precision |
| `model.embed_tokens` | Full precision | Full precision |
| `lm_head` | Full precision | Full precision |
| MLP experts | MXFP4 4-bit | MXFP4 4-bit |

The default `quant_predicate` (for non-MXFP4 modes) leaves routers at their existing behavior.

### Result

Models quantized with `--q-mode mxfp4` now match OpenAI's quantization strategy with full-precision layers.