### PR TITLE
Add tokenizer_config support to LoRA YAML configuration

### DIFF
--- a/mlx_lm/LORA.md
+++ b/mlx_lm/LORA.md
@@ -22,6 +22,7 @@ LoRA (QLoRA).[^qlora] LoRA fine-tuning works with the following model families:
   - [Generate](#Generate)
 - [Fuse](#Fuse)
 - [Data](#Data)
+- [Custom Chat Templates](#Custom-Chat-Templates)
 - [Memory Issues](#Memory-Issues)
 
 ## Run
@@ -359,6 +360,28 @@ How can I assistant you today.<|im_end|>
 If you are unsure of the format to use, the `chat` or `completions` are good to
 start with. For custom requirements on the format of the dataset, use the
 `text` format to assemble the content yourself.
+
+## Custom Chat Templates
+
+You can customize the tokenizer behavior, including specifying a custom chat
+template, using the `tokenizer_config` option in your YAML config file:
+
+```yaml
+tokenizer_config:
+  trust_remote_code: true
+  chat_template_file: "path/to/chat_template.jinja"
+```
+
+The `chat_template_file` option loads a Jinja2 template from the specified file
+path. Alternatively, you can provide the template directly as a string:
+
+```yaml
+tokenizer_config:
+  chat_template: "{% for message in messages %}..."
+```
+
+Any options specified in `tokenizer_config` are passed to the HuggingFace
+`AutoTokenizer.from_pretrained()` function.
 
 ## Memory Issues
 


### PR DESCRIPTION
This PR adds support for specifying custom tokenizer configuration, including custom chat templates, directly in LoRA YAML config files.

## Changes

- Add `tokenizer_config` to `CONFIG_DEFAULTS` with `trust_remote_code` default
- Support `chat_template_file` to load Jinja2 templates from file paths
- Support inline `chat_template` strings
- Update documentation with usage examples
- Add comprehensive unit tests

## Usage

Users can now specify tokenizer configuration in their YAML config:

```yaml
# Option 1: Load chat template from file
tokenizer_config:
  trust_remote_code: true
  chat_template_file: "path/to/chat_template.jinja"

# Option 2: Inline chat template string
tokenizer_config:
  trust_remote_code: true
  chat_template: "{% for message in messages %}..."
```

## Testing

- Added unit tests for both file-based and inline chat templates
- All existing tests pass
- Code formatted with black via pre-commit

Fixes the need to modify source code to use custom chat templates during LoRA fine-tuning.