### PR TITLE
Bump to transformer v5

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -26,7 +26,7 @@ setup(
     install_requires=[
         f"mlx>={MIN_MLX_VERSION}; platform_system == 'Darwin'",
         "numpy",
-        "transformers>=4.39.3",
+        "transformers==5.0.0rc1",
         "sentencepiece",
         "protobuf",
         "pyyaml",


### PR DESCRIPTION
Transformers stopped supporting clean up tokenization spaces. So it's removed from our tokenizer decoder as well (so that the two are consistent). It's very much an edge case.. so I think it's fine to remove it.