### PR TITLE
Revert return dict and wrap apply_chat_template

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ prompt = "Write a story about Einstein"
 
 messages = [{"role": "user", "content": prompt}]
 prompt = tokenizer.apply_chat_template(
-    messages, add_generation_prompt=True, return_dict=False,
+    messages, add_generation_prompt=True,
 )
 
 text = generate(model, tokenizer, prompt=prompt, verbose=True)
@@ -130,7 +130,7 @@ prompt = "Write a story about Einstein"
 
 messages = [{"role": "user", "content": prompt}]
 prompt = tokenizer.apply_chat_template(
-    messages, add_generation_prompt=True, return_dict=False,
+    messages, add_generation_prompt=True,
 )
 
 for response in stream_generate(model, tokenizer, prompt, max_tokens=512):

--- a/mlx_lm/cache_prompt.py
+++ b/mlx_lm/cache_prompt.py
@@ -117,7 +117,6 @@ def main():
             messages,
             add_generation_prompt=False,
             continue_final_message=True,
-            return_dict=False,
         )
 
     else:

--- a/mlx_lm/chat.py
+++ b/mlx_lm/chat.py
@@ -140,7 +140,8 @@ def main():
             messages.append({"role": "system", "content": args.system_prompt})
         messages.append({"role": "user", "content": query})
         prompt = tokenizer.apply_chat_template(
-            messages, add_generation_prompt=True, return_dict=False
+            messages,
+            add_generation_prompt=True,
         )
         for response in stream_generate(
             model,

--- a/mlx_lm/evaluate.py
+++ b/mlx_lm/evaluate.py
@@ -63,7 +63,6 @@ def chat_template_fn(**extra_kwargs):
             tokenize=False,
             add_generation_prompt=add_generation_prompt,
             continue_final_message=not add_generation_prompt,
-            return_dict=False,
             **extra_kwargs,
         )
 

--- a/mlx_lm/examples/batch_generate_response.py
+++ b/mlx_lm/examples/batch_generate_response.py
@@ -21,7 +21,6 @@ prompts = [
     tokenizer.apply_chat_template(
         [{"role": "user", "content": p}],
         add_generation_prompt=True,
-        return_dict=False,
     )
     for p in prompts
 ]
@@ -42,7 +41,6 @@ prompts = [
     tokenizer.apply_chat_template(
         [{"role": "user", "content": p}],
         add_generation_prompt=True,
-        return_dict=False,
     )
     for p in prompts
 ]

--- a/mlx_lm/examples/chat.py
+++ b/mlx_lm/examples/chat.py
@@ -16,7 +16,8 @@ prompt_cache = make_prompt_cache(model)
 prompt = "Hi my name is <Name>."
 messages = [{"role": "user", "content": prompt}]
 prompt = tokenizer.apply_chat_template(
-    messages, add_generation_prompt=True, return_dict=False
+    messages,
+    add_generation_prompt=True,
 )
 
 # Assistant response
@@ -32,7 +33,8 @@ response = generate(
 prompt = "What's my name?"
 messages = [{"role": "user", "content": prompt}]
 prompt = tokenizer.apply_chat_template(
-    messages, add_generation_prompt=True, return_dict=False
+    messages,
+    add_generation_prompt=True,
 )
 
 # Assistant response

--- a/mlx_lm/examples/generate_response.py
+++ b/mlx_lm/examples/generate_response.py
@@ -16,7 +16,6 @@ conversation = [{"role": "user", "content": prompt}]
 prompt = tokenizer.apply_chat_template(
     conversation=conversation,
     add_generation_prompt=True,
-    return_dict=False,
 )
 
 # Specify the maximum number of tokens

--- a/mlx_lm/examples/sharded_generate.py
+++ b/mlx_lm/examples/sharded_generate.py
@@ -64,7 +64,8 @@ if __name__ == "__main__":
 
     messages = [{"role": "user", "content": args.prompt}]
     prompt = tokenizer.apply_chat_template(
-        messages, add_generation_prompt=True, return_dict=False
+        messages,
+        add_generation_prompt=True,
     )
 
     for response in stream_generate(

--- a/mlx_lm/examples/tool_use.py
+++ b/mlx_lm/examples/tool_use.py
@@ -34,7 +34,6 @@ prompt = tokenizer.apply_chat_template(
     messages,
     add_generation_prompt=True,
     tools=list(tools.values()),
-    return_dict=False,
 )
 
 prompt_cache = make_prompt_cache(model)
@@ -63,7 +62,6 @@ messages = [{"role": "tool", "name": tool_call["name"], "content": tool_result}]
 prompt = tokenizer.apply_chat_template(
     messages,
     add_generation_prompt=True,
-    return_dict=False,
 )
 
 # Generate the final response:

--- a/mlx_lm/generate.py
+++ b/mlx_lm/generate.py
@@ -1325,7 +1325,6 @@ def main():
             tokenize=False,
             continue_final_message=has_prefill,
             add_generation_prompt=not has_prefill,
-            return_dict=False,
             **template_kwargs,
         )
 
@@ -1337,7 +1336,6 @@ def main():
                 messages,
                 tokenize=False,
                 continue_final_message=has_prefill,
-                return_dict=False,
                 add_generation_prompt=not has_prefill,
             )
             prompt = prompt[test_prompt.index("<query>") :]

--- a/mlx_lm/server.py
+++ b/mlx_lm/server.py
@@ -494,7 +494,6 @@ class ResponseGenerator:
                     tools,
                     add_generation_prompt=True,
                     tokenize=True,
-                    return_dict=False,
                     **self.model_provider.cli_args.chat_template_args,
                 )
             else:

--- a/mlx_lm/tokenizer_utils.py
+++ b/mlx_lm/tokenizer_utils.py
@@ -278,6 +278,10 @@ class TokenizerWrapper:
                     self._tool_call_end = tool_call_end
                     break
 
+    def apply_chat_template(self, *args, **kwargs):
+        kwargs["return_dict"] = False
+        return self._tokenizer.apply_chat_template(*args, **kwargs)
+
     def add_eos_token(self, token: str):
         token_id = None
         try:

--- a/tests/test_generate.py
+++ b/tests/test_generate.py
@@ -47,7 +47,6 @@ class TestGenerate(unittest.TestCase):
             [{"role": "user", "content": "Write a story about Einstein"}],
             tokenize=True,
             add_generation_prompt=True,
-            return_dict=False,
         )
 
         tokens = []
@@ -93,7 +92,6 @@ class TestGenerate(unittest.TestCase):
         prompt = self.tokenizer.apply_chat_template(
             messages,
             add_generation_prompt=True,
-            return_dict=False,
         )
 
         for generation_result in stream_generate(
@@ -122,7 +120,6 @@ class TestGenerate(unittest.TestCase):
         prompt = self.tokenizer.apply_chat_template(
             messages,
             add_generation_prompt=True,
-            return_dict=False,
         )
         prompt_embeddings = self.model.model.embed_tokens(prompt)
 
@@ -147,7 +144,6 @@ class TestGenerate(unittest.TestCase):
         prompt = self.tokenizer.apply_chat_template(
             messages,
             add_generation_prompt=True,
-            return_dict=False,
         )
         prompt_embeddings = self.model.model.embed_tokens(prompt)
 
@@ -192,7 +188,6 @@ class TestGenerate(unittest.TestCase):
                 [{"role": "user", "content": p}],
                 tokenize=True,
                 add_generation_prompt=True,
-                return_dict=False,
             )
             for p in prompts
         ]
@@ -227,7 +222,6 @@ class TestGenerate(unittest.TestCase):
                 [{"role": "user", "content": p}],
                 tokenize=True,
                 add_generation_prompt=True,
-                return_dict=False,
             )
             for p in prompts
         ]
@@ -278,7 +272,6 @@ class TestGenerate(unittest.TestCase):
                 [{"role": "user", "content": p}],
                 tokenize=True,
                 add_generation_prompt=True,
-                return_dict=False,
             )
             for p in prompts
         ]
@@ -324,7 +317,6 @@ class TestGenerate(unittest.TestCase):
                 [{"role": "user", "content": p}],
                 tokenize=True,
                 add_generation_prompt=True,
-                return_dict=False,
             )
             for p in prompts
         ]
@@ -382,7 +374,6 @@ class TestGenerate(unittest.TestCase):
                     [{"role": "user", "content": p}],
                     tokenize=True,
                     add_generation_prompt=True,
-                    return_dict=False,
                 )
                 for p in prompts_a
             ]
@@ -397,7 +388,6 @@ class TestGenerate(unittest.TestCase):
                     [{"role": "user", "content": p}],
                     tokenize=True,
                     add_generation_prompt=True,
-                    return_dict=False,
                 )
                 for p in prompts_b
             ]


### PR DESCRIPTION
This reverts a previous change I made using `return_dict=False` in `apply_chat_template` and instead wraps the method. 

I think it's preferable since it's simpler and doesn't break old examples we have everywhere (e.g. in all our models on Hugging Face).

Also I this is a useful step towards enabling custom chat templates / other tokenization (e.g. for DSV3.2).