### PR TITLE
Ignore generation_config decode errors

### DIFF
--- a/mlx_lm/utils.py
+++ b/mlx_lm/utils.py
@@ -149,8 +149,12 @@ def load_config(model_path: Path) -> dict:
 
     generation_config_file = model_path / "generation_config.json"
     if generation_config_file.exists():
-        with open(generation_config_file, "r") as f:
-            generation_config = json.load(f)
+        generation_config = {}
+        try:
+            with open(generation_config_file, "r") as f:
+                generation_config = json.load(f)
+        except json.JSONDecodeError:
+            pass
 
         if eos_token_id := generation_config.get("eos_token_id", False):
             config["eos_token_id"] = eos_token_id


### PR DESCRIPTION
Commit https://github.com/ml-explore/mlx-lm/commit/f5ae09a8077ffbe05511877f11b81ae3484535cd is causing load failures with models that previously worked. For example, `mlx-community/Mistral-Small-3.2-24B-Instruct-2506-8bit`'s [generation_config.json](https://huggingface.co/mlx-community/Mistral-Small-3.2-24B-Instruct-2506-8bit/blob/main/generation_config.json) has an invalid trailing `,`.

The previous behavior was to not attempt to load this file, so the rest of the model load would still succeed despite this invalid file. We can restore the ability to load the model by catching a `JSONDecodeError` when loading.
