### PR TITLE
Allow mxfp8 and nvfp4

### DIFF
--- a/mlx_lm/convert.py
+++ b/mlx_lm/convert.py
@@ -187,17 +187,23 @@ def configure_parser() -> argparse.ArgumentParser:
         "-q", "--quantize", help="Generate a quantized model.", action="store_true"
     )
     parser.add_argument(
-        "--q-group-size", help="Group size for quantization.", type=int, default=64
+        "--q-group-size",
+        help="Group size for quantization.",
+        type=int,
+        default=None,
     )
     parser.add_argument(
-        "--q-bits", help="Bits per weight for quantization.", type=int, default=4
+        "--q-bits",
+        help="Bits per weight for quantization.",
+        type=int,
+        default=None,
     )
     parser.add_argument(
         "--q-mode",
         help="The quantization mode.",
         type=str,
         default="affine",
-        choices=["affine", "mxfp4"],
+        choices=["affine", "mxfp4", "nvfp4", "mxfp8"],
     )
     parser.add_argument(
         "--quant-predicate",


### PR DESCRIPTION
- Adds `mxfp8` and `nvfp4` as options for quantization 
- `bits` and `group_size` default to `None` and a reasonable value is chosen based on the mode (same as MLX).