### PR TITLE
feat: allow callers to cancel stream generation via callback check, and ensure prompt cache consistency

### DIFF
--- a/mlx_lm/generate.py
+++ b/mlx_lm/generate.py
@@ -287,6 +287,10 @@ class GenerationResponse:
     finish_reason: Optional[str] = None
 
 
+class GenerationCancelled(Exception):
+    """Raised when generation is cooperatively cancelled."""
+
+
 def maybe_quantize_kv_cache(prompt_cache, quantized_kv_start, kv_group_size, kv_bits):
     if kv_bits is None:
         return
@@ -309,6 +313,7 @@ def generate_step(
     kv_group_size: int = 64,
     quantized_kv_start: int = 0,
     prompt_progress_callback: Optional[Callable[[int, int], None]] = None,
+    should_cancel: Optional[Callable[[], bool]] = None,
     input_embeddings: Optional[mx.array] = None,
 ) -> Generator[Tuple[mx.array, mx.array], None, None]:
     """
@@ -366,6 +371,7 @@ def generate_step(
         )
 
     prompt_progress_callback = prompt_progress_callback or (lambda *_: None)
+    should_cancel = should_cancel or (lambda: False)
 
     quantize_cache_fn = functools.partial(
         maybe_quantize_kv_cache,
@@ -417,8 +423,12 @@ def generate_step(
             len(input_embeddings) if input_embeddings is not None else len(prompt)
         )
         prompt_processed_tokens = 0
+        if should_cancel():
+            raise GenerationCancelled()
         prompt_progress_callback(prompt_processed_tokens, total_prompt_tokens)
         while total_prompt_tokens - prompt_processed_tokens > 1:
+            if should_cancel():
+                raise GenerationCancelled()
             remaining = (total_prompt_tokens - prompt_processed_tokens) - 1
             n_to_process = min(prefill_step_size, remaining)
             _model_call(
@@ -433,6 +443,8 @@ def generate_step(
             mx.eval([c.state for c in prompt_cache])
             prompt_processed_tokens += n_to_process
             prompt_progress_callback(prompt_processed_tokens, total_prompt_tokens)
+            if should_cancel():
+                raise GenerationCancelled()
             prompt = prompt[n_to_process:]
             input_embeddings = (
                 input_embeddings[n_to_process:]
@@ -441,11 +453,15 @@ def generate_step(
             )
             mx.clear_cache()
 
+        if should_cancel():
+            raise GenerationCancelled()
         y, logprobs = _step(input_tokens=prompt, input_embeddings=input_embeddings)
 
     mx.async_eval(y, logprobs)
     n = 0
     while True:
+        if should_cancel():
+            raise GenerationCancelled()
         if n != max_tokens:
             next_y, next_logprobs = _step(y)
             mx.async_eval(next_y, next_logprobs)
@@ -475,6 +491,8 @@ def speculative_generate_step(
     kv_bits: Optional[int] = None,
     kv_group_size: int = 64,
     quantized_kv_start: int = 0,
+    prompt_progress_callback: Optional[Callable[[int, int], None]] = None,
+    should_cancel: Optional[Callable[[], bool]] = None,
 ) -> Generator[Tuple[mx.array, mx.array, bool], None, None]:
     """
     A generator producing token ids based on the given prompt from the model.
@@ -526,6 +544,9 @@ def speculative_generate_step(
         kv_bits=kv_bits,
     )
 
+    prompt_progress_callback = prompt_progress_callback or (lambda *_: None)
+    should_cancel = should_cancel or (lambda: False)
+
     def _process_and_sample(tokens, logits):
         if logits_processors:
             for processor in logits_processors:
@@ -559,15 +580,6 @@ def speculative_generate_step(
             else:
                 return _process_and_sample(None, logits.squeeze(0))
 
-    def _prefill(model, cache, y):
-        while y.size > prefill_step_size:
-            model(y[:prefill_step_size][None], cache=cache)
-            quantize_cache_fn(cache)
-            mx.eval([c.state for c in cache])
-            y = y[prefill_step_size:]
-            mx.clear_cache()
-        return y
-
     def _rewind_cache(num_draft, num_accept):
         cache.trim_prompt_cache(model_cache, num_draft - num_accept)
         cache.trim_prompt_cache(draft_cache, max(num_draft - num_accept - 1, 0))
@@ -583,15 +595,44 @@ def speculative_generate_step(
         return mx.concatenate(ys)
 
     with mx.stream(generation_stream):
-        draft_y = _prefill(draft_model, draft_cache, y)
-        y = _prefill(model, model_cache, y)
+        total_prompt_tokens = y.size
+        prompt_processed_tokens = 0
+        if should_cancel():
+            raise GenerationCancelled()
+        prompt_progress_callback(prompt_processed_tokens, total_prompt_tokens)
+
+        while total_prompt_tokens - prompt_processed_tokens > 1:
+            if should_cancel():
+                raise GenerationCancelled()
+            remaining = (total_prompt_tokens - prompt_processed_tokens) - 1
+            n_to_process = min(prefill_step_size, remaining)
+            if n_to_process <= 0:
+                break
+
+            chunk = y[:n_to_process]
+            draft_model(chunk[None], cache=draft_cache)
+            quantize_cache_fn(draft_cache)
+            model(chunk[None], cache=model_cache)
+            quantize_cache_fn(model_cache)
+            mx.eval([c.state for c in draft_cache] + [c.state for c in model_cache])
+            prompt_processed_tokens += n_to_process
+            prompt_progress_callback(prompt_processed_tokens, total_prompt_tokens)
+            y = y[n_to_process:]
+            mx.clear_cache()
+            if should_cancel():
+                raise GenerationCancelled()
+
+        draft_y = y
 
     ntoks = 0
     # Set these so the finally block doesn't raise
     num_draft = 0
     n = 0
+    prompt_fully_processed = False
     try:
         while True:
+            if should_cancel():
+                raise GenerationCancelled()
             num_draft = min(max_tokens - ntoks, num_draft_tokens)
             draft_tokens = _draft_generate(draft_y, num_draft)
             if prev_tokens is not None:
@@ -599,6 +640,11 @@ def speculative_generate_step(
             y = mx.concatenate([y, draft_tokens])
             tokens, logprobs = _step(model, model_cache, y, num_draft + 1)
             mx.eval(tokens, draft_tokens)
+            if not prompt_fully_processed:
+                prompt_progress_callback(total_prompt_tokens, total_prompt_tokens)
+                prompt_fully_processed = True
+            if should_cancel():
+                raise GenerationCancelled()
             draft_tokens = draft_tokens.tolist()
             tokens = tokens.tolist()
             n = 0
@@ -689,7 +735,6 @@ def stream_generate(
         )
     else:
         kwargs.pop("max_kv_size", None)
-        kwargs.pop("prompt_progress_callback", None)
         token_generator = speculative_generate_step(
             prompt, model, draft_model, **kwargs
         )

--- a/tests/test_generate.py
+++ b/tests/test_generate.py
@@ -7,6 +7,7 @@ import mlx.core as mx
 
 from mlx_lm.generate import (
     BatchGenerator,
+    GenerationCancelled,
     GenerationResponse,
     generate,
     stream_generate,
@@ -23,6 +24,13 @@ class TestGenerate(unittest.TestCase):
         cls.HF_MODEL_PATH = "mlx-community/Qwen1.5-0.5B-Chat-4bit"
         cls.model, cls.tokenizer = load(cls.HF_MODEL_PATH)
         cls.model.set_dtype(mx.float32)
+
+    def _chat_prompt_tokens(self, content: str) -> List[int]:
+        return self.tokenizer.apply_chat_template(
+            [{"role": "user", "content": content}],
+            tokenize=True,
+            add_generation_prompt=True,
+        )
 
     def test_generate(self):
         # Simple test that generation runs
@@ -42,6 +50,20 @@ class TestGenerate(unittest.TestCase):
         )
         self.assertEqual(text, "!!!!!")
 
+    def test_generate_propagates_generationcancelled(self):
+        def should_cancel() -> bool:
+            return True
+
+        with self.assertRaises(GenerationCancelled):
+            generate(
+                self.model,
+                self.tokenizer,
+                "hello",
+                max_tokens=5,
+                verbose=False,
+                should_cancel=should_cancel,
+            )
+
     def test_stream_generate_max_tokens(self):
         prompt = self.tokenizer.apply_chat_template(
             [{"role": "user", "content": "Write a story about Einstein"}],
@@ -58,6 +80,87 @@ class TestGenerate(unittest.TestCase):
         ):
             tokens.append(response.token)
         self.assertEqual(len(tokens), 4)
+
+    def test_stream_generate_cancel_immediate(self):
+        prompt = self._chat_prompt_tokens("hello")
+
+        def should_cancel() -> bool:
+            return True
+
+        gen = stream_generate(
+            self.model,
+            self.tokenizer,
+            prompt,
+            max_tokens=5,
+            should_cancel=should_cancel,
+        )
+        with self.assertRaises(GenerationCancelled):
+            next(gen)
+
+    def test_stream_generate_cancel_during_prefill(self):
+        prompt = self._chat_prompt_tokens("Please cancel during prefill. " * 16)
+
+        progress: List[tuple[int, int]] = []
+        cancelled = False
+
+        def progress_callback(processed: int, total: int) -> None:
+            nonlocal cancelled
+            progress.append((processed, total))
+            if processed > 0:
+                cancelled = True
+
+        def should_cancel() -> bool:
+            return cancelled
+
+        gen = stream_generate(
+            self.model,
+            self.tokenizer,
+            prompt,
+            max_tokens=5,
+            prefill_step_size=4,
+            prompt_progress_callback=progress_callback,
+            should_cancel=should_cancel,
+        )
+        with self.assertRaises(GenerationCancelled):
+            next(gen)
+
+        self.assertGreaterEqual(len(progress), 2)
+        self.assertEqual(progress[0][0], 0)
+        self.assertGreater(progress[0][1], 0)
+        self.assertTrue(any(p > 0 for p, _ in progress))
+
+    def test_stream_generate_cancel_before_first_step(self):
+        prompt = self._chat_prompt_tokens("Please cancel before first-step. " * 16)
+
+        ready = False
+        calls_after_ready = 0
+
+        def progress_callback(processed: int, total: int) -> None:
+            nonlocal ready
+            if processed == total - 1:
+                ready = True
+
+        def should_cancel() -> bool:
+            nonlocal calls_after_ready
+            if not ready:
+                return False
+            calls_after_ready += 1
+            return calls_after_ready >= 2
+
+        gen = stream_generate(
+            self.model,
+            self.tokenizer,
+            prompt,
+            max_tokens=5,
+            prefill_step_size=2048,
+            prompt_progress_callback=progress_callback,
+            should_cancel=should_cancel,
+        )
+        with self.assertRaises(GenerationCancelled):
+            next(gen)
+
+        self.assertTrue(ready)
+        self.assertEqual(calls_after_ready, 2)
 
     def test_generate_with_processor(self):
         init_toks = self.tokenizer.encode("hello")
@@ -111,6 +214,142 @@ class TestGenerate(unittest.TestCase):
         # first 2 generations should be drafts, the third should come
         # from the target model, and last two should be drafts
         self.assertEqual(drafted, [True, True, False, True, True])
+
+    def test_stream_generate_speculative_cancel_immediate(self):
+        # Use same model as draft model to exercise the speculative path
+        draft_model = self.model
+        sampler = make_sampler(temp=0.0)
+        prompt = self._chat_prompt_tokens("hello")
+
+        def should_cancel() -> bool:
+            return True
+
+        gen = stream_generate(
+            model=self.model,
+            tokenizer=self.tokenizer,
+            prompt=prompt,
+            max_tokens=5,
+            draft_model=draft_model,
+            num_draft_tokens=2,
+            sampler=sampler,
+            should_cancel=should_cancel,
+        )
+        with self.assertRaises(GenerationCancelled):
+            next(gen)
+
+    def test_stream_generate_speculative_cancel_during_prefill(self):
+        draft_model = self.model
+        sampler = make_sampler(temp=0.0)
+        prompt = self._chat_prompt_tokens(
+            "Please cancel during speculative prefill. " * 16
+        )
+
+        progress: List[tuple[int, int]] = []
+        cancelled = False
+
+        def progress_callback(processed: int, total: int) -> None:
+            nonlocal cancelled
+            progress.append((processed, total))
+            if processed > 0:
+                cancelled = True
+
+        def should_cancel() -> bool:
+            return cancelled
+
+        gen = stream_generate(
+            model=self.model,
+            tokenizer=self.tokenizer,
+            prompt=prompt,
+            max_tokens=5,
+            draft_model=draft_model,
+            num_draft_tokens=2,
+            sampler=sampler,
+            prefill_step_size=4,
+            prompt_progress_callback=progress_callback,
+            should_cancel=should_cancel,
+        )
+        with self.assertRaises(GenerationCancelled):
+            next(gen)
+
+        self.assertGreaterEqual(len(progress), 2)
+        self.assertEqual(progress[0][0], 0)
+        self.assertGreater(progress[0][1], 0)
+        self.assertTrue(any(p > 0 for p, _ in progress))
+
+    def test_stream_generate_speculative_cancel_before_first_step(self):
+        draft_model = self.model
+        sampler = make_sampler(temp=0.0)
+        prompt = self._chat_prompt_tokens(
+            "Please cancel before speculative first-step. " * 16
+        )
+
+        ready = False
+        calls_after_ready = 0
+
+        def progress_callback(processed: int, total: int) -> None:
+            nonlocal ready
+            if processed == total - 1:
+                ready = True
+
+        def should_cancel() -> bool:
+            nonlocal calls_after_ready
+            if not ready:
+                return False
+            calls_after_ready += 1
+            return calls_after_ready >= 2
+
+        gen = stream_generate(
+            model=self.model,
+            tokenizer=self.tokenizer,
+            prompt=prompt,
+            max_tokens=5,
+            draft_model=draft_model,
+            num_draft_tokens=2,
+            sampler=sampler,
+            prefill_step_size=2048,
+            prompt_progress_callback=progress_callback,
+            should_cancel=should_cancel,
+        )
+        with self.assertRaises(GenerationCancelled):
+            next(gen)
+
+        self.assertTrue(ready)
+        self.assertEqual(calls_after_ready, 2)
+
+    def test_stream_generate_speculative_prompt_progress_callback(self):
+        draft_model = self.model
+        sampler = make_sampler(temp=0.0)
+        prompt = self._chat_prompt_tokens("Track speculative prompt progress. " * 16)
+
+        progress: List[tuple[int, int]] = []
+
+        def progress_callback(processed: int, total: int) -> None:
+            progress.append((processed, total))
+
+        for _ in stream_generate(
+            model=self.model,
+            tokenizer=self.tokenizer,
+            prompt=prompt,
+            max_tokens=4,
+            draft_model=draft_model,
+            num_draft_tokens=2,
+            sampler=sampler,
+            prefill_step_size=4,
+            prompt_progress_callback=progress_callback,
+        ):
+            pass
+
+        self.assertGreaterEqual(len(progress), 2)
+        first_processed, first_total = progress[0]
+        self.assertEqual(first_processed, 0)
+        self.assertGreater(first_total, 0)
+        self.assertTrue(any(p == t and t > 0 for p, t in progress))
+
+        prev = -1
+        for processed, total in progress:
+            self.assertGreaterEqual(processed, prev)
+            self.assertLessEqual(processed, total)
+            prev = processed
 
     def test_stream_generate_input_embeddings(self):
         sampler = make_sampler(temp=0.0)  # determinate sampler


### PR DESCRIPTION
# feat: allow callers to cancel stream generation via callback check, and ensure prompt cache consistency.

## 1.1 Add a first-class cancellation signal
- Add `class GenerationCancelled(Exception): ...` near `GenerationResponse`.
- Add a new optional kwarg to both token generators:
  - `generate_step(..., should_cancel: Callable[[], bool] | None = None, ...)`
  - `speculative_generate_step(..., should_cancel: Callable[[], bool] | None = None, prompt_progress_callback: Callable[[int,int], None] | None = None, ...)`

## 1.2 Cooperative cancel in `generate_step` (non-speculative) Implement cancellation checks exactly at safe boundaries:
- Initialize: `should_cancel = should_cancel or (lambda: False)`
- Before prefill loop starts (inside the `with mx.stream(generation_stream)`): if `should_cancel(): raise GenerationCancelled()`
- For each prefill chunk iteration:
  - check `should_cancel()` **before** `_model_call(...)` for that chunk
  - after `mx.eval([c.state for c in prompt_cache])` + `prompt_progress_callback(...)`, check `should_cancel()` and raise
- Before the “first-step” call (`y, logprobs = _step(input_tokens=prompt, ...)`): if `should_cancel(): raise GenerationCancelled()`
- Decode loop: check `should_cancel()` once per iteration at a consistent point (e.g., top of `while True`) and raise.

Notes:
- Keep using existing `prompt_progress_callback` calls for prefill chunks.
- Don’t introduce new “heartbeat yields”; cancellation should be via exception so callers can treat it as non-error.

## 1.3 Add equivalent hooks/cancel points to `speculative_generate_step` This needs two parts: (a) prompt-progress parity, (b) safe cancel points.

**(a) Reuse `prompt_progress_callback`**
- Add `prompt_progress_callback` param (same signature as in `generate_step`).
- Move speculative prefill to a “prefill all-but-last-token” structure (like `generate_step`) so you can report progress per chunk:
  - For each chunk processed:
    - run both draft + main model on the same chunk
    - `mx.eval([c.state for c in draft_cache])` and `mx.eval([c.state for c in model_cache])`
    - update `prompt_processed_tokens` and call `prompt_progress_callback(prompt_processed_tokens, total_prompt_tokens)`

**(b) Cancellation checks**
- Same pattern: check at prefill chunk boundaries and **before** entering the first speculative step.
- In the speculative decode loop, only check cancellation at boundaries that preserve cache consistency (e.g., before `_draft_generate(...)` begins, and after `_rewind_cache(...)` completes), not mid-way through draft generation unless you also add rollback logic there.

## 1.4 Thread cancellation through `stream_generate`
- Add no new top-level API function; keep `stream_generate(..., **kwargs)` but:
  - Stop dropping `prompt_progress_callback` for speculative (`remove kwargs.pop("prompt_progress_callback", None)`).
  - Ensure `should_cancel` passes through to either `generate_step` or `speculative_generate_step`.
- Wrap the token loop so `GenerationCancelled` propagates cleanly (no “final response” emission on cancel).