### PR TITLE
Fix chat template detection for models with custom tokenizers

### DIFF
--- a/mlx_lm/server.py
+++ b/mlx_lm/server.py
@@ -487,7 +487,7 @@ class ResponseGenerator:
             tools = request.tools
             role_mapping = request.role_mapping
 
-            if tokenizer.chat_template:
+            if tokenizer.has_chat_template:
                 process_message_content(messages)
                 return tokenizer.apply_chat_template(
                     messages,


### PR DESCRIPTION
This fixes the server to use `has_chat_template` instead of `chat_template` when checking for chat template support. Without this fix, models with custom chat templates templates (e.g. `deepseek_v32`) fall back to the generic `convert_chat()` function.

  For DeepSeek V3.2, this caused the model to receive:
  ASSISTANT's RULE: ...
  USER: What is 2+2?
  ASSISTANT:

  Instead of the correct format:
  <｜begin▁of▁sentence｜>...<｜User｜>What is 2+2?<｜Assistant｜>
