### PR TITLE
Add sanitize() method to olmo3 model

### DIFF
--- a/mlx_lm/models/olmo3.py
+++ b/mlx_lm/models/olmo3.py
@@ -233,3 +233,9 @@ class Model(nn.Module):
             else:
                 caches.append(RotatingKVCache(max_size=self.args.sliding_window))
         return caches
+
+    def sanitize(self, weights):
+        # Remove unused precomputed rotary freqs
+        return {
+            k: v for k, v in weights.items() if "self_attn.rotary_emb.inv_freq" not in k
+        }


### PR DESCRIPTION
Add missing `sanitize()` method to filter out unused precomputed rotary frequencies (`rotary_emb.inv_freq`) from HuggingFace weights. 

This matches the pattern used in olmo2.py and other RoPE-based models.