### PR TITLE
Add --no-batch flag to disable request batching

### DIFF
--- a/mlx_lm/server.py
+++ b/mlx_lm/server.py
@@ -535,6 +535,8 @@ class ResponseGenerator:
             return tokenizer.encode(request.prompt)
 
     def _is_batchable(self, args):
+        if getattr(self.model_provider.cli_args, "no_batch", False):
+            return False
         if (
             args.model.draft != "default_model"
             or self.model_provider.cli_args.draft_model is not None
@@ -1644,6 +1646,11 @@ def main():
         type=json.loads,
         help="""A JSON formatted string of arguments for the tokenizer's apply_chat_template, e.g. '{"enable_thinking":false}'""",
         default="{}",
+    )
+    parser.add_argument(
+        "--no-batch",
+        action="store_true",
+        help="Disable request batching (useful for models with sliding_window that have BatchRotatingKVCache merge issues)",
     )
     args = parser.parse_args()
     if mx.metal.is_available():


### PR DESCRIPTION
## Summary

Models with `sliding_window` configuration (like Rosetta-27B) crash when handling concurrent or sequential requests due to a bug in `BatchRotatingKVCache.merge()`:

```
ValueError: [broadcast_shapes] Shapes (1,16,256,128) and (1,16,7,128) cannot be broadcast.
```

The current workaround requires adding `"seed": <int>` to every request, which is cumbersome for users.

## Changes

This PR adds a `--no-batch` CLI flag that disables batching server-side:

```bash
mlx_lm.server --model <model> --no-batch
```

When enabled, `_is_batchable()` returns `False`, preventing the `BatchRotatingKVCache.merge` bug for affected models.

## Implementation

- Added `--no-batch` argument to argparse (action="store_true")
- Modified `_is_batchable()` to check for the flag first

## Testing

Tested with Rosetta-27B (which has `sliding_window: 1024`):
- Without `--no-batch`: Crashes on 2nd sequential request
- With `--no-batch`: 10/10 sequential requests succeed

Fixes #735