### PR TITLE
Fix tools parameter in apply_chat_template call

### DIFF
--- a/mlx_lm/server.py
+++ b/mlx_lm/server.py
@@ -526,7 +526,7 @@ class ResponseGenerator:
                 process_message_content(messages)
                 return tokenizer.apply_chat_template(
                     messages,
-                    tools,
+                    tools=tools,
                     add_generation_prompt=True,
                     tokenize=True,
                     **self.model_provider.cli_args.chat_template_args,


### PR DESCRIPTION
Fix to set the `tools` parameter as a keyword argument in `apply_chat_template` to avoid misinterpretation by custom tokenizers.

Example:

```
mlx_lm.server --model /Volumes/WD_EXTRA/models/catalyst/IQuest-Coder-V1-40B-Instruct-4bit --max-tokens 16384 --host 0.0.0.0 --port 8080 
The repository /Volumes/WD_EXTRA/models/catalyst/IQuest-Coder-V1-40B-Instruct-4bit contains custom code which must be executed to correctly load the model. You can inspect the repository content at /Volumes/WD_EXTRA/models/catalyst/IQuest-Coder-V1-40B-Instruct-4bit .
 You can inspect the repository content at https://hf.co//Volumes/WD_EXTRA/models/catalyst/IQuest-Coder-V1-40B-Instruct-4bit.
You can avoid this prompt in future by passing the argument `trust_remote_code=True`.

Do you wish to run the custom code? [y/N] y
/Users/optimus/repo/mlx-lm/mlx_lm/server.py:1682: UserWarning: mlx_lm.server is not recommended for production as it only implements basic security checks.
  warnings.warn(
2026-01-10 00:23:34,663 - INFO - Starting httpd at 0.0.0.0 on port 8080...
Exception in thread Thread-1 (_generate):
Traceback (most recent call last):
  File "/Library/Frameworks/Python.framework/Versions/3.12/lib/python3.12/threading.py", line 1075, in _bootstrap_inner
    self.run()
  File "/Library/Frameworks/Python.framework/Versions/3.12/lib/python3.12/threading.py", line 1012, in run
    self._target(*self._args, **self._kwargs)
  File "/Users/optimus/repo/mlx-lm/mlx_lm/server.py", line 717, in _generate
    prompt = self._tokenize(current_tokenizer, request)
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/optimus/repo/mlx-lm/mlx_lm/server.py", line 647, in _tokenize
    return tokenizer.apply_chat_template(
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/optimus/repo/mlx-lm/mlx_lm/tokenizer_utils.py", line 307, in apply_chat_template
    return self._tokenizer.apply_chat_template(*args, tokenize=tokenize, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/optimus/.cache/huggingface/modules/transformers_modules/IQuest_hyphen_Coder_hyphen_V1_hyphen_40B_hyphen_Instruct_hyphen_4bit/tokenization_iquestcoder.py", line 374, in apply_chat_template
    return super().apply_chat_template(
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/optimus/repo/mlx-lm/.venv/lib/python3.12/site-packages/transformers/tokenization_utils_base.py", line 1667, in apply_chat_template
    rendered_chat, generation_indices = render_jinja_template(
                                        ^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/optimus/repo/mlx-lm/.venv/lib/python3.12/site-packages/transformers/utils/chat_template_utils.py", line 482, in render_jinja_template
    compiled_template = _compile_jinja_template(chat_template)
                        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
TypeError: unhashable type: 'list'
```