### PR TITLE
Add OPT model support for local training on Mac

### DIFF
--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -844,6 +844,26 @@ class TestModels(unittest.TestCase):
             len(args.ffn_multipliers),
         )
 
+    def test_opt(self):
+        from mlx_lm.models import opt
+
+        args = opt.ModelArgs(
+            model_type="opt",
+            vocab_size=10_000,
+            hidden_size=1024,
+            ffn_dim=4096,
+            num_hidden_layers=4,
+            num_attention_heads=16,
+            max_position_embeddings=2048,
+            layer_norm_eps=1e-5,
+            word_embed_proj_dim=512,
+            do_layer_norm_before=False,
+        )
+        model = opt.Model(args)
+        self.model_test_runner(
+            model, args.model_type, args.vocab_size, args.num_hidden_layers
+        )
+
     def test_internlm2(self):
         from mlx_lm.models import internlm2
 


### PR DESCRIPTION
## Motivation
I wanted to train OPT-350M locally on my Mac, replicating the approach in ["Small Language Models for Efficient Agentic Tool Calling: Outperforming Large Models with Targeted Fine-tuning"](https://arxiv.org/pdf/2512.15943) by Jhandi et al. This required adding OPT model support to mlx-lm.

## Changes
- Implemented OPT architecture with pre/post LayerNorm support
- Added weight tying for lm_head and embed_tokens
- Includes unit tests

## Verification
- Tested with facebook/opt-350m
- Generates coherent text at ~305 tokens/sec on Apple Silicon m3 max 
- All tests passing