### PR TITLE
feat: Add --revision parameter to all CLI tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,17 +1,17 @@
-## MLX LM 
+## MLX LM
 
 MLX LM is a Python package for generating text and fine-tuning large language
 models on Apple silicon with MLX.
 
 Some key features include:
 
-* Integration with the Hugging Face Hub to easily use thousands of LLMs with a
-  single command. 
-* Support for quantizing and uploading models to the Hugging Face Hub.
-* [Low-rank and full model
+- Integration with the Hugging Face Hub to easily use thousands of LLMs with a
+  single command.
+- Support for quantizing and uploading models to the Hugging Face Hub.
+- [Low-rank and full model
   fine-tuning](https://github.com/ml-explore/mlx-lm/blob/main/mlx_lm/LORA.md)
   with support for quantized models.
-* Distributed inference and fine-tuning with `mx.distributed`
+- Distributed inference and fine-tuning with `mx.distributed`
 
 The easiest way to get started is to install the `mlx-lm` package:
 
@@ -53,10 +53,11 @@ mlx_lm.generate -h
 ```
 
 The default model for generation and chat is
-`mlx-community/Llama-3.2-3B-Instruct-4bit`.  You can specify any MLX-compatible
+`mlx-community/Llama-3.2-3B-Instruct-4bit`. You can specify any MLX-compatible
 model with the `--model` flag. Thousands are available in the
 [MLX Community](https://huggingface.co/mlx-community) Hugging Face
-organization.
+organization. You can also load a specific revision (branch, tag, or commit) of
+a model using `--revision`.
 
 ### Python API
 
@@ -142,7 +143,7 @@ print()
 
 The `generate` and `stream_generate` functions accept `sampler` and
 `logits_processors` keyword arguments. A sampler is any callable which accepts
-a possibly batched logits array and returns an array of sampled tokens.  The
+a possibly batched logits array and returns an array of sampled tokens. The
 `logits_processors` must be a list of callables which take the token history
 and current logits as input and return the processed logits. The logits
 processors are applied in order.
@@ -194,7 +195,7 @@ Models can also be converted and quantized directly in the
 [mlx-my-repo](https://huggingface.co/spaces/mlx-community/mlx-my-repo) Hugging
 Face Space.
 
-### Long Prompts and Generations 
+### Long Prompts and Generations
 
 `mlx-lm` has some tools to scale efficiently to long prompts and generations:
 
@@ -214,7 +215,7 @@ cat prompt.txt | mlx_lm.cache_prompt \
   --model mistralai/Mistral-7B-Instruct-v0.3 \
   --prompt - \
   --prompt-cache-file mistral_prompt.safetensors
-``` 
+```
 
 Then use the cached prompt with `mlx_lm.generate`:
 
@@ -246,7 +247,7 @@ Face organization.
 For some models the tokenizer may require you to enable the `trust_remote_code`
 option. You can do this by passing `--trust-remote-code` in the command line.
 If you don't specify the flag explicitly, you will be prompted to trust remote
-code in the terminal when running the model. 
+code in the terminal when running the model.
 
 Tokenizer options can also be set in the Python API. For example:
 
@@ -260,6 +261,7 @@ model, tokenizer = load(
 ### Large Models
 
 > [!NOTE]
+
     This requires macOS 15.0 or higher to work.
 
 Models which are large relative to the total RAM available on the machine can

--- a/mlx_lm/benchmark.py
+++ b/mlx_lm/benchmark.py
@@ -54,6 +54,12 @@ def setup_arg_parser():
         action="store_true",
         help="Use pipelining instead of tensor parallelism",
     )
+    parser.add_argument(
+        "--revision",
+        help="Revision to load the model from.",
+        type=str,
+        default=None,
+    )
     return parser
 
 
@@ -79,7 +85,7 @@ def main():
         )
     else:
         model, tokenizer, config = load(
-            args.model, return_config=True, tokenizer_config={"trust_remote_code": True}
+            args.model, revision=args.revision, return_config=True, tokenizer_config={"trust_remote_code": True}
         )
 
     # Empty to avoid early stopping

--- a/mlx_lm/cache_prompt.py
+++ b/mlx_lm/cache_prompt.py
@@ -77,6 +77,12 @@ def setup_arg_parser():
         type=int,
         default=DEFAULT_QUANTIZED_KV_START,
     )
+    parser.add_argument(
+        "--revision",
+        help="Revision to load the model from.",
+        type=str,
+        default=None,
+    )
     return parser
 
 
@@ -92,6 +98,7 @@ def main():
     model, tokenizer = load(
         args.model,
         adapter_path=args.adapter_path,
+        revision=args.revision,
         tokenizer_config=tokenizer_config,
     )
 

--- a/mlx_lm/chat.py
+++ b/mlx_lm/chat.py
@@ -84,6 +84,12 @@ def setup_arg_parser():
         action="store_true",
         help="Use pipelining instead of tensor parallelism",
     )
+    parser.add_argument(
+        "--revision",
+        help="Revision to load the model from.",
+        type=str,
+        default=None,
+    )
     return parser
 
 
@@ -111,6 +117,7 @@ def main():
         model, tokenizer = load(
             args.model,
             adapter_path=args.adapter_path,
+            revision=args.revision,
             tokenizer_config={
                 "trust_remote_code": True if args.trust_remote_code else None
             },

--- a/mlx_lm/convert.py
+++ b/mlx_lm/convert.py
@@ -230,6 +230,14 @@ def configure_parser() -> argparse.ArgumentParser:
         type=str,
         default=None,
     )
+
+    parser.add_argument(
+        "--revision",
+        help="Revision to load the model from.",
+        type=str,
+        default=None,
+    )
+    
     parser.add_argument(
         "-d",
         "--dequantize",

--- a/mlx_lm/evaluate.py
+++ b/mlx_lm/evaluate.py
@@ -82,11 +82,12 @@ class MLXLM(LM):
         use_chat_template: Optional[bool] = None,
         trust_remote_code: bool = False,
         sampler: Optional[Callable[[mx.array], mx.array]] = None,
+        revision: Optional[str] = None,
     ) -> None:
         super().__init__()
         tokenizer_config = {"trust_remote_code": True if trust_remote_code else None}
         self._model, self.tokenizer = load(
-            path_or_hf_repo, tokenizer_config=tokenizer_config
+            path_or_hf_repo, revision=revision, tokenizer_config=tokenizer_config
         )
         self._max_tokens = max_tokens
         self._batch_size = 8
@@ -452,6 +453,12 @@ def main():
     parser.add_argument("--temp", type=float, default=0.0, help="Sampling temperature")
     parser.add_argument("--top-p", type=float, default=1.0, help="Sampling top-p")
     parser.add_argument("--top-k", type=int, default=0, help="Sampling top-k")
+    parser.add_argument(
+        "--revision",
+        help="Revision to load the model from.",
+        type=str,
+        default=None,
+    )
     args = parser.parse_args()
 
     output_dir = Path(args.output_dir)
@@ -479,6 +486,7 @@ def main():
         use_chat_template=args.apply_chat_template,
         trust_remote_code=args.trust_remote_code,
         sampler=sampler,
+        revision=args.revision,
     )
     MLXLM.apply_chat_template = chat_template_fn(**args.chat_template_args)
 

--- a/mlx_lm/fuse.py
+++ b/mlx_lm/fuse.py
@@ -54,6 +54,12 @@ def parse_arguments() -> argparse.Namespace:
         default="ggml-model-f16.gguf",
         type=str,
     )
+    parser.add_argument(
+        "--revision",
+        help="Revision to load the model from.",
+        type=str,
+        default=None,
+    )
     return parser.parse_args()
 
 
@@ -62,7 +68,7 @@ def main() -> None:
     args = parse_arguments()
 
     model, tokenizer, config = load(
-        args.model, adapter_path=args.adapter_path, return_config=True
+        args.model, adapter_path=args.adapter_path, revision=args.revision, return_config=True
     )
 
     fused_linears = [

--- a/mlx_lm/generate.py
+++ b/mlx_lm/generate.py
@@ -209,6 +209,12 @@ def setup_arg_parser():
         help="Number of tokens to draft when using speculative decoding.",
         default=3,
     )
+    parser.add_argument(
+        "--revision",
+        help="Revision to load the model from.",
+        type=str,
+        default=None,
+    )
     return parser
 
 
@@ -1373,6 +1379,7 @@ def main():
         model_path,
         adapter_path=args.adapter_path,
         tokenizer_config=tokenizer_config,
+        revision=args.revision,
     )
     for eos_token in args.extra_eos_token:
         tokenizer.add_eos_token(eos_token)

--- a/mlx_lm/lora.py
+++ b/mlx_lm/lora.py
@@ -203,6 +203,12 @@ def build_parser():
         help="Project name for logging. Defaults to the name of the root directory.",
     )
     parser.add_argument("--seed", type=int, help="The PRNG seed")
+    parser.add_argument(
+        "--revision",
+        help="Revision to load the model from.",
+        type=str,
+        default=None,
+    )
     return parser
 
 
@@ -319,7 +325,7 @@ def run(args, training_callback: TrainingCallback = None):
     )
 
     print("Loading pretrained model")
-    model, tokenizer = load(args.model, tokenizer_config={"trust_remote_code": True})
+    model, tokenizer = load(args.model, revision=args.revision, tokenizer_config={"trust_remote_code": True})
 
     print("Loading datasets")
     train_set, valid_set, test_set = load_dataset(args, tokenizer)

--- a/mlx_lm/perplexity.py
+++ b/mlx_lm/perplexity.py
@@ -130,6 +130,12 @@ def main():
     parser.add_argument(
         "--seed", type=int, default=123, help="Random seed for data sampling"
     )
+    parser.add_argument(
+        "--revision",
+        help="Revision to load the model from.",
+        type=str,
+        default=None,
+    )
 
     args = parser.parse_args()
 
@@ -139,7 +145,7 @@ def main():
 
     # Load model
     print(f"Loading model from {args.model}...")
-    model, tokenizer = load(args.model)
+    model, tokenizer = load(args.model, revision=args.revision)
 
     # Count parameters
     total_params = get_total_parameters(model)

--- a/mlx_lm/server.py
+++ b/mlx_lm/server.py
@@ -429,11 +429,12 @@ class ModelProvider:
             model, tokenizer = load(
                 self.cli_args.model,
                 adapter_path=adapter_path,
+                revision=self.cli_args.revision,
                 tokenizer_config=tokenizer_config,
             )
         else:
             model, tokenizer = load(
-                model_path, adapter_path=adapter_path, tokenizer_config=tokenizer_config
+                model_path, adapter_path=adapter_path, revision=self.cli_args.revision, tokenizer_config=tokenizer_config
             )
 
         if self.cli_args.use_default_chat_template:
@@ -457,11 +458,11 @@ class ModelProvider:
             draft_model_path == "default_model"
             and self.cli_args.draft_model is not None
         ):
-            self.draft_model, draft_tokenizer = load(self.cli_args.draft_model)
+            self.draft_model, draft_tokenizer = load(self.cli_args.draft_model, revision=self.cli_args.revision)
             validate_draft_tokenizer(draft_tokenizer)
 
         elif draft_model_path is not None and draft_model_path != "default_model":
-            self.draft_model, draft_tokenizer = load(draft_model_path)
+            self.draft_model, draft_tokenizer = load(draft_model_path, revision=self.cli_args.revision)
             validate_draft_tokenizer(draft_tokenizer)
 
         if self.draft_model is None:
@@ -1644,6 +1645,12 @@ def main():
         type=json.loads,
         help="""A JSON formatted string of arguments for the tokenizer's apply_chat_template, e.g. '{"enable_thinking":false}'""",
         default="{}",
+    )
+    parser.add_argument(
+        "--revision",
+        help="Revision to load the model from.",
+        type=str,
+        default=None,
     )
     args = parser.parse_args()
     if mx.metal.is_available():

--- a/tests/test_chat.py
+++ b/tests/test_chat.py
@@ -42,6 +42,8 @@ class TestChat(unittest.TestCase):
                 "512",
                 "--system-prompt",
                 "You are a helpful assistant.",
+                "--revision",
+                "abc123",
             ]
         )
 
@@ -55,6 +57,7 @@ class TestChat(unittest.TestCase):
         self.assertEqual(args.max_kv_size, 1024)
         self.assertEqual(args.max_tokens, 512)
         self.assertEqual(args.system_prompt, "You are a helpful assistant.")
+        self.assertEqual(args.revision, "abc123")
 
     @patch("mlx_lm.chat.load")
     @patch("mlx_lm.chat.make_prompt_cache")


### PR DESCRIPTION
## Summary

This PR adds the `--revision` parameter to all CLI tools that load models from HuggingFace Hub, enabling users to specify a particular model version (branch, tag, or commit hash) when loading models.

## Motivation

When working with models on HuggingFace Hub, users often need to load a specific version of a model rather than the latest. The underlying `load()` function in `utils.py` already supports the `revision` parameter, but it was not exposed through the CLI tools. This change provides a consistent interface across all CLI entry points.

## Changes

### CLI Tools Updated (10 files)
- `convert.py` - Added `--revision` argument to argument parser
- `fuse.py` - Added `--revision` argument and passed to `load()`
- `lora.py` - Added `--revision` argument and passed to `load()`
- `generate.py` - Added `--revision` argument and passed to `load()`
- `chat.py` - Added `--revision` argument and passed to `load()`
- `perplexity.py` - Added `--revision` argument and passed to `load()`
- `benchmark.py` - Added `--revision` argument and passed to `load()`
- `cache_prompt.py` - Added `--revision` argument and passed to `load()`
- `evaluate.py` - Added `--revision` argument to `MLXLM` class and CLI
- `server.py` - Added `--revision` argument and passed to all `load()` calls

### Tests
- Updated `tests/test_chat.py` to include `--revision` in the argument parser tests

### Documentation
- Updated `README.md` to mention the `--revision` option

## Example Usage

```bash
# Load a specific commit
mlx_lm.generate --model mlx-community/Llama-3.2-3B-Instruct-4bit --revision abc123 --prompt "hello"

# Load a specific branch
mlx_lm.convert --model mistralai/Mistral-7B-Instruct-v0.3 --revision main -q

# Load a specific tag
mlx_lm.chat --model mlx-community/Llama-3.2-3B-Instruct-4bit --revision v1.0
```

## Testing

- [x] All modified CLI tools accept `--revision` parameter (verified with `--help`)
- [x] Parameter is passed correctly through to `load()` function
- [x] Existing tests continue to pass
- [x] New test case added for `--revision` in `test_chat.py`