### PR TITLE
Fix swiglu parameter order

### DIFF
--- a/mlx_lm/models/switch_layers.py
+++ b/mlx_lm/models/switch_layers.py
@@ -154,7 +154,7 @@ class SwiGLU(nn.Module):
         super().__init__()
 
     def __call__(self, x, gate):
-        return swiglu(x, gate)
+        return swiglu(gate, x)
 
 
 class SwitchGLU(nn.Module):


### PR DESCRIPTION
The `SwiGLU` wrapper class in `switch_layers.py` wasn't updated in edbf61d, causing it to compute `silu(x) * gate` instead of `silu(gate) * x`.