### PR TITLE
Fix LongCat Flash extended context support

### DIFF
--- a/mlx_lm/models/rope_utils.py
+++ b/mlx_lm/models/rope_utils.py
@@ -221,7 +221,7 @@ def initialize_rope(
             base=base,
             scaling_config=scaling_config,
         )
-    elif rope_type == "yarn":
+    elif rope_type in ("yarn", "deepseek_yarn"):
         scaling_factor = scaling_config["factor"]
         rope_kwargs = {
             key: scaling_config[key]


### PR DESCRIPTION
This PR fixes support for variants of LongCat Flash using YarnRoPE, e.g. [LongCat-Flash-Thinking-2601](https://huggingface.co/meituan-longcat/LongCat-Flash-Thinking-2601).
Previously this model would produce garbled output after 8192 tokens.

Additional notes:
- The HuggingFace model is currently missing a `model_type` so this must be manually set to `longcat_flash` prior to using `mlx_lm.convert`.
- This PR needs the fix addressed in #767