### PR TITLE
Fix CacheList batching

### DIFF
--- a/mlx_lm/generate.py
+++ b/mlx_lm/generate.py
@@ -1003,7 +1003,8 @@ class BatchGenerator:
             self.uid_count += 1
         # Sort in ascending order of length
         self.unprocessed_prompts = sorted(
-            self.unprocessed_prompts, key=lambda x: len(x[1]) + cache.cache_length(x[3])
+            self.unprocessed_prompts,
+            key=lambda x: len(x[1]) + max(c.size() for c in x[3]),
         )
         return uids
 
@@ -1023,15 +1024,6 @@ class BatchGenerator:
 
     def _process_prompts(self, prompts):
         uids, inputs, max_tokens, caches, samplers, logits_processors = zip(*prompts)
-        if hasattr(caches[0][0], "keys"):
-            cache_is_empty = all(c[0].keys is None for c in caches)
-        elif hasattr(caches[0][0], "caches"):
-            kv_idx = next(
-                (i for i, x in enumerate(caches[0][0].caches) if hasattr(x, "keys")), 0
-            )
-            cache_is_empty = all(c[0][kv_idx].keys is None for c in caches)
-        else:
-            cache_is_empty = all(c[0][0] is None for c in caches)
 
         lengths = [len(p) for p in inputs]
         max_length = max(lengths)
@@ -1045,7 +1037,7 @@ class BatchGenerator:
         # New prompts so
         #   1. Left-pad the inputs
         #   2. Process
-        if cache_is_empty:
+        if all(c[0].empty() for c in caches):
             inputs = _left_pad_prompts(inputs, max_length=max_length)
             prompt_cache = _make_cache(self.model, padding)
 

--- a/mlx_lm/models/cache.py
+++ b/mlx_lm/models/cache.py
@@ -109,10 +109,6 @@ def trim_prompt_cache(cache: List[Any], num_tokens: int) -> List[Any]:
     return [c.trim(num_tokens) for c in cache][0]
 
 
-def cache_length(cache: List[Any]):
-    return max(len(c) for c in cache)
-
-
 def create_attention_mask(
     N: int, offset: int, return_array: bool, window_size: Optional[int]
 ):
@@ -146,23 +142,20 @@ class _BaseCache:
     def is_trimmable(self):
         return False
 
-    def __len__(self):
-        """The length of a cache is meant to represent the number of elements
-        that we need to process in the attention. For instance for KVCache it
-        is the size of the state, for RotatingKVCache it would be up to
-        max_size etc."""
+    def size(self):
+        """
+        Return the size (i.e. sequence length) of the cache.
+
+        Not every cache is required to implement this, in which case the size
+        will always be 0 (though the cache may not be empty).
+        """
         return 0
 
-    def __bool__(self):
-        """When an object defines __len__ then python defines the bool operator
-        as len(obj) != 0. This, for instance, doesn't allow us to write
-
-            cache = cache or make_cache()
-
-        which is why we are overriding that behaviour with a constant bool
-        operator return True.
+    def empty(self):
         """
-        return True
+        Return if the cache is empty or not.
+        """
+        raise NotImplementedError("Cache sub-class must implement this.")
 
     @classmethod
     def from_state(cls, state, meta_state):
@@ -216,6 +209,9 @@ class ConcatenateKVCache(_BaseCache):
 
     def make_mask(self, *args, **kwargs):
         return create_attention_mask(*args, offset=self.offset, **kwargs)
+
+    def empty(self):
+        return self.keys is None
 
 
 class QuantizedKVCache(_BaseCache):
@@ -303,6 +299,9 @@ class QuantizedKVCache(_BaseCache):
     def make_mask(self, *args, **kwargs):
         return create_attention_mask(*args, offset=self.offset, **kwargs)
 
+    def empty(self):
+        return self.keys is None
+
 
 class KVCache(_BaseCache):
     step = 256
@@ -336,7 +335,7 @@ class KVCache(_BaseCache):
         self.values[..., prev : self.offset, :] = values
         return self.keys[..., : self.offset, :], self.values[..., : self.offset, :]
 
-    def __len__(self):
+    def size(self):
         return self.offset
 
     @property
@@ -378,6 +377,9 @@ class KVCache(_BaseCache):
     @classmethod
     def merge(_, caches):
         return BatchKVCache.merge(caches)
+
+    def empty(self):
+        return self.keys is None
 
 
 class RotatingKVCache(_BaseCache):
@@ -487,7 +489,7 @@ class RotatingKVCache(_BaseCache):
             return self._update_in_place(keys, values)
         return self._update_concat(keys, values)
 
-    def __len__(self):
+    def size(self):
         return min(self.offset, self.max_size)
 
     @property
@@ -553,6 +555,9 @@ class RotatingKVCache(_BaseCache):
     @classmethod
     def merge(_, caches):
         return BatchRotatingKVCache.merge(caches)
+
+    def empty(self):
+        return self.keys is None
 
 
 class ArraysCache(_BaseCache):
@@ -630,6 +635,9 @@ class ArraysCache(_BaseCache):
                     continue
                 cache[e][i : i + 1] = caches[i][e]
         return cache
+
+    def empty(self):
+        return self.cache[0] is None
 
 
 class MambaCache(ArraysCache):
@@ -710,6 +718,9 @@ class ChunkedKVCache(_BaseCache):
     def meta_state(self, v):
         self.chunk_size, self.start_position = map(int, v)
 
+    def empty(self):
+        return self.keys is None
+
 
 class CacheList(_BaseCache):
     def __init__(self, *caches):
@@ -772,6 +783,12 @@ class CacheList(_BaseCache):
     def finalize(self):
         for c in self.caches:
             c.finalize()
+
+    def size(self):
+        return max(c.size() for c in self.caches)
+
+    def empty(self):
+        return self.caches[0].empty()
 
 
 def dynamic_roll(x, shifts, axis):
@@ -837,9 +854,6 @@ class BatchKVCache(_BaseCache):
         self.keys[..., prev : self._idx, :] = keys
         self.values[..., prev : self._idx, :] = values
         return self.keys[..., : self._idx, :], self.values[..., : self._idx, :]
-
-    def __len__(self):
-        return self._idx
 
     def prepare(self, *, left_padding=None, lengths=None, right_padding=None):
         if left_padding is not None:
@@ -946,7 +960,7 @@ class BatchKVCache(_BaseCache):
 
     @classmethod
     def merge(cls, caches):
-        lengths = [len(c) for c in caches]
+        lengths = [c.size() for c in caches]
         max_length = max(lengths)
         padding = [max_length - l for l in lengths]
         B = len(caches)
@@ -970,6 +984,9 @@ class BatchKVCache(_BaseCache):
         cache._idx = keys.shape[2]
 
         return cache
+
+    def empty(self):
+        return self.keys is None
 
 
 class BatchRotatingKVCache(_BaseCache):
@@ -1103,9 +1120,6 @@ class BatchRotatingKVCache(_BaseCache):
         if keys.shape[2] == 1:
             return self._update_in_place(keys, values)
         return self._update_concat(keys, values)
-
-    def __len__(self):
-        return min(self._offset, self.max_size)
 
     def prepare(self, *, left_padding=None, lengths=None, right_padding=None):
         if left_padding is not None:
@@ -1260,7 +1274,7 @@ class BatchRotatingKVCache(_BaseCache):
             )
 
         offsets = [c.offset for c in caches]
-        lengths = [len(c) for c in caches]
+        lengths = [c.size() for c in caches]
         max_length = max(lengths)
         padding = [max_length - l for l in lengths]
         B = len(caches)
@@ -1285,3 +1299,6 @@ class BatchRotatingKVCache(_BaseCache):
         cache._offset = keys.shape[2]
 
         return cache
+
+    def empty(self):
+        return self.keys is None


### PR DESCRIPTION
This fixes a couple of issues with models using `CacheList` when using the server (`BatchGenerator`)

### Changes

1. Update `cache_is_empty` logic to handle `CacheList`
2. Add missing `prepare()`/`finalize()` to `CacheList` implementation

### Observed failures

The following failures were observed prior to making these changes.

#### Missing handling of CacheList in cache_is_empty logic

```
mlx_lm.server --model /Volumes/WD_EXTRA/models/catalyst/LongCat-Flash-Thinking-2601-4bit --max-tokens 16384 --host 0.0.0.0 --port 8080
The tokenizer you are loading from '/Volumes/WD_EXTRA/models/catalyst/LongCat-Flash-Thinking-2601-4bit' with an incorrect regex pattern: https://huggingface.co/mistralai/Mistral-Small-3.1-24B-Instruct-2503/discussions/84#69121093e8b480e709447d5e. This will lead to incorrect tokenization. You should set the `fix_mistral_regex=True` flag when loading this tokenizer to fix this issue.
/Users/optimus/repo/mlx-lm/mlx_lm/server.py:1540: UserWarning: mlx_lm.server is not recommended for production as it only implements basic security checks.
  warnings.warn(
2026-01-17 14:30:30,803 - INFO - Starting httpd at 0.0.0.0 on port 8080...
2026-01-17 14:30:36,076 - WARNING - Received tools but model does not support tool calling. If you think this is an error, file an issue here: https://github.com/ml-explore/mlx-lm/issues
192.168.50.35 - - [17/Jan/2026 14:30:36] "POST /v1/chat/completions HTTP/1.1" 200 -
Exception in thread Thread-1 (_generate):
Traceback (most recent call last):
  File "/Library/Frameworks/Python.framework/Versions/3.12/lib/python3.12/threading.py", line 1075, in _bootstrap_inner
    self.run()
  File "/Library/Frameworks/Python.framework/Versions/3.12/lib/python3.12/threading.py", line 1012, in run
    self._target(*self._args, **self._kwargs)
  File "/Users/optimus/repo/mlx-lm/mlx_lm/server.py", line 692, in _generate
    responses = batch_generator.next()
                ^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/optimus/repo/mlx-lm/mlx_lm/generate.py", line 1248, in next
    return self._next()
           ^^^^^^^^^^^^
  File "/Users/optimus/repo/mlx-lm/mlx_lm/generate.py", line 1179, in _next
    batch = self._process_prompts(prompts)
            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/optimus/repo/mlx-lm/mlx_lm/generate.py", line 1068, in _process_prompts
    prompt_cache = _merge_caches(caches)
                   ^^^^^^^^^^^^^^^^^^^^^
  File "/Users/optimus/repo/mlx-lm/mlx_lm/generate.py", line 912, in _merge_caches
    batch_cache.append(caches[0][i].merge([c[i] for c in caches]))
                       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/optimus/repo/mlx-lm/mlx_lm/models/cache.py", line 759, in merge
    cache.caches = tuple(
                   ^^^^^^
  File "/Users/optimus/repo/mlx-lm/mlx_lm/models/cache.py", line 760, in <genexpr>
    caches[0].caches[i].merge([c.caches[i] for c in caches])
  File "/Users/optimus/repo/mlx-lm/mlx_lm/models/cache.py", line 380, in merge
    return BatchKVCache.merge(caches)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/optimus/repo/mlx-lm/mlx_lm/models/cache.py", line 945, in merge
    H = max(c.keys.shape[1] for c in caches if c.keys is not None)
        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
ValueError: max() iterable argument is empty
```

#### Missing prepare/finalize

```
mlx_lm.server --model /Volumes/WD_EXTRA/models/catalyst/LongCat-Flash-Thinking-2601-4bit --max-tokens 16384 --host 0.0.0.0 --port 8080
The tokenizer you are loading from '/Volumes/WD_EXTRA/models/catalyst/LongCat-Flash-Thinking-2601-4bit' with an incorrect regex pattern: https://huggingface.co/mistralai/Mistral-Small-3.1-24B-Instruct-2503/discussions/84#69121093e8b480e709447d5e. This will lead to incorrect tokenization. You should set the `fix_mistral_regex=True` flag when loading this tokenizer to fix this issue.
/Users/optimus/repo/mlx-lm/mlx_lm/server.py:1540: UserWarning: mlx_lm.server is not recommended for production as it only implements basic security checks.
  warnings.warn(
2026-01-17 14:17:37,464 - INFO - Starting httpd at 0.0.0.0 on port 8080...
2026-01-17 14:17:39,107 - WARNING - Received tools but model does not support tool calling. If you think this is an error, file an issue here: https://github.com/ml-explore/mlx-lm/issues
192.168.50.35 - - [17/Jan/2026 14:17:39] "POST /v1/chat/completions HTTP/1.1" 200 -
2026-01-17 14:17:47,935 - INFO - Prompt processing progress: 2048/10663
2026-01-17 14:17:55,300 - INFO - Prompt processing progress: 4096/10663
2026-01-17 14:18:03,269 - INFO - Prompt processing progress: 6144/10663
2026-01-17 14:18:11,886 - INFO - Prompt processing progress: 8192/10663
2026-01-17 14:18:21,134 - INFO - Prompt processing progress: 10240/10663
Exception in thread Thread-1 (_generate):
Traceback (most recent call last):
  File "/Library/Frameworks/Python.framework/Versions/3.12/lib/python3.12/threading.py", line 1075, in _bootstrap_inner
2026-01-17 14:18:23,709 - INFO - Prompt processing progress: 10662/10663
    self.run()
  File "/Library/Frameworks/Python.framework/Versions/3.12/lib/python3.12/threading.py", line 1012, in run
    self._target(*self._args, **self._kwargs)
  File "/Users/optimus/repo/mlx-lm/mlx_lm/server.py", line 692, in _generate
    responses = batch_generator.next()
                ^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/optimus/repo/mlx-lm/mlx_lm/generate.py", line 1245, in next
    return self._next()
           ^^^^^^^^^^^^
  File "/Users/optimus/repo/mlx-lm/mlx_lm/generate.py", line 1176, in _next
    batch = self._process_prompts(prompts)
            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/optimus/repo/mlx-lm/mlx_lm/generate.py", line 1089, in _process_prompts
    c.finalize()
    ^^^^^^^^^^
AttributeError: 'CacheList' object has no attribute 'finalize'
```