### PR TITLE
server: use OpenAI compatible finish_reason

### DIFF
--- a/mlx_lm/server.py
+++ b/mlx_lm/server.py
@@ -1302,7 +1302,7 @@ class APIHandler(BaseHTTPRequestHandler):
                 stop_words,
             )
             if stop_condition.stop_met:
-                finish_reason = "tool_call" if made_tool_call else "stop"
+                finish_reason = "tool_calls" if made_tool_call else "stop"
                 ctx.stop()
                 tokens = tokens[: len(tokens) - stop_condition.trim_length]
                 text = text[: len(text) - stop_condition.trim_text_length]


### PR DESCRIPTION
`finish_reason ` should be `"tool_calls"` rather than `"tool_call"`, as per https://platform.openai.com/docs/api-reference/chat/object#chat-object-choices-finish_reason

I ran into this trying to swap in mlx_lm.server as a OpenAIProvider backend for pydantic-ai. It complains about `"tool_call"`, but seems happy about this patch.