### PR TITLE
Fix: Added missing logging import causing `NameError`

### DIFF
--- a/mlx_lm/utils.py
+++ b/mlx_lm/utils.py
@@ -5,6 +5,7 @@ import glob
 import importlib
 import inspect
 import json
+import logging
 import os
 import resource
 import shutil


### PR DESCRIPTION
## Summary of changes
- Added missing import for [logging](https://docs.python.org/3/library/logging.html) in [utils.py](https://github.com/ml-explore/mlx-lm/blob/main/mlx_lm/utils.py)

## Description
Fixes a `NameError` triggered when the library or external modules attempt to use the logging namespace.

## Validation
Verified the fix by successfully calling the logger through the utility namespace:
```
python -c "from mlx_lm import utils; print(utils.logging.root)"
```