### PR TITLE
Fix: add missing `huggingface_hub.logging` import to `utils.py`

### DIFF
--- a/mlx_lm/utils.py
+++ b/mlx_lm/utils.py
@@ -8,6 +8,7 @@ import json
 import os
 import resource
 import shutil
+from huggingface_hub import logging
 from pathlib import Path
 from textwrap import dedent
 from typing import (


### PR DESCRIPTION
### Summary
- Add missing `huggingface_hub.logging` import to `mlx_lm/utils.py`.

### Description
Fixes a `NameError` on line **609** within the load function. The code calls `logging.set_verbosity_info()` without the import, which crashes the library during model initialization.

### Validation
Verified the fix by ensuring the huggingface_hub logging namespace is correctly resolved through the utility module:
```
python -c "from mlx_lm import utils; utils.logging.set_verbosity_info()"
```
PS - @awni this should make more sense