### PR TITLE
fix: handle GLM 4.7 tool call fallbacks

### DIFF
--- a/mlx_lm/tool_parsers/glm47.py
+++ b/mlx_lm/tool_parsers/glm47.py
@@ -22,22 +22,21 @@ tool_call_start = "<tool_call>"
 tool_call_end = "</tool_call>"
 
 
-def _is_string_type(
-    tool_name: str,
-    arg_name: str,
-    tools: list[Any] | None,
-) -> bool:
+def _get_string_arg_names(tool_name: str, tools: list[Any] | None) -> set[str]:
     if tools is None:
-        return False
+        return set()
     for tool in tools:
-        func = tool["function"]
-        if func["name"] == tool_name:
-            params = func["parameters"]
-            if params is None:
-                return False
-            arg_type = params.get("properties", {}).get(arg_name, {}).get("type", None)
-            return arg_type == "string"
-    return False
+        func = tool.get("function")
+        if not func or func.get("name") != tool_name:
+            continue
+        params = func.get("parameters") or {}
+        properties = params.get("properties") or {}
+        return {
+            name
+            for name, schema in properties.items()
+            if schema.get("type") == "string"
+        }
+    return set()
 
 
 def _deserialize(value: str) -> Any:
@@ -58,11 +57,14 @@ def _normalize_arguments(
     func_name: str,
     arguments: dict[str, Any],
     tools: list[Any] | None,
+    string_args: set[str] | None = None,
 ) -> dict[str, Any]:
+    if string_args is None:
+        string_args = _get_string_arg_names(func_name, tools)
     normalized = {}
     for key, value in arguments.items():
         # Preserve declared string types; coerce others when values are strings.
-        if _is_string_type(func_name, key, tools):
+        if key in string_args:
             normalized[key] = value if isinstance(value, str) else str(value)
             continue
         if isinstance(value, str):
@@ -106,10 +108,17 @@ def _parse_json_tool_call(text: str, tools: list[Any] | None):
     if isinstance(arguments, str):
         arguments = _deserialize(arguments)
 
+    string_args = _get_string_arg_names(name, tools) if isinstance(name, str) else None
+
     if isinstance(name, str) and arguments is None:
         return dict(name=name, arguments={})
     if isinstance(name, str) and isinstance(arguments, dict):
-        return dict(name=name, arguments=_normalize_arguments(name, arguments, tools))
+        return dict(
+            name=name,
+            arguments=_normalize_arguments(
+                name, arguments, tools, string_args=string_args
+            ),
+        )
 
     return None
 
@@ -119,13 +128,19 @@ def _parse_key_value_pairs(
     text: str,
     func_name: str,
     tools: list[Any] | None,
+    string_args: set[str] | None = None,
 ) -> dict[str, Any] | None:
+    if "=" not in text:
+        return None
     try:
         tokens = shlex.split(text)
     except ValueError:
         return None
     if not tokens:
         return None
+
+    if string_args is None:
+        string_args = _get_string_arg_names(func_name, tools)
 
     arguments = {}
     for token in tokens:
@@ -136,7 +151,7 @@ def _parse_key_value_pairs(
         key = key.strip()
         if not key:
             return None
-        if _is_string_type(func_name, key, tools):
+        if key in string_args:
             arguments[key] = value
         else:
             arguments[key] = _deserialize(value)
@@ -155,11 +170,14 @@ def _parse_plain_text_tool_call(text: str, tools: list[Any] | None):
         name = first_line.strip()
         rest = rest.strip()
         if name and rest:
+            string_args = _get_string_arg_names(name, tools)
             arguments = _deserialize(rest)
             if isinstance(arguments, dict):
                 return dict(
                     name=name,
-                    arguments=_normalize_arguments(name, arguments, tools),
+                    arguments=_normalize_arguments(
+                        name, arguments, tools, string_args=string_args
+                    ),
                 )
 
     # Split on whitespace to get name + arguments segment.
@@ -170,14 +188,17 @@ def _parse_plain_text_tool_call(text: str, tools: list[Any] | None):
     if not rest:
         return dict(name=name, arguments={})
 
+    string_args = _get_string_arg_names(name, tools)
     arguments = _deserialize(rest)
     if isinstance(arguments, dict):
         return dict(
             name=name,
-            arguments=_normalize_arguments(name, arguments, tools),
+            arguments=_normalize_arguments(
+                name, arguments, tools, string_args=string_args
+            ),
         )
 
-    kv_arguments = _parse_key_value_pairs(rest, name, tools)
+    kv_arguments = _parse_key_value_pairs(rest, name, tools, string_args=string_args)
     if kv_arguments is not None:
         return dict(name=name, arguments=kv_arguments)
 
@@ -198,12 +219,12 @@ def parse_tool_call(text: str, tools: list[Any] | None = None):
         return dict(name="unknown", arguments={"raw": text.strip()})
 
     func_name = match.group(1)
-    pairs = _func_arg_regex.findall(text)
+    string_args = _get_string_arg_names(func_name, tools)
     arg_dct = {}
-    for key, value in pairs:
-        arg_key = key.strip()
-        arg_val = value.strip()
-        if not _is_string_type(func_name, arg_key, tools):
+    for match in _func_arg_regex.finditer(text):
+        arg_key = match.group(1).strip()
+        arg_val = match.group(2).strip()
+        if arg_key not in string_args:
             arg_val = _deserialize(arg_val)
         arg_dct[arg_key] = arg_val
     return dict(name=func_name, arguments=arg_dct)

--- a/tests/test_tool_parsing.py
+++ b/tests/test_tool_parsing.py
@@ -15,14 +15,6 @@ from mlx_lm.tool_parsers import (
 class TestToolParsing(unittest.TestCase):
 
     def test_parsers(self):
-<<<<<<< HEAD
-        test_cases = [
-            "call:multiply{a:12234585,b:48838483920}",
-            "multiply<arg_key>a</arg_key><arg_value>12234585</arg_value><arg_key>b</arg_key><arg_value>48838483920</arg_value>",
-            '{"name": "multiply", "arguments": {"a": 12234585, "b": 48838483920}}',
-            '<invoke name="multiply">\n<parameter name="a">12234585</parameter>\n<parameter name="b">48838483920</parameter>\n</invoke>',
-            "<function=multiply>\n<parameter=a>\n12234585\n</parameter>\n<parameter=b>\n48838483920\n</parameter>\n</function>",
-
         test_cases = [
             ("call:multiply{a:12234585,b:48838483920}", function_gemma),
             (
@@ -46,9 +38,14 @@ class TestToolParsing(unittest.TestCase):
                 "<function=multiply>\n<parameter=a>\n12234585\n</parameter>\n<parameter=b>\n48838483920\n</parameter>\n</function>",
                 qwen3_coder,
             ),
-            ("multiply<longcat_arg_key>a</longcat_arg_key>\n<longcat_arg_value>12234585</longcat_arg_value>\n<longcat_arg_key>b</longcat_arg_key>\n<longcat_arg_value>48838483920</longcat_arg_value>", longcat),
-            ('{"name": "multiply", "arguments": {"a": 12234585, "b": 48838483920}}', longcat),
-
+            (
+                "multiply<longcat_arg_key>a</longcat_arg_key>\n<longcat_arg_value>12234585</longcat_arg_value>\n<longcat_arg_key>b</longcat_arg_key>\n<longcat_arg_value>48838483920</longcat_arg_value>",
+                longcat,
+            ),
+            (
+                '{"name": "multiply", "arguments": {"a": 12234585, "b": 48838483920}}',
+                longcat,
+            ),
         ]
 
         tools = [
@@ -79,11 +76,6 @@ class TestToolParsing(unittest.TestCase):
                 self.assertEqual(tool_call, expected)
 
         test_cases = [
-            "call:get_current_temperature{location:<escape>London<escape>}",
-            'get_current_temperature<arg_key>location</arg_key><arg_value>"London"</arg_value>',
-            '{"name": "get_current_temperature", "arguments": {"location": "London"}}',
-            '<invoke name="get_current_temperature">\n<parameter name="location">London</parameter>\n</invoke>',
-            "<function=get_current_temperature>\n<parameter=location>\nLondon\n</parameter>\n</function>",
             (
                 "call:get_current_temperature{location:<escape>London<escape>}",
                 function_gemma,
@@ -104,8 +96,14 @@ class TestToolParsing(unittest.TestCase):
                 "<function=get_current_temperature>\n<parameter=location>\nLondon\n</parameter>\n</function>",
                 qwen3_coder,
             ),
-            ("get_current_temperature<longcat_arg_key>location</longcat_arg_key>\n<longcat_arg_value>London</longcat_arg_value>", longcat),
-            ('{"name": "get_current_temperature", "arguments": {"location": "London"}}', longcat),
+            (
+                "get_current_temperature<longcat_arg_key>location</longcat_arg_key>\n<longcat_arg_value>London</longcat_arg_value>",
+                longcat,
+            ),
+            (
+                '{"name": "get_current_temperature", "arguments": {"location": "London"}}',
+                longcat,
+            ),
         ]
         tools = [
             {
@@ -133,7 +131,6 @@ class TestToolParsing(unittest.TestCase):
                 }
                 self.assertEqual(tool_call, expected)
 
-<<<<<<< HEAD
     def test_kimi_k2(self):
         # Single tool call
         test_case = (
@@ -172,8 +169,6 @@ class TestToolParsing(unittest.TestCase):
         ]
         self.assertEqual(tool_calls, expected)
 
-=======
->>>>>>> 4cdbb3f (simplify test)
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary
When using GLM 4.7 with OpenCode/Codex, the tool parser crashes if the model outputs tool calls in a format that doesn't match the expected `<arg_key>` regex pattern.

## Problem
```python
func_name = _func_name_regex.search(text).group(1)
# AttributeError: 'NoneType' object has no attribute 'group'
```

The regex `^(.*?)<arg_key>` doesn't match all GLM tool call formats (JSON, plain text, etc.).

## Solution
- Add JSON fallback parsing for common tool call shapes (`name+arguments`, `function+arguments`, nested `tool` objects)
- Add plain-text fallback (`name {json}` or `name key=value`)
- Return safe unknown tool with raw text if nothing matches
- Normalize argument values using tool schema types
- Add tests covering fallback paths

## Testing
- Added tests in `tests/test_tool_parsing.py`
- Verified fix works with OpenCode + GLM 4.7 Flash via mlx-lm server

Closes issue with tool parsing crashes when using coding agents with local GLM models.