### PR TITLE
fix: use correct variable for logprobs in batch generation

### DIFF
--- a/mlx_lm/server.py
+++ b/mlx_lm/server.py
@@ -702,10 +702,10 @@ class ResponseGenerator:
                         top_tokens = None
                         if args.logprobs > 0:
                             sorted_indices = mx.argpartition(
-                                -gen.logprobs, kth=args.logprobs - 1
+                                -r.logprobs, kth=args.logprobs - 1
                             )
                             top_indices = sorted_indices[: args.logprobs]
-                            top_logprobs = gen.logprobs[top_indices]
+                            top_logprobs = r.logprobs[top_indices]
                             top_token_info = zip(
                                 top_indices.tolist(), top_logprobs.tolist()
                             )


### PR DESCRIPTION
## Summary

- Fix incorrect variable reference in batch generation logprobs handling
- Changed `gen.logprobs` to `r.logprobs` in `ResponseGenerator._generate()`
- `gen` doesn't exist in the batch code path; `r` is the correct batch response object

## Test plan
- [x] Ran pre-commit hooks
- [x] Tests pass with `python -m unittest discover tests/`