### PR TITLE
Sync random seed across ranks in distributed chat

### DIFF
--- a/mlx_lm/chat.py
+++ b/mlx_lm/chat.py
@@ -13,7 +13,7 @@ DEFAULT_TEMP = 0.0
 DEFAULT_TOP_P = 1.0
 DEFAULT_XTC_PROBABILITY = 0.0
 DEFAULT_XTC_THRESHOLD = 0.0
-DEFAULT_SEED = None
+DEFAULT_SEED = 0
 DEFAULT_MAX_TOKENS = 256
 DEFAULT_MODEL = "mlx-community/Llama-3.2-3B-Instruct-4bit"
 
@@ -100,12 +100,9 @@ def main():
         if rank == 0:
             print(*args, **kwargs)
 
-    if args.seed is not None:
-        mx.random.seed(args.seed)
+    mx.random.seed(args.seed)
 
     if group.size() > 1:
-        if args.seed is None:
-            mx.random.seed(0)
         if args.adapter_path:
             parser.error("Adapters not supported in distributed mode")
         model, tokenizer = sharded_load(args.model, pipeline_group, tensor_group)


### PR DESCRIPTION
This fixes an issue affecting distributed chat where a temperature > 0 would result in ranks having a different random state, causing them to sample different tokens and diverge (often seen as artifacts in the output, shown below).

This fix follows the approach used in #741 and [1d76aab](https://github.com/ml-explore/mlx-lm/pull/741/commits/1d76aabc39ad357ddf30189134b392ca704a8356)

```
mlx.launch --verbose --backend jaccl --hostfile hosts-jaccl.json --env MLX_METAL_FAST_SYNCH=1 -- /Users/optimus/repo/mlx-lm/.venv/bin/mlx_lm.chat --model mlx-community/Qwen3-4B-Instruct-2507-8bit --temp 1.0
[INFO] Running /Users/optimus/repo/mlx-lm/.venv/bin/python /Users/optimus/repo/mlx-lm/.venv/bin/mlx_lm.chat --model mlx-community/Qwen3-4B-Instruct-2507-8bit --temp 1.0 
Fetching 10 files: 100% 10/10 [00:00<00:00, 106184.91it/s]
Download complete: : 0.00B [00:00, ?B/s]              
Fetching 11 files: 100% 11/11 [00:00<00:00, 38067.12it/s]
Download complete: : 0.00B [00:00, ?B/s]              
Fetching 10 files: 100% 10/10 [00:02<00:00,  4.07it/s]MB/s]                
Fetching 11 files: 100% 11/11 [00:49<00:00,  4.46s/it]     
Download complete: 100% 4.27G/4.27G [00:49<00:00, 86.9MB/s]00:00, 152MB/s]  
Download complete: : 15.9MB [00:52, 306kB/s] :00, 152MB/s]                
[INFO] Starting chat session with mlx-community/Qwen3-4B-Instruct-2507-8bit.
The command list:
- 'q' to exit
- 'r' to reset the chat
- 'h' to display these commands
>> hello!
Hello! � How can I assist you today?
```