### PR TITLE
Fix ArraysCache.from_state not initializing left_padding and lengths

### DIFF
--- a/mlx_lm/models/cache.py
+++ b/mlx_lm/models/cache.py
@@ -561,10 +561,16 @@ class RotatingKVCache(_BaseCache):
 
 
 class ArraysCache(_BaseCache):
+    def __new__(cls, *args, **kwargs):
+        instance = super().__new__(cls)
+        instance.left_padding = None
+        instance.lengths = None
+        return instance
+
     def __init__(self, size, left_padding: Optional[List[int]] = None):
         self.cache = [None] * size
-        self.left_padding = mx.array(left_padding) if left_padding else None
-        self.lengths = None
+        if left_padding:
+            self.left_padding = mx.array(left_padding)
 
     def __setitem__(self, idx, value):
         self.cache[idx] = value
@@ -638,17 +644,6 @@ class ArraysCache(_BaseCache):
 
     def empty(self):
         return self.cache[0] is None
-
-    @classmethod
-    def from_state(cls, state, meta_state):
-        # Create instance without calling __init__
-        obj = cls.__new__(cls)
-        # Initialize attributes that __init__ sets but state.setter doesn't
-        obj.left_padding = None
-        obj.lengths = None
-        obj.state = state
-        obj.meta_state = meta_state
-        return obj
 
 
 class MambaCache(ArraysCache):

--- a/tests/test_prompt_cache.py
+++ b/tests/test_prompt_cache.py
@@ -133,6 +133,19 @@ class TestPromptCache(unittest.TestCase):
                 self.assertTrue(mx.array_equal(k, lk))
                 self.assertTrue(mx.array_equal(v, lv))
 
+    def test_save_load_mamba_cache(self):
+        cache_file = os.path.join(self.test_dir, "prompt_cache.safetensors")
+
+        cache = [MambaCache()]
+        cache[0][0] = mx.zeros((1, 4, 4))
+        cache[0][1] = mx.zeros((1, 4, 4))
+
+        save_prompt_cache(cache_file, cache)
+        loaded = load_prompt_cache(cache_file)
+
+        # Try to make a mask
+        mask = loaded[0].make_mask(4)
+
     def test_cache_with_generate(self):
         model, tokenizer = self.model, self.tokenizer
         prompt = tokenizer.encode("this is a prompt", return_tensors="mlx")[0]


### PR DESCRIPTION
# Fix ArraysCache.from_state not initializing left_padding and lengths

## Summary

- Fixes `AttributeError: 'MambaCache' object has no attribute 'left_padding'` when loading saved prompt caches for models using `MambaCache` (e.g., Qwen3-Next)

## Problem

`_BaseCache.from_state()` uses `__new__` to bypass `__init__`, but `ArraysCache.state.setter` only sets `self.cache`. The `left_padding` and `lengths` attributes are never initialized, causing `AttributeError` when `make_mask()` is called on a loaded cache.

## Solution

Override `from_state` in `ArraysCache` to initialize `left_padding` and `lengths` before setting state:

```python
@classmethod
def from_state(cls, state, meta_state):
    obj = cls.__new__(cls)
    obj.left_padding = None
    obj.lengths = None
    obj.state = state
    obj.meta_state = meta_state
    return obj
```

## Test Plan

- [x] Existing tests pass: `python -m pytest tests/test_prompt_cache.py -v -k "save_load"`
- [x] Manual test with Qwen3-Next model save/load cycle works

## Reproduction

```python
from mlx_lm.models.cache import MambaCache, save_prompt_cache, load_prompt_cache
import mlx.core as mx

cache = [MambaCache()]
cache[0][0] = mx.zeros((1, 4, 4))
cache[0][1] = mx.zeros((1, 4, 4))

save_prompt_cache("test.safetensors", cache)
loaded = load_prompt_cache("test.safetensors")

# Before fix: AttributeError: 'MambaCache' object has no attribute 'left_padding'
# After fix: Returns None (expected)
loaded[0].make_mask(4)
```
