### PR TITLE
Fix for Exception - MultiLinear.to_quantized() missing 'mode'

### DIFF
--- a/mlx_lm/convert.py
+++ b/mlx_lm/convert.py
@@ -18,8 +18,9 @@ from .utils import (
 
 
 def mixed_quant_predicate_builder(
-    recipe: str, model: nn.Module, group_size: int = 64, mode: str = "affine"
+    recipe: str, model: nn.Module, group_size: int = 64
 ) -> Callable[[str, nn.Module, dict], Union[bool, dict]]:
+    mode = "affine"
     high_bits = 6
 
     if recipe == "mixed_2_6":
@@ -117,6 +118,8 @@ def convert(
     )
 
     if isinstance(quant_predicate, str):
+        if q_mode != "affine":
+            raise ValueError(f"Quant predicates only support 'affine' quantization.")
         quant_predicate = mixed_quant_predicate_builder(
             quant_predicate, model, q_group_size, q_mode
         )


### PR DESCRIPTION
Add mode parameter to mixed_quant_predicate_builder as MLX now requires mode to be specified for nn.quantize class_predicate

How to reproduce: Try to convert GLM-4.7-Flash with a mixed quant predicate
MLX: v0.30.3