### PR TITLE
Fix NemotronH config compatibility with HuggingFace format

### DIFF
--- a/mlx_lm/models/nemotron_h.py
+++ b/mlx_lm/models/nemotron_h.py
@@ -36,7 +36,6 @@ class ModelArgs(BaseModelArgs):
     ssm_state_size: int
     conv_kernel: int
     n_groups: int
-    time_step_limit: Tuple[float, float]
     mlp_bias: bool
     layer_norm_epsilon: float
     use_bias: bool
@@ -52,6 +51,17 @@ class ModelArgs(BaseModelArgs):
     num_experts_per_tok: Optional[int] = None
     norm_topk_prob: Optional[bool] = None
     routed_scaling_factor: Optional[float] = None
+    time_step_limit: Optional[Tuple[float, float]] = None
+    time_step_min: Optional[float] = None
+    time_step_max: Optional[float] = None
+
+    def __post_init__(self):
+        if (
+            self.time_step_limit is None
+            and self.time_step_min is not None
+            and self.time_step_max is not None
+        ):
+            self.time_step_limit = (self.time_step_min, self.time_step_max)
 
 
 class MambaRMSNormGated(nn.Module):


### PR DESCRIPTION
HuggingFace's NemotronH config uses separate `time_step_min` and `time_step_max` fields, but mlx-lm expected a `time_step_limit` tuple. This caused loading failures since `time_step_limit` was required but never populated from the config.

- Make `time_step_limit` optional with default None
- Add `time_step_min` and `time_step_max` optional fields
- Add `__post_init__` to construct tuple from separate fields