### PR TITLE
server: support chat_template_kwargs and top_logprobs

### DIFF
--- a/mlx_lm/server.py
+++ b/mlx_lm/server.py
@@ -728,7 +728,11 @@ class ResponseGenerator:
                     and current_model == args.model
                     and is_batchable
                 ):
-                    prompt = self._tokenize(current_tokenizer, request, args)
+                    try:
+                        prompt = self._tokenize(current_tokenizer, request, args)
+                    except Exception as e:
+                        rqueue.put(e)
+                        continue
 
                     ctx = GenerationContext(
                         has_tool_calling=tokenizer.has_tool_calling,


### PR DESCRIPTION
* Adds support for clients sending "chat_template_kwargs", matching other open source LLM servers. This is gated behind `--trust-client-kwargs` because transformers does not provide any safe way to do this.

* changes the server's logprobs response to better match the OpenAI chat api & other open source servers.

It's not perfect, there are some missing fields, but it's enough to allow mlx_lm.server to be a compatible backend for a pydantic-ai based app I'm working on.