### PR TITLE
Fix Step 3.5 Flash model conversion

### DIFF
--- a/mlx_lm/models/step3p5.py
+++ b/mlx_lm/models/step3p5.py
@@ -406,6 +406,10 @@ class Model(nn.Module):
             (".share_expert.", ".mlp.share_expert."),
         ]
 
+        is_vanilla = any(
+            src in k and dst not in k for k in weights for src, dst in remappings
+        )
+
         new_weights = {}
         for k, v in weights.items():
             if ".mtp" in k:
@@ -421,9 +425,8 @@ class Model(nn.Module):
                     k = k.replace(src, dst)
                     break
 
-            if k.endswith(".weight") and "norm" in k:
-                if mx.mean(v).item() < 0.5:
-                    v = v + 1
+            if is_vanilla and k.endswith(".weight") and "norm" in k:
+                v = v + 1
 
             new_weights[k] = v
 


### PR DESCRIPTION
Fix to avoid applying the RMSNorm delta twice, at conversion and subsequently at load.
This simply reverts back to the original approach from [b8c4549](https://github.com/ml-explore/mlx-lm/pull/836/commits/b8c4549cee8f97d40f37a50218ff227bd496e5f4). Maybe theres a better way?

More info: https://github.com/ml-explore/mlx-lm/pull/836#issuecomment-3838891260