### PR TITLE
refactor: use time.perf_counter() for duration measurements

### DIFF
--- a/mlx_lm/cache_prompt.py
+++ b/mlx_lm/cache_prompt.py
@@ -112,11 +112,11 @@ def main():
     y = mx.array(prompt)
 
     # Process the prompt
-    start = time.time()
+    start = time.perf_counter()
     max_msg_len = 0
 
     def callback(processed, total_tokens):
-        current = time.time()
+        current = time.perf_counter()
         speed = processed / (current - start)
         msg = f"\rProcessed {processed:6d} tokens ({speed:6.2f} tok/s)"
         nonlocal max_msg_len

--- a/mlx_lm/perplexity.py
+++ b/mlx_lm/perplexity.py
@@ -166,11 +166,11 @@ def main():
 
     # Evaluate perplexity
     print(f"\nEvaluating perplexity with batch size {args.batch_size}...")
-    start_time = time.time()
+    start_time = time.perf_counter()
 
     ppl, se = eval_ppl(model, data, batch_size=args.batch_size)
 
-    eval_time = time.time() - start_time
+    eval_time = time.perf_counter() - start_time
     tokens_evaluated = data.shape[0] * (data.shape[1] - 1)  # B * (L - 1)
     # Print results
     print("\n" + "=" * 60)

--- a/mlx_lm/quant/dwq.py
+++ b/mlx_lm/quant/dwq.py
@@ -159,7 +159,7 @@ def dwq_quantize(
     total_tokens = 0
     tokens = 0
 
-    tic = time.time()
+    tic = time.perf_counter()
 
     # Compute initial validation loss
     initial_valid_loss = valid_loss = validate(params, it=0)
@@ -184,7 +184,7 @@ def dwq_quantize(
         if rank == 0:
             pbar.set_description(desc=f"{loss=:.4f}")
             if (it + 1) % 20 == 0:
-                toks_per_sec = tokens / (time.time() - tic)
+                toks_per_sec = tokens / (time.perf_counter() - tic)
                 peak_memory_gb = mx.get_peak_memory() / 1e9
                 avg_loss = total_loss / tokens
                 total_tokens += tokens
@@ -192,7 +192,7 @@ def dwq_quantize(
                     f"{it=}, {avg_loss=:.4f}, {total_tokens=},"
                     f" {toks_per_sec=:.3f}, {peak_memory_gb=:.3f}",
                 )
-                tic = time.time()
+                tic = time.perf_counter()
                 tokens = 0
                 total_loss = 0
         if (it + 1) % 200 == 0:

--- a/mlx_lm/server.py
+++ b/mlx_lm/server.py
@@ -459,20 +459,20 @@ class TimeBudget:
         self._time_spent = 0
 
     def __iter__(self):
-        self._start = time.time()
+        self._start = time.perf_counter()
         self._current_iterations = 0
         return self
 
     def __next__(self):
         if not self._is_distributed:
-            if time.time() - self._start > self._budget:
+            if time.perf_counter() - self._start > self._budget:
                 raise StopIteration()
             return None
 
         self._current_iterations += 1
         if self._current_iterations > self._iterations:
             self._loops += 1
-            self._time_spent += time.time() - self._start
+            self._time_spent += time.perf_counter() - self._start
             if self._loops % self._sync_frequency == 0:
                 with mx.stream(generation_stream):
                     loop_time = mx.distributed.all_sum(self._time_spent).item()

--- a/mlx_lm/share.py
+++ b/mlx_lm/share.py
@@ -123,7 +123,7 @@ def share_file(path, file, src, group=None):
     group = group or mx.distributed.init()
     all_sum = partial(mx.distributed.all_sum, group=group)
     total_size = 0
-    start_time = time.time()
+    start_time = time.perf_counter()
 
     if group.rank() == src:
         with open(path / file, "rb") as f:
@@ -168,7 +168,7 @@ def share_file(path, file, src, group=None):
                 f.write(bytes(data))
                 data = next_data
 
-    return total_size, time.time() - start_time
+    return total_size, time.perf_counter() - start_time
 
 
 def share_files(path, files, src, group=None):


### PR DESCRIPTION
Refactor to use `time.perf_counter()` instead of `time.time()` for duration measurements.

Files modified:
- `mlx_lm/cache_prompt.py`
- `mlx_lm/perplexity.py`
- `mlx_lm/quant/dwa.py`
- `mlx_lm/server.py`

Rationale:

- Monotonicity: `time.time()` can be affected by system clock updates (NTP sync), whereas `time.perf_counter()` is a monotonic clock that never goes backward.
- Precision: Provides the highest resolution possible to calculate precise duration.
- Consistency: This aligns `mlx-lm` with the timing approach already adopted in the core MLX library (see [[ml-explore/mlx#2943](https://github.com/ml-explore/mlx/pull/2943)](https://github.com/ml-explore/mlx/pull/2943)).

**Note:** `time.time()` is intentionally preserved in `server.py` line 244 (`self.created = int(time.time())`) as this generates an epoch timestamp for API responses, not a duration measurement.