### PR TITLE
server: log bad tool_calls from model

### DIFF
--- a/mlx_lm/server.py
+++ b/mlx_lm/server.py
@@ -1383,7 +1383,11 @@ class APIHandler(BaseHTTPRequestHandler):
                 return []
             result = []
             for tool_text in tool_calls:
-                parsed = ctx.tool_parser(tool_text, request.tools)
+                try:
+                    parsed = ctx.tool_parser(tool_text, request.tools)
+                except Exception:
+                    logging.exception(f"Unparsable tool call from model {tool_text=}")
+                    parsed = []
                 if isinstance(parsed, list):
                     result.extend(format_tool_call(tc) for tc in parsed)
                 else:


### PR DESCRIPTION
Makes the server more robust against failed tool call parsing.

I was occasionally running into the issue in #792 and didn't want exceptions here to blow up the http response. I don't need this patch anymore now that that's been fixed, but, it might still make sense. Feel free to reject if this isn't how you want to handle Exceptions here.