### PR TITLE
Fix gradient computation in moe_gate_select function

### DIFF
--- a/mlx_lm/models/step3p5.py
+++ b/mlx_lm/models/step3p5.py
@@ -110,7 +110,7 @@ def moe_gate_select(gates, router_bias, top_k, routed_scaling_factor, norm_topk_
             mx.sum(topk_weights, axis=-1, keepdims=True) + 1e-20
         )
 
-    return topk_indices, topk_weights * routed_scaling_factor
+    return mx.stop_gradient(topk_indices), topk_weights * routed_scaling_factor
 
 
 class Step3p5MoEGate(nn.Module):


### PR DESCRIPTION
addreses [PR](https://github.com/Goekdeniz-Guelmez/mlx-lm-lora/issues/44) The value error: `[GatherMM] Cannot calculate VJP with respect to indices` is because the attempt to calculate gradients for the indices and then passed to the gather_mm operation.