### PR TITLE
Fix dynamic_quant for MoE and VL models

### DIFF
--- a/mlx_lm/models/qwen3_moe.py
+++ b/mlx_lm/models/qwen3_moe.py
@@ -28,9 +28,9 @@ class ModelArgs(BaseModelArgs):
     num_key_value_heads: int
     head_dim: int
     rope_theta: float
-    tie_word_embeddings: bool
-    max_position_embeddings: int
     norm_topk_prob: bool
+    tie_word_embeddings: bool = False
+    max_position_embeddings: int = 40960
     rope_scaling: Optional[Dict[str, Union[float, str]]] = None
 
 


### PR DESCRIPTION
## Summary

`mlx_lm.dynamic_quant` fails on several model architectures. This PR fixes three issues:

- **Skip layers with incompatible weight dimensions**: Models like Gemma 3n have small `(4,4)` weight matrices (e.g. router/gating layers) that are not divisible by `group_size=64`, causing `ValueError` in `mx.quantize`. These layers are now skipped in sensitivity estimation, threshold search, and final quantization — they contribute negligibly to model size.

- **Enable training mode during sensitivity estimation**: MoE models (e.g. GLM-4.7-Flash, Qwen3-MoE) use `gather_mm` via `SwitchLinear`. `SwitchGLU` only applies `mx.stop_gradient` on routing indices when `self.training is True`, but `dynamic_quant` never set training mode, causing `ValueError: [GatherMM] Cannot calculate VJP with respect to indices` during gradient computation.

- **Add default values for `tie_word_embeddings` and `max_position_embeddings` in Qwen3 MoE `ModelArgs`**: VL wrapper models (e.g. Qwen3-VL-30B-A3B-Thinking) pass a `text_config` dict that may omit these fields, causing `TypeError: ModelArgs.__init__() missing 1 required positional argument`.

### Models tested
- `google/gemma-3n-E4B-it` (small weight matrix issue)
- `zai-org/GLM-4.7-Flash` (MoE GatherMM VJP issue)
- `Qwen/Qwen3-VL-30B-A3B-Thinking` (missing ModelArgs defaults)

## Test plan
- [x] `mlx_lm.dynamic_quant` completes successfully on `google/gemma-3n-E4B-it`
- [x] `mlx_lm.dynamic_quant` completes successfully on `zai-org/GLM-4.7-Flash`
- [x] `mlx_lm.dynamic_quant` loads `Qwen/Qwen3-VL-30B-A3B-Thinking` without TypeError

🤖 Generated with [Claude Code](https://claude.com/claude-code)