### PR TITLE
Add `--max-kv-size` support to `mlx_lm.server`

### DIFF
--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -39,6 +39,7 @@ class DummyModelProvider:
                 "top_k": 0,
                 "min_p": 0.0,
                 "max_tokens": 512,
+                "max_kv_size": None,
                 "chat_template_args": {},
                 "model": None,
                 "decode_concurrency": 32,


### PR DESCRIPTION
## Summary

- Adds `--max-kv-size` CLI argument to `mlx_lm.server`, bringing parity with the `generate` CLI
- Passes `max_kv_size` through to `make_prompt_cache()` and `BatchGenerator` so the server uses a `RotatingKVCache` when the flag is set
- Caps KV cache growth during long sessions, preventing unbounded unified memory usage on Apple Silicon (which can cause macOS kernel panics)

Fixes #883 and closes #615. This is a startup-only parameter per maintainer guidance on PR #834.

## Changes

- `mlx_lm/server.py`: 5 edits — add `--max-kv-size` argparse argument; pass `max_kv_size` to `make_prompt_cache()` in `ModelProvider.load()`, `_generate()` (batch path), and `_serve_single()` (both calls); pass `max_kv_size` to `BatchGenerator()` constructor
- `tests/test_server.py`: add `max_kv_size=None` to `DummyModelProvider.cli_args`