### PR TITLE
Add `mixed_2_3` and `mixed_2_4` quant predicates

### DIFF
--- a/mlx_lm/convert.py
+++ b/mlx_lm/convert.py
@@ -23,7 +23,13 @@ def mixed_quant_predicate_builder(
     mode = "affine"
     high_bits = 6
 
-    if recipe == "mixed_2_6":
+    if recipe == "mixed_2_3":
+        low_bits = 2
+        high_bits = 3
+    elif recipe == "mixed_2_4":
+        low_bits = 2
+        high_bits = 4
+    elif recipe == "mixed_2_6":
         low_bits = 2
     elif recipe == "mixed_3_4":
         low_bits = 3
@@ -77,7 +83,7 @@ def mixed_quant_predicate_builder(
     return mixed_quant_predicate
 
 
-QUANT_RECIPES = ["mixed_2_6", "mixed_3_4", "mixed_3_6", "mixed_4_6"]
+QUANT_RECIPES = ["mixed_2_3", "mixed_2_4", "mixed_2_6", "mixed_3_4", "mixed_3_6", "mixed_4_6"]
 
 MODEL_CONVERSION_DTYPES = ["float16", "bfloat16", "float32"]
 


### PR DESCRIPTION
Huge models like Kimi K2.5, even quantized to 3 bits or `mixed_3_4`, barely fit on a Mac Studio M3 512G.

This PR adds even more aggressive versions which hopefully strike a usable balance.

---

EDIT: Turns out K2.5 at `mixed_2_4` gets... loopy. So probably no hope for `mixed_2_3` either, at least for this particular case.

I'll leave this open in case folks think there's value in more options, or feel free to close.