### PR TITLE
fix: handle tool call parse errors gracefully in server

### DIFF
--- a/mlx_lm/server.py
+++ b/mlx_lm/server.py
@@ -1383,7 +1383,11 @@ class APIHandler(BaseHTTPRequestHandler):
                 return []
             result = []
             for tool_text in tool_calls:
-                parsed = ctx.tool_parser(tool_text, request.tools)
+                try:
+                    parsed = ctx.tool_parser(tool_text, request.tools)
+                except (json.JSONDecodeError, ValueError, KeyError) as e:
+                    logging.warning(f"Failed to parse tool call: {e}")
+                    continue
                 if isinstance(parsed, list):
                     result.extend(format_tool_call(tc) for tc in parsed)
                 else:

--- a/tests/test_tool_parsing.py
+++ b/tests/test_tool_parsing.py
@@ -1,3 +1,4 @@
+import json
 import unittest
 from pathlib import Path
 
@@ -186,6 +187,19 @@ class TestToolParsing(unittest.TestCase):
             },
         ]
         self.assertEqual(tool_calls, expected)
+
+    def test_invalid_json_raises(self):
+        """Verify parsers raise on invalid JSON so server can catch it."""
+        invalid_inputs = [
+            # Raw regex with invalid escape (model produces literal \d)
+            r'{"name": "grep", "arguments": {"pattern": "\d+"}}',
+            # Completely malformed
+            "not json at all",
+        ]
+        for text in invalid_inputs:
+            with self.subTest(text=text[:40]):
+                with self.assertRaises((json.JSONDecodeError, ValueError)):
+                    json_tools.parse_tool_call(text)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Problem

When a model produces tool call arguments with invalid JSON (e.g. raw regex like `\d+`, unescaped backslash paths), `json.loads()` in the tool parser raises `JSONDecodeError`. This exception is unhandled in `parse_tools()`, crashes the HTTP handler, and drops the client connection mid-response.

Affected parsers: `json_tools.py`, `mistral.py`, and any parser that calls `json.loads()` or raises `ValueError` on malformed input.

## Fix

Wrap the `ctx.tool_parser()` call in `parse_tools()` with a try/except that catches `JSONDecodeError`, `ValueError`, and `KeyError`. On failure, the server logs a warning and skips the malformed tool call instead of crashing.

This is a 4-line change at the call site in `server.py`, so it covers all current and future tool parsers.

## Reproduction

1. Run `mlx_lm.server` with a model that supports tool use (e.g. Qwen3-32B)
2. Send a prompt that causes the model to generate regex patterns in tool arguments
3. Server crashes with `JSONDecodeError: Invalid \escape`

## Testing

Tested with Qwen3-32B-4bit across 4 prompt categories (regex-heavy, backslash paths, newline escapes, clean JSON) — all pass, server stays up, malformed tool calls are logged and skipped.