### PR TITLE
Fix JSONDecodeError in qwen3_coder tool parser

### DIFF
--- a/mlx_lm/tool_parsers/qwen3_coder.py
+++ b/mlx_lm/tool_parsers/qwen3_coder.py
@@ -65,14 +65,10 @@ def _convert_param_value(param_value: str, param_name: str, param_config: dict) 
     elif param_type in _bool_types:
         return param_value.lower() == "true"
     else:
-        if (
-            param_type in _obj_types
-            or param_type.startswith("dict")
-            or param_type.startswith("list")
-        ):
+        try:
             return json.loads(param_value)
-
-        return ast.literal_eval(param_value)
+        except (json.JSONDecodeError, ValueError):
+            return ast.literal_eval(param_value)
 
 
 def _parse_xml_function_call(function_call_str: str, tools: Optional[Any]):


### PR DESCRIPTION
## Summary

Fixes #912

- `_convert_param_value()` crashes with `JSONDecodeError` when the model outputs object/array parameters with single quotes instead of valid JSON
- Replace the bare `json.loads()` + separate `ast.literal_eval()` paths with a single try/except that falls back gracefully

## Change

```python
# Before (crashes on single-quoted dicts)
if param_type in _obj_types or ...:
    return json.loads(param_value)
return ast.literal_eval(param_value)

# After (falls back to ast.literal_eval)
try:
    return json.loads(param_value)
except (json.JSONDecodeError, ValueError):
    return ast.literal_eval(param_value)
```

## Test

Reproduced by running `Qwen3-Coder-30B-A3B-Instruct` via `mlx_lm.server` with tool-calling requests. The model intermittently outputs `{'key': 'value'}` instead of `{"key": "value"}` for object parameters, crashing the server. After this fix the server handles both formats.