### PR TITLE
fix: avoid extra _step/async_eval call when n reaches max_tokens

### DIFF
--- a/mlx_lm/generate.py
+++ b/mlx_lm/generate.py
@@ -451,7 +451,7 @@ def generate_step(
     mx.async_eval(y, logprobs)
     n = 0
     while True:
-        if n != max_tokens:
+        if n + 1 < max_tokens:
             next_y, next_logprobs = _step(y)
             mx.async_eval(next_y, next_logprobs)
         if n == 0:


### PR DESCRIPTION
Fixes #226

When max_tokens == 1, the condition `n != max_tokens` evaluates 
to True on the first iteration (n=0), causing an unnecessary 
_step/async_eval call for a token that will never be used.

Changing the condition to `n + 1 < max_tokens` ensures the next 
token is only prefetched when it will actually be needed.