### PR TITLE
Add 'mx.clear_cache()' to piecewise prompt processing in server.

### DIFF
--- a/mlx_lm/generate.py
+++ b/mlx_lm/generate.py
@@ -1081,6 +1081,7 @@ class BatchGenerator:
                         for uid, length in zip(uids, lengths)
                     ]
                 )
+                mx.clear_cache()
 
         # Further prompt processing so we need to
         #   1. Merge the KV caches and prepare for right padded prompts


### PR DESCRIPTION
Prompts that were being newly added to the server didn't have cache-clearing enabled while being processed. This lead to massive memory hang.

For prompts of length ~16K on GLM 4.7 Flash 6bit, this took peak memory from 50+GB to a more reasonable 28GB.