### PR TITLE
Add filter guard to ArraysCache.nbytes property

### DIFF
--- a/mlx_lm/models/cache.py
+++ b/mlx_lm/models/cache.py
@@ -676,7 +676,7 @@ class ArraysCache(_BaseCache):
 
     @property
     def nbytes(self):
-        return sum(c.nbytes for c in self.cache)
+        return sum(c.nbytes for c in self.cache if c is not None)
 
 
 class ChunkedKVCache(_BaseCache):


### PR DESCRIPTION
Fixes #916, where an accessor operation was processing the None value in the populated values while summing