### PR TITLE
fix(types): improve type hints for `mlx_lm.utils.load` method

### DIFF
--- a/mlx_lm/utils.py
+++ b/mlx_lm/utils.py
@@ -8,7 +8,6 @@ import json
 import os
 import resource
 import shutil
-import sys
 from pathlib import Path
 from textwrap import dedent
 from typing import (
@@ -21,10 +20,8 @@ from typing import (
     Tuple,
     Type,
     Union,
+    overload,
 )
-
-if sys.version_info >= (3, 11):
-    from typing import overload
 
 import mlx.core as mx
 import mlx.nn as nn
@@ -443,52 +440,52 @@ def load_tokenizer(model_path, tokenizer_config_extra=None, eos_token_ids=None):
     )
 
 
-if sys.version_info >= (3, 11):
+@overload
+def load(
+    path_or_hf_repo: str,
+    return_config: Literal[False] = False,
+    tokenizer_config: Optional[Dict[str, Any]] = ...,
+    model_config: Optional[Dict[str, Any]] = ...,
+    adapter_path: Optional[str] = ...,
+    lazy: bool = ...,
+    revision: Optional[str] = ...,
+) -> Tuple[nn.Module, TokenizerWrapper]: ...
 
-    @overload
-    def load(
-        path_or_hf_repo: str,
-        tokenizer_config: Optional[Dict[str, Any]],
-        model_config: Optional[Dict[str, Any]],
-        adapter_path: Optional[str],
-        lazy: bool,
-        revision: Optional[str],
-        return_config: Literal[False] = False,
-    ) -> Tuple[nn.Module, TokenizerWrapper]: ...
 
-    @overload
-    def load(
-        path_or_hf_repo: str,
-        tokenizer_config: Optional[Dict[str, Any]],
-        model_config: Optional[Dict[str, Any]],
-        adapter_path: Optional[str],
-        lazy: bool,
-        revision: Optional[str],
-        return_config: Literal[True],
-    ) -> Tuple[nn.Module, TokenizerWrapper, Dict[str, Any]]: ...
+@overload
+def load(
+    path_or_hf_repo: str,
+    return_config: Literal[True],
+    tokenizer_config: Optional[Dict[str, Any]] = ...,
+    model_config: Optional[Dict[str, Any]] = ...,
+    adapter_path: Optional[str] = ...,
+    lazy: bool = ...,
+    revision: Optional[str] = ...,
+) -> Tuple[nn.Module, TokenizerWrapper, Dict[str, Any]]: ...
 
-    @overload
-    def load(
-        path_or_hf_repo: str,
-        tokenizer_config: Optional[Dict[str, Any]],
-        model_config: Optional[Dict[str, Any]],
-        adapter_path: Optional[str],
-        lazy: bool,
-        revision: Optional[str],
-        return_config: bool,
-    ) -> Union[
-        Tuple[nn.Module, TokenizerWrapper],
-        Tuple[nn.Module, TokenizerWrapper, Dict[str, Any]],
-    ]: ...
+
+@overload
+def load(
+    path_or_hf_repo: str,
+    return_config: bool = ...,
+    tokenizer_config: Optional[Dict[str, Any]] = ...,
+    model_config: Optional[Dict[str, Any]] = ...,
+    adapter_path: Optional[str] = ...,
+    lazy: bool = ...,
+    revision: Optional[str] = ...,
+) -> Union[
+    Tuple[nn.Module, TokenizerWrapper],
+    Tuple[nn.Module, TokenizerWrapper, Dict[str, Any]],
+]: ...
 
 
 def load(
     path_or_hf_repo: str,
+    return_config: bool = False,
     tokenizer_config: Optional[Dict[str, Any]] = None,
     model_config: Optional[Dict[str, Any]] = None,
     adapter_path: Optional[str] = None,
     lazy: bool = False,
-    return_config: bool = False,
     revision: Optional[str] = None,
 ) -> Union[
     Tuple[nn.Module, TokenizerWrapper],

--- a/mlx_lm/utils.py
+++ b/mlx_lm/utils.py
@@ -8,6 +8,7 @@ import json
 import os
 import resource
 import shutil
+import sys
 from pathlib import Path
 from textwrap import dedent
 from typing import (
@@ -15,11 +16,15 @@ from typing import (
     Callable,
     Dict,
     List,
+    Literal,
     Optional,
     Tuple,
     Type,
     Union,
 )
+
+if sys.version_info >= (3, 11):
+    from typing import overload
 
 import mlx.core as mx
 import mlx.nn as nn
@@ -436,6 +441,45 @@ def load_tokenizer(model_path, tokenizer_config_extra=None, eos_token_ids=None):
         tokenizer_config_extra,
         eos_token_ids=eos_token_ids,
     )
+
+
+if sys.version_info >= (3, 11):
+
+    @overload
+    def load(
+        path_or_hf_repo: str,
+        tokenizer_config: Optional[Dict[str, Any]],
+        model_config: Optional[Dict[str, Any]],
+        adapter_path: Optional[str],
+        lazy: bool,
+        revision: Optional[str],
+        return_config: Literal[False] = False,
+    ) -> Tuple[nn.Module, TokenizerWrapper]: ...
+
+    @overload
+    def load(
+        path_or_hf_repo: str,
+        tokenizer_config: Optional[Dict[str, Any]],
+        model_config: Optional[Dict[str, Any]],
+        adapter_path: Optional[str],
+        lazy: bool,
+        revision: Optional[str],
+        return_config: Literal[True],
+    ) -> Tuple[nn.Module, TokenizerWrapper, Dict[str, Any]]: ...
+
+    @overload
+    def load(
+        path_or_hf_repo: str,
+        tokenizer_config: Optional[Dict[str, Any]],
+        model_config: Optional[Dict[str, Any]],
+        adapter_path: Optional[str],
+        lazy: bool,
+        revision: Optional[str],
+        return_config: bool,
+    ) -> Union[
+        Tuple[nn.Module, TokenizerWrapper],
+        Tuple[nn.Module, TokenizerWrapper, Dict[str, Any]],
+    ]: ...
 
 
 def load(

--- a/mlx_lm/utils.py
+++ b/mlx_lm/utils.py
@@ -443,11 +443,11 @@ def load_tokenizer(model_path, tokenizer_config_extra=None, eos_token_ids=None):
 @overload
 def load(
     path_or_hf_repo: str,
-    return_config: Literal[False] = False,
     tokenizer_config: Optional[Dict[str, Any]] = ...,
     model_config: Optional[Dict[str, Any]] = ...,
     adapter_path: Optional[str] = ...,
     lazy: bool = ...,
+    return_config: Literal[False] = False,
     revision: Optional[str] = ...,
 ) -> Tuple[nn.Module, TokenizerWrapper]: ...
 
@@ -455,11 +455,11 @@ def load(
 @overload
 def load(
     path_or_hf_repo: str,
-    return_config: Literal[True],
     tokenizer_config: Optional[Dict[str, Any]] = ...,
     model_config: Optional[Dict[str, Any]] = ...,
     adapter_path: Optional[str] = ...,
     lazy: bool = ...,
+    return_config: Literal[True] = True,
     revision: Optional[str] = ...,
 ) -> Tuple[nn.Module, TokenizerWrapper, Dict[str, Any]]: ...
 
@@ -467,11 +467,11 @@ def load(
 @overload
 def load(
     path_or_hf_repo: str,
-    return_config: bool = ...,
     tokenizer_config: Optional[Dict[str, Any]] = ...,
     model_config: Optional[Dict[str, Any]] = ...,
     adapter_path: Optional[str] = ...,
     lazy: bool = ...,
+    return_config: bool = ...,
     revision: Optional[str] = ...,
 ) -> Union[
     Tuple[nn.Module, TokenizerWrapper],
@@ -481,11 +481,11 @@ def load(
 
 def load(
     path_or_hf_repo: str,
-    return_config: bool = False,
     tokenizer_config: Optional[Dict[str, Any]] = None,
     model_config: Optional[Dict[str, Any]] = None,
     adapter_path: Optional[str] = None,
     lazy: bool = False,
+    return_config: bool = False,
     revision: Optional[str] = None,
 ) -> Union[
     Tuple[nn.Module, TokenizerWrapper],


### PR DESCRIPTION
## Problem

The [mlx_lm.utils.load](https://github.com/ml-explore/mlx-lm/blob/321e764e0ab6dfa80d52a478f75d453313e00c9a/mlx_lm/utils.py#L441-L452) returns a `Tuple[nn.Module, TokenizerWrapper]` when `return_config=False` and `Tuple[nn.Module, TokenizerWrapper, Dict[str, Any]]` when `return_config=True`. Since the return type is controlled by a function argument, the types can improved to determine the correct return type based on the value of `return_config`.

## Solution

We can use the [`@overload`](https://docs.python.org/3.8/library/typing.html#typing.overload) decroator to help provide the proper type hints to the callers based on the value of `return_config`.