### PR TITLE
Add --q-override for per-layer quantization

### DIFF
--- a/mlx_lm/convert.py
+++ b/mlx_lm/convert.py
@@ -206,8 +206,8 @@ def convert(
     hf_path: str,
     mlx_path: str = "mlx_model",
     quantize: bool = False,
-    q_group_size: int = 64,
-    q_bits: int = 4,
+    q_group_size: Optional[int] = None,
+    q_bits: Optional[int] = None,
     q_mode: str = "affine",
     dtype: Optional[str] = None,
     upload_repo: str = None,
@@ -230,15 +230,7 @@ def convert(
         )
 
     default_gs, default_bits = QUANT_MODE_DEFAULTS[q_mode]
-    q_group_size_override = (
-        None if q_group_size in (None, 64) else q_group_size
-    )
-    q_bits_override = (
-        None if q_bits in (None, 4) else q_bits
-    )
-    warn_mode_override_conflicts(
-        q_mode, q_group_size_override, q_bits_override, default_gs, default_bits
-    )
+    warn_mode_override_conflicts(q_mode, q_group_size, q_bits, default_gs, default_bits)
     q_group_size = default_gs if q_group_size is None else q_group_size
     q_bits = default_bits if q_bits is None else q_bits
 

--- a/mlx_lm/convert.py
+++ b/mlx_lm/convert.py
@@ -9,6 +9,7 @@ import mlx.nn as nn
 from mlx.utils import tree_map_with_path
 
 from .utils import (
+    QUANT_MODE_DEFAULTS,
     dequantize_model,
     load,
     quantize_model,
@@ -86,8 +87,8 @@ def convert(
     hf_path: str,
     mlx_path: str = "mlx_model",
     quantize: bool = False,
-    q_group_size: int = 64,
-    q_bits: int = 4,
+    q_group_size: Optional[int] = None,
+    q_bits: Optional[int] = None,
     q_mode: str = "affine",
     dtype: Optional[str] = None,
     upload_repo: str = None,
@@ -107,6 +108,10 @@ def convert(
             f"Cannot save to the path {mlx_path} as it already exists."
             " Please delete the file/directory or specify a new path to save to."
         )
+
+    default_gs, default_bits = QUANT_MODE_DEFAULTS[q_mode]
+    q_group_size = default_gs if q_group_size is None else q_group_size
+    q_bits = default_bits if q_bits is None else q_bits
 
     print("[INFO] Loading")
     model, tokenizer, config = load(
@@ -215,7 +220,7 @@ def configure_parser() -> argparse.ArgumentParser:
         help="The quantization mode.",
         type=str,
         default="affine",
-        choices=["affine", "mxfp4", "nvfp4", "mxfp8"],
+        choices=list(QUANT_MODE_DEFAULTS),
     )
     parser.add_argument(
         "--quant-predicate",

--- a/mlx_lm/convert.py
+++ b/mlx_lm/convert.py
@@ -95,6 +95,31 @@ QUANT_MODES = {
 }
 
 
+def warn_mode_override_conflicts(
+    q_mode: str,
+    q_group_size: Optional[int],
+    q_bits: Optional[int],
+    default_group_size: int,
+    default_bits: int,
+) -> None:
+    if q_mode == "affine":
+        return
+
+    conflicts = []
+    if q_group_size is not None and q_group_size != default_group_size:
+        conflicts.append(f"q-group-size={q_group_size}")
+    if q_bits is not None and q_bits != default_bits:
+        conflicts.append(f"q-bits={q_bits}")
+
+    if conflicts:
+        details = ", ".join(conflicts)
+        print(
+            f"[WARN] --q-mode {q_mode} default is "
+            f"q-group-size={default_group_size}, q-bits={default_bits}; "
+            f"received {details}. This may produce unexpected results."
+        )
+
+
 def parse_overrides(overrides: list[str]) -> list[tuple[re.Pattern, Union[int, str]]]:
     parsed = []
     for entry in overrides:
@@ -191,6 +216,9 @@ def convert(
         "mxfp8": (32, 8),
     }
     default_gs, default_bits = mode_defaults[q_mode]
+    warn_mode_override_conflicts(
+        q_mode, q_group_size, q_bits, default_gs, default_bits
+    )
     q_group_size = q_group_size or default_gs
     q_bits = q_bits or default_bits
 

--- a/mlx_lm/convert.py
+++ b/mlx_lm/convert.py
@@ -259,6 +259,8 @@ def convert(
             model,
             q_group_size,
         )
+    elif quant_predicate is None:
+        quant_predicate = getattr(model, "quant_predicate", None)
 
     parsed_overrides = None
     if q_overrides:

--- a/mlx_lm/convert.py
+++ b/mlx_lm/convert.py
@@ -95,7 +95,58 @@ QUANT_MODES = {
     if mode != "affine"
 }
 
-ParsedOverride = tuple[re.Pattern, Union[int, str]]
+OverrideValue = Union[int, str, tuple[int, int]]
+ParsedOverride = tuple[re.Pattern, OverrideValue]
+
+
+def is_int_override(value: OverrideValue) -> bool:
+    if isinstance(value, int):
+        return True
+    return (
+        isinstance(value, tuple)
+        and len(value) == 2
+        and all(isinstance(v, int) for v in value)
+    )
+
+
+def resolve_int_override(value: OverrideValue) -> tuple[int, Optional[int]]:
+    if not is_int_override(value):
+        raise ValueError(f"Expected integer override, received {value!r}")
+    if isinstance(value, int):
+        return value, None
+    return value
+
+
+def format_override_value(value: OverrideValue) -> str:
+    if isinstance(value, str):
+        return value
+    bits, group_size = resolve_int_override(value)
+    if group_size is None:
+        return str(bits)
+    return f"{bits},{group_size}"
+
+
+def resolve_override_quant_params(
+    value: OverrideValue,
+    group_size: int,
+    int_group_size: Optional[int] = None,
+) -> Optional[dict]:
+    if isinstance(value, str) and value in QUANT_MODES:
+        return dict(QUANT_MODES[value])
+    if isinstance(value, str):
+        return None
+
+    bits, override_group_size = resolve_int_override(value)
+    resolved_group_size = override_group_size
+    if resolved_group_size is None:
+        resolved_group_size = (
+            group_size if int_group_size is None else int_group_size
+        )
+    return {
+        "group_size": resolved_group_size,
+        "bits": bits,
+        "mode": "affine",
+    }
 
 
 def warn_mode_override_conflicts(
@@ -128,7 +179,7 @@ def warn_mixed_mode_overrides(
 ) -> None:
     if q_mode == "affine":
         return
-    if not any(isinstance(value, int) for _, value in overrides):
+    if not any(is_int_override(value) for _, value in overrides):
         return
     print(
         f"[WARN] Integer --q-override values force affine quantization on "
@@ -149,17 +200,63 @@ def parse_overrides(overrides: list[str]) -> list[ParsedOverride]:
             compiled = re.compile(pattern)
         except re.error as e:
             raise ValueError(f"Invalid regex in override '{pattern}': {e}")
-        if value in FLOAT_DTYPES or value in QUANT_MODES:
-            parsed.append((compiled, value))
-        else:
-            try:
-                parsed.append((compiled, int(value)))
-            except ValueError:
-                valid = list(FLOAT_DTYPES) + list(QUANT_MODES)
+        parts = value.split(",")
+        if len(parts) > 2:
+            raise ValueError(
+                f"Invalid override value '{value}'. Expected VALUE or BITS,GROUP_SIZE"
+            )
+
+        base_value = parts[0]
+        group_size = None
+        if len(parts) == 2:
+            if not parts[1]:
                 raise ValueError(
-                    f"Invalid override value '{value}'. "
-                    f"Expected an integer (bit width) or one of {valid}"
+                    f"Invalid override value '{value}'. Missing group size."
                 )
+            try:
+                group_size = int(parts[1])
+            except ValueError:
+                raise ValueError(
+                    f"Invalid group size '{parts[1]}' in override '{entry}'. "
+                    "Expected an integer."
+                )
+            if group_size <= 0:
+                raise ValueError(
+                    f"Invalid group size '{group_size}' in override '{entry}'. "
+                    "Expected a positive integer."
+                )
+
+        if base_value in FLOAT_DTYPES:
+            if group_size is not None:
+                raise ValueError(
+                    f"Invalid override value '{value}'. Group size is only "
+                    "supported with integer bit-width overrides."
+                )
+            parsed.append((compiled, base_value))
+            continue
+
+        if base_value in QUANT_MODES:
+            if group_size is not None:
+                raise ValueError(
+                    f"Invalid override value '{value}'. Group size cannot be "
+                    "combined with quant modes."
+                )
+            parsed.append((compiled, base_value))
+            continue
+
+        try:
+            bits = int(base_value)
+        except ValueError:
+            valid = list(FLOAT_DTYPES) + list(QUANT_MODES)
+            raise ValueError(
+                f"Invalid override value '{value}'. "
+                f"Expected an integer (bit width), BITS,GROUP_SIZE, or one of {valid}"
+            )
+
+        if group_size is None:
+            parsed.append((compiled, bits))
+        else:
+            parsed.append((compiled, (bits, group_size)))
     return parsed
 
 
@@ -172,18 +269,14 @@ def build_override_predicate(
     def predicate(path, module):
         for regex, value in overrides:
             if regex.search(path):
-                if value in QUANT_MODES:
-                    return dict(QUANT_MODES[value])
-                if isinstance(value, str):
-                    return False
-                resolved_group_size = (
-                    group_size if int_group_size is None else int_group_size
+                resolved = resolve_override_quant_params(
+                    value,
+                    group_size,
+                    int_group_size=int_group_size,
                 )
-                return {
-                    "group_size": resolved_group_size,
-                    "bits": value,
-                    "mode": "affine",
-                }
+                if resolved is None:
+                    return False
+                return resolved
         if base_predicate is not None:
             return base_predicate(path, module)
         return True
@@ -192,7 +285,11 @@ def build_override_predicate(
 
 
 def apply_float_overrides(model: nn.Module, overrides: list[ParsedOverride]) -> None:
-    float_overrides = [(r, FLOAT_DTYPES[v]) for r, v in overrides if v in FLOAT_DTYPES]
+    float_overrides = [
+        (r, FLOAT_DTYPES[v])
+        for r, v in overrides
+        if isinstance(v, str) and v in FLOAT_DTYPES
+    ]
     if not float_overrides:
         return
 
@@ -208,6 +305,38 @@ def apply_float_overrides(model: nn.Module, overrides: list[ParsedOverride]) -> 
         return value
 
     model.update(tree_map_with_path(maybe_cast, model.parameters()))
+
+
+def validate_quant_override_group_sizes(
+    model: nn.Module,
+    overrides: list[ParsedOverride],
+    group_size: int,
+    int_group_size: Optional[int] = None,
+) -> None:
+    for regex, value in overrides:
+        quant_params = resolve_override_quant_params(
+            value,
+            group_size,
+            int_group_size=int_group_size,
+        )
+        if quant_params is None:
+            continue
+
+        for path, module in model.named_modules():
+            if not hasattr(module, "to_quantized") or not hasattr(module, "weight"):
+                continue
+            match_path = f"model.{path}" if path else "model"
+            if not (regex.search(path) or regex.search(match_path)):
+                continue
+
+            input_dim = module.weight.shape[-1]
+            override_group_size = quant_params["group_size"]
+            if input_dim % override_group_size != 0:
+                raise ValueError(
+                    f"--q-override {regex.pattern}={format_override_value(value)} "
+                    f"matched module '{match_path}' with input dimension {input_dim}, "
+                    f"which is not divisible by group_size {override_group_size}."
+                )
 
 
 def convert(
@@ -270,6 +399,13 @@ def convert(
         int_override_group_size = (
             q_group_size if q_mode == "affine" else affine_group_size
         )
+        if quantize:
+            validate_quant_override_group_sizes(
+                model,
+                parsed_overrides,
+                q_group_size,
+                int_group_size=int_override_group_size,
+            )
         quant_predicate = build_override_predicate(
             parsed_overrides,
             quant_predicate,
@@ -384,9 +520,10 @@ def configure_parser() -> argparse.ArgumentParser:
         help=(
             "Per-layer quantization override as PATTERN=VALUE (repeatable). "
             "PATTERN is a regex matched against the module path. "
-            "VALUE is a bit width (int), dtype (float16, bfloat16, float32), "
-            "or quant mode (mxfp4, nvfp4, mxfp8). Integer bit overrides are "
-            "affine for matching layers."
+            "VALUE is a bit width (int or int,group_size), "
+            "dtype (float16, bfloat16, float32), or quant mode "
+            "(mxfp4, nvfp4, mxfp8). Integer bit overrides are affine "
+            "for matching layers."
         ),
         action="append",
         default=None,

--- a/mlx_lm/utils.py
+++ b/mlx_lm/utils.py
@@ -804,7 +804,7 @@ def quantize_model(
         fine_grained_config = True
     else:
         fine_grained_config = False
-        quantized_config["quantization"] = quant_params
+        quantized_config["quantization"] = dict(quant_params)
 
     skipped_layers = []
 
@@ -833,10 +833,10 @@ def quantize_model(
             return False
 
         if isinstance(bool_or_params, dict):
-            quantized_config["quantization"][path] = effective_params
+            quantized_config["quantization"][path] = dict(effective_params)
             return effective_params
         elif fine_grained_config and bool_or_params:
-            quantized_config["quantization"][path] = quant_params
+            quantized_config["quantization"][path] = dict(quant_params)
         return bool_or_params
 
     nn.quantize(

--- a/mlx_lm/utils.py
+++ b/mlx_lm/utils.py
@@ -56,6 +56,13 @@ MODEL_REMAPPING = {
 
 MAX_FILE_SIZE_GB = 5
 
+QUANT_MODE_DEFAULTS = {
+    "affine": (64, 4),
+    "mxfp4": (32, 4),
+    "nvfp4": (16, 4),
+    "mxfp8": (32, 8),
+}
+
 
 def _unpack_awq_weights(qweight: mx.array) -> mx.array:
     bits = 4
@@ -784,14 +791,12 @@ def quantize_model(
     """
 
     def defaults_for_mode(mode, group_size, bits):
-        mode_defaults = {
-            "affine": (64, 4),
-            "mxfp4": (32, 4),
-            "nvfp4": (16, 4),
-            "mxfp8": (32, 8),
-        }
-        default_group_size, default_bits = mode_defaults[mode]
-        return group_size or default_group_size, bits or default_bits
+        default_group_size, default_bits = QUANT_MODE_DEFAULTS[mode]
+        resolved_group_size = (
+            default_group_size if group_size is None else group_size
+        )
+        resolved_bits = default_bits if bits is None else bits
+        return resolved_group_size, resolved_bits
 
     quantized_config = copy.deepcopy(config)
 

--- a/mlx_lm/utils.py
+++ b/mlx_lm/utils.py
@@ -790,18 +790,12 @@ def quantize_model(
         Tuple: Tuple containing quantized model and config.
     """
 
-    def defaults_for_mode(mode, group_size, bits):
-        default_group_size, default_bits = QUANT_MODE_DEFAULTS[mode]
-        resolved_group_size = (
-            default_group_size if group_size is None else group_size
-        )
-        resolved_bits = default_bits if bits is None else bits
-        return resolved_group_size, resolved_bits
-
     quantized_config = copy.deepcopy(config)
 
     quant_predicate = quant_predicate or getattr(model, "quant_predicate", None)
-    group_size, bits = defaults_for_mode(mode, group_size, bits)
+    default_group_size, default_bits = QUANT_MODE_DEFAULTS[mode]
+    group_size = default_group_size if group_size is None else group_size
+    bits = default_bits if bits is None else bits
     quant_params = {"group_size": group_size, "bits": bits, "mode": mode}
     if "quantization" in quantized_config:
         # If the model is already partially quantized, return params so that

--- a/tests/test_convert.py
+++ b/tests/test_convert.py
@@ -1,0 +1,135 @@
+import re
+import unittest
+
+import mlx.core as mx
+import mlx.nn as nn
+
+from mlx_lm.convert import (
+    apply_float_overrides,
+    build_override_predicate,
+    parse_overrides,
+)
+
+
+class TestParseOverrides(unittest.TestCase):
+
+    def test_int_value(self):
+        result = parse_overrides(["lm_head=8"])
+        self.assertEqual(len(result), 1)
+        self.assertIsInstance(result[0][0], re.Pattern)
+        self.assertEqual(result[0][1], 8)
+
+    def test_float_dtype_value(self):
+        for dtype in ("float16", "bfloat16", "float32"):
+            result = parse_overrides([f"embed_tokens={dtype}"])
+            self.assertEqual(result[0][1], dtype)
+
+    def test_multiple_overrides(self):
+        result = parse_overrides(["lm_head=8", "embed_tokens=float16"])
+        self.assertEqual(len(result), 2)
+        self.assertEqual(result[0][1], 8)
+        self.assertEqual(result[1][1], "float16")
+
+    def test_regex_pattern(self):
+        result = parse_overrides([r"layers\.0\..*=6"])
+        self.assertTrue(result[0][0].search("model.layers.0.mlp.down_proj"))
+        self.assertIsNone(result[0][0].search("model.layers.1.mlp.down_proj"))
+
+    def test_missing_equals(self):
+        with self.assertRaises(ValueError):
+            parse_overrides(["lm_head"])
+
+    def test_invalid_regex(self):
+        with self.assertRaises(ValueError):
+            parse_overrides(["[invalid=8"])
+
+    def test_quant_mode_value(self):
+        for mode in ("mxfp4", "nvfp4", "mxfp8"):
+            result = parse_overrides([f"down_proj={mode}"])
+            self.assertEqual(result[0][1], mode)
+
+    def test_invalid_value(self):
+        with self.assertRaises(ValueError):
+            parse_overrides(["lm_head=garbage"])
+
+
+class TestBuildOverridePredicate(unittest.TestCase):
+
+    def test_int_override_matches(self):
+        overrides = [(re.compile("lm_head"), 8)]
+        pred = build_override_predicate(overrides, None, 64)
+        result = pred("model.lm_head", None)
+        self.assertEqual(result, {"group_size": 64, "bits": 8, "mode": "affine"})
+
+    def test_float_override_returns_false(self):
+        overrides = [(re.compile("embed_tokens"), "float16")]
+        pred = build_override_predicate(overrides, None, 64)
+        result = pred("model.embed_tokens", None)
+        self.assertFalse(result)
+
+    def test_no_match_delegates_to_base(self):
+        overrides = [(re.compile("lm_head"), 8)]
+        base = lambda path, module: {"group_size": 64, "bits": 4, "mode": "affine"}
+        pred = build_override_predicate(overrides, base, 64)
+        result = pred("model.layers.0.mlp.down_proj", None)
+        self.assertEqual(result, {"group_size": 64, "bits": 4, "mode": "affine"})
+
+    def test_no_match_no_base_returns_true(self):
+        overrides = [(re.compile("lm_head"), 8)]
+        pred = build_override_predicate(overrides, None, 64)
+        result = pred("model.layers.0.mlp.down_proj", None)
+        self.assertTrue(result)
+
+    def test_first_match_wins(self):
+        overrides = [
+            (re.compile("lm_head"), 8),
+            (re.compile("lm_head"), 6),
+        ]
+        pred = build_override_predicate(overrides, None, 64)
+        result = pred("model.lm_head", None)
+        self.assertEqual(result["bits"], 8)
+
+    def test_quant_mode_override(self):
+        overrides = [(re.compile("down_proj"), "mxfp4")]
+        pred = build_override_predicate(overrides, None, 64)
+        result = pred("model.layers.0.mlp.down_proj", None)
+        self.assertEqual(result, {"group_size": 32, "bits": 4, "mode": "mxfp4"})
+
+    def test_group_size_passthrough(self):
+        overrides = [(re.compile("lm_head"), 4)]
+        pred = build_override_predicate(overrides, None, 32)
+        result = pred("model.lm_head", None)
+        self.assertEqual(result["group_size"], 32)
+
+
+class _Wrapper(nn.Module):
+    def __init__(self):
+        super().__init__()
+        self.linear = nn.Linear(64, 64)
+
+
+class TestApplyFloatOverrides(unittest.TestCase):
+
+    def test_cast_matching_weight(self):
+        model = _Wrapper()
+        overrides = [(re.compile("linear"), "float16")]
+        apply_float_overrides(model, overrides)
+        self.assertEqual(model.linear.weight.dtype, mx.float16)
+
+    def test_no_cast_non_matching(self):
+        model = _Wrapper()
+        original_dtype = model.linear.weight.dtype
+        overrides = [(re.compile("lm_head"), "float16")]
+        apply_float_overrides(model, overrides)
+        self.assertEqual(model.linear.weight.dtype, original_dtype)
+
+    def test_skips_int_overrides(self):
+        model = _Wrapper()
+        original_dtype = model.linear.weight.dtype
+        overrides = [(re.compile("linear"), 8)]
+        apply_float_overrides(model, overrides)
+        self.assertEqual(model.linear.weight.dtype, original_dtype)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_convert.py
+++ b/tests/test_convert.py
@@ -207,7 +207,7 @@ class TestConvertOverridePrecedence(unittest.TestCase):
 
         self.assertEqual(captured["weight_dtype"], mx.float32)
 
-    def test_legacy_defaults_do_not_warn_on_non_affine_mode(self):
+    def test_default_q_args_do_not_warn_on_non_affine_mode(self):
         model = _Wrapper()
 
         def fake_load(*_args, **_kwargs):

--- a/tests/test_convert.py
+++ b/tests/test_convert.py
@@ -31,6 +31,10 @@ class TestParseOverrides(unittest.TestCase):
             result = parse_overrides([f"embed_tokens={dtype}"])
             self.assertEqual(result[0][1], dtype)
 
+    def test_int_value_with_group_size(self):
+        result = parse_overrides(["lm_head=8,32"])
+        self.assertEqual(result[0][1], (8, 32))
+
     def test_multiple_overrides(self):
         result = parse_overrides(["lm_head=8", "embed_tokens=float16"])
         self.assertEqual(len(result), 2)
@@ -54,6 +58,12 @@ class TestParseOverrides(unittest.TestCase):
         for mode in ("mxfp4", "nvfp4", "mxfp8"):
             result = parse_overrides([f"down_proj={mode}"])
             self.assertEqual(result[0][1], mode)
+
+    def test_non_int_value_with_group_size_rejected(self):
+        for entry in ("down_proj=mxfp4,32", "embed_tokens=float16,32"):
+            with self.subTest(entry=entry):
+                with self.assertRaises(ValueError):
+                    parse_overrides([entry])
 
     def test_invalid_value(self):
         with self.assertRaises(ValueError):
@@ -119,6 +129,12 @@ class _Wrapper(nn.Module):
     def __init__(self):
         super().__init__()
         self.linear = nn.Linear(64, 64)
+
+
+class _SmallWrapper(nn.Module):
+    def __init__(self):
+        super().__init__()
+        self.linear = nn.Linear(48, 64)
 
 
 class TestApplyFloatOverrides(unittest.TestCase):
@@ -482,6 +498,68 @@ class TestConvertOverridePrecedence(unittest.TestCase):
             {"group_size": 64, "bits": 4, "mode": "affine"},
         )
         self.assertEqual(captured["base"], {"group_size": 64, "bits": 8})
+
+    def test_int_override_with_group_size_uses_override_value(self):
+        model = _Wrapper()
+        captured = {}
+
+        def fake_load(*_args, **_kwargs):
+            return model, object(), {"torch_dtype": "float16"}
+
+        def fake_quantize_model(
+            model,
+            config,
+            group_size,
+            bits,
+            mode="affine",
+            quant_predicate=None,
+        ):
+            captured["override"] = quant_predicate("model.linear", None)
+            return model, config
+
+        with tempfile.TemporaryDirectory() as test_dir:
+            mlx_path = f"{test_dir}/mlx_model"
+            with patch("mlx_lm.convert.load", side_effect=fake_load):
+                with patch(
+                    "mlx_lm.convert.quantize_model", side_effect=fake_quantize_model
+                ):
+                    with patch("mlx_lm.convert.save", side_effect=lambda *_args: None):
+                        convert(
+                            "stub/repo",
+                            mlx_path=mlx_path,
+                            quantize=True,
+                            q_overrides=["linear=8,32"],
+                        )
+
+        self.assertEqual(
+            captured["override"],
+            {"group_size": 32, "bits": 8, "mode": "affine"},
+        )
+
+    def test_override_group_size_errors_before_quantize(self):
+        model = _SmallWrapper()
+
+        def fake_load(*_args, **_kwargs):
+            return model, object(), {"torch_dtype": "float16"}
+
+        with tempfile.TemporaryDirectory() as test_dir:
+            mlx_path = f"{test_dir}/mlx_model"
+            with patch("mlx_lm.convert.load", side_effect=fake_load):
+                for override, group_size in (("linear=8,64", 64), ("linear=mxfp4", 32)):
+                    with self.subTest(override=override):
+                        with patch(
+                            "mlx_lm.convert.quantize_model",
+                            side_effect=AssertionError("quantize_model should not run"),
+                        ):
+                            with self.assertRaisesRegex(
+                                ValueError, f"not divisible by group_size {group_size}"
+                            ):
+                                convert(
+                                    "stub/repo",
+                                    mlx_path=mlx_path,
+                                    quantize=True,
+                                    q_overrides=[override],
+                                )
 
 
 if __name__ == "__main__":

--- a/tests/test_convert.py
+++ b/tests/test_convert.py
@@ -437,6 +437,52 @@ class TestConvertOverridePrecedence(unittest.TestCase):
         self.assertEqual(captured["override"]["bits"], 4)
         self.assertEqual(captured["override"]["group_size"], 32)
 
+    def test_q_overrides_preserve_model_quant_predicate_for_other_layers(self):
+        model = _Wrapper()
+        captured = {}
+
+        def predicate(path, _):
+            if path.endswith("gate"):
+                return {"group_size": 64, "bits": 8}
+            return True
+
+        model.quant_predicate = predicate
+
+        def fake_load(*_args, **_kwargs):
+            return model, object(), {"torch_dtype": "float16"}
+
+        def fake_quantize_model(
+            model,
+            config,
+            group_size,
+            bits,
+            mode="affine",
+            quant_predicate=None,
+        ):
+            captured["override"] = quant_predicate("model.lm_head", None)
+            captured["base"] = quant_predicate("model.layers.0.mlp.gate", None)
+            return model, config
+
+        with tempfile.TemporaryDirectory() as test_dir:
+            mlx_path = f"{test_dir}/mlx_model"
+            with patch("mlx_lm.convert.load", side_effect=fake_load):
+                with patch(
+                    "mlx_lm.convert.quantize_model", side_effect=fake_quantize_model
+                ):
+                    with patch("mlx_lm.convert.save", side_effect=lambda *_args: None):
+                        convert(
+                            "stub/repo",
+                            mlx_path=mlx_path,
+                            quantize=True,
+                            q_overrides=["lm_head=4"],
+                        )
+
+        self.assertEqual(
+            captured["override"],
+            {"group_size": 64, "bits": 4, "mode": "affine"},
+        )
+        self.assertEqual(captured["base"], {"group_size": 64, "bits": 8})
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -3,6 +3,8 @@
 import os
 import tempfile
 import unittest
+from contextlib import redirect_stdout
+from io import StringIO
 
 import mlx.core as mx
 import mlx.nn as nn
@@ -11,6 +13,12 @@ from mlx.utils import tree_flatten
 from mlx_lm import convert, utils
 
 HF_MODEL_PATH = "mlx-community/Qwen1.5-0.5B-Chat-4bit"
+
+
+class _QuantGateModel(nn.Module):
+    def __init__(self):
+        super().__init__()
+        self.linear = nn.Linear(96, 96)
 
 
 class TestUtils(unittest.TestCase):
@@ -77,6 +85,59 @@ class TestUtils(unittest.TestCase):
         self.assertTrue("model.layers.2.mlp.up_proj.biases" in weights)
         self.assertEqual(config["quantization"]["group_size"], 64)
         self.assertEqual(config["quantization"]["bits"], 4)
+
+    def test_quantize_override_group_size_applies_before_gate(self):
+        model = _QuantGateModel()
+        out = StringIO()
+
+        with redirect_stdout(out):
+            model, _ = utils.quantize_model(
+                model,
+                {},
+                64,
+                4,
+                quant_predicate=lambda _path, _module: {
+                    "group_size": 32,
+                    "bits": 4,
+                    "mode": "mxfp4",
+                },
+            )
+
+        weights = dict(tree_flatten(model.parameters()))
+        self.assertIn("linear.scales", weights)
+        self.assertNotIn("Skipping quantization for linear", out.getvalue())
+
+    def test_quantize_logs_incompatible_group_size_skip(self):
+        model = _QuantGateModel()
+        out = StringIO()
+
+        with redirect_stdout(out):
+            model, _ = utils.quantize_model(model, {}, 64, 4)
+
+        weights = dict(tree_flatten(model.parameters()))
+        log_output = out.getvalue()
+        self.assertNotIn("linear.scales", weights)
+        self.assertIn("Skipping quantization for linear", log_output)
+        self.assertIn("Skipped 1 layer(s) due to incompatible group size", log_output)
+
+    def test_quantize_does_not_log_group_size_skip_for_predicate_false(self):
+        model = _QuantGateModel()
+        out = StringIO()
+
+        with redirect_stdout(out):
+            model, _ = utils.quantize_model(
+                model,
+                {},
+                64,
+                4,
+                quant_predicate=lambda _path, _module: False,
+            )
+
+        weights = dict(tree_flatten(model.parameters()))
+        log_output = out.getvalue()
+        self.assertNotIn("linear.scales", weights)
+        self.assertNotIn("Skipping quantization for linear", log_output)
+        self.assertNotIn("incompatible group size", log_output)
 
     def test_convert(self):
         mlx_path = os.path.join(self.test_dir, "mlx_model")


### PR DESCRIPTION
Adds a repeatable `--q-override PATTERN=VALUE` flag to override quantization on a per-layer basis. Patterns are regexes matched against module paths, where the first match wins.

Similar to (and inspired by) `llama-quantize`. I was applying this via a custom script but felt it might be a helpful option to upstream.

Values can be:
  - a bit width (e.g. `8`)
  - a quant mode (`mxfp4`, `nvfp4`, `mxfp8`)
  - a float dtype (`float16`, `bfloat16`, `float32`)

Example:
```sh
mlx_lm.convert \
  --quantize \
  --q-bits 4 \
  --override "lm_head=6" \
  --override "embed_tokens=4" \
  --override "layers\.(0|1|2|4|5|6|8|9|10|12|13|14|16|17|18|20|21|22|24|25|26|28|29|30|32|33|34|36|37|38|40|41|42|44)\.self_attn\.q_proj=mxfp4" \
  --override "layers\.(45|46)\.self_attn\.q_proj=5" \
  --override "layers\.(0|1|2|4|5|6|8|9|10|12|13|14|16|17|18|20|21|22|24|25|26|28|29|30|32|33|34|36|37|38|40|41|42|44)\.linear_attn\.in_proj_qkvz=mxfp4" \
  --override "layers\.(45|46)\.linear_attn\.in_proj_qkvz=5" \
  --override "layers\.(0|2|3|4|5|7|8|9|11|12|13|15|16|17|18|19|20|21|23|24|25|26|27|28|29|30|32|33|34|35|36|37|38|40|41|44)\.mlp\.switch_mlp\.down_proj=mxfp4" \
  --override "layers\.(1|6|10|14|22|31|39|42|43|45|46|47)\.mlp\.switch_mlp\.down_proj=6" \
  --override "layers\.(0|2|3|4|5|7|8|9|11|12|13|15|16|17|18|19|21|23|24|25|26|27|28|29|30|33|34|35|36|37|38|40|41|44)\.mlp\.shared_experts\.down_proj=6" \
  --override "layers\.(1|6|10|14|20|22|31|32|39|42|43|45|46|47)\.mlp\.shared_experts\.down_proj=8" \
  --override "layers\.(\d+)\.mlp\.switch_mlp\.gate_proj=mxfp4" \
  --override "layers\.(\d+)\.mlp\.gate=float32" \
  --override "layers\.(\d+)\.mlp\.shared_experts\.gate_proj=mxfp4" \
  --override "layers\.(\d+)\.mlp\.switch_mlp\.up_proj=mxfp4" \
  --override "layers\.(\d+)\.mlp\.shared_experts\.up_proj=mxfp4" \
  --override "layers\.(\d+)\.linear_attn\.in_proj_ba=4" \
  --override "layers\.(\d+)\.linear_attn\.conv1d=float32" \
  --override "layers\.(0|1|2|4|5|6|8|9|10|13|14|18|20|21|22|24|25|26|28|29|33|36|37|38|40|41|42)\.linear_attn\.out_proj=5" \
  --override "layers\.(12|16|17|30|32|34|44)\.linear_attn\.out_proj=6" \
  --override "layers\.(45|46)\.linear_attn\.out_proj=8" \
  --override "layers\.(3|7|11|15|19|23|27|31|35|39)\.self_attn\.k_proj=mxfp4" \
  --override "layers\.(43|47)\.self_attn\.k_proj=5" \
  --override "layers\.(3|7|11|15|19|23|27|31|35|39)\.self_attn\.o_proj=mxfp4" \
  --override "layers\.(43|47)\.self_attn\.o_proj=5" \
  --override "layers\.(3|7|11|15|19|23|27|31|35|39)\.self_attn\.q_proj=mxfp4" \
  --override "layers\.(43|47)\.self_attn\.q_proj=5" \
  --override "layers\.(3|7|11|15|19|23|27|31|35|39)\.self_attn\.v_proj=mxfp4" \
  --override "layers\.(43|47)\.self_attn\.v_proj=5" \
  --hf-path Qwen/Qwen3-Coder-Next \
  --mlx-path ....
```

Also fixes a subtle issue where `convert()` hardcoded `q_group_size=64` and `q_bits=4` as signature defaults. The CLI was fine (argparse passes`None`), but calling `convert()` from Python with `q_mode="mxfp4"` would silently use the wrong group size. Now both paths go through the same mode-aware default logic.

Adds unit tests for the three new helpers (`parse_overrides`, `build_override_predicate`, `apply_float_overrides`).