### PR TITLE
Add tokens to eval to avoid large graphs when they are not used

### DIFF
--- a/mlx_lm/generate.py
+++ b/mlx_lm/generate.py
@@ -1228,7 +1228,7 @@ class BatchGenerator:
             batch.tokens,
         )
 
-        mx.async_eval(batch.y, batch.logprobs)
+        mx.async_eval(batch.y, batch.logprobs, batch.tokens)
 
         y = y.tolist()
         toc = time.perf_counter()


### PR DESCRIPTION
The `batch.tokens` arrays are not always used and this can create some big graphs for long generations.