### PR TITLE
Clear the cache during batch generation

### DIFF
--- a/mlx_lm/generate.py
+++ b/mlx_lm/generate.py
@@ -965,6 +965,7 @@ class BatchGenerator:
         self.completion_batch_size = max(completion_batch_size, prefill_batch_size)
         self.prompt_progress_callback = prompt_progress_callback or (lambda *_: None)
         self._stats = BatchStats()
+        self._next_count = 0
         self.max_kv_size = max_kv_size
 
         self.active_batch = None
@@ -1266,6 +1267,9 @@ class BatchGenerator:
             else:
                 self.active_batch = None
 
+        self._next_count += 1
+        if self._next_count % 512 == 0:
+            mx.clear_cache()
         self._stats.generation_tokens += len(responses)
         return responses
 


### PR DESCRIPTION
This follows the same pattern as regular generation and clears the cache every now and then. I chose 512 instead of 256 to avoid clearing the cache during in the middle of a cache step size.

The amount of cache memory falls dramatically. For example with:

```
mlx_lm.benchmark --model mlx-community/Qwen3-4B-Instruct-2507-4bit --prompt 128 -g 4096 -b 8 -n 1
```

Cache memory goes from 46.64 -> 5.14 GB