### PR TITLE
fix: catch specific exceptions instead of bare except in to_json

### DIFF
--- a/mlx_lm/chat_templates/deepseek_v32.py
+++ b/mlx_lm/chat_templates/deepseek_v32.py
@@ -68,7 +68,7 @@ tool_output_template: str = "\n<result>{content}</result>"
 def to_json(value: Any) -> str:
     try:
         return json.dumps(value, ensure_ascii=False)
-    except:
+    except (UnicodeEncodeError, ValueError):
         return json.dumps(value, ensure_ascii=True)
 
 


### PR DESCRIPTION
Replace bare `except:` with `except (UnicodeEncodeError, ValueError):` in `deepseek_v32.py`'s `to_json()`. The `json.dumps(ensure_ascii=False)` fallback only needs to handle encoding-related exceptions, not `KeyboardInterrupt` or `SystemExit`.