### PR TITLE
Cast to model dtype on load

### DIFF
--- a/mlx_lm/convert.py
+++ b/mlx_lm/convert.py
@@ -7,13 +7,13 @@ from typing import Callable, Optional, Union
 import mlx.nn as nn
 
 from .utils import (
+    MODEL_CONVERSION_DTYPES,
     cast_model_dtype,
     dequantize_model,
     load,
     quantize_model,
     save,
     upload_to_hub,
-    MODEL_CONVERSION_DTYPES,
 )
 
 

--- a/mlx_lm/utils.py
+++ b/mlx_lm/utils.py
@@ -35,7 +35,13 @@ else:
 # For large models with lots of files
 resource.setrlimit(resource.RLIMIT_NOFILE, (2048, 4096))
 
-from mlx.utils import tree_flatten, tree_map, tree_map_with_path, tree_reduce, tree_unflatten
+from mlx.utils import (
+    tree_flatten,
+    tree_map,
+    tree_map_with_path,
+    tree_reduce,
+    tree_unflatten,
+)
 
 # Local imports
 from .tokenizer_utils import TokenizerWrapper
@@ -779,6 +785,7 @@ def cast_model_dtype(
                 return v
 
         model.update(tree_map_with_path(set_dtype, model.parameters()))
+
 
 def quantize_model(
     model: nn.Module,


### PR DESCRIPTION
When running inference from native transformers safetensors (without converting), casting to the model dtype is not performed. This may cause inadvertently slow inference when a float32 layer pollutes the forward pass.

Consider the recently released `Qwen/Qwen3.5-35B-A3B`:
```
mlx_lm.generate --model Qwen/Qwen3.5-35B-A3B --prompt "Why is the sky blue?" -m 200
```

* **Before**: ~3tps
* **After**: ~68 tps - consistent with the same model converted locally using `bfloat16`, without quantization.

This PR applies casting to both code paths.