### PR TITLE
fix(model definition): granitemoehybrid rope_parameters and time_step_limit

### DIFF
--- a/mlx_lm/models/base.py
+++ b/mlx_lm/models/base.py
@@ -135,3 +135,12 @@ def scaled_dot_product_attention(
             mask=mask,
             sinks=sinks,
         )
+
+
+def deserialize_float(x):
+    if isinstance(x, dict) and "__float__" in x:
+        if x["__float__"] == "Infinity":
+            return float("inf")
+        if x["__float__"] == "-Infinity":
+            return float("-inf")
+    return x


### PR DESCRIPTION
# Support Granite configs from `transformers >= 5.0.0`

## Problem

Recent `transformers` updates changed the Granite config format, breaking MLX conversion:

1. `rope_theta` moved into:
   ```json
   "rope_parameters": {
     "rope_theta": 10000,
     "rope_type": "default"
   }
2. Default for `time_step_limit` was changed. Now it serialises as:
```json
 "time_step_limit": [
    0.0,
    {
      "__float__": "Infinity"
    }
  ],
```
The `"__float__": "Infinity"` cannot be deserialized. 

## Fix
1. Read `rope_theta` from `rope_parameters` when present.
2. Normalize `{ "__float__": "Infinity" } → float("inf")` during init.
3. Fully backward compatible with older configs.

### Links
https://github.com/huggingface/transformers/blob/main/src/transformers/models/granitemoehybrid/configuration_granitemoehybrid.py