### PR TITLE
lora: add --epochs training argument (with --iters compatibility)

### DIFF
--- a/mlx_lm/LORA.md
+++ b/mlx_lm/LORA.md
@@ -60,8 +60,12 @@ mlx_lm.lora \
     --model <path_to_model> \
     --train \
     --data <path_to_data> \
-    --iters 600
+    --epochs 3
 ```
+
+You can use either `--epochs` or `--iters` to control training length. They
+are mutually exclusive. If neither is specified, `mlx_lm.lora` defaults to
+`--iters 1000` for backward compatibility.
 
 To fine-tune the full model weights, add the `--fine-tune-type full` flag.
 Currently supported fine-tuning types are `lora` (default), `dora`, and `full`.

--- a/mlx_lm/examples/lora_config.yaml
+++ b/mlx_lm/examples/lora_config.yaml
@@ -28,6 +28,10 @@ num_layers: 16
 # Minibatch size.
 batch_size: 4
 
+# Use either epochs or iters (mutually exclusive).
+# Epochs to train for.
+# epochs: 3
+
 # Iterations to train for.
 iters: 1000
 


### PR DESCRIPTION
## Summary
This PR adds an `--epochs` parameter to `mlx_lm.lora` so users can specify training length in dataset passes, while preserving existing `--iters` behavior.

## Why
`--iters` is sensitive to dataset size and batch size, which makes run configuration less intuitive and easier to misconfigure. `--epochs` provides a more stable and user-friendly way to express training duration.

## What changed
- Added `--epochs` to `mlx_lm.lora` CLI.
- Added validation and resolution logic:
  - `--epochs` and `--iters` are mutually exclusive.
  - `--epochs` is converted to iterations via:
    - `steps_per_epoch = len(train_set) // batch_size`
    - `iters = ceil(epochs * steps_per_epoch)`
  - Clear input validation for invalid values and too-small datasets.
- Kept trainer internals iteration-based for minimal code churn.
- Preserved backward compatibility:
  - If neither option is provided, behavior remains equivalent to prior default (`iters=1000`).
- Updated docs/examples:
  - `mlx_lm/LORA.md`
  - `mlx_lm/examples/lora_config.yaml`
- Added unit tests for new resolution/validation behavior in `tests/test_finetune.py`.

## Notes
- This change does not alter existing batch construction semantics (remainder samples are still dropped by current iterator behavior).

## Validation
- `python -m unittest tests/test_finetune.py` passed.
- `pre-commit run --all-files` passed.