### PR TITLE
Use float32 accumulation in MoE expert weighted sum

### DIFF
--- a/mlx_lm/models/Klear.py
+++ b/mlx_lm/models/Klear.py
@@ -146,7 +146,7 @@ class KlearSparseMoeBlock(nn.Module):
             scores = scores / mx.sum(scores, axis=-1, keepdims=True)
         scores = scores.astype(x.dtype)
         expert_out = self.experts(x, inds)
-        y_experts = (expert_out * scores[..., None]).sum(axis=-2)
+        y_experts = (expert_out * scores[..., None].astype(mx.float32)).sum(axis=-2).astype(expert_out.dtype)
         coef = mx.softmax(self.coefficient(x), axis=-1, precise=True)
         shared = self.shared_experts(x)
         y = y_experts * coef[..., :1] + shared * coef[..., 1:]

--- a/mlx_lm/models/afmoe.py
+++ b/mlx_lm/models/afmoe.py
@@ -231,7 +231,7 @@ class AfmoeMoE(nn.Module):
         selected_scores = selected_scores * self.route_scale
 
         y = self.experts(x, inds)
-        y = (y * selected_scores[..., None]).sum(axis=-2).astype(y.dtype)
+        y = (y * selected_scores[..., None].astype(mx.float32)).sum(axis=-2).astype(y.dtype)
 
         if self.args.num_shared_experts > 0:
             y = y + self.shared_experts(x)

--- a/mlx_lm/models/bailing_moe.py
+++ b/mlx_lm/models/bailing_moe.py
@@ -53,7 +53,7 @@ class ModelArgs(BaseModelArgs):
 @partial(mx.compile, shapeless=True)
 def aggregate_expert_outputs(expert_outputs, scores):
     return (
-        (expert_outputs * scores[..., None]).sum(axis=-2).astype(expert_outputs.dtype)
+        (expert_outputs * scores[..., None].astype(mx.float32)).sum(axis=-2).astype(expert_outputs.dtype)
     )
 
 

--- a/mlx_lm/models/bailing_moe_linear.py
+++ b/mlx_lm/models/bailing_moe_linear.py
@@ -424,7 +424,7 @@ class SparseMoeBlock(nn.Module):
     def __call__(self, x: mx.array) -> mx.array:
         topk_idx, topk_weight = self.gate(x)
         out = self.switch_mlp(x, topk_idx)
-        out = (out * topk_weight[..., None]).sum(axis=-2)
+        out = (out * topk_weight[..., None].astype(mx.float32)).sum(axis=-2).astype(out.dtype)
         if self.shared_experts is not None:
             out = out + self.shared_experts(x)
         return out

--- a/mlx_lm/models/deepseek.py
+++ b/mlx_lm/models/deepseek.py
@@ -159,7 +159,7 @@ class DeepseekMoE(nn.Module):
     def __call__(self, x):
         inds, scores = self.gate(x)
         y = self.switch_mlp(x, inds)
-        y = (y * scores[..., None]).sum(axis=-2)
+        y = (y * scores[..., None].astype(mx.float32)).sum(axis=-2).astype(y.dtype)
         if self.config.n_shared_experts is not None:
             y = y + self.shared_experts(x)
 

--- a/mlx_lm/models/deepseek_v2.py
+++ b/mlx_lm/models/deepseek_v2.py
@@ -325,7 +325,7 @@ class DeepseekV2MoE(nn.Module):
 
         inds, scores = self.gate(x)
         y = self.switch_mlp(x, inds)
-        y = (y * scores[..., None]).sum(axis=-2)
+        y = (y * scores[..., None].astype(mx.float32)).sum(axis=-2).astype(y.dtype)
         if self.config.n_shared_experts is not None:
             y = y + self.shared_experts(x)
 

--- a/mlx_lm/models/deepseek_v3.py
+++ b/mlx_lm/models/deepseek_v3.py
@@ -276,7 +276,7 @@ class DeepseekV3MoE(nn.Module):
 
         inds, scores = self.gate(x)
         y = self.switch_mlp(x, inds)
-        y = (y * scores[..., None]).sum(axis=-2).astype(y.dtype)
+        y = (y * scores[..., None].astype(mx.float32)).sum(axis=-2).astype(y.dtype)
         if self.config.n_shared_experts is not None:
             y = y + self.shared_experts(x)
 

--- a/mlx_lm/models/deepseek_v32.py
+++ b/mlx_lm/models/deepseek_v32.py
@@ -369,7 +369,7 @@ class DeepseekV32MoE(nn.Module):
 
         inds, scores = self.gate(x)
         y = self.switch_mlp(x, inds)
-        y = (y * scores[..., None]).sum(axis=-2).astype(y.dtype)
+        y = (y * scores[..., None].astype(mx.float32)).sum(axis=-2).astype(y.dtype)
         if self.config.n_shared_experts is not None:
             y = y + self.shared_experts(x)
 

--- a/mlx_lm/models/dots1.py
+++ b/mlx_lm/models/dots1.py
@@ -206,7 +206,7 @@ class Dots1MoE(nn.Module):
     def __call__(self, x):
         inds, scores = self.gate(x)
         y = self.experts(x, inds)
-        y = (y * scores[..., None]).sum(axis=-2).astype(y.dtype)
+        y = (y * scores[..., None].astype(mx.float32)).sum(axis=-2).astype(y.dtype)
         if self.n_shared_experts is not None:
             y = y + self.shared_experts(x)
 

--- a/mlx_lm/models/ernie4_5_moe.py
+++ b/mlx_lm/models/ernie4_5_moe.py
@@ -152,7 +152,7 @@ class Ernie4_5_MoeMLP(nn.Module):
         scores = scores / mx.maximum(scores.sum(axis=-1, keepdims=True), 1e-12)
 
         y = self.switch_mlp(x, inds)
-        y = (y * scores[..., None]).sum(axis=-2).astype(y.dtype)
+        y = (y * scores[..., None].astype(mx.float32)).sum(axis=-2).astype(y.dtype)
 
         if self.shared_experts is not None:
             y = y + self.shared_experts(x)

--- a/mlx_lm/models/exaone_moe.py
+++ b/mlx_lm/models/exaone_moe.py
@@ -151,7 +151,7 @@ class MoE(nn.Module):
 
         inds, scores = self.gate(x)
         y = self.switch_mlp(x, inds)
-        y = (y * scores[..., None]).sum(axis=-2).astype(y.dtype)
+        y = (y * scores[..., None].astype(mx.float32)).sum(axis=-2).astype(y.dtype)
         if self.shared_experts is not None:
             y = y + self.shared_experts(x)
 

--- a/mlx_lm/models/glm4_moe.py
+++ b/mlx_lm/models/glm4_moe.py
@@ -215,7 +215,7 @@ class MoE(nn.Module):
 
         inds, scores = self.gate(x)
         y = self.switch_mlp(x, inds)
-        y = (y * scores[..., None]).sum(axis=-2).astype(y.dtype)
+        y = (y * scores[..., None].astype(mx.float32)).sum(axis=-2).astype(y.dtype)
         if self.config.n_shared_experts is not None:
             y = y + self.shared_experts(x)
 

--- a/mlx_lm/models/glm4_moe_lite.py
+++ b/mlx_lm/models/glm4_moe_lite.py
@@ -280,7 +280,7 @@ class Glm4MoeLiteMoE(nn.Module):
 
         inds, scores = self.gate(x)
         y = self.switch_mlp(x, inds)
-        y = (y * scores[..., None]).sum(axis=-2).astype(y.dtype)
+        y = (y * scores[..., None].astype(mx.float32)).sum(axis=-2).astype(y.dtype)
         if self.config.n_shared_experts is not None:
             y = y + self.shared_experts(x)
 

--- a/mlx_lm/models/granitemoe.py
+++ b/mlx_lm/models/granitemoe.py
@@ -125,7 +125,7 @@ class GraniteMoeMoE(nn.Module):
     def __call__(self, x: mx.array) -> mx.array:
         token_ids, gates = self.router(x)
         y = self.switch_mlp(x, token_ids)
-        return (y * gates[..., None]).sum(axis=-2).astype(y.dtype)
+        return (y * gates[..., None].astype(mx.float32)).sum(axis=-2).astype(y.dtype)
 
 
 class GraniteMoeDecoderLayer(nn.Module):

--- a/mlx_lm/models/granitemoehybrid.py
+++ b/mlx_lm/models/granitemoehybrid.py
@@ -323,7 +323,7 @@ class GraniteMoeHybridMoE(nn.Module):
     def __call__(self, x: mx.array) -> mx.array:
         token_ids, gates = self.router(x)
         y = self.switch_mlp(x, token_ids)
-        return (y * gates[..., None]).sum(axis=-2)
+        return (y * gates[..., None].astype(mx.float32)).sum(axis=-2).astype(y.dtype)
 
 
 class GraniteMoeHybridSharedMLP(nn.Module):

--- a/mlx_lm/models/jamba.py
+++ b/mlx_lm/models/jamba.py
@@ -243,7 +243,7 @@ class JambaSparseMoeBlock(nn.Module):
         scores = mx.take_along_axis(gates, inds, axis=-1)
         scores = mx.softmax(scores, axis=-1, precise=True)
         y = self.switch_mlp(x, inds)
-        y = (y * scores[..., None]).sum(axis=-2)
+        y = (y * scores[..., None].astype(mx.float32)).sum(axis=-2).astype(y.dtype)
         return y
 
 

--- a/mlx_lm/models/kimi_linear.py
+++ b/mlx_lm/models/kimi_linear.py
@@ -149,7 +149,7 @@ class KimiSparseMoE(nn.Module):
             self.args.moe_router_activation_func,
         )
         out = self.switch_mlp(x, inds)
-        out = (out * weights[..., None]).sum(axis=-2)
+        out = (out * weights[..., None].astype(mx.float32)).sum(axis=-2).astype(out.dtype)
         if self.shared_experts is not None:
             out = out + self.shared_experts(x)
         return out

--- a/mlx_lm/models/lfm2_moe.py
+++ b/mlx_lm/models/lfm2_moe.py
@@ -221,7 +221,7 @@ class Lfm2MoeSparseMoeBlock(nn.Module):
         scores = scores.astype(x.dtype)
 
         y = self.switch_mlp(x, inds)
-        y = (y * scores[..., None]).sum(axis=-2)
+        y = (y * scores[..., None].astype(mx.float32)).sum(axis=-2).astype(y.dtype)
 
         return y
 

--- a/mlx_lm/models/mimo_v2_flash.py
+++ b/mlx_lm/models/mimo_v2_flash.py
@@ -230,7 +230,7 @@ class MoE(nn.Module):
     def __call__(self, x):
         inds, scores = self.gate(x)
         y = self.switch_mlp(x, inds)
-        y = (y * scores[..., None]).sum(axis=-2).astype(y.dtype)
+        y = (y * scores[..., None].astype(mx.float32)).sum(axis=-2).astype(y.dtype)
         if self.config.n_shared_experts is not None:
             y = y + self.shared_experts(x)
 

--- a/mlx_lm/models/minimax.py
+++ b/mlx_lm/models/minimax.py
@@ -189,7 +189,7 @@ class MiniMaxSparseMoeBlock(nn.Module):
         scores = scores.astype(x.dtype)
 
         y = self.switch_mlp(x, inds)
-        y = (y * scores[..., None]).sum(axis=-2)
+        y = (y * scores[..., None].astype(mx.float32)).sum(axis=-2).astype(y.dtype)
 
         if self.sharding_group is not None:
             y = mx.distributed.all_sum(y, group=self.sharding_group)

--- a/mlx_lm/models/mixtral.py
+++ b/mlx_lm/models/mixtral.py
@@ -116,7 +116,7 @@ class MixtralSparseMoeBlock(nn.Module):
         scores = mx.softmax(scores, axis=-1, precise=True)
 
         y = self.switch_mlp(x, inds)
-        y = (y * scores[..., None]).sum(axis=-2)
+        y = (y * scores[..., None].astype(mx.float32)).sum(axis=-2).astype(y.dtype)
 
         return y
 

--- a/mlx_lm/models/nemotron_h.py
+++ b/mlx_lm/models/nemotron_h.py
@@ -382,7 +382,7 @@ class NemotronHMoE(nn.Module):
     def __call__(self, x):
         inds, scores = self.gate(x)
         y = self.switch_mlp(x, inds)
-        y = (y * scores[..., None]).sum(axis=-2).astype(y.dtype)
+        y = (y * scores[..., None].astype(mx.float32)).sum(axis=-2).astype(y.dtype)
         if self.config.n_shared_experts is not None:
             y = y + self.shared_experts(x)
 

--- a/mlx_lm/models/olmoe.py
+++ b/mlx_lm/models/olmoe.py
@@ -121,7 +121,7 @@ class OlmoeSparseMoeBlock(nn.Module):
         if self.norm_topk_prob:
             scores = scores / scores.sum(axis=-1, keepdims=True)
         y = self.switch_mlp(x_flat, indices)
-        y = (y * scores[..., None]).sum(axis=-2)
+        y = (y * scores[..., None].astype(mx.float32)).sum(axis=-2).astype(y.dtype)
         return y.reshape(B, L, D)
 
 

--- a/mlx_lm/models/phimoe.py
+++ b/mlx_lm/models/phimoe.py
@@ -106,7 +106,7 @@ class PhiMoESparseMoeBlock(nn.Module):
         scores = mx.softmax(scores, axis=-1, precise=True)
 
         y = self.switch_mlp(x, inds)
-        y = (y * scores[..., None]).sum(axis=-2)
+        y = (y * scores[..., None].astype(mx.float32)).sum(axis=-2).astype(y.dtype)
 
         return y
 

--- a/mlx_lm/models/phixtral.py
+++ b/mlx_lm/models/phixtral.py
@@ -105,7 +105,7 @@ class MOE(nn.Module):
         scores = mx.softmax(scores, axis=-1, precise=True)
 
         y = self.switch_mlp(x, inds)
-        y = (y * scores[..., None]).sum(axis=-2)
+        y = (y * scores[..., None].astype(mx.float32)).sum(axis=-2).astype(y.dtype)
 
         return y
 

--- a/mlx_lm/models/qwen2_moe.py
+++ b/mlx_lm/models/qwen2_moe.py
@@ -135,7 +135,7 @@ class Qwen2MoeSparseMoeBlock(nn.Module):
         scores = mx.take_along_axis(gates, inds, axis=-1)
 
         y = self.switch_mlp(x, inds)
-        y = (y * scores[..., None]).sum(axis=-2)
+        y = (y * scores[..., None].astype(mx.float32)).sum(axis=-2).astype(y.dtype)
 
         shared_expert_output = self.shared_expert(x)
         shared_expert_output = (

--- a/mlx_lm/models/qwen3_moe.py
+++ b/mlx_lm/models/qwen3_moe.py
@@ -134,7 +134,7 @@ class Qwen3MoeSparseMoeBlock(nn.Module):
             scores /= mx.sum(scores, axis=-1, keepdims=True)
 
         y = self.switch_mlp(x, inds)
-        y = (y * scores[..., None]).sum(axis=-2)
+        y = (y * scores[..., None].astype(mx.float32)).sum(axis=-2).astype(y.dtype)
 
         return y
 

--- a/mlx_lm/models/qwen3_next.py
+++ b/mlx_lm/models/qwen3_next.py
@@ -326,7 +326,7 @@ class Qwen3NextSparseMoeBlock(nn.Module):
             scores = scores / scores.sum(axis=-1, keepdims=True)
 
         y = self.switch_mlp(x, inds)
-        y = (y * scores[..., None]).sum(axis=-2)
+        y = (y * scores[..., None].astype(mx.float32)).sum(axis=-2).astype(y.dtype)
 
         shared_y = self.shared_expert(x)
         shared_y = mx.sigmoid(self.shared_expert_gate(x)) * shared_y

--- a/mlx_lm/models/step3p5.py
+++ b/mlx_lm/models/step3p5.py
@@ -171,7 +171,7 @@ class Step3p5MoE(nn.Module):
         topk_indices, topk_weights = self.gate(x)
         routed_output = self.switch_mlp(x, topk_indices)
         routed_output = (
-            (routed_output * topk_weights[..., None])
+            (routed_output * topk_weights[..., None].astype(mx.float32))
             .sum(axis=-2)
             .astype(routed_output.dtype)
         )


### PR DESCRIPTION
## Summary

All MoE models accumulate the expert weighted sum `(y * scores[..., None]).sum(axis=-2)` in the input dtype (typically bfloat16/float16). This causes precision loss during the reduction step.

The fix casts gating scores to `float32` before the multiply-sum so the entire reduction runs in float32, then casts the result back to the original dtype:

```python
# Before
y = (y * scores[..., None]).sum(axis=-2)

# After
y = (y * scores[..., None].astype(mx.float32)).sum(axis=-2).astype(y.dtype)
```

This pattern was already used in `hunyuan.py` and is now applied consistently across all 29 MoE model files.

### Why this matters

When running inference in bfloat16, the 7-bit mantissa means each multiply-add in the weighted sum loses ~0.8% precision. For models with higher `top_k` (e.g., Qwen3.5 with `num_experts_per_tok=10`), the cumulative error grows with each expert contribution. This leads to greedy-decoding divergence compared to float32 reference implementations — tokens that should be identical diverge after ~20-40 tokens of generation.

### Verification

Tested on Qwen3.5-397B-A17B with 2-node Expert Parallelism (EP), where the EP Metal kernel already uses float32 accumulation internally. After applying this fix to the baseline (non-EP) path, greedy outputs match between EP and single-node inference.

### Affected models (29 files)

Mixtral, DeepSeek (v1/v2/v3/v3.2), Qwen2-MoE, Qwen3-MoE, Qwen3.5, Jamba, OLMoE, Kimi, MiniMax, Phi-MoE, Phixtral, GraniteMoE, GraniteMoEHybrid, EXAONE-MoE, GLM-4-MoE, MIMO-v2, BaiLing-MoE, Step-3.5, ERNIE-4.5-MoE, Nemotron-H, LFM2-MoE, Dots1, AFMoE, Klear

`hunyuan.py` (already correct) and `gpt_oss.py` (different structure) were not modified.

## Test plan

- [x] Verified no MoE model files remain with bfloat16 accumulation (`grep` for pattern without `float32`)
- [x] Confirmed greedy output parity between float32-accumulated path and EP kernel (Qwen3.5-397B)
- [x] Run existing model unit tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)