### PR TITLE
Support KV cache quantization with continuous batching

### DIFF
--- a/mlx_lm/generate.py
+++ b/mlx_lm/generate.py
@@ -879,8 +879,8 @@ class Batch:
         for c, o in zip(self.cache, other.cache):
             c.extend(o)
 
-    def extract_cache(self, idx):
-        return [c.extract(idx) for c in self.cache]
+    def extract_cache(self, idx, quantize_config=None):
+        return [c.extract(idx, quantize_config=quantize_config) for c in self.cache]
 
 
 def _make_cache(model, left_padding, max_kv_size):
@@ -890,7 +890,7 @@ def _make_cache(model, left_padding, max_kv_size):
     """
 
     def to_batch_cache(c):
-        if type(c) is KVCache:
+        if type(c) is KVCache or type(c) is QuantizedKVCache:
             return BatchKVCache(left_padding)
         elif isinstance(c, ArraysCache):
             c.left_padding = mx.array(left_padding)
@@ -952,6 +952,8 @@ class BatchGenerator:
             Callable[[List[Tuple[int, int, int]]], None]
         ] = None,
         max_kv_size: Optional[int] = None,
+        kv_bits: Optional[int] = None,
+        kv_group_size: int = 64,
     ):
         self.model = model
         self.unprocessed_prompts = []
@@ -966,6 +968,11 @@ class BatchGenerator:
         self.prompt_progress_callback = prompt_progress_callback or (lambda *_: None)
         self._stats = BatchStats()
         self.max_kv_size = max_kv_size
+        self._quantize_config = (
+            {"group_size": kv_group_size, "bits": kv_bits}
+            if kv_bits is not None
+            else None
+        )
 
         self.active_batch = None
 
@@ -1029,7 +1036,9 @@ class BatchGenerator:
                 for e, uid in enumerate(batch.uids):
                     if uid not in uids:
                         continue
-                    caches[uid] = batch.extract_cache(e)
+                    caches[uid] = batch.extract_cache(
+                        e, quantize_config=self._quantize_config
+                    )
             keep_idx = [e for e, uid in enumerate(batch.uids) if uid not in uids]
             if len(keep_idx) > 0:
                 batch.filter(keep_idx)
@@ -1256,7 +1265,9 @@ class BatchGenerator:
                 finish_reason = None
                 keep_idx.append(e)
             if finish_reason is not None:
-                cache = batch.extract_cache(e)
+                cache = batch.extract_cache(
+                    e, quantize_config=self._quantize_config
+                )
             responses.append(self.Response(uid, t, logprobs[e], finish_reason, cache))
 
         # Remove any finished completions

--- a/mlx_lm/models/cache.py
+++ b/mlx_lm/models/cache.py
@@ -5,7 +5,7 @@ from typing import Any, Dict, List, Optional
 
 import mlx.core as mx
 import mlx.nn as nn
-from mlx.utils import tree_flatten, tree_map, tree_unflatten
+from mlx.utils import tree_flatten, tree_map, tree_reduce, tree_unflatten
 
 from .base import create_causal_mask
 
@@ -309,8 +309,33 @@ class QuantizedKVCache(_BaseCache):
         self.offset -= n
         return n
 
+    def size(self):
+        return self.offset
+
     def make_mask(self, *args, **kwargs):
         return create_attention_mask(*args, offset=self.offset, **kwargs)
+
+    @classmethod
+    def merge(cls, caches):
+        """Merge multiple QuantizedKVCache instances for batching.
+
+        Dequantizes each cache to float, delegates to BatchKVCache.merge,
+        then returns the float-based BatchKVCache.  KV quantization is
+        re-applied on extract via ``BatchKVCache.extract_quantized``.
+        """
+        float_caches = []
+        for c in caches:
+            fc = KVCache()
+            if c.keys is not None:
+                fc.keys = mx.dequantize(
+                    *c.keys, group_size=c.group_size, bits=c.bits
+                )
+                fc.values = mx.dequantize(
+                    *c.values, group_size=c.group_size, bits=c.bits
+                )
+                fc.offset = c.offset
+            float_caches.append(fc)
+        return BatchKVCache.merge(float_caches)
 
     def empty(self):
         return self.keys is None
@@ -627,7 +652,7 @@ class ArraysCache(_BaseCache):
         """
         self.cache = [mx.concatenate([c, o]) for c, o in zip(self.cache, other.cache)]
 
-    def extract(self, idx):
+    def extract(self, idx, **kwargs):
         cache = ArraysCache(len(self.cache))
         cache.cache = [c[idx : idx + 1] for c in self.cache]
         return cache
@@ -821,8 +846,8 @@ class CacheList(_BaseCache):
         )
         return cache
 
-    def extract(self, idx):
-        return CacheList(*(c.extract(idx) for c in self.caches))
+    def extract(self, idx, **kwargs):
+        return CacheList(*(c.extract(idx, **kwargs) for c in self.caches))
 
     def prepare(self, **kwargs):
         for c in self.caches:
@@ -1010,12 +1035,22 @@ class BatchKVCache(_BaseCache):
         )
         self._idx = max_idx
 
-    def extract(self, idx):
+    def extract(self, idx, quantize_config=None):
+        """Extract a single-sequence cache from the batch.
+
+        Args:
+            idx: Batch index to extract.
+            quantize_config: If provided, a dict with ``group_size`` and
+                ``bits`` keys.  The extracted cache will be returned as a
+                :class:`QuantizedKVCache` to save memory in LRU storage.
+        """
         cache = KVCache()
         padding = self.left_padding[idx].item()
         cache.keys = mx.contiguous(self.keys[idx : idx + 1, :, padding : self._idx])
         cache.values = mx.contiguous(self.values[idx : idx + 1, :, padding : self._idx])
         cache.offset = cache.keys.shape[2]
+        if quantize_config is not None:
+            return cache.to_quantized(**quantize_config)
         return cache
 
     @classmethod
@@ -1315,7 +1350,7 @@ class BatchRotatingKVCache(_BaseCache):
         self._idx = max_idx
         self._offset = max(self._offset, other._offset)
 
-    def extract(self, idx):
+    def extract(self, idx, **kwargs):
         cache = RotatingKVCache(self.max_size)
         padding = self.left_padding[idx].item()
         offset = self.offset[idx].item()

--- a/tests/test_prompt_cache.py
+++ b/tests/test_prompt_cache.py
@@ -662,6 +662,131 @@ class TestPromptCache(unittest.TestCase):
         c_out = KVCache.merge((c1, c2))
         self.assertEqual(c_out.keys.shape, (2, 4, 4, 4))
 
+    def test_quantized_kv_cache_merge(self):
+        """Test merging QuantizedKVCache instances into a BatchKVCache."""
+        num_heads = 4
+        head_dim = 64  # must be divisible by group_size
+        seq_len1, seq_len2 = 5, 8
+        bits = 4
+        group_size = 32
+
+        # Create two QuantizedKVCaches with different sequence lengths
+        c1 = QuantizedKVCache(bits=bits, group_size=group_size)
+        k1 = mx.random.uniform(shape=(1, num_heads, seq_len1, head_dim))
+        v1 = mx.random.uniform(shape=(1, num_heads, seq_len1, head_dim))
+        c1.update_and_fetch(k1, v1)
+
+        c2 = QuantizedKVCache(bits=bits, group_size=group_size)
+        k2 = mx.random.uniform(shape=(1, num_heads, seq_len2, head_dim))
+        v2 = mx.random.uniform(shape=(1, num_heads, seq_len2, head_dim))
+        c2.update_and_fetch(k2, v2)
+
+        # Merge should produce a BatchKVCache
+        merged = QuantizedKVCache.merge([c1, c2])
+        self.assertIsInstance(merged, BatchKVCache)
+
+        # Batch size should be 2
+        self.assertEqual(merged.keys.shape[0], 2)
+        # Sequence length should be max(seq_len1, seq_len2)
+        self.assertEqual(merged.keys.shape[2], seq_len2)
+        # Heads and head_dim preserved
+        self.assertEqual(merged.keys.shape[1], num_heads)
+        self.assertEqual(merged.keys.shape[3], head_dim)
+
+    def test_quantized_kv_cache_merge_with_empty(self):
+        """Test merging when one QuantizedKVCache is empty."""
+        bits = 4
+        group_size = 32
+
+        c1 = QuantizedKVCache(bits=bits, group_size=group_size)
+        c2 = QuantizedKVCache(bits=bits, group_size=group_size)
+        k = mx.random.uniform(shape=(1, 2, 4, 64))
+        v = mx.random.uniform(shape=(1, 2, 4, 64))
+        c2.update_and_fetch(k, v)
+
+        merged = QuantizedKVCache.merge([c1, c2])
+        self.assertIsInstance(merged, BatchKVCache)
+        self.assertEqual(merged.keys.shape[0], 2)
+
+    def test_batch_kv_cache_extract_quantized(self):
+        """Test extracting a QuantizedKVCache from a BatchKVCache."""
+        num_heads = 2
+        head_dim = 64
+        bits = 4
+        group_size = 32
+        quantize_config = {"bits": bits, "group_size": group_size}
+
+        # Create a KVCache, merge into batch, then extract with quantization
+        c1 = KVCache()
+        k = mx.random.uniform(shape=(1, num_heads, 6, head_dim))
+        v = mx.random.uniform(shape=(1, num_heads, 6, head_dim))
+        c1.update_and_fetch(k, v)
+
+        c2 = KVCache()
+        k2 = mx.random.uniform(shape=(1, num_heads, 4, head_dim))
+        v2 = mx.random.uniform(shape=(1, num_heads, 4, head_dim))
+        c2.update_and_fetch(k2, v2)
+
+        batch = BatchKVCache.merge([c1, c2])
+
+        # Extract without quantization -> KVCache
+        extracted_float = batch.extract(0)
+        self.assertIsInstance(extracted_float, KVCache)
+        self.assertEqual(extracted_float.offset, 6)
+
+        # Extract with quantization -> QuantizedKVCache
+        extracted_quant = batch.extract(0, quantize_config=quantize_config)
+        self.assertIsInstance(extracted_quant, QuantizedKVCache)
+        self.assertEqual(extracted_quant.offset, 6)
+        self.assertEqual(extracted_quant.bits, bits)
+        self.assertEqual(extracted_quant.group_size, group_size)
+
+        # Keys/values should be quantized tuples (data, scales, biases)
+        self.assertIsNotNone(extracted_quant.keys)
+        self.assertEqual(len(extracted_quant.keys), 3)
+
+    def test_quantized_roundtrip_merge_extract(self):
+        """Test full roundtrip: QuantizedKVCache -> merge -> extract(quantized)."""
+        bits = 8
+        group_size = 32
+        num_heads = 2
+        head_dim = 64
+        quantize_config = {"bits": bits, "group_size": group_size}
+
+        # Start with quantized caches
+        c1 = QuantizedKVCache(bits=bits, group_size=group_size)
+        k1 = mx.random.uniform(shape=(1, num_heads, 5, head_dim))
+        v1 = mx.random.uniform(shape=(1, num_heads, 5, head_dim))
+        c1.update_and_fetch(k1, v1)
+
+        c2 = QuantizedKVCache(bits=bits, group_size=group_size)
+        k2 = mx.random.uniform(shape=(1, num_heads, 3, head_dim))
+        v2 = mx.random.uniform(shape=(1, num_heads, 3, head_dim))
+        c2.update_and_fetch(k2, v2)
+
+        # Merge (dequantizes into BatchKVCache)
+        batch = QuantizedKVCache.merge([c1, c2])
+        self.assertIsInstance(batch, BatchKVCache)
+
+        # Extract back as quantized
+        ex1 = batch.extract(0, quantize_config=quantize_config)
+        ex2 = batch.extract(1, quantize_config=quantize_config)
+
+        self.assertIsInstance(ex1, QuantizedKVCache)
+        self.assertIsInstance(ex2, QuantizedKVCache)
+        self.assertEqual(ex1.offset, 5)
+        self.assertEqual(ex2.offset, 3)
+
+    def test_quantized_kv_cache_size(self):
+        """Test QuantizedKVCache.size() returns offset."""
+        c = QuantizedKVCache()
+        self.assertEqual(c.size(), 0)
+
+        k = mx.random.uniform(shape=(1, 2, 10, 64))
+        v = mx.random.uniform(shape=(1, 2, 10, 64))
+        c.update_and_fetch(k, v)
+        self.assertEqual(c.size(), 10)
+
     def test_window_mask_with_full_kv_cache(self):
         c = KVCache()
         kv = mx.zeros((1, 1, 32, 128))


### PR DESCRIPTION
## Summary

- Add `QuantizedKVCache.merge()` — dequantizes to float, delegates to `BatchKVCache.merge()`, enabling quantized caches to participate in batch generation
- Add `quantize_config` parameter to `BatchKVCache.extract()` — extracted caches can be re-quantized as `QuantizedKVCache` for memory-efficient LRU storage
- Wire `kv_bits`/`kv_group_size` through `BatchGenerator` so callers can opt into quantized cache storage
- Add `QuantizedKVCache.size()` for consistency with other cache types

Currently `QuantizedKVCache` and `BatchGenerator` are mutually exclusive (the `is_batchable` guard rejects `kv_bits`). This PR adds the missing `merge()` support so they can work together. The approach keeps batch computation in float (short-lived, needed for padding/concatenation) and only quantizes on extract (long-lived LRU storage), which is where memory savings matter most.

## Test plan

- [x] 5 new tests covering merge, extract with quantization, roundtrip, empty cache merge, and `size()`
- [x] All 25 tests pass (`tests/test_prompt_cache.py`)
- [x] No changes to existing test behavior

🤖 Generated with [Claude Code](https://claude.com/claude-code)