### PR TITLE
Fix qwen3_coder tool parser JSONDecodeError on single-quoted dicts

### DIFF
--- a/mlx_lm/tool_parsers/qwen3_coder.py
+++ b/mlx_lm/tool_parsers/qwen3_coder.py
@@ -70,7 +70,10 @@ def _convert_param_value(param_value: str, param_name: str, param_config: dict) 
             or param_type.startswith("dict")
             or param_type.startswith("list")
         ):
-            return json.loads(param_value)
+            try:
+                return json.loads(param_value)
+            except json.JSONDecodeError:
+                return ast.literal_eval(param_value)
 
         return ast.literal_eval(param_value)
 

--- a/tests/test_tool_parsing.py
+++ b/tests/test_tool_parsing.py
@@ -187,6 +187,88 @@ class TestToolParsing(unittest.TestCase):
         ]
         self.assertEqual(tool_calls, expected)
 
+    def test_qwen3_coder_object_params(self):
+        tools = [
+            {
+                "type": "function",
+                "function": {
+                    "name": "send_message",
+                    "description": "Send a message.",
+                    "parameters": {
+                        "type": "object",
+                        "required": ["recipient", "tags"],
+                        "properties": {
+                            "recipient": {
+                                "type": "object",
+                                "description": "The recipient.",
+                            },
+                            "tags": {
+                                "type": "array",
+                                "description": "Tags.",
+                            },
+                            "metadata": {
+                                "type": "dict",
+                                "description": "Metadata.",
+                            },
+                        },
+                    },
+                },
+            }
+        ]
+
+        test_cases = [
+            # Case 1: Single-quoted dict and array (the bug — json.loads fails,
+            # ast.literal_eval succeeds)
+            (
+                "object",
+                "recipient",
+                "{'name': 'Alice', 'email': 'a@b.com'}",
+                {"name": "Alice", "email": "a@b.com"},
+            ),
+            (
+                "array",
+                "tags",
+                "['meeting', 'daily']",
+                ["meeting", "daily"],
+            ),
+            # Case 2: Valid JSON dict and array (regression guard —
+            # json.loads succeeds, no fallback)
+            (
+                "object",
+                "recipient",
+                '{"name": "Alice", "email": "a@b.com"}',
+                {"name": "Alice", "email": "a@b.com"},
+            ),
+            (
+                "array",
+                "tags",
+                '["meeting", "daily"]',
+                ["meeting", "daily"],
+            ),
+            # Case 3: Dict type prefix with mixed types (covers
+            # startswith("dict") branch)
+            (
+                "dict",
+                "metadata",
+                "{'key': 123}",
+                {"key": 123},
+            ),
+        ]
+
+        for param_type, param_name, param_value, expected in test_cases:
+            with self.subTest(
+                param_type=param_type,
+                param_name=param_name,
+                param_value=param_value,
+            ):
+                param_config = {
+                    param_name: {"type": param_type},
+                }
+                result = qwen3_coder._convert_param_value(
+                    param_value, param_name, param_config
+                )
+                self.assertEqual(result, expected)
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary

Wraps `json.loads()` in `_convert_param_value()` (line 73 of `mlx_lm/tool_parsers/qwen3_coder.py`) with try/except `json.JSONDecodeError`, falling back to `ast.literal_eval()` when the model outputs single-quoted Python dicts instead of valid JSON.

Closes #3

## Deliverables

- `mlx_lm/tool_parsers/qwen3_coder.py` — 2-line fix (try/except wrapper)
- `tests/test_tool_parsing.py` — new `test_qwen3_coder_object_params` method with 5 test cases

## Execution Summary

- Steps completed: 3/3
- Quality gates: formatting (pass), tool parsing tests (pass)
- All 3 tool parsing tests pass. Full suite pre-existing failures unchanged.

---
*Created by `/structured-workflows:execute`*