### PR TITLE
Add --served-model-name flag to server

### DIFF
--- a/mlx_lm/server.py
+++ b/mlx_lm/server.py
@@ -490,6 +490,10 @@ class ModelProvider:
         self.default_model_map = {}
         if self.cli_args.model is not None:
             self.default_model_map[self.cli_args.model] = "default_model"
+            if getattr(self.cli_args, "served_model_name", None) is not None:
+                self.default_model_map[self.cli_args.served_model_name] = (
+                    "default_model"
+                )
             self.load(self.cli_args.model, draft_model_path="default_model")
 
     # Added in adapter_path to load dynamically
@@ -1728,10 +1732,25 @@ class APIHandler(BaseHTTPRequestHandler):
             for repo in downloaded_models
         ]
 
-        if self.response_generator.cli_args.model:
+        served_model_name = getattr(
+            self.response_generator.cli_args, "served_model_name", None
+        )
+        if served_model_name is not None:
+            if filter_repo_id is None or filter_repo_id == served_model_name:
+                models.append(
+                    {
+                        "id": served_model_name,
+                        "object": "model",
+                        "created": self.created,
+                    }
+                )
+        elif self.response_generator.cli_args.model:
             model_path = Path(self.response_generator.cli_args.model)
             if model_path.exists():
                 model_id = str(model_path.resolve())
+            else:
+                model_id = self.response_generator.cli_args.model
+            if filter_repo_id is None or filter_repo_id == model_id:
                 models.append(
                     {
                         "id": model_id,
@@ -1802,6 +1821,13 @@ def main():
         "--model",
         type=str,
         help="The path to the MLX model weights, tokenizer, and config",
+    )
+    parser.add_argument(
+        "--served-model-name",
+        type=str,
+        default=None,
+        help="The model name reported in the API. If not specified, "
+        "the --model path is used.",
     )
     parser.add_argument(
         "--adapter-path",

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -20,6 +20,7 @@ class DummyModelProvider:
         self.model, self.tokenizer = load(HF_MODEL_PATH)
         self.model_key = (HF_MODEL_PATH, None)
         self.is_batchable = True
+        self.default_model_map = {}
 
         # Add draft model support
         self.draft_model = None
@@ -41,6 +42,7 @@ class DummyModelProvider:
                 "max_tokens": 512,
                 "chat_template_args": {},
                 "model": None,
+                "served_model_name": None,
                 "decode_concurrency": 32,
                 "prompt_concurrency": 8,
                 "prompt_cache_size": 10,
@@ -56,6 +58,7 @@ class DummyModelProvider:
             self.cli_args.draft_model = HF_MODEL_PATH
 
     def load(self, model, adapter=None, draft_model=None):
+        model = self.default_model_map.get(model, model)
         assert model in ["default_model", "chat_model"]
         return self.model, self.tokenizer
 
@@ -366,6 +369,66 @@ class TestServerWithDraftModel(unittest.TestCase):
         # Ensure both generated content
         self.assertIsNotNone(first_response_body["choices"][0]["message"]["content"])
         self.assertIsNotNone(second_response_body["choices"][0]["message"]["content"])
+
+
+class TestServedModelName(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        provider = DummyModelProvider()
+        provider.cli_args.served_model_name = "my-custom-model"
+        provider.default_model_map["my-custom-model"] = "default_model"
+        cls.response_generator = ResponseGenerator(provider, LRUPromptCache())
+        cls.server_address = ("localhost", 0)
+        cls.httpd = http.server.HTTPServer(
+            cls.server_address,
+            lambda *args, **kwargs: APIHandler(cls.response_generator, *args, **kwargs),
+        )
+        cls.port = cls.httpd.server_port
+        cls.server_thread = threading.Thread(target=cls.httpd.serve_forever)
+        cls.server_thread.daemon = True
+        cls.server_thread.start()
+
+    @classmethod
+    def tearDownClass(cls):
+        cls.httpd.shutdown()
+        cls.httpd.server_close()
+        cls.server_thread.join()
+        cls.response_generator.stop_and_join()
+
+    def test_models_endpoint_lists_served_name(self):
+        url = f"http://localhost:{self.port}/v1/models"
+        response = requests.get(url)
+        self.assertEqual(response.status_code, 200)
+        response_body = json.loads(response.text)
+        model_ids = [m["id"] for m in response_body["data"]]
+        self.assertIn("my-custom-model", model_ids)
+
+    def test_completions_with_served_name(self):
+        url = f"http://localhost:{self.port}/v1/completions"
+        post_data = {
+            "model": "my-custom-model",
+            "prompt": "Once upon a time",
+            "max_tokens": 5,
+            "temperature": 0.0,
+        }
+        response = requests.post(url, json=post_data)
+        self.assertEqual(response.status_code, 200)
+        response_body = json.loads(response.text)
+        self.assertEqual(response_body["model"], "my-custom-model")
+        self.assertIn("choices", response_body)
+
+    def test_default_model_still_works(self):
+        url = f"http://localhost:{self.port}/v1/completions"
+        post_data = {
+            "model": "default_model",
+            "prompt": "Hello",
+            "max_tokens": 5,
+            "temperature": 0.0,
+        }
+        response = requests.post(url, json=post_data)
+        self.assertEqual(response.status_code, 200)
+        response_body = json.loads(response.text)
+        self.assertEqual(response_body["model"], "default_model")
 
 
 class TestKeepalive(unittest.TestCase):


### PR DESCRIPTION
## Summary

- Add `--served-model-name` CLI flag to the server, allowing operators to configure a custom model name for the API (similar to vLLM's `--served-model-name`)
- When set, the served name appears in `/v1/models` listings and is accepted in request bodies alongside the original model path
- When not set, behavior is fully backward compatible

## Details

The implementation leverages the existing `default_model_map` aliasing mechanism in `ModelProvider`. The served name is registered as an additional alias that resolves to `"default_model"`, so requests using either the served name or the original `--model` path work seamlessly.

**`/v1/models` behavior:**
- With `--served-model-name`: the served name is listed as the model id (replaces the raw path)
- Without: existing behavior preserved; also fixes a minor gap where HF repo IDs (non-local paths) were not listed

## Test plan

- [x] New `TestServedModelName` test class with 3 tests:
  - `/v1/models` endpoint lists the served name
  - Completions using the served name succeed and echo it back in the response
  - Backward compatibility: `"default_model"` still works as before
- [x] All 17 existing + new tests pass