### PR TITLE
Eval self.left_padding whenever it is updated in BatchRotatingKVCache

### DIFF
--- a/mlx_lm/models/cache.py
+++ b/mlx_lm/models/cache.py
@@ -1124,6 +1124,10 @@ class BatchRotatingKVCache(_BaseCache):
         self.offset += keys.shape[2]
         self._offset += keys.shape[2]
         self._idx = self.keys.shape[2]
+
+        # Make sure left_padding and offset are evaluated
+        self.keys = mx.depends(self.keys, (self.left_padding, self.offset))
+
         return self.keys, self.values
 
     def _update_in_place(self, keys, values):
@@ -1159,7 +1163,6 @@ class BatchRotatingKVCache(_BaseCache):
             self.values = self._trim(trim_size, self.values)
             self._idx = self.max_size
             self.left_padding -= trim_size
-            mx.eval(self.left_padding)
 
         # Rotate
         if self._idx == self.max_size:
@@ -1167,7 +1170,6 @@ class BatchRotatingKVCache(_BaseCache):
             self._idx = 0
         if self.rotated:
             self.left_padding -= S
-            mx.eval(self.left_padding)
 
         # Assign
         self.keys[..., self._idx : self._idx + S, :] = keys
@@ -1175,6 +1177,9 @@ class BatchRotatingKVCache(_BaseCache):
         self._offset += S
         self.offset += S
         self._idx += S
+
+        # Make sure left_padding and offset are evaluated
+        self.keys = mx.depends(self.keys, (self.left_padding, self.offset))
 
         # If the buffer is not full, slice off the end
         if self._offset < self.max_size:


### PR DESCRIPTION
**Motivation:**

I was running into `RuntimeError: [metal::malloc] Resource limit (499000) exceeded.` when using batching for GPT OSS. (see the attached [log.txt](https://github.com/user-attachments/files/25814878/reproduce_crash_log.txt)). Upon investigation, this happened for any model with rotating KV cache.

**Steps to Reproduce:**
Run my attached [reproduce_batch_kvcache_leak.py](https://github.com/user-attachments/files/25814964/reproduce_batch_kvcache_leak.py) with any model that uses sliding window attention with `python reproduce_batch_kvcache_leak.py --model <model path> --crash`. This runs the model in a batch generator with two requests for 50000 steps together. I have been using GPT OSS 120B MXFP4 Q8 primarily. 

--add-eval adds an eval to the left padding, which prevents this from occurring.

**Issue and Proposed changes**
I think the issue is caused by the left padding never being evaluated, meaning buffers are accumulated in an unbounded fashion.
I am not sure whether you'd prefer moving the evals outside this function. However, it is only necessary to evaluate the left padding when it is updated (from testing).