### PR TITLE
Fix iterate_batches KeyError by calling process() in dataset __getitem__

### DIFF
--- a/mlx_lm/tuner/datasets.py
+++ b/mlx_lm/tuner/datasets.py
@@ -30,7 +30,7 @@ class TextDataset:
         return (d, 0)
 
     def __getitem__(self, idx: int):
-        return self._data[idx]
+        return self.process(self._data[idx])
 
     def __len__(self):
         return len(self._data)
@@ -77,7 +77,7 @@ class ChatDataset:
             return (tokens, 0)
 
     def __getitem__(self, idx: int):
-        return self._data[idx]
+        return self.process(self._data[idx])
 
     def __len__(self):
         return len(self._data)
@@ -127,7 +127,7 @@ class CompletionsDataset:
         return (tokens, 0)
 
     def __getitem__(self, idx: int):
-        return self._data[idx]
+        return self.process(self._data[idx])
 
     def __len__(self):
         return len(self._data)

--- a/mlx_lm/tuner/datasets.py
+++ b/mlx_lm/tuner/datasets.py
@@ -30,7 +30,7 @@ class TextDataset:
         return (d, 0)
 
     def __getitem__(self, idx: int):
-        return self.process(self._data[idx])
+        return self._data[idx]
 
     def __len__(self):
         return len(self._data)
@@ -77,7 +77,7 @@ class ChatDataset:
             return (tokens, 0)
 
     def __getitem__(self, idx: int):
-        return self.process(self._data[idx])
+        return self._data[idx]
 
     def __len__(self):
         return len(self._data)
@@ -127,7 +127,7 @@ class CompletionsDataset:
         return (tokens, 0)
 
     def __getitem__(self, idx: int):
-        return self.process(self._data[idx])
+        return self._data[idx]
 
     def __len__(self):
         return len(self._data)
@@ -161,7 +161,7 @@ class CacheDataset:
         self._proc_data = [None] * len(data)
 
     def itemlen(self, idx: int):
-        return len(self._data[idx])
+        return len(self[idx][0])
 
     def __getitem__(self, idx: int):
         if self._proc_data[idx] is None:

--- a/mlx_lm/tuner/trainer.py
+++ b/mlx_lm/tuner/trainer.py
@@ -96,6 +96,10 @@ def iterate_batches(
     seed=None,
     comm_group=None,
 ):
+    # Wrap in CacheDataset if not already wrapped
+    if not isinstance(dataset, CacheDataset) and hasattr(dataset, "process"):
+        dataset = CacheDataset(dataset)
+
     # Sort by length:
     if isinstance(dataset, CacheDataset):
         len_fn = lambda idx: dataset.itemlen(idx)

--- a/tests/test_tuner_trainer.py
+++ b/tests/test_tuner_trainer.py
@@ -50,5 +50,45 @@ class TestTunerTrainer(unittest.TestCase):
         run(3, 4, 8)
 
 
+from unittest.mock import MagicMock
+
+from mlx_lm.tuner.datasets import ChatDataset, CompletionsDataset, TextDataset
+
+
+def make_tokenizer():
+    tokenizer = MagicMock()
+    tokenizer.apply_chat_template = lambda msgs, **kw: [1, 2, 3, 4, 5]
+    tokenizer.eos_token_id = 2
+    tokenizer.encode = lambda text: [1, 2, 3]
+    return tokenizer
+
+
+class TestIterateBatchesWithDatasets(unittest.TestCase):
+    def test_chat_dataset(self):
+        data = [
+            {"messages": [{"role": "user", "content": f"msg{i}"}]} for i in range(4)
+        ]
+        dataset = ChatDataset(data, make_tokenizer())
+        batches = iterate_batches(dataset, batch_size=2, max_seq_length=512)
+        batch, lengths = next(batches)
+        self.assertIsNotNone(batch)
+
+    def test_text_dataset(self):
+        data = [{"text": f"hello {i}"} for i in range(4)]
+        dataset = TextDataset(data, make_tokenizer())
+        batches = iterate_batches(dataset, batch_size=2, max_seq_length=512)
+        batch, lengths = next(batches)
+        self.assertIsNotNone(batch)
+
+    def test_completions_dataset(self):
+        data = [{"prompt": f"q{i}", "completion": f"a{i}"} for i in range(4)]
+        dataset = CompletionsDataset(
+            data, make_tokenizer(), "prompt", "completion", False
+        )
+        batches = iterate_batches(dataset, batch_size=2, max_seq_length=512)
+        batch, lengths = next(batches)
+        self.assertIsNotNone(batch)
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
Fix KeyError: 0 in iterate_batches when using non-cached datasets

`iterate_batches` expects `dataset[idx]` to return processed tuples
`(tokens, offset)`, but `TextDataset`, `ChatDataset`, and
`CompletionsDataset.__getitem__` return raw dicts.

Fixed by wrapping the dataset in `CacheDataset` at the start of
`iterate_batches` if it has a `process` method and is not already
wrapped. This is consistent with how `CacheDataset` already handles
processing and caching, and avoids duplicating logic across dataset
classes.

Fixes #766