### PR TITLE
Fix SuScaledRoPE input mutation

### DIFF
--- a/mlx_lm/models/rope_utils.py
+++ b/mlx_lm/models/rope_utils.py
@@ -58,6 +58,7 @@ class SuScaledRoPE(nn.Module):
         self._scale = long_mscale or (1.0 if factor <= 1.0 else default_scale(factor))
 
     def __call__(self, x, offset: Union[int, mx.array] = 0):
+        x = mx.array(x)
         x[..., : self.dim] = self._scale * x[..., : self.dim]
         return mx.fast.rope(
             x,

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -238,6 +238,22 @@ class TestModels(unittest.TestCase):
         )
         self.assertTrue(isinstance(rope, rope_utils.Llama3RoPE))
 
+    def test_suscaledrope_does_not_mutate_input(self):
+        rope = rope_utils.SuScaledRoPE(
+            dims=2,
+            max_position_embeddings=8192,
+            original_max_position_embeddings=4096,
+        )
+        x = mx.array([[[[1.0, 2.0, 3.0, 4.0]]]])
+        original = mx.array(x)
+
+        y = rope(x)
+        mx.eval(x, original, y)
+
+        self.assertTrue(mx.array_equal(x, original))
+        self.assertFalse(mx.array_equal(y[..., :2], original[..., :2]))
+        self.assertTrue(mx.array_equal(y[..., 2:], original[..., 2:]))
+
     def test_quantized_sdpa(self):
         cache = KVCache()
 


### PR DESCRIPTION
SuScaledRoPE currently mutates the input tensor by scaling the rotary slice in place. Copy the input before applying the scale and add a regression test for the non-mutating behavior.

Fixes #939