### PR TITLE
Fix: Extract full eos_token_ids array to prevent conversational hallucinations

### DIFF
--- a/mlx_lm/tokenizer_utils.py
+++ b/mlx_lm/tokenizer_utils.py
@@ -272,10 +272,15 @@ class TokenizerWrapper:
     ):
         self._tokenizer = tokenizer
         self._detokenizer_class = detokenizer_class
+        _eids = getattr(tokenizer, "eos_token_ids", [])
+        if _eids is None: _eids = []
+        if isinstance(_eids, int): _eids = [_eids]
+        _eid = getattr(tokenizer, "eos_token_id", None)
+        if _eid is not None: _eids.append(_eid)
         self._eos_token_ids = (
             set(eos_token_ids)
             if eos_token_ids is not None
-            else {tokenizer.eos_token_id}
+            else set(_eids)
         )
         self._think_start = None
         self._think_end = None


### PR DESCRIPTION
### Bug Description
In `mlx_lm.tokenizer_utils.TokenizerWrapper`, the initialization logic only falls back to the scalar `eos_token_id`, effectively dropping the plural `eos_token_ids` array from the tokenizer config if no explicit list is passed in.

This causes models that rely on conversational end-of-turn tokens (like `<|im_end|>` or `<|eot_id|>` which are often defined in `eos_token_ids`) to ignore stop conditions and continually generate hallucinations or pseudo-user responses.

### Reproduction
Load any model with multiple EOS tokens defined in its tokenizer config, such as `Qwen2.5-Instruct` or `Llama-3.1-Instruct`:

```python
from mlx_lm.tokenizer_utils import load
model, tokenizer = load('Qwen/Qwen2.5-32B-Instruct')

print('Expected EOS:', getattr(tokenizer._tokenizer, 'eos_token_ids', []))
print('Captured MLX EOS:', tokenizer.eos_token_ids)
```

### The Fix
The fallback initialization in `TokenizerWrapper.__init__` now safely extracts the full array.

*Resolves #973*