### PR TITLE
feat(server): Add opt-in prompt cache warmup

### DIFF
--- a/mlx_lm/server.py
+++ b/mlx_lm/server.py
@@ -523,7 +523,9 @@ class ResponseGenerator:
         rq = request[0] if request is not None else Queue()
         return rq, *shareable
 
-    def _tokenize_chat(self, tokenizer, messages, tools, role_mapping, extra_args):
+    def _prepare_chat_prompt(
+        self, tokenizer, messages, tools, role_mapping, extra_args
+    ):
         if tokenizer.has_chat_template:
             process_message_content(messages)
             if tools and not tokenizer.has_tool_calling:

--- a/mlx_lm/server.py
+++ b/mlx_lm/server.py
@@ -856,6 +856,10 @@ class ResponseGenerator:
                 cache, uncached = self.prompt_cache.fetch_nearest_cache(
                     self.model_provider.model_key, prompt
                 )
+                # Ignore tiny uncached lengths (close checkpoint already exists)
+                if len(uncached) < 10:
+                    return True
+
                 def progress(tokens_processed, total_tokens):
                     logging.info(
                         f"Prompt cache warmup progress: {tokens_processed}/{total_tokens}"

--- a/mlx_lm/server.py
+++ b/mlx_lm/server.py
@@ -986,6 +986,11 @@ class ResponseGenerator:
             # We got a request
             if request is not None:
                 rqueue, request, args = request
+                if self.cli_args.prompt_cache_warmup:
+                    with self._prompt_cache_warmup_lock:
+                        warmup = self._prompt_cache_warmup
+                        if warmup is not None and warmup.model != args.model:
+                            self._prompt_cache_warmup = None
 
                 # Can it be added to the current batch?
                 if (
@@ -1161,13 +1166,17 @@ class ResponseGenerator:
                                 del batch_results[uid]
                     continue
 
-            # Prefer a newly arrived foreground request over best-effort warmup.
-            request = get_next_request(timeout=0)
-            if request is not None:
-                unprocessed_requests.append(request)
-                continue
+            if self.cli_args.prompt_cache_warmup:
+                with self._prompt_cache_warmup_lock:
+                    has_pending_warmup = self._prompt_cache_warmup is not None
+                if has_pending_warmup:
+                    # Prefer a newly arrived foreground request over best-effort warmup.
+                    request = get_next_request(timeout=0)
+                    if request is not None:
+                        unprocessed_requests.append(request)
+                        continue
 
-            self._run_prompt_cache_warmup()
+                    self._run_prompt_cache_warmup()
 
     def _serve_single(self, request):
         rqueue, request, args = request

--- a/mlx_lm/server.py
+++ b/mlx_lm/server.py
@@ -653,61 +653,63 @@ class ResponseGenerator:
                 warmup.model.draft,
             )
             prompt = self._build_prefill_request(tokenizer, warmup)
-            if prompt is not None:
-                self.prompt_cache.log_cache_stats()
-                cache, uncached = self.prompt_cache.fetch_nearest_cache(
-                    self.model_provider.model_key, prompt
+            if prompt is None:
+                return True
+
+            self._log_cache_stats()
+            cache, uncached = self.prompt_cache.fetch_nearest_cache(
+                self.model_provider.model_key, prompt
+            )
+            # Ignore tiny uncached lengths (close checkpoint already exists)
+            if len(uncached) < 10:
+                return True
+
+            def progress(tokens_processed, total_tokens):
+                logging.info(
+                    f"Prompt cache warmup progress: {tokens_processed}/{total_tokens}"
                 )
-                # Ignore tiny uncached lengths (close checkpoint already exists)
-                if len(uncached) < 10:
-                    return True
+                if tokens_processed > 0 and not self.requests.empty():
+                    raise _WarmupInterrupted(tokens_processed)
 
-                def progress(tokens_processed, total_tokens):
-                    logging.info(
-                        f"Prompt cache warmup progress: {tokens_processed}/{total_tokens}"
+            if cache is None:
+                cache = make_prompt_cache(model)
+
+            # Flush outstanding work on the shared generation stream before
+            # setting the wired limit for warm-up prefill.
+            mx.synchronize(generation_stream)
+            try:
+                with wired_limit(model, [generation_stream]):
+                    for _ in generate_step(
+                        mx.array(uncached),
+                        model,
+                        max_tokens=0,
+                        prompt_cache=cache,
+                        prefill_step_size=self.cli_args.prefill_step_size,
+                        prompt_progress_callback=progress,
+                    ):
+                        pass
+            except _WarmupInterrupted as e:
+                # Save whatever we prefilled so far. The offset
+                # accounts for tokens already in the cache.
+                prefix_len = len(prompt) - len(uncached) + e.tokens_processed
+                if prefix_len > 0:
+                    self.prompt_cache.insert_cache(
+                        self.model_provider.model_key,
+                        prompt[:prefix_len],
+                        cache,
+                        cache_type="user",
                     )
-                    if tokens_processed > 0 and not self.requests.empty():
-                        raise _WarmupInterrupted(tokens_processed)
-
-                if cache is None:
-                    cache = make_prompt_cache(model)
-                if len(uncached) > 0:
-                    # Flush outstanding work on the shared generation stream before
-                    # setting the wired limit for warm-up prefill.
-                    mx.synchronize(generation_stream)
-                    try:
-                        with wired_limit(model, [generation_stream]):
-                            for _ in generate_step(
-                                mx.array(uncached),
-                                model,
-                                max_tokens=0,
-                                prompt_cache=cache,
-                                prefill_step_size=self.cli_args.prefill_step_size,
-                                prompt_progress_callback=progress,
-                            ):
-                                pass
-                    except _WarmupInterrupted as e:
-                        # Save whatever we prefilled so far. The offset
-                        # accounts for tokens already in the cache.
-                        prefix_len = len(prompt) - len(uncached) + e.tokens_processed
-                        if prefix_len > 0:
-                            self.prompt_cache.insert_cache(
-                                self.model_provider.model_key,
-                                prompt[:prefix_len],
-                                cache,
-                                checkpoint=True,
-                            )
-                        logging.info(
-                            f"Prompt cache warmup interrupted at {e.tokens_processed}/{len(uncached)} tokens, "
-                            "partial cache checkpointed."
-                        )
-                    else:
-                        self.prompt_cache.insert_cache(
-                            self.model_provider.model_key,
-                            prompt,
-                            cache,
-                            checkpoint=True,
-                        )
+                logging.info(
+                    f"Prompt cache warmup interrupted at {e.tokens_processed}/{len(uncached)} tokens, "
+                    "partial cache checkpointed."
+                )
+            else:
+                self.prompt_cache.insert_cache(
+                    self.model_provider.model_key,
+                    prompt,
+                    cache,
+                    cache_type="user",
+                )
         except Exception:
             logging.exception("Prompt cache warmup failed.")
         return True

--- a/mlx_lm/server.py
+++ b/mlx_lm/server.py
@@ -1,6 +1,7 @@
 # Copyright © 2023-2024 Apple Inc.
 
 import argparse
+import copy
 import json
 import logging
 import pickle

--- a/mlx_lm/server.py
+++ b/mlx_lm/server.py
@@ -856,12 +856,9 @@ class ResponseGenerator:
                 cache, uncached = self.prompt_cache.fetch_nearest_cache(
                     self.model_provider.model_key, prompt
                 )
-                cached_tokens = len(prompt) - len(uncached)
-
                 def progress(tokens_processed, total_tokens):
                     logging.info(
-                        "Prompt cache warmup progress: "
-                        f"{cached_tokens + tokens_processed}/{cached_tokens + total_tokens}"
+                        f"Prompt cache warmup progress: {tokens_processed}/{total_tokens}"
                     )
                     if tokens_processed > 0 and not self.requests.empty():
                         raise _WarmupInterrupted(tokens_processed)
@@ -895,8 +892,7 @@ class ResponseGenerator:
                                 checkpoint=True,
                             )
                         logging.info(
-                            "Prompt cache warmup interrupted at "
-                            f"{cached_tokens + e.tokens_processed}/{len(prompt)} tokens, "
+                            f"Prompt cache warmup interrupted at {e.tokens_processed}/{len(uncached)} tokens, "
                             "partial cache checkpointed."
                         )
                     else:

--- a/mlx_lm/server.py
+++ b/mlx_lm/server.py
@@ -844,13 +844,6 @@ class ResponseGenerator:
                 return False
             self._prompt_cache_warmup = None
 
-        def progress(tokens_processed, total_tokens):
-            logging.info(
-                f"Prompt cache warmup progress: {tokens_processed}/{total_tokens}"
-            )
-            if tokens_processed > 0 and not self.requests.empty():
-                raise _WarmupInterrupted(tokens_processed)
-
         try:
             model, tokenizer = self.model_provider.load(
                 warmup.model.model,
@@ -863,6 +856,16 @@ class ResponseGenerator:
                 cache, uncached = self.prompt_cache.fetch_nearest_cache(
                     self.model_provider.model_key, prompt
                 )
+                cached_tokens = len(prompt) - len(uncached)
+
+                def progress(tokens_processed, total_tokens):
+                    logging.info(
+                        "Prompt cache warmup progress: "
+                        f"{cached_tokens + tokens_processed}/{cached_tokens + total_tokens}"
+                    )
+                    if tokens_processed > 0 and not self.requests.empty():
+                        raise _WarmupInterrupted(tokens_processed)
+
                 if cache is None:
                     cache = make_prompt_cache(model)
                 if len(uncached) > 0:
@@ -892,7 +895,8 @@ class ResponseGenerator:
                                 checkpoint=True,
                             )
                         logging.info(
-                            f"Prompt cache warmup interrupted at {e.tokens_processed}/{len(uncached)} tokens, "
+                            "Prompt cache warmup interrupted at "
+                            f"{cached_tokens + e.tokens_processed}/{len(prompt)} tokens, "
                             "partial cache checkpointed."
                         )
                     else:

--- a/mlx_lm/server.py
+++ b/mlx_lm/server.py
@@ -179,10 +179,8 @@ def process_message_content(messages):
         if tool_calls := message.get("tool_calls", False):
             for tool_call in tool_calls:
                 if func := tool_call.get("function", False):
-                    if isinstance(
-                        args := func.get("arguments", False),
-                        (str, bytes, bytearray),
-                    ) and args:
+                    args = func.get("arguments")
+                    if isinstance(args, (str, bytes, bytearray)) and args:
                         func["arguments"] = json.loads(args)
 
 
@@ -1698,7 +1696,7 @@ class APIHandler(BaseHTTPRequestHandler):
                     in_reasoning = True
                     break
         reasoning_text = ""
-        warmup_reasoning = "" # Separate accumulator; reasoning_text resets during streaming
+        full_reasoning = ""
 
         # Variables to save the generated tokens and the corresponding probs
         tokens = []
@@ -1721,7 +1719,7 @@ class APIHandler(BaseHTTPRequestHandler):
                     in_reasoning = False
                 else:
                     reasoning_text += gen.text
-                    warmup_reasoning += gen.text
+                    full_reasoning += gen.text
             elif ctx.has_tool_calling and gen.text == ctx.tool_call_start:
                 made_tool_call = True
                 in_tool_call = True
@@ -1795,10 +1793,10 @@ class APIHandler(BaseHTTPRequestHandler):
                 "role": "assistant",
                 "content": text or "",
             }
-            if warmup_reasoning:
+            if full_reasoning:
                 # Preserve both the response-facing and template-facing keys.
-                assistant_message["reasoning"] = warmup_reasoning
-                assistant_message["reasoning_content"] = warmup_reasoning
+                assistant_message["reasoning"] = full_reasoning
+                assistant_message["reasoning_content"] = full_reasoning
             self.response_generator.enqueue_prompt_cache_warmup(
                 request,
                 args,

--- a/mlx_lm/server.py
+++ b/mlx_lm/server.py
@@ -538,15 +538,20 @@ class ResponseGenerator:
                 chat_template_args = chat_template_args.copy()
                 chat_template_args.update(extra_args)
 
-            return tokenizer.apply_chat_template(
-                messages,
+            template_kwargs = dict(
                 tools=tools,
-                add_generation_prompt=True,
                 tokenize=True,
                 **chat_template_args,
             )
+            prompt = tokenizer.apply_chat_template(
+                messages,
+                add_generation_prompt=True,
+                **template_kwargs,
+            )
+            return prompt, template_kwargs
 
-        return tokenizer.encode(convert_chat(messages, role_mapping))
+        prompt = tokenizer.encode(convert_chat(messages, role_mapping))
+        return prompt, None
 
     def _tokenize(self, tokenizer, request, args):
         """Tokenize a request and split the prompt into segments.
@@ -567,31 +572,14 @@ class ResponseGenerator:
             tools = request.tools
             role_mapping = request.role_mapping
 
-            if tokenizer.has_chat_template:
-                process_message_content(messages)
-                if tools and not tokenizer.has_tool_calling:
-                    logging.warning(
-                        "Received tools but model does not support tool calling. "
-                        "If you think this is an error, file an issue here: "
-                        "https://github.com/ml-explore/mlx-lm/issues"
-                    )
-
-                chat_template_args = self.model_provider.cli_args.chat_template_args
-                if args.chat_template_kwargs:
-                    chat_template_args = chat_template_args.copy()
-                    chat_template_args.update(args.chat_template_kwargs)
-                template_kwargs = dict(
-                    tools=tools,
-                    tokenize=True,
-                    **chat_template_args,
-                )
-                prompt = tokenizer.apply_chat_template(
-                    messages,
-                    add_generation_prompt=True,
-                    **template_kwargs,
-                )
-            else:
-                prompt = tokenizer.encode(convert_chat(messages, role_mapping))
+            prompt, template_kwargs = self._prepare_chat_prompt(
+                tokenizer,
+                messages,
+                tools,
+                role_mapping,
+                args.chat_template_kwargs,
+            )
+            if template_kwargs is None:
                 return prompt, [prompt], ["assistant"], "normal"
         else:
             prompt = tokenizer.encode(request.prompt)
@@ -676,13 +664,13 @@ class ResponseGenerator:
             messages = copy.deepcopy(warmup.messages)
             messages.append({"role": "user", "content": content})
             prompts.append(
-                self._tokenize_chat(
+                self._prepare_chat_prompt(
                     tokenizer,
                     messages,
                     warmup.tools,
                     warmup.role_mapping,
                     warmup.chat_template_kwargs,
-                )
+                )[0]
             )
 
         prompt = shared_prefix(*prompts)

--- a/mlx_lm/server.py
+++ b/mlx_lm/server.py
@@ -436,20 +436,6 @@ class CompletionRequest:
 
 
 @dataclass
-class _PromptCacheWarmup:
-    model: ModelDescription
-    messages: List[Any]
-    tools: Optional[List[Any]]
-    role_mapping: Optional[Dict[str, Any]]
-    chat_template_kwargs: Optional[Dict[str, Any]]
-
-
-class _WarmupInterrupted(Exception):
-    def __init__(self, tokens_processed):
-        self.tokens_processed = tokens_processed
-
-
-@dataclass
 class GenerationContext:
     has_tool_calling: bool
     tool_call_start: str
@@ -669,7 +655,20 @@ def _format_top_logprobs(logprobs, top_logprobs, tokenizer) -> Tuple[Dict[str, A
     )
 
 
+class _WarmupInterrupted(Exception):
+    def __init__(self, tokens_processed):
+        self.tokens_processed = tokens_processed
+
+
 class ResponseGenerator:
+    @dataclass
+    class _Warmup:
+        model: ModelDescription
+        messages: List[Any]
+        tools: Optional[List[Any]]
+        role_mapping: Optional[Dict[str, Any]]
+        chat_template_kwargs: Optional[Dict[str, Any]]
+
     def __init__(self, model_provider: ModelProvider, prompt_cache: LRUPromptCache):
         self.model_provider = model_provider
         self.prompt_cache = prompt_cache
@@ -828,7 +827,7 @@ class ResponseGenerator:
         messages = copy.deepcopy(request.messages)
         messages.append(assistant_message)
         with self._prompt_cache_warmup_lock:
-            self._prompt_cache_warmup = _PromptCacheWarmup(
+            self._prompt_cache_warmup = self._Warmup(
                 model=generation_args.model,
                 messages=messages,
                 tools=copy.deepcopy(request.tools),
@@ -841,9 +840,9 @@ class ResponseGenerator:
     def _run_prompt_cache_warmup(self):
         with self._prompt_cache_warmup_lock:
             warmup = self._prompt_cache_warmup
+            if warmup is None:
+                return False
             self._prompt_cache_warmup = None
-        if warmup is None:
-            return False
 
         def progress(tokens_processed, total_tokens):
             logging.info(
@@ -882,10 +881,8 @@ class ResponseGenerator:
                             ):
                                 pass
                     except _WarmupInterrupted as e:
-                        # Checkpoint partial work so the next request (likely extending
-                        # this same conversation) can reuse it.
-                        # `tokens_processed` is reported against `uncached`, so extend the
-                        # cached prompt prefix by that many tokens.
+                        # Save whatever we prefilled so far. The offset
+                        # accounts for tokens already in the cache.
                         prefix_len = len(prompt) - len(uncached) + e.tokens_processed
                         if prefix_len > 0:
                             self.prompt_cache.insert_cache(
@@ -1110,73 +1107,61 @@ class ResponseGenerator:
                         batch_generator.close()
                         batch_generator = None
                         drain_batch = False
-                        continue
-                else:
-                    uids_to_remove = []
-                    for _ in self._time_budget:
-                        responses = batch_generator.next()
-                        if not responses:
-                            break
-
-                        for r in responses:
-                            result = batch_results[r.uid]
-                            result["cache_key"].append(r.token)
-                            if r.finish_reason != "stop":
-                                result["detokenizer"].add_token(r.token)
-
-                            result["rqueue"].put(
-                                Response(
-                                    result["detokenizer"].last_segment,
-                                    r.token,
-                                    r.logprobs[r.token].item(),
-                                    r.finish_reason,
-                                    _format_top_logprobs(
-                                        r.logprobs, args.top_logprobs, current_tokenizer
-                                    ),
-                                ),
-                            )
-
-                            if r.finish_reason is not None:
-                                result["rqueue"].put(None)
-                                self.prompt_cache.insert_cache(
-                                    current_model_key,
-                                    result["cache_key"],
-                                    r.prompt_cache,
-                                )
-                                del batch_results[r.uid]
-
-                            if result["ctx"]._should_stop:
-                                uids_to_remove.append(r.uid)
-
-                    uids_to_remove = self._share_object(uids_to_remove)
-                    if uids_to_remove:
-                        with mx.stream(generation_stream):
-                            caches = batch_generator.remove(
-                                uids_to_remove, return_prompt_caches=True
-                            )
-                            for uid, prompt_cache in caches.items():
-                                if uid not in batch_results:
-                                    continue
-                                result = batch_results[uid]
-                                self.prompt_cache.insert_cache(
-                                    current_model_key,
-                                    result["cache_key"],
-                                    prompt_cache,
-                                )
-                                del batch_results[uid]
+                    else:
+                        self._run_prompt_cache_warmup()
                     continue
 
-            if self.cli_args.prompt_cache_warmup:
-                with self._prompt_cache_warmup_lock:
-                    has_pending_warmup = self._prompt_cache_warmup is not None
-                if has_pending_warmup:
-                    # Prefer a newly arrived foreground request over best-effort warmup.
-                    request = get_next_request(timeout=0)
-                    if request is not None:
-                        unprocessed_requests.append(request)
-                        continue
+                uids_to_remove = []
+                for _ in self._time_budget:
+                    responses = batch_generator.next()
+                    if not responses:
+                        break
 
-                    self._run_prompt_cache_warmup()
+                    for r in responses:
+                        result = batch_results[r.uid]
+                        result["cache_key"].append(r.token)
+                        if r.finish_reason != "stop":
+                            result["detokenizer"].add_token(r.token)
+
+                        result["rqueue"].put(
+                            Response(
+                                result["detokenizer"].last_segment,
+                                r.token,
+                                r.logprobs[r.token].item(),
+                                r.finish_reason,
+                                _format_top_logprobs(
+                                    r.logprobs, args.top_logprobs, current_tokenizer
+                                ),
+                            )
+                        )
+
+                        if r.finish_reason is not None:
+                            result["rqueue"].put(None)
+                            self.prompt_cache.insert_cache(
+                                current_model_key, result["cache_key"], r.prompt_cache
+                            )
+                            del batch_results[r.uid]
+
+                        if result["ctx"]._should_stop:
+                            uids_to_remove.append(r.uid)
+
+                uids_to_remove = self._share_object(uids_to_remove)
+                if uids_to_remove:
+                    with mx.stream(generation_stream):
+                        caches = batch_generator.remove(
+                            uids_to_remove, return_prompt_caches=True
+                        )
+                        for uid, prompt_cache in caches.items():
+                            if uid not in batch_results:
+                                continue
+                            result = batch_results[uid]
+                            self.prompt_cache.insert_cache(
+                                current_model_key, result["cache_key"], prompt_cache
+                            )
+                            del batch_results[uid]
+
+            else:
+                self._run_prompt_cache_warmup()
 
     def _serve_single(self, request):
         rqueue, request, args = request
@@ -1739,8 +1724,8 @@ class APIHandler(BaseHTTPRequestHandler):
                 elif ctx.prompt[i] == ctx.think_start_id:
                     in_reasoning = True
                     break
-        reasoning_delta = ""
-        reasoning_full = ""
+        reasoning_text = ""
+        reasoning_full = ""  # accumulated across stream chunks for warmup
 
         # Variables to save the generated tokens and the corresponding probs
         tokens = []
@@ -1762,7 +1747,7 @@ class APIHandler(BaseHTTPRequestHandler):
                 if gen.text == ctx.think_end:
                     in_reasoning = False
                 else:
-                    reasoning_delta += gen.text
+                    reasoning_text += gen.text
                     reasoning_full += gen.text
             elif ctx.has_tool_calling and gen.text == ctx.tool_call_start:
                 made_tool_call = True
@@ -1812,16 +1797,16 @@ class APIHandler(BaseHTTPRequestHandler):
                     )
                 ):
                     continue
-                elif segment or tool_calls or reasoning_delta:
+                elif segment or tool_calls or reasoning_text:
                     response = self.generate_response(
                         segment,
                         None,
                         tool_calls=parse_tools(tool_calls),
-                        reasoning_text=reasoning_delta,
+                        reasoning_text=reasoning_text,
                     )
                     self.wfile.write(f"data: {json.dumps(response)}\n\n".encode())
                     self.wfile.flush()
-                    reasoning_delta = ""
+                    reasoning_text = ""
                     segment = ""
                     tool_calls = []
 
@@ -1852,7 +1837,7 @@ class APIHandler(BaseHTTPRequestHandler):
                 segment,
                 finish_reason,
                 tool_calls=parse_tools(tool_calls),
-                reasoning_text=reasoning_delta,
+                reasoning_text=reasoning_text,
             )
             self.wfile.write(f"data: {json.dumps(response)}\n\n".encode())
             self.wfile.flush()
@@ -1876,7 +1861,7 @@ class APIHandler(BaseHTTPRequestHandler):
                 token_logprobs=token_logprobs,
                 top_tokens=top_tokens,
                 tokens=tokens,
-                reasoning_text=reasoning_delta,
+                reasoning_text=reasoning_text,
                 tool_calls=parse_tools(tool_calls),
             )
             response_json = json.dumps(response).encode()

--- a/mlx_lm/server.py
+++ b/mlx_lm/server.py
@@ -179,7 +179,7 @@ def process_message_content(messages):
         if tool_calls := message.get("tool_calls", False):
             for tool_call in tool_calls:
                 if func := tool_call.get("function", False):
-                    if isinstance(args := func.get("arguments", False), str):
+                    if args := func.get("arguments", False):
                         func["arguments"] = json.loads(args)
 
 
@@ -774,20 +774,17 @@ class ResponseGenerator:
             return tokenizer.encode(request.prompt)
 
     def _build_prefill_request(self, tokenizer, warmup):
-        # Warm the replayed assistant turn against two synthetic next-user turns
-        # and use the shared token prefix as the cache key.
+        # Tokenize the conversation twice with different synthetic next-user
+        # messages and take the shared prefix as the cacheable portion.
         def common_prefix(s1, s2):
-            prefix_length = 0
-            for left, right in zip(s1, s2):
-                if left != right:
+            n = 0
+            for a, b in zip(s1, s2):
+                if a != b:
                     break
-                prefix_length += 1
-            return list(s1[:prefix_length])
+                n += 1
+            return list(s1[:n])
 
-        probes = (
-            "Any pair of distinct",
-            "strings would work.",
-        )
+        probes = ("A", "B")
         prompts = []
         for content in probes:
             messages = copy.deepcopy(warmup.messages)
@@ -810,26 +807,23 @@ class ResponseGenerator:
     def enqueue_prompt_cache_warmup(self, request, generation_args, assistant_message):
         if not self.cli_args.prompt_cache_warmup or request.request_type != "chat":
             return
-        if generation_args.model.draft not in (None, "default_model") or (
-            generation_args.model.draft == "default_model"
-            and self.cli_args.draft_model is not None
-        ):
+        if generation_args.model.draft not in (None, "default_model"):
             logging.debug("Skipping prompt cache warmup with draft model enabled.")
             return
         if not any(assistant_message.get(key) for key in ("content", "reasoning")):
             return
 
         messages = copy.deepcopy(request.messages)
-        messages.append(copy.deepcopy(assistant_message))
+        messages.append(assistant_message)
         with self._prompt_cache_warmup_lock:
             self._prompt_cache_warmup = _PromptCacheWarmup(
-                model=copy.deepcopy(generation_args.model),
+                model=generation_args.model,
                 messages=messages,
                 tools=copy.deepcopy(request.tools),
-                role_mapping=copy.deepcopy(request.role_mapping),
-                chat_template_kwargs=copy.deepcopy(
-                    generation_args.chat_template_kwargs
-                ),
+                role_mapping=request.role_mapping,
+                chat_template_kwargs=generation_args.chat_template_kwargs.copy()
+                if generation_args.chat_template_kwargs
+                else {},
             )
 
     def _run_prompt_cache_warmup(self):
@@ -1096,7 +1090,7 @@ class ResponseGenerator:
                                     r.logprobs[r.token].item(),
                                     r.finish_reason,
                                     _format_top_logprobs(
-                                        r.logprobs, args.top_logprobs, current_tokenizer,
+                                        r.logprobs, args.top_logprobs, current_tokenizer
                                     ),
                                 ),
                             )
@@ -1701,7 +1695,7 @@ class APIHandler(BaseHTTPRequestHandler):
                     in_reasoning = True
                     break
         reasoning_text = ""
-        warmup_reasoning = ""
+        warmup_reasoning = "" # Separate accumulator; reasoning_text resets during streaming
 
         # Variables to save the generated tokens and the corresponding probs
         tokens = []

--- a/mlx_lm/server.py
+++ b/mlx_lm/server.py
@@ -35,7 +35,13 @@ import mlx.core as mx
 from huggingface_hub import scan_cache_dir
 
 from ._version import __version__
-from .generate import BatchGenerator, generate_step, generation_stream, stream_generate
+from .generate import (
+    BatchGenerator,
+    generate_step,
+    generation_stream,
+    stream_generate,
+    wired_limit,
+)
 from .models.cache import (
     can_trim_prompt_cache,
     make_prompt_cache,
@@ -438,6 +444,11 @@ class _PromptCacheWarmup:
     chat_template_kwargs: Optional[Dict[str, Any]]
 
 
+class _WarmupInterrupted(Exception):
+    def __init__(self, tokens_processed):
+        self.tokens_processed = tokens_processed
+
+
 @dataclass
 class GenerationContext:
     has_tool_calling: bool
@@ -775,15 +786,13 @@ class ResponseGenerator:
             return tokenizer.encode(request.prompt)
 
     def _build_prefill_request(self, tokenizer, warmup):
-        # Tokenize the conversation twice with different synthetic next-user
-        # messages and take the shared prefix as the cacheable portion.
-        def common_prefix(s1, s2):
-            n = 0
-            for a, b in zip(s1, s2):
-                if a != b:
-                    break
-                n += 1
-            return list(s1[:n])
+        # Tokenize the conversation twice with different next user messages and
+        # take the shared prefix. Actual messages used don't matter.
+        def shared_prefix(left, right):
+            for idx, (left_tok, right_tok) in enumerate(zip(left, right)):
+                if left_tok != right_tok:
+                    return list(left[:idx])
+            return list(left[: min(len(left), len(right))])
 
         probes = ("A", "B")
         prompts = []
@@ -800,7 +809,7 @@ class ResponseGenerator:
                 )
             )
 
-        prompt = common_prefix(*prompts)
+        prompt = shared_prefix(*prompts)
         if len(prompt) == 0:
             return None
         return prompt
@@ -808,6 +817,8 @@ class ResponseGenerator:
     def enqueue_prompt_cache_warmup(self, request, generation_args, assistant_message):
         if not self.cli_args.prompt_cache_warmup or request.request_type != "chat":
             return
+        # CLI startup already rejects a configured draft model, but requests can
+        # still ask for one explicitly via `draft_model`.
         if generation_args.model.draft not in (None, "default_model"):
             logging.debug("Skipping prompt cache warmup with draft model enabled.")
             return
@@ -838,6 +849,8 @@ class ResponseGenerator:
             logging.info(
                 f"Prompt cache warmup progress: {tokens_processed}/{total_tokens}"
             )
+            if tokens_processed > 0 and not self.requests.empty():
+                raise _WarmupInterrupted(tokens_processed)
 
         try:
             model, tokenizer = self.model_provider.load(
@@ -848,27 +861,50 @@ class ResponseGenerator:
             prompt = self._build_prefill_request(tokenizer, warmup)
             if prompt is not None:
                 self.prompt_cache.log_cache_stats()
-                cache, rest = self.prompt_cache.fetch_nearest_cache(
+                cache, uncached = self.prompt_cache.fetch_nearest_cache(
                     self.model_provider.model_key, prompt
                 )
                 if cache is None:
                     cache = make_prompt_cache(model)
-                if len(rest) > 0:
-                    for _ in generate_step(
-                        mx.array(rest),
-                        model,
-                        max_tokens=0,
-                        prompt_cache=cache,
-                        prefill_step_size=self.cli_args.prefill_step_size,
-                        prompt_progress_callback=progress,
-                    ):
-                        pass
-                    self.prompt_cache.insert_cache(
-                        self.model_provider.model_key,
-                        prompt,
-                        cache,
-                        checkpoint=True,
-                    )
+                if len(uncached) > 0:
+                    # Flush outstanding work on the shared generation stream before
+                    # setting the wired limit for warm-up prefill.
+                    mx.synchronize(generation_stream)
+                    try:
+                        with wired_limit(model, [generation_stream]):
+                            for _ in generate_step(
+                                mx.array(uncached),
+                                model,
+                                max_tokens=0,
+                                prompt_cache=cache,
+                                prefill_step_size=self.cli_args.prefill_step_size,
+                                prompt_progress_callback=progress,
+                            ):
+                                pass
+                    except _WarmupInterrupted as e:
+                        # Checkpoint partial work so the next request (likely extending
+                        # this same conversation) can reuse it.
+                        # `tokens_processed` is reported against `uncached`, so extend the
+                        # cached prompt prefix by that many tokens.
+                        prefix_len = len(prompt) - len(uncached) + e.tokens_processed
+                        if prefix_len > 0:
+                            self.prompt_cache.insert_cache(
+                                self.model_provider.model_key,
+                                prompt[:prefix_len],
+                                cache,
+                                checkpoint=True,
+                            )
+                        logging.info(
+                            f"Prompt cache warmup interrupted at {e.tokens_processed}/{len(uncached)} tokens, "
+                            "partial cache checkpointed."
+                        )
+                    else:
+                        self.prompt_cache.insert_cache(
+                            self.model_provider.model_key,
+                            prompt,
+                            cache,
+                            checkpoint=True,
+                        )
         except Exception:
             logging.exception("Prompt cache warmup failed.")
         return True
@@ -987,7 +1023,7 @@ class ResponseGenerator:
                     )
                     ctx.prompt_cache_count = len(prompt) - len(rest)
                     if cache is None:
-                        cache = make_prompt_cache(self.model_provider.model)
+                        cache = make_prompt_cache(batch_model)
 
                     do_checkpoint, checkpoint_position = (
                         self._compute_prompt_checkpoint(tokenizer, request, prompt)
@@ -1034,6 +1070,7 @@ class ResponseGenerator:
                         continue
 
                     current_model = args.model
+                    batch_model = model
                     current_tokenizer = tokenizer
                     current_model_key = self.model_provider.model_key
                     batch_results = {}
@@ -1059,18 +1096,16 @@ class ResponseGenerator:
             # No request so serve from the current batch
             elif batch_generator is not None:
                 if len(batch_results) == 0:
-                    with self._prompt_cache_warmup_lock:
-                        warmup_pending = self._prompt_cache_warmup is not None
-                    should_close_batch = drain_batch or warmup_pending
-                    if should_close_batch:
+                    if drain_batch:
                         current_model = None
+                        batch_model = None
                         current_sampling = None
                         current_tokenizer = None
                         current_model_key = None
                         batch_generator.close()
                         batch_generator = None
                         drain_batch = False
-                    continue
+                        continue
                 else:
                     uids_to_remove = []
                     for _ in self._time_budget:
@@ -1695,8 +1730,8 @@ class APIHandler(BaseHTTPRequestHandler):
                 elif ctx.prompt[i] == ctx.think_start_id:
                     in_reasoning = True
                     break
-        reasoning_text = ""
-        full_reasoning = ""
+        reasoning_delta = ""
+        reasoning_full = ""
 
         # Variables to save the generated tokens and the corresponding probs
         tokens = []
@@ -1718,8 +1753,8 @@ class APIHandler(BaseHTTPRequestHandler):
                 if gen.text == ctx.think_end:
                     in_reasoning = False
                 else:
-                    reasoning_text += gen.text
-                    full_reasoning += gen.text
+                    reasoning_delta += gen.text
+                    reasoning_full += gen.text
             elif ctx.has_tool_calling and gen.text == ctx.tool_call_start:
                 made_tool_call = True
                 in_tool_call = True
@@ -1768,16 +1803,16 @@ class APIHandler(BaseHTTPRequestHandler):
                     )
                 ):
                     continue
-                elif segment or tool_calls or reasoning_text:
+                elif segment or tool_calls or reasoning_delta:
                     response = self.generate_response(
                         segment,
                         None,
                         tool_calls=parse_tools(tool_calls),
-                        reasoning_text=reasoning_text,
+                        reasoning_text=reasoning_delta,
                     )
                     self.wfile.write(f"data: {json.dumps(response)}\n\n".encode())
                     self.wfile.flush()
-                    reasoning_text = ""
+                    reasoning_delta = ""
                     segment = ""
                     tool_calls = []
 
@@ -1793,10 +1828,10 @@ class APIHandler(BaseHTTPRequestHandler):
                 "role": "assistant",
                 "content": text or "",
             }
-            if full_reasoning:
+            if reasoning_full:
                 # Preserve both the response-facing and template-facing keys.
-                assistant_message["reasoning"] = full_reasoning
-                assistant_message["reasoning_content"] = full_reasoning
+                assistant_message["reasoning"] = reasoning_full
+                assistant_message["reasoning_content"] = reasoning_full
             self.response_generator.enqueue_prompt_cache_warmup(
                 request,
                 args,
@@ -1808,7 +1843,7 @@ class APIHandler(BaseHTTPRequestHandler):
                 segment,
                 finish_reason,
                 tool_calls=parse_tools(tool_calls),
-                reasoning_text=reasoning_text,
+                reasoning_text=reasoning_delta,
             )
             self.wfile.write(f"data: {json.dumps(response)}\n\n".encode())
             self.wfile.flush()
@@ -1832,7 +1867,7 @@ class APIHandler(BaseHTTPRequestHandler):
                 token_logprobs=token_logprobs,
                 top_tokens=top_tokens,
                 tokens=tokens,
-                reasoning_text=reasoning_text,
+                reasoning_text=reasoning_delta,
                 tool_calls=parse_tools(tool_calls),
             )
             response_json = json.dumps(response).encode()

--- a/mlx_lm/server.py
+++ b/mlx_lm/server.py
@@ -17,7 +17,7 @@ from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
 from pathlib import Path
 from queue import Empty as QueueEmpty
 from queue import Queue
-from threading import Thread
+from threading import Lock, Thread
 from typing import (
     Any,
     Callable,
@@ -35,7 +35,7 @@ import mlx.core as mx
 from huggingface_hub import scan_cache_dir
 
 from ._version import __version__
-from .generate import BatchGenerator, generation_stream, stream_generate
+from .generate import BatchGenerator, generate_step, generation_stream, stream_generate
 from .models.cache import (
     can_trim_prompt_cache,
     make_prompt_cache,
@@ -179,7 +179,7 @@ def process_message_content(messages):
         if tool_calls := message.get("tool_calls", False):
             for tool_call in tool_calls:
                 if func := tool_call.get("function", False):
-                    if args := func.get("arguments", False):
+                    if isinstance(args := func.get("arguments", False), str):
                         func["arguments"] = json.loads(args)
 
 
@@ -429,6 +429,15 @@ class CompletionRequest:
 
 
 @dataclass
+class _PromptCacheWarmup:
+    model: ModelDescription
+    messages: List[Any]
+    tools: Optional[List[Any]]
+    role_mapping: Optional[Dict[str, Any]]
+    chat_template_kwargs: Optional[Dict[str, Any]]
+
+
+@dataclass
 class GenerationContext:
     has_tool_calling: bool
     tool_call_start: str
@@ -653,10 +662,21 @@ class ResponseGenerator:
         self.model_provider = model_provider
         self.prompt_cache = prompt_cache
         self.requests = Queue()
+        self._prompt_cache_warmup = None
+        self._prompt_cache_warmup_lock = Lock()
 
         self._time_budget = TimeBudget()
         self._is_distributed = mx.distributed.init().size() > 1
         self._rank = mx.distributed.init().rank()
+        if self.cli_args.prompt_cache_warmup:
+            if self._is_distributed:
+                raise ValueError(
+                    "prompt cache warmup is not supported in distributed mode"
+                )
+            if self.cli_args.draft_model is not None:
+                raise ValueError(
+                    "prompt cache warmup is not supported with a draft model"
+                )
         self._stop = False
         self._generation_thread = Thread(target=self._generate)
         self._generation_thread.start()
@@ -716,36 +736,147 @@ class ResponseGenerator:
         rq = request[0] if request is not None else Queue()
         return rq, *shareable
 
+    def _tokenize_chat(self, tokenizer, messages, tools, role_mapping, extra_args):
+        if tokenizer.has_chat_template:
+            process_message_content(messages)
+            if tools and not tokenizer.has_tool_calling:
+                logging.warning(
+                    "Received tools but model does not support tool calling. "
+                    "If you think this is an error, file an issue here: "
+                    "https://github.com/ml-explore/mlx-lm/issues"
+                )
+
+            chat_template_args = self.model_provider.cli_args.chat_template_args
+            if extra_args:
+                chat_template_args = chat_template_args.copy()
+                chat_template_args.update(extra_args)
+
+            return tokenizer.apply_chat_template(
+                messages,
+                tools=tools,
+                add_generation_prompt=True,
+                tokenize=True,
+                **chat_template_args,
+            )
+
+        return tokenizer.encode(convert_chat(messages, role_mapping))
+
     def _tokenize(self, tokenizer, request, args):
         if request.request_type == "chat":
-            messages = request.messages
-            tools = request.tools
-            role_mapping = request.role_mapping
-
-            if tokenizer.has_chat_template:
-                process_message_content(messages)
-                if tools and not tokenizer.has_tool_calling:
-                    logging.warning(
-                        "Received tools but model does not support tool calling. "
-                        "If you think this is an error, file an issue here: "
-                        "https://github.com/ml-explore/mlx-lm/issues"
-                    )
-
-                chat_template_args = self.model_provider.cli_args.chat_template_args
-                if args.chat_template_kwargs:
-                    chat_template_args = chat_template_args.copy()
-                    chat_template_args.update(args.chat_template_kwargs)
-                return tokenizer.apply_chat_template(
-                    messages,
-                    tools=tools,
-                    add_generation_prompt=True,
-                    tokenize=True,
-                    **chat_template_args,
-                )
-            else:
-                return tokenizer.encode(convert_chat(messages, role_mapping))
+            return self._tokenize_chat(
+                tokenizer,
+                request.messages,
+                request.tools,
+                request.role_mapping,
+                args.chat_template_kwargs,
+            )
         else:
             return tokenizer.encode(request.prompt)
+
+    def _build_prefill_request(self, tokenizer, warmup):
+        # Warm the replayed assistant turn against two synthetic next-user turns
+        # and use the shared token prefix as the cache key.
+        def common_prefix(s1, s2):
+            prefix_length = 0
+            for left, right in zip(s1, s2):
+                if left != right:
+                    break
+                prefix_length += 1
+            return list(s1[:prefix_length])
+
+        probes = (
+            "Any pair of distinct",
+            "strings would work.",
+        )
+        prompts = []
+        for content in probes:
+            messages = copy.deepcopy(warmup.messages)
+            messages.append({"role": "user", "content": content})
+            prompts.append(
+                self._tokenize_chat(
+                    tokenizer,
+                    messages,
+                    warmup.tools,
+                    warmup.role_mapping,
+                    warmup.chat_template_kwargs,
+                )
+            )
+
+        prompt = common_prefix(*prompts)
+        if len(prompt) == 0:
+            return None
+        return prompt
+
+    def enqueue_prompt_cache_warmup(self, request, generation_args, assistant_message):
+        if not self.cli_args.prompt_cache_warmup or request.request_type != "chat":
+            return
+        if generation_args.model.draft not in (None, "default_model") or (
+            generation_args.model.draft == "default_model"
+            and self.cli_args.draft_model is not None
+        ):
+            logging.debug("Skipping prompt cache warmup with draft model enabled.")
+            return
+        if not any(assistant_message.get(key) for key in ("content", "reasoning")):
+            return
+
+        messages = copy.deepcopy(request.messages)
+        messages.append(copy.deepcopy(assistant_message))
+        with self._prompt_cache_warmup_lock:
+            self._prompt_cache_warmup = _PromptCacheWarmup(
+                model=copy.deepcopy(generation_args.model),
+                messages=messages,
+                tools=copy.deepcopy(request.tools),
+                role_mapping=copy.deepcopy(request.role_mapping),
+                chat_template_kwargs=copy.deepcopy(
+                    generation_args.chat_template_kwargs
+                ),
+            )
+
+    def _run_prompt_cache_warmup(self):
+        with self._prompt_cache_warmup_lock:
+            warmup = self._prompt_cache_warmup
+            self._prompt_cache_warmup = None
+        if warmup is None:
+            return False
+
+        def progress(tokens_processed, total_tokens):
+            logging.info(
+                f"Prompt cache warmup progress: {tokens_processed}/{total_tokens}"
+            )
+
+        try:
+            model, tokenizer = self.model_provider.load(
+                warmup.model.model,
+                warmup.model.adapter,
+                warmup.model.draft,
+            )
+            prompt = self._build_prefill_request(tokenizer, warmup)
+            if prompt is not None:
+                self.prompt_cache.log_cache_stats()
+                cache, rest = self.prompt_cache.fetch_nearest_cache(
+                    self.model_provider.model_key, prompt
+                )
+                if cache is None:
+                    cache = make_prompt_cache(model)
+                if len(rest) > 0:
+                    for _ in generate_step(
+                        mx.array(rest),
+                        model,
+                        max_tokens=0,
+                        prompt_cache=cache,
+                        prefill_step_size=self.cli_args.prefill_step_size,
+                        prompt_progress_callback=progress,
+                    ):
+                        pass
+                    self.prompt_cache.insert_cache(
+                        self.model_provider.model_key,
+                        prompt,
+                        cache,
+                        checkpoint=True,
+                    )
+        except Exception:
+            logging.exception("Prompt cache warmup failed.")
+        return True
 
     def _compute_prompt_checkpoint(self, tokenizer, request, prompt):
         if request.request_type != "chat":
@@ -933,7 +1064,10 @@ class ResponseGenerator:
             # No request so serve from the current batch
             elif batch_generator is not None:
                 if len(batch_results) == 0:
-                    if drain_batch:
+                    with self._prompt_cache_warmup_lock:
+                        warmup_pending = self._prompt_cache_warmup is not None
+                    should_close_batch = drain_batch or warmup_pending
+                    if should_close_batch:
                         current_model = None
                         current_sampling = None
                         current_tokenizer = None
@@ -942,55 +1076,68 @@ class ResponseGenerator:
                         batch_generator = None
                         drain_batch = False
                     continue
+                else:
+                    uids_to_remove = []
+                    for _ in self._time_budget:
+                        responses = batch_generator.next()
+                        if not responses:
+                            break
 
-                uids_to_remove = []
-                for _ in self._time_budget:
-                    responses = batch_generator.next()
-                    if not responses:
-                        break
+                        for r in responses:
+                            result = batch_results[r.uid]
+                            result["cache_key"].append(r.token)
+                            if r.finish_reason != "stop":
+                                result["detokenizer"].add_token(r.token)
 
-                    for r in responses:
-                        result = batch_results[r.uid]
-                        result["cache_key"].append(r.token)
-                        if r.finish_reason != "stop":
-                            result["detokenizer"].add_token(r.token)
-
-                        result["rqueue"].put(
-                            Response(
-                                result["detokenizer"].last_segment,
-                                r.token,
-                                r.logprobs[r.token].item(),
-                                r.finish_reason,
-                                _format_top_logprobs(
-                                    r.logprobs, args.top_logprobs, current_tokenizer
+                            result["rqueue"].put(
+                                Response(
+                                    result["detokenizer"].last_segment,
+                                    r.token,
+                                    r.logprobs[r.token].item(),
+                                    r.finish_reason,
+                                    _format_top_logprobs(
+                                        r.logprobs, args.top_logprobs, current_tokenizer,
+                                    ),
                                 ),
                             )
-                        )
 
-                        if r.finish_reason is not None:
-                            result["rqueue"].put(None)
-                            self.prompt_cache.insert_cache(
-                                current_model_key, result["cache_key"], r.prompt_cache
+                            if r.finish_reason is not None:
+                                result["rqueue"].put(None)
+                                self.prompt_cache.insert_cache(
+                                    current_model_key,
+                                    result["cache_key"],
+                                    r.prompt_cache,
+                                )
+                                del batch_results[r.uid]
+
+                            if result["ctx"]._should_stop:
+                                uids_to_remove.append(r.uid)
+
+                    uids_to_remove = self._share_object(uids_to_remove)
+                    if uids_to_remove:
+                        with mx.stream(generation_stream):
+                            caches = batch_generator.remove(
+                                uids_to_remove, return_prompt_caches=True
                             )
-                            del batch_results[r.uid]
+                            for uid, prompt_cache in caches.items():
+                                if uid not in batch_results:
+                                    continue
+                                result = batch_results[uid]
+                                self.prompt_cache.insert_cache(
+                                    current_model_key,
+                                    result["cache_key"],
+                                    prompt_cache,
+                                )
+                                del batch_results[uid]
+                    continue
 
-                        if result["ctx"]._should_stop:
-                            uids_to_remove.append(r.uid)
+            # Prefer a newly arrived foreground request over best-effort warmup.
+            request = get_next_request(timeout=0)
+            if request is not None:
+                unprocessed_requests.append(request)
+                continue
 
-                uids_to_remove = self._share_object(uids_to_remove)
-                if uids_to_remove:
-                    with mx.stream(generation_stream):
-                        caches = batch_generator.remove(
-                            uids_to_remove, return_prompt_caches=True
-                        )
-                        for uid, prompt_cache in caches.items():
-                            if uid not in batch_results:
-                                continue
-                            result = batch_results[uid]
-                            self.prompt_cache.insert_cache(
-                                current_model_key, result["cache_key"], prompt_cache
-                            )
-                            del batch_results[uid]
+            self._run_prompt_cache_warmup()
 
     def _serve_single(self, request):
         rqueue, request, args = request
@@ -1554,6 +1701,7 @@ class APIHandler(BaseHTTPRequestHandler):
                     in_reasoning = True
                     break
         reasoning_text = ""
+        warmup_reasoning = ""
 
         # Variables to save the generated tokens and the corresponding probs
         tokens = []
@@ -1576,6 +1724,7 @@ class APIHandler(BaseHTTPRequestHandler):
                     in_reasoning = False
                 else:
                     reasoning_text += gen.text
+                    warmup_reasoning += gen.text
             elif ctx.has_tool_calling and gen.text == ctx.tool_call_start:
                 made_tool_call = True
                 in_tool_call = True
@@ -1643,6 +1792,21 @@ class APIHandler(BaseHTTPRequestHandler):
         # Flush any remaining tool text (e.g. when tool_call_end is empty)
         if in_tool_call and tool_text:
             tool_calls.append(tool_text)
+
+        if not made_tool_call and finish_reason != "tool_calls":
+            assistant_message = {
+                "role": "assistant",
+                "content": text or "",
+            }
+            if warmup_reasoning:
+                # Preserve both the response-facing and template-facing keys.
+                assistant_message["reasoning"] = warmup_reasoning
+                assistant_message["reasoning_content"] = warmup_reasoning
+            self.response_generator.enqueue_prompt_cache_warmup(
+                request,
+                args,
+                assistant_message,
+            )
 
         if self.stream:
             response = self.generate_response(
@@ -2007,6 +2171,11 @@ def main():
         "--prompt-cache-bytes",
         type=parse_size,
         help="Maximum size in bytes of the KV caches",
+    )
+    parser.add_argument(
+        "--prompt-cache-warmup",
+        action="store_true",
+        help="Best-effort warmup of the next-turn prompt cache after each chat completion",
     )
     parser.add_argument(
         "--pipeline",

--- a/mlx_lm/server.py
+++ b/mlx_lm/server.py
@@ -179,7 +179,10 @@ def process_message_content(messages):
         if tool_calls := message.get("tool_calls", False):
             for tool_call in tool_calls:
                 if func := tool_call.get("function", False):
-                    if args := func.get("arguments", False):
+                    if isinstance(
+                        args := func.get("arguments", False),
+                        (str, bytes, bytearray),
+                    ) and args:
                         func["arguments"] = json.loads(args)
 
 

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -4,6 +4,7 @@ import http
 import io
 import json
 import threading
+import time
 import unittest
 from contextlib import nullcontext
 from queue import Queue
@@ -176,9 +177,11 @@ class TestPromptCacheWarmup(unittest.TestCase):
         gen._is_distributed = False
         return gen
 
-    def _make_gen_args(self, draft=None):
-        model = ModelDescription(model="default_model", adapter=None, draft=draft)
-        return SimpleNamespace(model=model, chat_template_kwargs={})
+    def _make_gen_args(self, draft=None, model="default_model"):
+        return SimpleNamespace(
+            model=ModelDescription(model=model, adapter=None, draft=draft),
+            chat_template_kwargs={},
+        )
 
     def _chat_request(self, messages=None):
         return CompletionRequest(
@@ -220,17 +223,6 @@ class TestPromptCacheWarmup(unittest.TestCase):
             finish_reason=finish_reason,
             top_tokens=(),
         )
-
-    def _assert_generate_step_call(self, generate_step_mock, rest, prompt_cache):
-        call_args, call_kwargs = generate_step_mock.call_args
-        self.assertEqual(call_args[0].tolist(), rest)
-        self.assertEqual(call_kwargs["max_tokens"], 0)
-        if isinstance(prompt_cache, list):
-            self.assertEqual(call_kwargs["prompt_cache"], prompt_cache)
-        else:
-            self.assertIs(call_kwargs["prompt_cache"], prompt_cache)
-        self.assertEqual(call_kwargs["prefill_step_size"], 16)
-        self.assertIn("prompt_progress_callback", call_kwargs)
 
     def _queue_warmup(
         self,
@@ -274,77 +266,51 @@ class TestPromptCacheWarmup(unittest.TestCase):
         return handler
 
     def test_enqueue_prompt_cache_warmup_handles_eligible_and_skipped_requests(self):
-        cases = (
-            {
-                "name": "stores chat reply",
-                "warmup_enabled": True,
-                "request": self._chat_request(),
-                "args": self._make_gen_args(),
-                "assistant_message": {"role": "assistant", "content": "Hi"},
-                "expected_messages": 2,
-            },
-            {
-                "name": "disabled",
-                "warmup_enabled": False,
-                "request": self._chat_request(),
-                "args": self._make_gen_args(),
-                "assistant_message": {"role": "assistant", "content": "Hi"},
-                "expected_messages": None,
-            },
-            {
-                "name": "draft model",
-                "warmup_enabled": True,
-                "request": self._chat_request(),
-                "args": self._make_gen_args(draft="draft-model"),
-                "assistant_message": {"role": "assistant", "content": "Hi"},
-                "expected_messages": None,
-            },
+        gen = self._make_generator(None, warmup_enabled=True)
+        gen.enqueue_prompt_cache_warmup(
+            self._chat_request(),
+            self._make_gen_args(),
+            {"role": "assistant", "content": "Hi"},
         )
+        self.assertIsNotNone(gen._prompt_cache_warmup)
+        self.assertEqual(len(gen._prompt_cache_warmup.messages), 2)
 
-        for case in cases:
-            with self.subTest(case=case["name"]):
-                gen = self._make_generator(
-                    None, warmup_enabled=case["warmup_enabled"]
-                )
-                gen.enqueue_prompt_cache_warmup(
-                    case["request"],
-                    case["args"],
-                    case["assistant_message"],
-                )
-                if case["expected_messages"] is None:
-                    self.assertIsNone(gen._prompt_cache_warmup)
-                else:
-                    self.assertIsNotNone(gen._prompt_cache_warmup)
-                    self.assertEqual(
-                        len(gen._prompt_cache_warmup.messages),
-                        case["expected_messages"],
-                    )
-
-    def test_run_warmup_syncs_stream_before_wired_limit(self):
-        # mx.synchronize(generation_stream) must happen before wired_limit is
-        # entered so that any outstanding async batch work is flushed before
-        # the wired memory state changes.
-        prompt_cache = MockPromptCacheManager(["base-cache"], [7])
-        gen = self._queue_warmup(
-            prompt_cache,
-            ([1, 2, 3, 7, 10], [1, 2, 3, 7, 20]),
+        gen = self._make_generator(None, warmup_enabled=False)
+        gen.enqueue_prompt_cache_warmup(
+            self._chat_request(),
+            self._make_gen_args(),
+            {"role": "assistant", "content": "Hi"},
         )
+        self.assertIsNone(gen._prompt_cache_warmup)
 
-        call_log = []
-        with patch("mlx_lm.server.generate_step", return_value=iter(())), patch(
-            "mlx_lm.server.wired_limit",
-            side_effect=lambda *a, **k: (call_log.append("wired_limit"), nullcontext())[1],
-        ), patch(
-            "mlx_lm.server.mx.synchronize",
-            side_effect=lambda *a, **k: call_log.append("sync"),
-        ):
-            gen._run_prompt_cache_warmup()
+        gen = self._make_generator(None, warmup_enabled=True)
+        gen.enqueue_prompt_cache_warmup(
+            self._chat_request(),
+            self._make_gen_args(draft="draft-model"),
+            {"role": "assistant", "content": "Hi"},
+        )
+        self.assertIsNone(gen._prompt_cache_warmup)
 
-        sync_pos = next((i for i, v in enumerate(call_log) if v == "sync"), None)
-        wl_pos = next((i for i, v in enumerate(call_log) if v == "wired_limit"), None)
-        self.assertIsNotNone(sync_pos, "mx.synchronize was not called")
-        self.assertIsNotNone(wl_pos, "wired_limit was not called")
-        self.assertLess(sync_pos, wl_pos, "sync must precede wired_limit")
+    def test_generate_discards_stale_prompt_cache_warmup_on_model_switch(self):
+        gen = self._make_generator(None)
+        gen._stop = False
+        gen._time_budget = ()
+        gen._prompt_cache_warmup = SimpleNamespace(model=self.MODEL)
+        request = (
+            Queue(),
+            self._chat_request(),
+            self._make_gen_args(model="other-model"),
+        )
+        gen._next_request = Mock(return_value=request)
+        gen._is_batchable = Mock(return_value=False)
+        gen.model_provider.load = Mock(return_value=(object(), object()))
+
+        def serve_single(_):
+            gen._stop = True
+
+        gen._serve_single = Mock(side_effect=serve_single)
+        gen._generate()
+        self.assertIsNone(gen._prompt_cache_warmup)
 
     def test_run_warmup_handles_interrupt_edges(self):
         def partial_interrupt_step(gen):
@@ -355,121 +321,55 @@ class TestPromptCacheWarmup(unittest.TestCase):
 
             return run_step
 
-        def zero_progress_step(_):
-            def run_step(*args, **kwargs):
-                kwargs["prompt_progress_callback"](0, 1)
-                return iter(())
+        prompt_cache = MockPromptCacheManager(["base-cache"], [7, 10])
+        gen = self._queue_warmup(prompt_cache, ([1, 2, 3, 7, 10, 99], [1, 2, 3, 7, 10, 88]))
 
-            return run_step
-
-        cases = (
-            {
-                "name": "partial interruption checkpoints work",
-                "prompt_cache": MockPromptCacheManager(["base-cache"], [7, 10]),
-                "prompts": ([1, 2, 3, 7, 10, 99], [1, 2, 3, 7, 10, 88]),
-                "generate_step": partial_interrupt_step,
-                "expected_tokens": [1, 2, 3, 7],
-            },
-            {
-                "name": "zero progress does not interrupt",
-                "prompt_cache": MockPromptCacheManager(["base-cache"], [7]),
-                "prompts": ([1, 2, 3, 7, 10], [1, 2, 3, 7, 20]),
-                "generate_step": zero_progress_step,
-                "queue_request": True,
-                "expected_tokens": [1, 2, 3, 7],
-                "expected_rest": [7],
-                "expected_cache": ["base-cache"],
-            },
-        )
-
-        for case in cases:
-            with self.subTest(case=case["name"]):
-                gen = self._queue_warmup(case["prompt_cache"], case["prompts"])
-                if case.get("queue_request"):
-                    gen.requests.put("incoming-request")
-
-                with patch(
-                    "mlx_lm.server.generate_step",
-                    side_effect=case["generate_step"](gen),
-                ) as gs, patch(
-                    "mlx_lm.server.wired_limit", return_value=nullcontext()
-                ):
-                    self.assertTrue(gen._run_prompt_cache_warmup())
-
-                if case.get("expected_rest") is not None:
-                    self._assert_generate_step_call(
-                        gs,
-                        case["expected_rest"],
-                        case["expected_cache"],
-                    )
-                self.assertEqual(len(case["prompt_cache"].insert_calls), 1)
-                _, tokens, _, checkpoint = case["prompt_cache"].insert_calls[0]
-                self.assertEqual(tokens, case["expected_tokens"])
-                self.assertTrue(checkpoint)
+        with patch(
+            "mlx_lm.server.generate_step",
+            side_effect=partial_interrupt_step(gen),
+        ) as gs, patch("mlx_lm.server.wired_limit", return_value=nullcontext()):
+            self.assertTrue(gen._run_prompt_cache_warmup())
+        gs.assert_called_once()
+        self.assertEqual(len(prompt_cache.insert_calls), 1)
+        _, tokens, _, checkpoint = prompt_cache.insert_calls[0]
+        self.assertEqual(tokens, [1, 2, 3, 7])
+        self.assertTrue(checkpoint)
 
     def test_run_warmup_prefills_uncached_tokens(self):
-        cases = (
-            {
-                "name": "partial cache hit",
-                "prompt_cache": MockPromptCacheManager(["base-cache"], [7]),
-                "prompts": ([1, 2, 3, 7, 10], [1, 2, 3, 7, 20]),
-                "expected_rest": [7],
-                "expected_cache": ["base-cache"],
-                "expected_fetch": [1, 2, 3, 7],
-            },
-            {
-                "name": "cold start",
-                "prompt_cache": MockPromptCacheManager(None, [1, 2, 3]),
-                "prompts": ([1, 2, 3, 9], [1, 2, 3, 8]),
-                "expected_rest": [1, 2, 3],
-                "new_cache": object(),
-                "expected_fetch": [1, 2, 3],
-            },
-            {
-                "name": "exact cache hit",
-                "prompt_cache": MockPromptCacheManager(["exact-cache"], []),
-                "prompts": ([1, 2, 3, 9], [1, 2, 3, 8]),
-                "expected_fetch": [1, 2, 3],
-                "expects_prefill": False,
-            },
-        )
+        prompt_cache = MockPromptCacheManager(None, [1, 2, 3])
+        gen = self._queue_warmup(prompt_cache, ([1, 2, 3, 9], [1, 2, 3, 8]))
+        new_cache = object()
+        with patch("mlx_lm.server.generate_step", return_value=iter(())) as gs, patch(
+            "mlx_lm.server.wired_limit", return_value=nullcontext()
+        ) as wl, patch(
+            "mlx_lm.server.make_prompt_cache", return_value=new_cache
+        ) as make_cache:
+            gen._run_prompt_cache_warmup()
 
-        for case in cases:
-            with self.subTest(case=case["name"]):
-                gen = self._queue_warmup(case["prompt_cache"], case["prompts"])
-                with patch(
-                    "mlx_lm.server.generate_step", return_value=iter(())
-                ) as gs, patch(
-                    "mlx_lm.server.wired_limit", return_value=nullcontext()
-                ) as wl, patch(
-                    "mlx_lm.server.make_prompt_cache",
-                    return_value=case.get("new_cache"),
-                ) as make_cache:
-                    gen._run_prompt_cache_warmup()
+        gs.assert_called_once()
+        wl.assert_called_once()
+        make_cache.assert_called_once()
+        self.assertEqual(len(prompt_cache.fetch_calls), 1)
+        fetched_model, fetched_tokens = prompt_cache.fetch_calls[0]
+        self.assertEqual(fetched_model, self.MODEL_KEY)
+        self.assertEqual(fetched_tokens, [1, 2, 3])
+        _, tokens, stored_cache, checkpoint = prompt_cache.insert_calls[0]
+        self.assertEqual(tokens, [1, 2, 3])
+        self.assertIs(stored_cache, new_cache)
+        self.assertTrue(checkpoint)
 
-                if not case.get("expects_prefill", True):
-                    gs.assert_not_called()
-                    wl.assert_not_called()
-                    make_cache.assert_not_called()
-                    self.assertEqual(case["prompt_cache"].insert_calls, [])
-                    continue
+    def test_run_warmup_skips_prefill_on_exact_cache_hit(self):
+        prompt_cache = MockPromptCacheManager(["exact-cache"], [])
+        gen = self._queue_warmup(prompt_cache, ([1, 2, 3, 9], [1, 2, 3, 8]))
+        with patch("mlx_lm.server.generate_step", return_value=iter(())) as gs, patch(
+            "mlx_lm.server.wired_limit", return_value=nullcontext()
+        ) as wl, patch("mlx_lm.server.make_prompt_cache") as make_cache:
+            gen._run_prompt_cache_warmup()
 
-                gs.assert_called_once()
-                wl.assert_called_once()
-                expected_cache = case.get("new_cache") or case["prompt_cache"].cache
-                self._assert_generate_step_call(gs, case["expected_rest"], expected_cache)
-                self.assertEqual(
-                    case["prompt_cache"].fetch_calls,
-                    [(self.MODEL_KEY, case["expected_fetch"])],
-                )
-                _, tokens, stored_cache, checkpoint = case["prompt_cache"].insert_calls[0]
-                self.assertEqual(tokens, case["expected_fetch"])
-                self.assertIs(stored_cache, expected_cache)
-                self.assertTrue(checkpoint)
-                if case["prompt_cache"].cache is None:
-                    make_cache.assert_called_once()
-                else:
-                    make_cache.assert_not_called()
+        gs.assert_not_called()
+        wl.assert_not_called()
+        make_cache.assert_not_called()
+        self.assertEqual(prompt_cache.insert_calls, [])
 
     def test_handle_completion_only_enqueues_for_text_reply(self):
         cases = (
@@ -542,7 +442,6 @@ class TestPromptCacheWarmup(unittest.TestCase):
     def test_process_message_content_handles_tool_arguments(self):
         cases = (
             ('{"a": 2, "b": 3}', {"a": 2, "b": 3}),  # string → parsed dict
-            ("", ""),  # empty string → unchanged
             ({"a": 2, "b": 3}, {"a": 2, "b": 3}),  # already a dict → not re-parsed
         )
 
@@ -601,6 +500,72 @@ class TestServer(unittest.TestCase):
         cls.httpd.server_close()
         cls.server_thread.join()
         cls.response_generator.stop_and_join()
+
+    def _chat_with_warmup_setting(self, warmup_enabled):
+        url = f"http://localhost:{self.port}/v1/chat/completions"
+        provider = self.response_generator.model_provider
+        previous_warmup = provider.cli_args.prompt_cache_warmup
+
+        provider.cli_args.prompt_cache_warmup = warmup_enabled
+        self.response_generator.prompt_cache.trim_to(n_sequences=0, n_bytes=0)
+        with self.response_generator._prompt_cache_warmup_lock:
+            self.response_generator._prompt_cache_warmup = None
+
+        messages = [
+            {"role": "system", "content": "You are a helpful assistant."},
+            {"role": "user", "content": "Reply with a short greeting."},
+        ]
+        body = {
+            "model": "chat_model",
+            "max_tokens": 24,
+            "temperature": 0.0,
+            "top_p": 1.0,
+            "messages": messages,
+        }
+
+        try:
+            first_response = requests.post(url, json=body)
+            first_payload = json.loads(first_response.text)
+            first_message = first_payload["choices"][0]["message"]
+
+            # Let best-effort warmup run before the follow-up turn.
+            if warmup_enabled:
+                deadline = time.time() + 2.0
+                while time.time() < deadline:
+                    with self.response_generator._prompt_cache_warmup_lock:
+                        if self.response_generator._prompt_cache_warmup is None:
+                            break
+                    time.sleep(0.02)
+
+            assistant_message = {
+                "role": "assistant",
+                "content": first_message.get("content") or "",
+            }
+            if first_message.get("reasoning"):
+                assistant_message["reasoning"] = first_message["reasoning"]
+                assistant_message["reasoning_content"] = first_message["reasoning"]
+
+            follow_up = {
+                "model": "chat_model",
+                "max_tokens": 24,
+                "temperature": 0.0,
+                "top_p": 1.0,
+                "messages": [
+                    *messages,
+                    assistant_message,
+                    {"role": "user", "content": "Now say it differently."},
+                ],
+            }
+            second_response = requests.post(url, json=follow_up)
+            second_payload = json.loads(second_response.text)
+
+            details = second_payload["usage"].get("prompt_tokens_details", {})
+            return details.get("cached_tokens", 0)
+        finally:
+            provider.cli_args.prompt_cache_warmup = previous_warmup
+            with self.response_generator._prompt_cache_warmup_lock:
+                self.response_generator._prompt_cache_warmup = None
+            self.response_generator.prompt_cache.trim_to(n_sequences=0, n_bytes=0)
 
     def test_handle_completions(self):
         url = f"http://localhost:{self.port}/v1/completions"
@@ -701,6 +666,11 @@ class TestServer(unittest.TestCase):
         response_body = response.text
         self.assertIn("id", response_body)
         self.assertIn("choices", response_body)
+
+    def test_prompt_cache_warmup_improves_follow_up_cache_reuse(self):
+        without_warmup = self._chat_with_warmup_setting(False)
+        with_warmup = self._chat_with_warmup_setting(True)
+        self.assertGreater(with_warmup, without_warmup)
 
     def test_handle_models(self):
         url = f"http://localhost:{self.port}/v1/models"

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -5,14 +5,25 @@ import io
 import json
 import threading
 import unittest
+from unittest.mock import Mock, patch
 
 import mlx.core as mx
 import requests
 
 from mlx_lm.models.cache import KVCache
-from mlx_lm.server import APIHandler, LRUPromptCache, ResponseGenerator
+from mlx_lm.server import (
+    APIHandler,
+    CompletionRequest,
+    GenerationArguments,
+    GenerationContext,
+    LogitsProcessorArguments,
+    LRUPromptCache,
+    ModelDescription,
+    Response as ServerResponse,
+    ResponseGenerator,
+    SamplingArguments,
+)
 from mlx_lm.utils import load
-
 
 class DummyModelProvider:
     def __init__(self, with_draft=False):
@@ -46,6 +57,7 @@ class DummyModelProvider:
                 "prefill_step_size": 2048,
                 "prompt_cache_size": 10,
                 "prompt_cache_bytes": 1 << 63,
+                "prompt_cache_warmup": False,
                 "prompt_cache_total_bytes": None,
             },
         )
@@ -79,6 +91,293 @@ class MockCache:
     def trim(self, n):
         assert self._is_trimmable
         return n
+
+
+class MockPromptCacheManager:
+    def __init__(self, cache, rest):
+        self.cache = cache
+        self.rest = rest
+        self.fetch_calls = []
+        self.insert_calls = []
+
+    def log_cache_stats(self):
+        return None
+
+    def fetch_nearest_cache(self, model_key, tokens):
+        self.fetch_calls.append((model_key, tokens))
+        return self.cache, self.rest
+
+    def insert_cache(self, model_key, tokens, prompt_cache, checkpoint=False):
+        self.insert_calls.append((model_key, tokens, prompt_cache, checkpoint))
+
+
+class SequencedTokenizer:
+    def __init__(self, prompts):
+        self.prompts = iter(prompts)
+        self.has_chat_template = True
+        self.has_tool_calling = True
+
+    def apply_chat_template(
+        self,
+        messages,
+        tools=None,
+        add_generation_prompt=True,
+        tokenize=True,
+        **kwargs,
+    ):
+        return next(self.prompts)
+
+
+class TestPromptCacheWarmup(unittest.TestCase):
+    def make_args(self):
+        return GenerationArguments(
+            model=ModelDescription(model="default_model", adapter=None, draft=None),
+            sampling=SamplingArguments(
+                temperature=0.0,
+                top_p=1.0,
+                top_k=0,
+                min_p=0.0,
+                xtc_probability=0.0,
+                xtc_threshold=0.1,
+            ),
+            logits=LogitsProcessorArguments(
+                logit_bias=None,
+                repetition_penalty=1.0,
+                repetition_context_size=20,
+            ),
+            stop_words=[],
+            max_tokens=16,
+            num_draft_tokens=0,
+            logprobs=False,
+            top_logprobs=0,
+            seed=None,
+            chat_template_kwargs={},
+        )
+
+    def make_generator(self, prompt_cache):
+        cli_args = type(
+            "obj",
+            (object,),
+            {
+                "chat_template_args": {},
+                "draft_model": None,
+                "prefill_step_size": 16,
+                "prompt_cache_warmup": True,
+            },
+        )
+        model_provider = type(
+            "obj",
+            (object,),
+            {
+                "cli_args": cli_args,
+                "draft_model": None,
+                "model": object(),
+                "model_key": ("default_model", None, None),
+                "load": Mock(
+                    return_value=(object(), SequencedTokenizer(([1], [1])))
+                ),
+            },
+        )
+        generator = ResponseGenerator.__new__(ResponseGenerator)
+        generator.model_provider = model_provider
+        generator.prompt_cache = prompt_cache
+        generator._prompt_cache_warmup = None
+        generator._prompt_cache_warmup_lock = threading.Lock()
+        generator._is_distributed = False
+        return generator
+
+    def make_context(self, *, has_thinking=False):
+        return GenerationContext(
+            has_tool_calling=True,
+            tool_call_start="<tool>",
+            tool_call_end="</tool>",
+            tool_parser=lambda *_: {"name": "demo", "arguments": {"value": 1}},
+            has_thinking=has_thinking,
+            think_start_id=1,
+            think_end_id=2,
+            think_end="</think>",
+            eos_token_ids=set(),
+            stop_token_sequences=[],
+            prompt=[1] if has_thinking else [3],
+        )
+
+    def make_handler(self, response_generator):
+        handler = APIHandler.__new__(APIHandler)
+        handler.created = 0
+        handler.response_generator = response_generator
+        handler.system_fingerprint = "fp"
+        handler.stream = False
+        handler.stream_options = None
+        handler.request_id = "chatcmpl-test"
+        handler.object_type = "chat.completion"
+        handler.requested_model = "chat_model"
+        handler.requested_draft_model = "default_model"
+        handler.adapter = None
+        handler.max_tokens = 16
+        handler.temperature = 0.0
+        handler.top_p = 1.0
+        handler.top_k = 0
+        handler.min_p = 0.0
+        handler.repetition_penalty = 1.0
+        handler.repetition_context_size = 20
+        handler.xtc_probability = 0.0
+        handler.xtc_threshold = 0.1
+        handler.logit_bias = None
+        handler.logprobs = False
+        handler.top_logprobs = 0
+        handler.seed = None
+        handler.chat_template_kwargs = {}
+        handler.num_draft_tokens = 0
+        handler.wfile = io.BytesIO()
+        handler._set_completion_headers = Mock()
+        handler._set_stream_headers = Mock()
+        handler.send_header = Mock()
+        handler.end_headers = Mock()
+        return handler
+
+    def test_handle_completion_enqueues_warmup_for_reasoning_reply(self):
+        response_generator = Mock()
+        response_generator.generate.return_value = (
+            self.make_context(has_thinking=True),
+            iter(
+                [
+                    ServerResponse("trace", 1, 0.0, None, ()),
+                    ServerResponse("</think>", 2, 0.0, None, ()),
+                    ServerResponse("answer", 3, 0.0, "stop", ()),
+                ]
+            ),
+        )
+        handler = self.make_handler(response_generator)
+        request = CompletionRequest(
+            "chat",
+            "",
+            [{"role": "user", "content": "Hello"}],
+            None,
+            None,
+        )
+
+        handler.handle_completion(request, [])
+
+        response_generator.enqueue_prompt_cache_warmup.assert_called_once()
+        assistant_message = response_generator.enqueue_prompt_cache_warmup.call_args.args[
+            2
+        ]
+        self.assertEqual(assistant_message["role"], "assistant")
+        self.assertEqual(assistant_message["content"], "answer")
+        self.assertEqual(assistant_message["reasoning"], "trace")
+        self.assertEqual(assistant_message["reasoning_content"], "trace")
+
+    def test_handle_completion_skips_warmup_for_tool_call_finish_reason(self):
+        response_generator = Mock()
+        response_generator.generate.return_value = (
+            self.make_context(),
+            iter(
+                [
+                    ServerResponse("<tool>", 1, 0.0, None, ()),
+                    ServerResponse('{"value": 1}', 2, 0.0, None, ()),
+                    ServerResponse("</tool>", 3, 0.0, "tool_calls", ()),
+                ]
+            ),
+        )
+        handler = self.make_handler(response_generator)
+        request = CompletionRequest(
+            "chat",
+            "",
+            [{"role": "user", "content": "Hello"}],
+            [{"type": "function", "function": {"name": "demo"}}],
+            None,
+        )
+
+        handler.handle_completion(request, [])
+
+        response_generator.enqueue_prompt_cache_warmup.assert_not_called()
+
+    def test_run_prompt_cache_warmup_prefills_partial_cache_hit(self):
+        prompt_cache = MockPromptCacheManager(["base-cache"], [7])
+        generator = self.make_generator(prompt_cache)
+        generator.model_provider.load = Mock(
+            return_value=(
+                generator.model_provider.model,
+                SequencedTokenizer(([1, 2, 3, 7, 10], [1, 2, 3, 7, 20])),
+            )
+        )
+        request = CompletionRequest(
+            "chat",
+            "",
+            [
+                {"role": "user", "content": "what is 2+3?"},
+                {
+                    "role": "assistant",
+                    "content": None,
+                    "tool_calls": [
+                        {
+                            "type": "function",
+                            "id": "123",
+                            "function": {
+                                "name": "add",
+                                "arguments": {"a": 2, "b": 3},
+                            },
+                        }
+                    ],
+                },
+                {"role": "tool", "content": "5", "tool_call_id": "123"},
+            ],
+            None,
+            None,
+        )
+        generator.enqueue_prompt_cache_warmup(
+            request,
+            self.make_args(),
+            {"role": "assistant", "content": "Hi"},
+        )
+
+        with patch("mlx_lm.server.generate_step", return_value=iter(())) as generate_step:
+            served = generator._run_prompt_cache_warmup()
+
+        self.assertTrue(served)
+        self.assertEqual(
+            prompt_cache.fetch_calls,
+            [(("default_model", None, None), [1, 2, 3, 7])],
+        )
+        generate_step.assert_called_once()
+        self.assertEqual(len(prompt_cache.insert_calls), 1)
+        model_key, tokens, _, checkpoint = prompt_cache.insert_calls[0]
+        self.assertEqual(model_key, ("default_model", None, None))
+        self.assertEqual(tokens, [1, 2, 3, 7])
+        self.assertTrue(checkpoint)
+
+    def test_run_prompt_cache_warmup_skips_exact_cache_hit(self):
+        prompt_cache = MockPromptCacheManager(["exact-cache"], [])
+        generator = self.make_generator(prompt_cache)
+        generator.model_provider.load = Mock(
+            return_value=(
+                generator.model_provider.model,
+                SequencedTokenizer(([1, 2, 3, 9], [1, 2, 3, 8])),
+            )
+        )
+        request = CompletionRequest(
+            "chat",
+            "",
+            [{"role": "user", "content": "Hello"}],
+            None,
+            None,
+        )
+        generator.enqueue_prompt_cache_warmup(
+            request,
+            self.make_args(),
+            {"role": "assistant", "content": "Hi"},
+        )
+
+        with patch("mlx_lm.server.generate_step", return_value=iter(())) as generate_step:
+            served = generator._run_prompt_cache_warmup()
+
+        self.assertTrue(served)
+        self.assertEqual(
+            prompt_cache.fetch_calls,
+            [(("default_model", None, None), [1, 2, 3])],
+        )
+        generate_step.assert_not_called()
+        self.assertEqual(prompt_cache.insert_calls, [])
 
 
 class TestServer(unittest.TestCase):

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -195,8 +195,11 @@ class TestPromptCacheWarmup(unittest.TestCase):
 
             return run_step
 
-        prompt_cache = MockPromptCacheManager(["base-cache"], [7, 10])
-        gen = self._queue_warmup(prompt_cache, ([1, 2, 3, 7, 10, 99], [1, 2, 3, 7, 10, 88]))
+        prompt_cache = MockPromptCacheManager(["base-cache"], list(range(4, 21)))
+        gen = self._queue_warmup(
+            prompt_cache,
+            (list(range(1, 21)) + [99], list(range(1, 21)) + [88]),
+        )
 
         with patch(
             "mlx_lm.server.generate_step",
@@ -206,18 +209,21 @@ class TestPromptCacheWarmup(unittest.TestCase):
         gs.assert_called_once()
         self.assertEqual(len(prompt_cache.insert_calls), 1)
         _, tokens, _, checkpoint = prompt_cache.insert_calls[0]
-        self.assertEqual(tokens, [1, 2, 3, 7])
+        self.assertEqual(tokens, [1, 2, 3, 4])
         self.assertTrue(checkpoint)
 
     def test_run_warmup_prefills_uncached_tokens(self):
-        prompt_cache = MockPromptCacheManager(None, [1, 2, 3])
-        gen = self._queue_warmup(prompt_cache, ([1, 2, 3, 9], [1, 2, 3, 8]))
+        tokens = list(range(1, 21))
+        prompt_cache = MockPromptCacheManager(None, tokens)
+        gen = self._queue_warmup(prompt_cache, (tokens + [99], tokens + [88]))
         new_cache = object()
-        with patch("mlx_lm.server.generate_step", return_value=iter(())) as gs, patch(
-            "mlx_lm.server.wired_limit", return_value=nullcontext()
-        ) as wl, patch(
-            "mlx_lm.server.make_prompt_cache", return_value=new_cache
-        ) as make_cache:
+        with (
+            patch("mlx_lm.server.generate_step", return_value=iter(())) as gs,
+            patch("mlx_lm.server.wired_limit", return_value=nullcontext()) as wl,
+            patch(
+                "mlx_lm.server.make_prompt_cache", return_value=new_cache
+            ) as make_cache,
+        ):
             gen._run_prompt_cache_warmup()
 
         gs.assert_called_once()
@@ -226,11 +232,28 @@ class TestPromptCacheWarmup(unittest.TestCase):
         self.assertEqual(len(prompt_cache.fetch_calls), 1)
         fetched_model, fetched_tokens = prompt_cache.fetch_calls[0]
         self.assertEqual(fetched_model, self.MODEL_KEY)
-        self.assertEqual(fetched_tokens, [1, 2, 3])
-        _, tokens, stored_cache, checkpoint = prompt_cache.insert_calls[0]
-        self.assertEqual(tokens, [1, 2, 3])
+        self.assertEqual(fetched_tokens, tokens)
+        _, stored_tokens, stored_cache, checkpoint = prompt_cache.insert_calls[0]
+        self.assertEqual(stored_tokens, list(range(1, 21)))
         self.assertIs(stored_cache, new_cache)
         self.assertTrue(checkpoint)
+
+    def test_run_warmup_skips_short_uncached_suffix(self):
+        prompt_cache = MockPromptCacheManager(["base-cache"], [7, 10, 11])
+        gen = self._queue_warmup(
+            prompt_cache,
+            ([1, 2, 3, 7, 10, 11, 99], [1, 2, 3, 7, 10, 11, 88]),
+        )
+
+        with (
+            patch("mlx_lm.server.generate_step", return_value=iter(())) as gs,
+            patch("mlx_lm.server.make_prompt_cache") as make_cache,
+        ):
+            self.assertTrue(gen._run_prompt_cache_warmup())
+
+        gs.assert_not_called()
+        make_cache.assert_not_called()
+        self.assertEqual(len(prompt_cache.insert_calls), 0)
 
     def test_build_prefill_request_extracts_shared_prefix(self):
         gen = self._make_generator(None)

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -14,16 +14,13 @@ from mlx_lm.models.cache import KVCache
 from mlx_lm.server import (
     APIHandler,
     CompletionRequest,
-    GenerationArguments,
-    GenerationContext,
-    LogitsProcessorArguments,
     LRUPromptCache,
     ModelDescription,
-    Response as ServerResponse,
     ResponseGenerator,
-    SamplingArguments,
+    _PromptCacheWarmup,
 )
 from mlx_lm.utils import load
+
 
 class DummyModelProvider:
     def __init__(self, with_draft=False):
@@ -112,49 +109,22 @@ class MockPromptCacheManager:
 
 
 class SequencedTokenizer:
+    """Returns pre-canned token sequences from apply_chat_template."""
+
     def __init__(self, prompts):
         self.prompts = iter(prompts)
         self.has_chat_template = True
         self.has_tool_calling = True
 
-    def apply_chat_template(
-        self,
-        messages,
-        tools=None,
-        add_generation_prompt=True,
-        tokenize=True,
-        **kwargs,
-    ):
+    def apply_chat_template(self, messages, **kwargs):
         return next(self.prompts)
 
 
 class TestPromptCacheWarmup(unittest.TestCase):
-    def make_args(self):
-        return GenerationArguments(
-            model=ModelDescription(model="default_model", adapter=None, draft=None),
-            sampling=SamplingArguments(
-                temperature=0.0,
-                top_p=1.0,
-                top_k=0,
-                min_p=0.0,
-                xtc_probability=0.0,
-                xtc_threshold=0.1,
-            ),
-            logits=LogitsProcessorArguments(
-                logit_bias=None,
-                repetition_penalty=1.0,
-                repetition_context_size=20,
-            ),
-            stop_words=[],
-            max_tokens=16,
-            num_draft_tokens=0,
-            logprobs=False,
-            top_logprobs=0,
-            seed=None,
-            chat_template_kwargs={},
-        )
+    MODEL = ModelDescription(model="default_model", adapter=None, draft=None)
+    MODEL_KEY = ("default_model", None, None)
 
-    def make_generator(self, prompt_cache):
+    def _make_generator(self, prompt_cache, *, warmup_enabled=True):
         cli_args = type(
             "obj",
             (object,),
@@ -162,7 +132,7 @@ class TestPromptCacheWarmup(unittest.TestCase):
                 "chat_template_args": {},
                 "draft_model": None,
                 "prefill_step_size": 16,
-                "prompt_cache_warmup": True,
+                "prompt_cache_warmup": warmup_enabled,
             },
         )
         model_provider = type(
@@ -170,213 +140,153 @@ class TestPromptCacheWarmup(unittest.TestCase):
             (object,),
             {
                 "cli_args": cli_args,
-                "draft_model": None,
                 "model": object(),
-                "model_key": ("default_model", None, None),
+                "model_key": self.MODEL_KEY,
                 "load": Mock(
                     return_value=(object(), SequencedTokenizer(([1], [1])))
                 ),
             },
         )
-        generator = ResponseGenerator.__new__(ResponseGenerator)
-        generator.model_provider = model_provider
-        generator.prompt_cache = prompt_cache
-        generator._prompt_cache_warmup = None
-        generator._prompt_cache_warmup_lock = threading.Lock()
-        generator._is_distributed = False
-        return generator
+        gen = ResponseGenerator.__new__(ResponseGenerator)
+        gen.model_provider = model_provider
+        gen.prompt_cache = prompt_cache
+        gen._prompt_cache_warmup = None
+        gen._prompt_cache_warmup_lock = threading.Lock()
+        gen._is_distributed = False
+        return gen
 
-    def make_context(self, *, has_thinking=False):
-        return GenerationContext(
-            has_tool_calling=True,
-            tool_call_start="<tool>",
-            tool_call_end="</tool>",
-            tool_parser=lambda *_: {"name": "demo", "arguments": {"value": 1}},
-            has_thinking=has_thinking,
-            think_start_id=1,
-            think_end_id=2,
-            think_end="</think>",
-            eos_token_ids=set(),
-            stop_token_sequences=[],
-            prompt=[1] if has_thinking else [3],
-        )
+    def _make_gen_args(self, draft=None):
+        model = ModelDescription(model="default_model", adapter=None, draft=draft)
+        return type("obj", (), {"model": model, "chat_template_kwargs": {}})
 
-    def make_handler(self, response_generator):
-        handler = APIHandler.__new__(APIHandler)
-        handler.created = 0
-        handler.response_generator = response_generator
-        handler.system_fingerprint = "fp"
-        handler.stream = False
-        handler.stream_options = None
-        handler.request_id = "chatcmpl-test"
-        handler.object_type = "chat.completion"
-        handler.requested_model = "chat_model"
-        handler.requested_draft_model = "default_model"
-        handler.adapter = None
-        handler.max_tokens = 16
-        handler.temperature = 0.0
-        handler.top_p = 1.0
-        handler.top_k = 0
-        handler.min_p = 0.0
-        handler.repetition_penalty = 1.0
-        handler.repetition_context_size = 20
-        handler.xtc_probability = 0.0
-        handler.xtc_threshold = 0.1
-        handler.logit_bias = None
-        handler.logprobs = False
-        handler.top_logprobs = 0
-        handler.seed = None
-        handler.chat_template_kwargs = {}
-        handler.num_draft_tokens = 0
-        handler.wfile = io.BytesIO()
-        handler._set_completion_headers = Mock()
-        handler._set_stream_headers = Mock()
-        handler.send_header = Mock()
-        handler.end_headers = Mock()
-        return handler
-
-    def test_handle_completion_enqueues_warmup_for_reasoning_reply(self):
-        response_generator = Mock()
-        response_generator.generate.return_value = (
-            self.make_context(has_thinking=True),
-            iter(
-                [
-                    ServerResponse("trace", 1, 0.0, None, ()),
-                    ServerResponse("</think>", 2, 0.0, None, ()),
-                    ServerResponse("answer", 3, 0.0, "stop", ()),
-                ]
-            ),
-        )
-        handler = self.make_handler(response_generator)
-        request = CompletionRequest(
+    def _chat_request(self, messages=None):
+        return CompletionRequest(
             "chat",
             "",
-            [{"role": "user", "content": "Hello"}],
+            messages or [{"role": "user", "content": "Hello"}],
             None,
             None,
         )
 
-        handler.handle_completion(request, [])
-
-        response_generator.enqueue_prompt_cache_warmup.assert_called_once()
-        assistant_message = response_generator.enqueue_prompt_cache_warmup.call_args.args[
-            2
-        ]
-        self.assertEqual(assistant_message["role"], "assistant")
-        self.assertEqual(assistant_message["content"], "answer")
-        self.assertEqual(assistant_message["reasoning"], "trace")
-        self.assertEqual(assistant_message["reasoning_content"], "trace")
-
-    def test_handle_completion_skips_warmup_for_tool_call_finish_reason(self):
-        response_generator = Mock()
-        response_generator.generate.return_value = (
-            self.make_context(),
-            iter(
-                [
-                    ServerResponse("<tool>", 1, 0.0, None, ()),
-                    ServerResponse('{"value": 1}', 2, 0.0, None, ()),
-                    ServerResponse("</tool>", 3, 0.0, "tool_calls", ()),
-                ]
-            ),
+    def test_build_prefill_request_returns_common_prefix(self):
+        gen = self._make_generator(None)
+        warmup = _PromptCacheWarmup(
+            model=self.MODEL,
+            messages=[{"role": "user", "content": "Hi"}],
+            tools=None,
+            role_mapping=None,
+            chat_template_kwargs={},
         )
-        handler = self.make_handler(response_generator)
-        request = CompletionRequest(
-            "chat",
-            "",
-            [{"role": "user", "content": "Hello"}],
-            [{"type": "function", "function": {"name": "demo"}}],
-            None,
+        tokenizer = SequencedTokenizer(([10, 20, 30, 99], [10, 20, 30, 88]))
+        self.assertEqual(gen._build_prefill_request(tokenizer, warmup), [10, 20, 30])
+
+    def test_build_prefill_request_returns_none_for_empty_prefix(self):
+        gen = self._make_generator(None)
+        warmup = _PromptCacheWarmup(
+            model=self.MODEL,
+            messages=[{"role": "user", "content": "Hi"}],
+            tools=None,
+            role_mapping=None,
+            chat_template_kwargs={},
         )
+        tokenizer = SequencedTokenizer(([1, 2], [3, 4]))
+        self.assertIsNone(gen._build_prefill_request(tokenizer, warmup))
 
-        handler.handle_completion(request, [])
+    def test_enqueue_stores_warmup(self):
+        gen = self._make_generator(MockPromptCacheManager(None, []))
+        gen.enqueue_prompt_cache_warmup(
+            self._chat_request(),
+            self._make_gen_args(),
+            {"role": "assistant", "content": "Hi"},
+        )
+        self.assertIsNotNone(gen._prompt_cache_warmup)
+        self.assertEqual(len(gen._prompt_cache_warmup.messages), 2)
 
-        response_generator.enqueue_prompt_cache_warmup.assert_not_called()
+    def test_enqueue_skips_when_disabled(self):
+        gen = self._make_generator(None, warmup_enabled=False)
+        gen.enqueue_prompt_cache_warmup(
+            self._chat_request(),
+            self._make_gen_args(),
+            {"role": "assistant", "content": "Hi"},
+        )
+        self.assertIsNone(gen._prompt_cache_warmup)
 
-    def test_run_prompt_cache_warmup_prefills_partial_cache_hit(self):
+    def test_enqueue_skips_for_text_request(self):
+        gen = self._make_generator(None)
+        request = CompletionRequest("text", "prompt", [], None, None)
+        gen.enqueue_prompt_cache_warmup(
+            request,
+            self._make_gen_args(),
+            {"role": "assistant", "content": "Hi"},
+        )
+        self.assertIsNone(gen._prompt_cache_warmup)
+
+    def test_enqueue_skips_for_draft_model(self):
+        gen = self._make_generator(None)
+        gen.enqueue_prompt_cache_warmup(
+            self._chat_request(),
+            self._make_gen_args(draft="some-draft"),
+            {"role": "assistant", "content": "Hi"},
+        )
+        self.assertIsNone(gen._prompt_cache_warmup)
+
+    def test_enqueue_skips_for_empty_reply(self):
+        gen = self._make_generator(None)
+        gen.enqueue_prompt_cache_warmup(
+            self._chat_request(),
+            self._make_gen_args(),
+            {"role": "assistant", "content": ""},
+        )
+        self.assertIsNone(gen._prompt_cache_warmup)
+
+    def test_run_warmup_returns_false_when_nothing_queued(self):
+        gen = self._make_generator(MockPromptCacheManager(None, []))
+        self.assertFalse(gen._run_prompt_cache_warmup())
+
+    def test_run_warmup_prefills_on_partial_cache_hit(self):
         prompt_cache = MockPromptCacheManager(["base-cache"], [7])
-        generator = self.make_generator(prompt_cache)
-        generator.model_provider.load = Mock(
+        gen = self._make_generator(prompt_cache)
+        gen.model_provider.load = Mock(
             return_value=(
-                generator.model_provider.model,
+                gen.model_provider.model,
                 SequencedTokenizer(([1, 2, 3, 7, 10], [1, 2, 3, 7, 20])),
             )
         )
-        request = CompletionRequest(
-            "chat",
-            "",
-            [
-                {"role": "user", "content": "what is 2+3?"},
-                {
-                    "role": "assistant",
-                    "content": None,
-                    "tool_calls": [
-                        {
-                            "type": "function",
-                            "id": "123",
-                            "function": {
-                                "name": "add",
-                                "arguments": {"a": 2, "b": 3},
-                            },
-                        }
-                    ],
-                },
-                {"role": "tool", "content": "5", "tool_call_id": "123"},
-            ],
-            None,
-            None,
-        )
-        generator.enqueue_prompt_cache_warmup(
-            request,
-            self.make_args(),
+        gen.enqueue_prompt_cache_warmup(
+            self._chat_request(),
+            self._make_gen_args(),
             {"role": "assistant", "content": "Hi"},
         )
 
-        with patch("mlx_lm.server.generate_step", return_value=iter(())) as generate_step:
-            served = generator._run_prompt_cache_warmup()
+        with patch("mlx_lm.server.generate_step", return_value=iter(())) as gs:
+            self.assertTrue(gen._run_prompt_cache_warmup())
 
-        self.assertTrue(served)
-        self.assertEqual(
-            prompt_cache.fetch_calls,
-            [(("default_model", None, None), [1, 2, 3, 7])],
-        )
-        generate_step.assert_called_once()
+        gs.assert_called_once()
+        self.assertEqual(prompt_cache.fetch_calls, [(self.MODEL_KEY, [1, 2, 3, 7])])
         self.assertEqual(len(prompt_cache.insert_calls), 1)
-        model_key, tokens, _, checkpoint = prompt_cache.insert_calls[0]
-        self.assertEqual(model_key, ("default_model", None, None))
+        _, tokens, _, checkpoint = prompt_cache.insert_calls[0]
         self.assertEqual(tokens, [1, 2, 3, 7])
         self.assertTrue(checkpoint)
 
-    def test_run_prompt_cache_warmup_skips_exact_cache_hit(self):
+    def test_run_warmup_skips_generate_on_exact_cache_hit(self):
         prompt_cache = MockPromptCacheManager(["exact-cache"], [])
-        generator = self.make_generator(prompt_cache)
-        generator.model_provider.load = Mock(
+        gen = self._make_generator(prompt_cache)
+        gen.model_provider.load = Mock(
             return_value=(
-                generator.model_provider.model,
+                gen.model_provider.model,
                 SequencedTokenizer(([1, 2, 3, 9], [1, 2, 3, 8])),
             )
         )
-        request = CompletionRequest(
-            "chat",
-            "",
-            [{"role": "user", "content": "Hello"}],
-            None,
-            None,
-        )
-        generator.enqueue_prompt_cache_warmup(
-            request,
-            self.make_args(),
+        gen.enqueue_prompt_cache_warmup(
+            self._chat_request(),
+            self._make_gen_args(),
             {"role": "assistant", "content": "Hi"},
         )
 
-        with patch("mlx_lm.server.generate_step", return_value=iter(())) as generate_step:
-            served = generator._run_prompt_cache_warmup()
+        with patch("mlx_lm.server.generate_step", return_value=iter(())) as gs:
+            self.assertTrue(gen._run_prompt_cache_warmup())
 
-        self.assertTrue(served)
-        self.assertEqual(
-            prompt_cache.fetch_calls,
-            [(("default_model", None, None), [1, 2, 3])],
-        )
-        generate_step.assert_not_called()
+        gs.assert_not_called()
         self.assertEqual(prompt_cache.insert_calls, [])
 
 

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -4,7 +4,6 @@ import http
 import io
 import json
 import threading
-import time
 import unittest
 from contextlib import nullcontext
 from queue import Queue
@@ -125,35 +124,7 @@ class SequencedTokenizer:
 
 
 class TestPromptCacheWarmup(unittest.TestCase):
-    MODEL = ModelDescription(model="default_model", adapter=None, draft=None)
     MODEL_KEY = ("default_model", None, None)
-    HANDLER_DEFAULTS = {
-        "request_id": "chatcmpl-test",
-        "system_fingerprint": "fp",
-        "requested_model": "chat_model",
-        "requested_draft_model": None,
-        "created": 0,
-        "adapter": None,
-        "temperature": 0.0,
-        "top_p": 1.0,
-        "top_k": 0,
-        "min_p": 0.0,
-        "xtc_probability": 0.0,
-        "xtc_threshold": 0.0,
-        "logit_bias": None,
-        "repetition_penalty": 1.0,
-        "repetition_context_size": 20,
-        "presence_penalty": 0.0,
-        "presence_context_size": 20,
-        "frequency_penalty": 0.0,
-        "frequency_context_size": 20,
-        "max_tokens": 16,
-        "num_draft_tokens": 3,
-        "logprobs": False,
-        "top_logprobs": 0,
-        "seed": None,
-        "chat_template_kwargs": {},
-    }
 
     def _make_generator(self, prompt_cache, *, warmup_enabled=True):
         cli_args = SimpleNamespace(
@@ -192,38 +163,6 @@ class TestPromptCacheWarmup(unittest.TestCase):
             None,
         )
 
-    def _make_ctx(self, **kwargs):
-        attrs = {
-            "has_tool_calling": False,
-            "tool_call_start": "<tool>",
-            "tool_call_end": "",
-            "tool_parser": lambda tool_text, tools: {
-                "name": "noop",
-                "arguments": {},
-            },
-            "has_thinking": False,
-            "think_start_id": 1,
-            "think_end_id": 2,
-            "think_end": "</think>",
-            "eos_token_ids": set(),
-            "stop_token_sequences": [],
-            "prompt": [0],
-            "prompt_cache_count": 0,
-            "_should_stop": False,
-            "stop": Mock(),
-        }
-        attrs.update(kwargs)
-        return SimpleNamespace(**attrs)
-
-    def _make_response(self, text, token, finish_reason=None):
-        return SimpleNamespace(
-            text=text,
-            token=token,
-            logprob=0.0,
-            finish_reason=finish_reason,
-            top_tokens=(),
-        )
-
     def _queue_warmup(
         self,
         prompt_cache,
@@ -246,71 +185,6 @@ class TestPromptCacheWarmup(unittest.TestCase):
             assistant_message or {"role": "assistant", "content": "Hi"},
         )
         return gen
-
-    def _make_handler(self, ctx, responses, *, stream):
-        handler = APIHandler.__new__(APIHandler)
-        handler.response_generator = Mock()
-        handler.response_generator.generate = Mock(return_value=(ctx, iter(responses)))
-        handler.wfile = io.BytesIO()
-        handler.stream = stream
-        handler.stream_options = None
-        handler._set_completion_headers = Mock()
-        handler._set_stream_headers = Mock()
-        handler.send_header = Mock()
-        handler.end_headers = Mock()
-        attrs = self.HANDLER_DEFAULTS | {
-            "object_type": "chat.completion.chunk" if stream else "chat.completion",
-        }
-        for key, value in attrs.items():
-            setattr(handler, key, value)
-        return handler
-
-    def test_enqueue_prompt_cache_warmup_handles_eligible_and_skipped_requests(self):
-        gen = self._make_generator(None, warmup_enabled=True)
-        gen.enqueue_prompt_cache_warmup(
-            self._chat_request(),
-            self._make_gen_args(),
-            {"role": "assistant", "content": "Hi"},
-        )
-        self.assertIsNotNone(gen._prompt_cache_warmup)
-        self.assertEqual(len(gen._prompt_cache_warmup.messages), 2)
-
-        gen = self._make_generator(None, warmup_enabled=False)
-        gen.enqueue_prompt_cache_warmup(
-            self._chat_request(),
-            self._make_gen_args(),
-            {"role": "assistant", "content": "Hi"},
-        )
-        self.assertIsNone(gen._prompt_cache_warmup)
-
-        gen = self._make_generator(None, warmup_enabled=True)
-        gen.enqueue_prompt_cache_warmup(
-            self._chat_request(),
-            self._make_gen_args(draft="draft-model"),
-            {"role": "assistant", "content": "Hi"},
-        )
-        self.assertIsNone(gen._prompt_cache_warmup)
-
-    def test_generate_discards_stale_prompt_cache_warmup_on_model_switch(self):
-        gen = self._make_generator(None)
-        gen._stop = False
-        gen._time_budget = ()
-        gen._prompt_cache_warmup = SimpleNamespace(model=self.MODEL)
-        request = (
-            Queue(),
-            self._chat_request(),
-            self._make_gen_args(model="other-model"),
-        )
-        gen._next_request = Mock(return_value=request)
-        gen._is_batchable = Mock(return_value=False)
-        gen.model_provider.load = Mock(return_value=(object(), object()))
-
-        def serve_single(_):
-            gen._stop = True
-
-        gen._serve_single = Mock(side_effect=serve_single)
-        gen._generate()
-        self.assertIsNone(gen._prompt_cache_warmup)
 
     def test_run_warmup_handles_interrupt_edges(self):
         def partial_interrupt_step(gen):
@@ -358,86 +232,30 @@ class TestPromptCacheWarmup(unittest.TestCase):
         self.assertIs(stored_cache, new_cache)
         self.assertTrue(checkpoint)
 
-    def test_run_warmup_skips_prefill_on_exact_cache_hit(self):
-        prompt_cache = MockPromptCacheManager(["exact-cache"], [])
-        gen = self._queue_warmup(prompt_cache, ([1, 2, 3, 9], [1, 2, 3, 8]))
-        with patch("mlx_lm.server.generate_step", return_value=iter(())) as gs, patch(
-            "mlx_lm.server.wired_limit", return_value=nullcontext()
-        ) as wl, patch("mlx_lm.server.make_prompt_cache") as make_cache:
-            gen._run_prompt_cache_warmup()
-
-        gs.assert_not_called()
-        wl.assert_not_called()
-        make_cache.assert_not_called()
-        self.assertEqual(prompt_cache.insert_calls, [])
-
-    def test_handle_completion_only_enqueues_for_text_reply(self):
-        cases = (
-            {
-                "name": "streaming reasoning reply",
-                "ctx": self._make_ctx(
-                    has_thinking=True,
-                    prompt=[9, 1],
-                ),
-                "responses": [
-                    self._make_response("A", 10),
-                    self._make_response("B", 11),
-                    self._make_response("</think>", 12),
-                    self._make_response("Hi", 13, "stop"),
-                ],
-                "stream": True,
-                "expected_message": {
-                    "content": "Hi",
-                    "reasoning": "AB",
-                    "reasoning_content": "AB",
-                },
-            },
-            {
-                "name": "tool call reply",
-                "ctx": self._make_ctx(
-                    has_tool_calling=True,
-                    tool_call_start="<tool>",
-                    tool_call_end="</tool>",
-                    tool_parser=lambda tool_text, tools: {
-                        "name": "noop",
-                        "arguments": {},
-                    },
-                ),
-                "responses": [
-                    self._make_response("<tool>", 10),
-                    self._make_response('{"name":"noop","arguments":{}}', 11),
-                    self._make_response("</tool>", 12, "tool_calls"),
-                ],
-                "stream": False,
-                "expected_message": None,
-            },
+    def test_build_prefill_request_extracts_shared_prefix(self):
+        gen = self._make_generator(None)
+        tokenizer = SequencedTokenizer(
+            ([10, 20, 30, 40, 99], [10, 20, 30, 40, 88])
         )
+        warmup = SimpleNamespace(
+            messages=[{"role": "user", "content": "Hi"}],
+            tools=None,
+            role_mapping=None,
+            chat_template_kwargs={},
+        )
+        prompt = gen._build_prefill_request(tokenizer, warmup)
+        self.assertEqual(prompt, [10, 20, 30, 40])
 
-        for case in cases:
-            with self.subTest(case=case["name"]):
-                handler = self._make_handler(
-                    case["ctx"],
-                    case["responses"],
-                    stream=case["stream"],
-                )
-                handler.handle_completion(self._chat_request(), [])
-
-                if case["expected_message"] is None:
-                    handler.response_generator.enqueue_prompt_cache_warmup.assert_not_called()
-                else:
-                    handler.response_generator.enqueue_prompt_cache_warmup.assert_called_once()
-                    _, _, assistant_message = (
-                        handler.response_generator.enqueue_prompt_cache_warmup.call_args.args
-                    )
-                    self.assertEqual(assistant_message["content"], "Hi")
-                    self.assertEqual(
-                        assistant_message["reasoning"],
-                        case["expected_message"]["reasoning"],
-                    )
-                    self.assertEqual(
-                        assistant_message["reasoning_content"],
-                        case["expected_message"]["reasoning_content"],
-                    )
+    def test_build_prefill_request_returns_none_on_empty_prefix(self):
+        gen = self._make_generator(None)
+        tokenizer = SequencedTokenizer(([99], [88]))
+        warmup = SimpleNamespace(
+            messages=[{"role": "user", "content": "Hi"}],
+            tools=None,
+            role_mapping=None,
+            chat_template_kwargs={},
+        )
+        self.assertIsNone(gen._build_prefill_request(tokenizer, warmup))
 
     def test_process_message_content_handles_tool_arguments(self):
         cases = (
@@ -500,72 +318,6 @@ class TestServer(unittest.TestCase):
         cls.httpd.server_close()
         cls.server_thread.join()
         cls.response_generator.stop_and_join()
-
-    def _chat_with_warmup_setting(self, warmup_enabled):
-        url = f"http://localhost:{self.port}/v1/chat/completions"
-        provider = self.response_generator.model_provider
-        previous_warmup = provider.cli_args.prompt_cache_warmup
-
-        provider.cli_args.prompt_cache_warmup = warmup_enabled
-        self.response_generator.prompt_cache.trim_to(n_sequences=0, n_bytes=0)
-        with self.response_generator._prompt_cache_warmup_lock:
-            self.response_generator._prompt_cache_warmup = None
-
-        messages = [
-            {"role": "system", "content": "You are a helpful assistant."},
-            {"role": "user", "content": "Reply with a short greeting."},
-        ]
-        body = {
-            "model": "chat_model",
-            "max_tokens": 24,
-            "temperature": 0.0,
-            "top_p": 1.0,
-            "messages": messages,
-        }
-
-        try:
-            first_response = requests.post(url, json=body)
-            first_payload = json.loads(first_response.text)
-            first_message = first_payload["choices"][0]["message"]
-
-            # Let best-effort warmup run before the follow-up turn.
-            if warmup_enabled:
-                deadline = time.time() + 2.0
-                while time.time() < deadline:
-                    with self.response_generator._prompt_cache_warmup_lock:
-                        if self.response_generator._prompt_cache_warmup is None:
-                            break
-                    time.sleep(0.02)
-
-            assistant_message = {
-                "role": "assistant",
-                "content": first_message.get("content") or "",
-            }
-            if first_message.get("reasoning"):
-                assistant_message["reasoning"] = first_message["reasoning"]
-                assistant_message["reasoning_content"] = first_message["reasoning"]
-
-            follow_up = {
-                "model": "chat_model",
-                "max_tokens": 24,
-                "temperature": 0.0,
-                "top_p": 1.0,
-                "messages": [
-                    *messages,
-                    assistant_message,
-                    {"role": "user", "content": "Now say it differently."},
-                ],
-            }
-            second_response = requests.post(url, json=follow_up)
-            second_payload = json.loads(second_response.text)
-
-            details = second_payload["usage"].get("prompt_tokens_details", {})
-            return details.get("cached_tokens", 0)
-        finally:
-            provider.cli_args.prompt_cache_warmup = previous_warmup
-            with self.response_generator._prompt_cache_warmup_lock:
-                self.response_generator._prompt_cache_warmup = None
-            self.response_generator.prompt_cache.trim_to(n_sequences=0, n_bytes=0)
 
     def test_handle_completions(self):
         url = f"http://localhost:{self.port}/v1/completions"
@@ -666,11 +418,6 @@ class TestServer(unittest.TestCase):
         response_body = response.text
         self.assertIn("id", response_body)
         self.assertIn("choices", response_body)
-
-    def test_prompt_cache_warmup_improves_follow_up_cache_reuse(self):
-        without_warmup = self._chat_with_warmup_setting(False)
-        with_warmup = self._chat_with_warmup_setting(True)
-        self.assertGreater(with_warmup, without_warmup)
 
     def test_handle_models(self):
         url = f"http://localhost:{self.port}/v1/models"

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -94,24 +94,6 @@ class MockCache:
         return n
 
 
-class MockPromptCacheManager:
-    def __init__(self, cache, rest):
-        self.cache = cache
-        self.rest = rest
-        self.fetch_calls = []
-        self.insert_calls = []
-
-    def log_cache_stats(self):
-        return None
-
-    def fetch_nearest_cache(self, model_key, tokens):
-        self.fetch_calls.append((model_key, tokens))
-        return self.cache, self.rest
-
-    def insert_cache(self, model_key, tokens, prompt_cache, checkpoint=False):
-        self.insert_calls.append((model_key, tokens, prompt_cache, checkpoint))
-
-
 class SequencedTokenizer:
     """Returns pre-canned token sequences from apply_chat_template."""
 
@@ -164,6 +146,11 @@ class TestPromptCacheWarmup(unittest.TestCase):
             None,
         )
 
+    def _seed_cache(self, prompt_cache, tokens, cache=None, *, cache_type="assistant"):
+        cache = cache or [MockCache(f"cache-{len(tokens)}")]
+        prompt_cache.insert_cache(self.MODEL_KEY, tokens, cache, cache_type=cache_type)
+        return cache
+
     def _queue_warmup(
         self,
         prompt_cache,
@@ -196,7 +183,8 @@ class TestPromptCacheWarmup(unittest.TestCase):
 
             return run_step
 
-        prompt_cache = MockPromptCacheManager(["base-cache"], list(range(4, 21)))
+        prompt_cache = LRUPromptCache()
+        self._seed_cache(prompt_cache, [1, 2, 3])
         gen = self._queue_warmup(
             prompt_cache,
             (list(range(1, 21)) + [99], list(range(1, 21)) + [88]),
@@ -208,16 +196,18 @@ class TestPromptCacheWarmup(unittest.TestCase):
         ) as gs, patch("mlx_lm.server.wired_limit", return_value=nullcontext()):
             self.assertTrue(gen._run_prompt_cache_warmup())
         gs.assert_called_once()
-        self.assertEqual(len(prompt_cache.insert_calls), 1)
-        _, tokens, _, checkpoint = prompt_cache.insert_calls[0]
-        self.assertEqual(tokens, [1, 2, 3, 4])
-        self.assertTrue(checkpoint)
+        cached, rest = prompt_cache.fetch_nearest_cache(self.MODEL_KEY, [1, 2, 3, 4])
+        self.assertEqual(cached, [MockCache("cache-3")])
+        self.assertEqual(rest, [])
+        cached, rest = prompt_cache.fetch_nearest_cache(self.MODEL_KEY, list(range(1, 21)))
+        self.assertEqual(cached, [MockCache("cache-3")])
+        self.assertEqual(rest, list(range(5, 21)))
 
     def test_run_warmup_prefills_uncached_tokens(self):
         tokens = list(range(1, 21))
-        prompt_cache = MockPromptCacheManager(None, tokens)
+        prompt_cache = LRUPromptCache()
         gen = self._queue_warmup(prompt_cache, (tokens + [99], tokens + [88]))
-        new_cache = object()
+        new_cache = [MockCache("warmup")]
         with (
             patch("mlx_lm.server.generate_step", return_value=iter(())) as gs,
             patch("mlx_lm.server.wired_limit", return_value=nullcontext()) as wl,
@@ -230,17 +220,13 @@ class TestPromptCacheWarmup(unittest.TestCase):
         gs.assert_called_once()
         wl.assert_called_once()
         make_cache.assert_called_once()
-        self.assertEqual(len(prompt_cache.fetch_calls), 1)
-        fetched_model, fetched_tokens = prompt_cache.fetch_calls[0]
-        self.assertEqual(fetched_model, self.MODEL_KEY)
-        self.assertEqual(fetched_tokens, tokens)
-        _, stored_tokens, stored_cache, checkpoint = prompt_cache.insert_calls[0]
-        self.assertEqual(stored_tokens, list(range(1, 21)))
-        self.assertIs(stored_cache, new_cache)
-        self.assertTrue(checkpoint)
+        cached, rest = prompt_cache.fetch_nearest_cache(self.MODEL_KEY, tokens)
+        self.assertEqual(cached, new_cache)
+        self.assertEqual(rest, [])
 
     def test_run_warmup_skips_short_uncached_suffix(self):
-        prompt_cache = MockPromptCacheManager(["base-cache"], [7, 10, 11])
+        prompt_cache = LRUPromptCache()
+        self._seed_cache(prompt_cache, [1, 2, 3])
         gen = self._queue_warmup(
             prompt_cache,
             ([1, 2, 3, 7, 10, 11, 99], [1, 2, 3, 7, 10, 11, 88]),
@@ -254,7 +240,11 @@ class TestPromptCacheWarmup(unittest.TestCase):
 
         gs.assert_not_called()
         make_cache.assert_not_called()
-        self.assertEqual(len(prompt_cache.insert_calls), 0)
+        cached, rest = prompt_cache.fetch_nearest_cache(
+            self.MODEL_KEY, [1, 2, 3, 7, 10, 11]
+        )
+        self.assertEqual(cached, [MockCache("cache-3")])
+        self.assertEqual(rest, [7, 10, 11])
 
     def test_build_prefill_request_extracts_shared_prefix(self):
         gen = self._make_generator(None)

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -168,6 +168,26 @@ class TestPromptCacheWarmup(unittest.TestCase):
             None,
         )
 
+    def _tool_messages(self, arguments):
+        return [
+            {"role": "user", "content": "What is 2+3?"},
+            {
+                "role": "assistant",
+                "content": "",
+                "tool_calls": [
+                    {
+                        "type": "function",
+                        "id": "123",
+                        "function": {
+                            "name": "add",
+                            "arguments": arguments,
+                        },
+                    }
+                ],
+            },
+            {"role": "tool", "content": "5", "tool_call_id": "123"},
+        ]
+
     def test_build_prefill_request_returns_common_prefix(self):
         gen = self._make_generator(None)
         warmup = _PromptCacheWarmup(
@@ -191,6 +211,43 @@ class TestPromptCacheWarmup(unittest.TestCase):
         )
         tokenizer = SequencedTokenizer(([1, 2], [3, 4]))
         self.assertIsNone(gen._build_prefill_request(tokenizer, warmup))
+
+    def test_build_prefill_request_accepts_dict_tool_arguments(self):
+        gen = self._make_generator(None)
+        warmup = _PromptCacheWarmup(
+            model=self.MODEL,
+            messages=self._tool_messages({"a": 2, "b": 3}),
+            tools=None,
+            role_mapping=None,
+            chat_template_kwargs={},
+        )
+        tokenizer = SequencedTokenizer(([10, 20, 30, 99], [10, 20, 30, 88]))
+        self.assertEqual(gen._build_prefill_request(tokenizer, warmup), [10, 20, 30])
+
+    def test_tokenize_chat_handles_tool_arguments(self):
+        gen = self._make_generator(None)
+        cases = (
+            ('{"a": 2, "b": 3}', {"a": 2, "b": 3}),
+            ("", ""),
+        )
+
+        for arguments, expected in cases:
+            with self.subTest(arguments=arguments):
+                tokenizer = SequencedTokenizer(([1], [2]))
+                messages = self._tool_messages(arguments)
+
+                self.assertEqual(
+                    gen._tokenize_chat(tokenizer, messages, None, None, None),
+                    [1],
+                )
+                self.assertEqual(
+                    messages[1]["tool_calls"][0]["function"]["arguments"],
+                    expected,
+                )
+                self.assertEqual(
+                    gen._tokenize_chat(tokenizer, messages, None, None, None),
+                    [2],
+                )
 
     def test_enqueue_stores_warmup(self):
         gen = self._make_generator(MockPromptCacheManager(None, []))

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -5,6 +5,7 @@ import io
 import json
 import threading
 import unittest
+from types import SimpleNamespace
 from unittest.mock import Mock, patch
 
 import mlx.core as mx
@@ -188,6 +189,80 @@ class TestPromptCacheWarmup(unittest.TestCase):
             {"role": "tool", "content": "5", "tool_call_id": "123"},
         ]
 
+    def _make_ctx(self, **kwargs):
+        attrs = {
+            "has_tool_calling": False,
+            "tool_call_start": "<tool>",
+            "tool_call_end": "",
+            "tool_parser": lambda tool_text, tools: {
+                "name": "noop",
+                "arguments": {},
+            },
+            "has_thinking": False,
+            "think_start_id": 1,
+            "think_end_id": 2,
+            "think_end": "</think>",
+            "eos_token_ids": set(),
+            "stop_token_sequences": [],
+            "prompt": [0],
+            "prompt_cache_count": 0,
+            "_should_stop": False,
+            "stop": Mock(),
+        }
+        attrs.update(kwargs)
+        return SimpleNamespace(**attrs)
+
+    def _make_response(self, text, token, finish_reason=None):
+        return SimpleNamespace(
+            text=text,
+            token=token,
+            logprob=0.0,
+            finish_reason=finish_reason,
+            top_tokens=(),
+        )
+
+    def _make_handler(self, ctx, responses, *, stream):
+        handler = APIHandler.__new__(APIHandler)
+        handler.response_generator = Mock()
+        handler.response_generator.generate = Mock(return_value=(ctx, iter(responses)))
+        handler.wfile = io.BytesIO()
+        handler.stream = stream
+        handler.stream_options = None
+        handler._set_completion_headers = Mock()
+        handler._set_stream_headers = Mock()
+        handler.send_header = Mock()
+        handler.end_headers = Mock()
+        for key, value in {
+            "request_id": "chatcmpl-test",
+            "system_fingerprint": "fp",
+            "object_type": "chat.completion.chunk" if stream else "chat.completion",
+            "requested_model": "chat_model",
+            "requested_draft_model": None,
+            "created": 0,
+            "adapter": None,
+            "temperature": 0.0,
+            "top_p": 1.0,
+            "top_k": 0,
+            "min_p": 0.0,
+            "xtc_probability": 0.0,
+            "xtc_threshold": 0.0,
+            "logit_bias": None,
+            "repetition_penalty": 1.0,
+            "repetition_context_size": 20,
+            "presence_penalty": 0.0,
+            "presence_context_size": 20,
+            "frequency_penalty": 0.0,
+            "frequency_context_size": 20,
+            "max_tokens": 16,
+            "num_draft_tokens": 3,
+            "logprobs": False,
+            "top_logprobs": 0,
+            "seed": None,
+            "chat_template_kwargs": {},
+        }.items():
+            setattr(handler, key, value)
+        return handler
+
     def test_build_prefill_request_returns_common_prefix(self):
         gen = self._make_generator(None)
         warmup = _PromptCacheWarmup(
@@ -212,23 +287,12 @@ class TestPromptCacheWarmup(unittest.TestCase):
         tokenizer = SequencedTokenizer(([1, 2], [3, 4]))
         self.assertIsNone(gen._build_prefill_request(tokenizer, warmup))
 
-    def test_build_prefill_request_accepts_dict_tool_arguments(self):
-        gen = self._make_generator(None)
-        warmup = _PromptCacheWarmup(
-            model=self.MODEL,
-            messages=self._tool_messages({"a": 2, "b": 3}),
-            tools=None,
-            role_mapping=None,
-            chat_template_kwargs={},
-        )
-        tokenizer = SequencedTokenizer(([10, 20, 30, 99], [10, 20, 30, 88]))
-        self.assertEqual(gen._build_prefill_request(tokenizer, warmup), [10, 20, 30])
-
     def test_tokenize_chat_handles_tool_arguments(self):
         gen = self._make_generator(None)
         cases = (
-            ('{"a": 2, "b": 3}', {"a": 2, "b": 3}),
-            ("", ""),
+            ('{"a": 2, "b": 3}', {"a": 2, "b": 3}),  # string → parsed dict
+            ("", ""),  # empty string → unchanged
+            ({"a": 2, "b": 3}, {"a": 2, "b": 3}),  # already a dict → not re-parsed
         )
 
         for arguments, expected in cases:
@@ -249,8 +313,8 @@ class TestPromptCacheWarmup(unittest.TestCase):
                     [2],
                 )
 
-    def test_enqueue_stores_warmup(self):
-        gen = self._make_generator(MockPromptCacheManager(None, []))
+    def test_enqueue_prompt_cache_warmup_stores_chat_reply(self):
+        gen = self._make_generator(None)
         gen.enqueue_prompt_cache_warmup(
             self._chat_request(),
             self._make_gen_args(),
@@ -258,47 +322,6 @@ class TestPromptCacheWarmup(unittest.TestCase):
         )
         self.assertIsNotNone(gen._prompt_cache_warmup)
         self.assertEqual(len(gen._prompt_cache_warmup.messages), 2)
-
-    def test_enqueue_skips_when_disabled(self):
-        gen = self._make_generator(None, warmup_enabled=False)
-        gen.enqueue_prompt_cache_warmup(
-            self._chat_request(),
-            self._make_gen_args(),
-            {"role": "assistant", "content": "Hi"},
-        )
-        self.assertIsNone(gen._prompt_cache_warmup)
-
-    def test_enqueue_skips_for_text_request(self):
-        gen = self._make_generator(None)
-        request = CompletionRequest("text", "prompt", [], None, None)
-        gen.enqueue_prompt_cache_warmup(
-            request,
-            self._make_gen_args(),
-            {"role": "assistant", "content": "Hi"},
-        )
-        self.assertIsNone(gen._prompt_cache_warmup)
-
-    def test_enqueue_skips_for_draft_model(self):
-        gen = self._make_generator(None)
-        gen.enqueue_prompt_cache_warmup(
-            self._chat_request(),
-            self._make_gen_args(draft="some-draft"),
-            {"role": "assistant", "content": "Hi"},
-        )
-        self.assertIsNone(gen._prompt_cache_warmup)
-
-    def test_enqueue_skips_for_empty_reply(self):
-        gen = self._make_generator(None)
-        gen.enqueue_prompt_cache_warmup(
-            self._chat_request(),
-            self._make_gen_args(),
-            {"role": "assistant", "content": ""},
-        )
-        self.assertIsNone(gen._prompt_cache_warmup)
-
-    def test_run_warmup_returns_false_when_nothing_queued(self):
-        gen = self._make_generator(MockPromptCacheManager(None, []))
-        self.assertFalse(gen._run_prompt_cache_warmup())
 
     def test_run_warmup_prefills_on_partial_cache_hit(self):
         prompt_cache = MockPromptCacheManager(["base-cache"], [7])
@@ -325,6 +348,33 @@ class TestPromptCacheWarmup(unittest.TestCase):
         self.assertEqual(tokens, [1, 2, 3, 7])
         self.assertTrue(checkpoint)
 
+    def test_run_warmup_creates_cache_on_cold_start(self):
+        prompt_cache = MockPromptCacheManager(None, [1, 2, 3])
+        gen = self._make_generator(prompt_cache)
+        gen.model_provider.load = Mock(
+            return_value=(
+                gen.model_provider.model,
+                SequencedTokenizer(([1, 2, 3, 9], [1, 2, 3, 8])),
+            )
+        )
+        gen.enqueue_prompt_cache_warmup(
+            self._chat_request(),
+            self._make_gen_args(),
+            {"role": "assistant", "content": "Hi"},
+        )
+
+        new_cache = object()
+        with patch("mlx_lm.server.generate_step", return_value=iter(())) as gs:
+            with patch("mlx_lm.server.make_prompt_cache", return_value=new_cache):
+                gen._run_prompt_cache_warmup()
+
+        gs.assert_called_once()
+        _, call_kwargs = gs.call_args
+        self.assertIs(call_kwargs["prompt_cache"], new_cache)
+        _, _, stored_cache, checkpoint = prompt_cache.insert_calls[0]
+        self.assertIs(stored_cache, new_cache)
+        self.assertTrue(checkpoint)
+
     def test_run_warmup_skips_generate_on_exact_cache_hit(self):
         prompt_cache = MockPromptCacheManager(["exact-cache"], [])
         gen = self._make_generator(prompt_cache)
@@ -345,6 +395,33 @@ class TestPromptCacheWarmup(unittest.TestCase):
 
         gs.assert_not_called()
         self.assertEqual(prompt_cache.insert_calls, [])
+
+    def test_handle_completion_enqueues_full_reasoning_for_streaming_reply(self):
+        request = self._chat_request()
+        ctx = self._make_ctx(
+            has_thinking=True,
+            prompt=[9, 1],
+        )
+        handler = self._make_handler(
+            ctx,
+            [
+                self._make_response("A", 10),
+                self._make_response("B", 11),
+                self._make_response(ctx.think_end, 12),
+                self._make_response("Hi", 13, "stop"),
+            ],
+            stream=True,
+        )
+
+        handler.handle_completion(request, [])
+
+        handler.response_generator.enqueue_prompt_cache_warmup.assert_called_once()
+        _, _, assistant_message = (
+            handler.response_generator.enqueue_prompt_cache_warmup.call_args.args
+        )
+        self.assertEqual(assistant_message["content"], "Hi")
+        self.assertEqual(assistant_message["reasoning"], "AB")
+        self.assertEqual(assistant_message["reasoning_content"], "AB")
 
 
 class TestServer(unittest.TestCase):

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -5,6 +5,8 @@ import io
 import json
 import threading
 import unittest
+from contextlib import nullcontext
+from queue import Queue
 from types import SimpleNamespace
 from unittest.mock import Mock, patch
 
@@ -18,7 +20,7 @@ from mlx_lm.server import (
     LRUPromptCache,
     ModelDescription,
     ResponseGenerator,
-    _PromptCacheWarmup,
+    process_message_content,
 )
 from mlx_lm.utils import load
 
@@ -124,33 +126,51 @@ class SequencedTokenizer:
 class TestPromptCacheWarmup(unittest.TestCase):
     MODEL = ModelDescription(model="default_model", adapter=None, draft=None)
     MODEL_KEY = ("default_model", None, None)
+    HANDLER_DEFAULTS = {
+        "request_id": "chatcmpl-test",
+        "system_fingerprint": "fp",
+        "requested_model": "chat_model",
+        "requested_draft_model": None,
+        "created": 0,
+        "adapter": None,
+        "temperature": 0.0,
+        "top_p": 1.0,
+        "top_k": 0,
+        "min_p": 0.0,
+        "xtc_probability": 0.0,
+        "xtc_threshold": 0.0,
+        "logit_bias": None,
+        "repetition_penalty": 1.0,
+        "repetition_context_size": 20,
+        "presence_penalty": 0.0,
+        "presence_context_size": 20,
+        "frequency_penalty": 0.0,
+        "frequency_context_size": 20,
+        "max_tokens": 16,
+        "num_draft_tokens": 3,
+        "logprobs": False,
+        "top_logprobs": 0,
+        "seed": None,
+        "chat_template_kwargs": {},
+    }
 
     def _make_generator(self, prompt_cache, *, warmup_enabled=True):
-        cli_args = type(
-            "obj",
-            (object,),
-            {
-                "chat_template_args": {},
-                "draft_model": None,
-                "prefill_step_size": 16,
-                "prompt_cache_warmup": warmup_enabled,
-            },
+        cli_args = SimpleNamespace(
+            chat_template_args={},
+            draft_model=None,
+            prefill_step_size=16,
+            prompt_cache_warmup=warmup_enabled,
         )
-        model_provider = type(
-            "obj",
-            (object,),
-            {
-                "cli_args": cli_args,
-                "model": object(),
-                "model_key": self.MODEL_KEY,
-                "load": Mock(
-                    return_value=(object(), SequencedTokenizer(([1], [1])))
-                ),
-            },
+        model_provider = SimpleNamespace(
+            cli_args=cli_args,
+            model=object(),
+            model_key=self.MODEL_KEY,
+            load=Mock(return_value=(object(), SequencedTokenizer(([1], [1])))),
         )
         gen = ResponseGenerator.__new__(ResponseGenerator)
         gen.model_provider = model_provider
         gen.prompt_cache = prompt_cache
+        gen.requests = Queue()
         gen._prompt_cache_warmup = None
         gen._prompt_cache_warmup_lock = threading.Lock()
         gen._is_distributed = False
@@ -158,7 +178,7 @@ class TestPromptCacheWarmup(unittest.TestCase):
 
     def _make_gen_args(self, draft=None):
         model = ModelDescription(model="default_model", adapter=None, draft=draft)
-        return type("obj", (), {"model": model, "chat_template_kwargs": {}})
+        return SimpleNamespace(model=model, chat_template_kwargs={})
 
     def _chat_request(self, messages=None):
         return CompletionRequest(
@@ -168,26 +188,6 @@ class TestPromptCacheWarmup(unittest.TestCase):
             None,
             None,
         )
-
-    def _tool_messages(self, arguments):
-        return [
-            {"role": "user", "content": "What is 2+3?"},
-            {
-                "role": "assistant",
-                "content": "",
-                "tool_calls": [
-                    {
-                        "type": "function",
-                        "id": "123",
-                        "function": {
-                            "name": "add",
-                            "arguments": arguments,
-                        },
-                    }
-                ],
-            },
-            {"role": "tool", "content": "5", "tool_call_id": "123"},
-        ]
 
     def _make_ctx(self, **kwargs):
         attrs = {
@@ -221,6 +221,40 @@ class TestPromptCacheWarmup(unittest.TestCase):
             top_tokens=(),
         )
 
+    def _assert_generate_step_call(self, generate_step_mock, rest, prompt_cache):
+        call_args, call_kwargs = generate_step_mock.call_args
+        self.assertEqual(call_args[0].tolist(), rest)
+        self.assertEqual(call_kwargs["max_tokens"], 0)
+        if isinstance(prompt_cache, list):
+            self.assertEqual(call_kwargs["prompt_cache"], prompt_cache)
+        else:
+            self.assertIs(call_kwargs["prompt_cache"], prompt_cache)
+        self.assertEqual(call_kwargs["prefill_step_size"], 16)
+        self.assertIn("prompt_progress_callback", call_kwargs)
+
+    def _queue_warmup(
+        self,
+        prompt_cache,
+        prompts,
+        *,
+        assistant_message=None,
+        request=None,
+        args=None,
+    ):
+        gen = self._make_generator(prompt_cache)
+        gen.model_provider.load = Mock(
+            return_value=(
+                gen.model_provider.model,
+                SequencedTokenizer(prompts),
+            )
+        )
+        gen.enqueue_prompt_cache_warmup(
+            request or self._chat_request(),
+            args or self._make_gen_args(),
+            assistant_message or {"role": "assistant", "content": "Hi"},
+        )
+        return gen
+
     def _make_handler(self, ctx, responses, *, stream):
         handler = APIHandler.__new__(APIHandler)
         handler.response_generator = Mock()
@@ -232,63 +266,280 @@ class TestPromptCacheWarmup(unittest.TestCase):
         handler._set_stream_headers = Mock()
         handler.send_header = Mock()
         handler.end_headers = Mock()
-        for key, value in {
-            "request_id": "chatcmpl-test",
-            "system_fingerprint": "fp",
+        attrs = self.HANDLER_DEFAULTS | {
             "object_type": "chat.completion.chunk" if stream else "chat.completion",
-            "requested_model": "chat_model",
-            "requested_draft_model": None,
-            "created": 0,
-            "adapter": None,
-            "temperature": 0.0,
-            "top_p": 1.0,
-            "top_k": 0,
-            "min_p": 0.0,
-            "xtc_probability": 0.0,
-            "xtc_threshold": 0.0,
-            "logit_bias": None,
-            "repetition_penalty": 1.0,
-            "repetition_context_size": 20,
-            "presence_penalty": 0.0,
-            "presence_context_size": 20,
-            "frequency_penalty": 0.0,
-            "frequency_context_size": 20,
-            "max_tokens": 16,
-            "num_draft_tokens": 3,
-            "logprobs": False,
-            "top_logprobs": 0,
-            "seed": None,
-            "chat_template_kwargs": {},
-        }.items():
+        }
+        for key, value in attrs.items():
             setattr(handler, key, value)
         return handler
 
-    def test_build_prefill_request_returns_common_prefix(self):
-        gen = self._make_generator(None)
-        warmup = _PromptCacheWarmup(
-            model=self.MODEL,
-            messages=[{"role": "user", "content": "Hi"}],
-            tools=None,
-            role_mapping=None,
-            chat_template_kwargs={},
+    def test_enqueue_prompt_cache_warmup_handles_eligible_and_skipped_requests(self):
+        cases = (
+            {
+                "name": "stores chat reply",
+                "warmup_enabled": True,
+                "request": self._chat_request(),
+                "args": self._make_gen_args(),
+                "assistant_message": {"role": "assistant", "content": "Hi"},
+                "expected_messages": 2,
+            },
+            {
+                "name": "disabled",
+                "warmup_enabled": False,
+                "request": self._chat_request(),
+                "args": self._make_gen_args(),
+                "assistant_message": {"role": "assistant", "content": "Hi"},
+                "expected_messages": None,
+            },
+            {
+                "name": "draft model",
+                "warmup_enabled": True,
+                "request": self._chat_request(),
+                "args": self._make_gen_args(draft="draft-model"),
+                "assistant_message": {"role": "assistant", "content": "Hi"},
+                "expected_messages": None,
+            },
         )
-        tokenizer = SequencedTokenizer(([10, 20, 30, 99], [10, 20, 30, 88]))
-        self.assertEqual(gen._build_prefill_request(tokenizer, warmup), [10, 20, 30])
 
-    def test_build_prefill_request_returns_none_for_empty_prefix(self):
-        gen = self._make_generator(None)
-        warmup = _PromptCacheWarmup(
-            model=self.MODEL,
-            messages=[{"role": "user", "content": "Hi"}],
-            tools=None,
-            role_mapping=None,
-            chat_template_kwargs={},
+        for case in cases:
+            with self.subTest(case=case["name"]):
+                gen = self._make_generator(
+                    None, warmup_enabled=case["warmup_enabled"]
+                )
+                gen.enqueue_prompt_cache_warmup(
+                    case["request"],
+                    case["args"],
+                    case["assistant_message"],
+                )
+                if case["expected_messages"] is None:
+                    self.assertIsNone(gen._prompt_cache_warmup)
+                else:
+                    self.assertIsNotNone(gen._prompt_cache_warmup)
+                    self.assertEqual(
+                        len(gen._prompt_cache_warmup.messages),
+                        case["expected_messages"],
+                    )
+
+    def test_run_warmup_syncs_stream_before_wired_limit(self):
+        # mx.synchronize(generation_stream) must happen before wired_limit is
+        # entered so that any outstanding async batch work is flushed before
+        # the wired memory state changes.
+        prompt_cache = MockPromptCacheManager(["base-cache"], [7])
+        gen = self._queue_warmup(
+            prompt_cache,
+            ([1, 2, 3, 7, 10], [1, 2, 3, 7, 20]),
         )
-        tokenizer = SequencedTokenizer(([1, 2], [3, 4]))
-        self.assertIsNone(gen._build_prefill_request(tokenizer, warmup))
 
-    def test_tokenize_chat_handles_tool_arguments(self):
-        gen = self._make_generator(None)
+        call_log = []
+        with patch("mlx_lm.server.generate_step", return_value=iter(())), patch(
+            "mlx_lm.server.wired_limit",
+            side_effect=lambda *a, **k: (call_log.append("wired_limit"), nullcontext())[1],
+        ), patch(
+            "mlx_lm.server.mx.synchronize",
+            side_effect=lambda *a, **k: call_log.append("sync"),
+        ):
+            gen._run_prompt_cache_warmup()
+
+        sync_pos = next((i for i, v in enumerate(call_log) if v == "sync"), None)
+        wl_pos = next((i for i, v in enumerate(call_log) if v == "wired_limit"), None)
+        self.assertIsNotNone(sync_pos, "mx.synchronize was not called")
+        self.assertIsNotNone(wl_pos, "wired_limit was not called")
+        self.assertLess(sync_pos, wl_pos, "sync must precede wired_limit")
+
+    def test_run_warmup_handles_interrupt_edges(self):
+        def partial_interrupt_step(gen):
+            def run_step(*args, **kwargs):
+                gen.requests.put("incoming-request")
+                kwargs["prompt_progress_callback"](1, 2)
+                return iter(())
+
+            return run_step
+
+        def zero_progress_step(_):
+            def run_step(*args, **kwargs):
+                kwargs["prompt_progress_callback"](0, 1)
+                return iter(())
+
+            return run_step
+
+        cases = (
+            {
+                "name": "partial interruption checkpoints work",
+                "prompt_cache": MockPromptCacheManager(["base-cache"], [7, 10]),
+                "prompts": ([1, 2, 3, 7, 10, 99], [1, 2, 3, 7, 10, 88]),
+                "generate_step": partial_interrupt_step,
+                "expected_tokens": [1, 2, 3, 7],
+            },
+            {
+                "name": "zero progress does not interrupt",
+                "prompt_cache": MockPromptCacheManager(["base-cache"], [7]),
+                "prompts": ([1, 2, 3, 7, 10], [1, 2, 3, 7, 20]),
+                "generate_step": zero_progress_step,
+                "queue_request": True,
+                "expected_tokens": [1, 2, 3, 7],
+                "expected_rest": [7],
+                "expected_cache": ["base-cache"],
+            },
+        )
+
+        for case in cases:
+            with self.subTest(case=case["name"]):
+                gen = self._queue_warmup(case["prompt_cache"], case["prompts"])
+                if case.get("queue_request"):
+                    gen.requests.put("incoming-request")
+
+                with patch(
+                    "mlx_lm.server.generate_step",
+                    side_effect=case["generate_step"](gen),
+                ) as gs, patch(
+                    "mlx_lm.server.wired_limit", return_value=nullcontext()
+                ):
+                    self.assertTrue(gen._run_prompt_cache_warmup())
+
+                if case.get("expected_rest") is not None:
+                    self._assert_generate_step_call(
+                        gs,
+                        case["expected_rest"],
+                        case["expected_cache"],
+                    )
+                self.assertEqual(len(case["prompt_cache"].insert_calls), 1)
+                _, tokens, _, checkpoint = case["prompt_cache"].insert_calls[0]
+                self.assertEqual(tokens, case["expected_tokens"])
+                self.assertTrue(checkpoint)
+
+    def test_run_warmup_prefills_uncached_tokens(self):
+        cases = (
+            {
+                "name": "partial cache hit",
+                "prompt_cache": MockPromptCacheManager(["base-cache"], [7]),
+                "prompts": ([1, 2, 3, 7, 10], [1, 2, 3, 7, 20]),
+                "expected_rest": [7],
+                "expected_cache": ["base-cache"],
+                "expected_fetch": [1, 2, 3, 7],
+            },
+            {
+                "name": "cold start",
+                "prompt_cache": MockPromptCacheManager(None, [1, 2, 3]),
+                "prompts": ([1, 2, 3, 9], [1, 2, 3, 8]),
+                "expected_rest": [1, 2, 3],
+                "new_cache": object(),
+                "expected_fetch": [1, 2, 3],
+            },
+            {
+                "name": "exact cache hit",
+                "prompt_cache": MockPromptCacheManager(["exact-cache"], []),
+                "prompts": ([1, 2, 3, 9], [1, 2, 3, 8]),
+                "expected_fetch": [1, 2, 3],
+                "expects_prefill": False,
+            },
+        )
+
+        for case in cases:
+            with self.subTest(case=case["name"]):
+                gen = self._queue_warmup(case["prompt_cache"], case["prompts"])
+                with patch(
+                    "mlx_lm.server.generate_step", return_value=iter(())
+                ) as gs, patch(
+                    "mlx_lm.server.wired_limit", return_value=nullcontext()
+                ) as wl, patch(
+                    "mlx_lm.server.make_prompt_cache",
+                    return_value=case.get("new_cache"),
+                ) as make_cache:
+                    gen._run_prompt_cache_warmup()
+
+                if not case.get("expects_prefill", True):
+                    gs.assert_not_called()
+                    wl.assert_not_called()
+                    make_cache.assert_not_called()
+                    self.assertEqual(case["prompt_cache"].insert_calls, [])
+                    continue
+
+                gs.assert_called_once()
+                wl.assert_called_once()
+                expected_cache = case.get("new_cache") or case["prompt_cache"].cache
+                self._assert_generate_step_call(gs, case["expected_rest"], expected_cache)
+                self.assertEqual(
+                    case["prompt_cache"].fetch_calls,
+                    [(self.MODEL_KEY, case["expected_fetch"])],
+                )
+                _, tokens, stored_cache, checkpoint = case["prompt_cache"].insert_calls[0]
+                self.assertEqual(tokens, case["expected_fetch"])
+                self.assertIs(stored_cache, expected_cache)
+                self.assertTrue(checkpoint)
+                if case["prompt_cache"].cache is None:
+                    make_cache.assert_called_once()
+                else:
+                    make_cache.assert_not_called()
+
+    def test_handle_completion_only_enqueues_for_text_reply(self):
+        cases = (
+            {
+                "name": "streaming reasoning reply",
+                "ctx": self._make_ctx(
+                    has_thinking=True,
+                    prompt=[9, 1],
+                ),
+                "responses": [
+                    self._make_response("A", 10),
+                    self._make_response("B", 11),
+                    self._make_response("</think>", 12),
+                    self._make_response("Hi", 13, "stop"),
+                ],
+                "stream": True,
+                "expected_message": {
+                    "content": "Hi",
+                    "reasoning": "AB",
+                    "reasoning_content": "AB",
+                },
+            },
+            {
+                "name": "tool call reply",
+                "ctx": self._make_ctx(
+                    has_tool_calling=True,
+                    tool_call_start="<tool>",
+                    tool_call_end="</tool>",
+                    tool_parser=lambda tool_text, tools: {
+                        "name": "noop",
+                        "arguments": {},
+                    },
+                ),
+                "responses": [
+                    self._make_response("<tool>", 10),
+                    self._make_response('{"name":"noop","arguments":{}}', 11),
+                    self._make_response("</tool>", 12, "tool_calls"),
+                ],
+                "stream": False,
+                "expected_message": None,
+            },
+        )
+
+        for case in cases:
+            with self.subTest(case=case["name"]):
+                handler = self._make_handler(
+                    case["ctx"],
+                    case["responses"],
+                    stream=case["stream"],
+                )
+                handler.handle_completion(self._chat_request(), [])
+
+                if case["expected_message"] is None:
+                    handler.response_generator.enqueue_prompt_cache_warmup.assert_not_called()
+                else:
+                    handler.response_generator.enqueue_prompt_cache_warmup.assert_called_once()
+                    _, _, assistant_message = (
+                        handler.response_generator.enqueue_prompt_cache_warmup.call_args.args
+                    )
+                    self.assertEqual(assistant_message["content"], "Hi")
+                    self.assertEqual(
+                        assistant_message["reasoning"],
+                        case["expected_message"]["reasoning"],
+                    )
+                    self.assertEqual(
+                        assistant_message["reasoning_content"],
+                        case["expected_message"]["reasoning_content"],
+                    )
+
+    def test_process_message_content_handles_tool_arguments(self):
         cases = (
             ('{"a": 2, "b": 3}', {"a": 2, "b": 3}),  # string → parsed dict
             ("", ""),  # empty string → unchanged
@@ -297,131 +548,35 @@ class TestPromptCacheWarmup(unittest.TestCase):
 
         for arguments, expected in cases:
             with self.subTest(arguments=arguments):
-                tokenizer = SequencedTokenizer(([1], [2]))
-                messages = self._tool_messages(arguments)
+                messages = [
+                    {"role": "user", "content": "What is 2+3?"},
+                    {
+                        "role": "assistant",
+                        "content": "",
+                        "tool_calls": [
+                            {
+                                "type": "function",
+                                "id": "123",
+                                "function": {
+                                    "name": "add",
+                                    "arguments": arguments,
+                                },
+                            }
+                        ],
+                    },
+                    {"role": "tool", "content": "5", "tool_call_id": "123"},
+                ]
 
-                self.assertEqual(
-                    gen._tokenize_chat(tokenizer, messages, None, None, None),
-                    [1],
-                )
+                process_message_content(messages)
                 self.assertEqual(
                     messages[1]["tool_calls"][0]["function"]["arguments"],
                     expected,
                 )
+                process_message_content(messages)
                 self.assertEqual(
-                    gen._tokenize_chat(tokenizer, messages, None, None, None),
-                    [2],
+                    messages[1]["tool_calls"][0]["function"]["arguments"],
+                    expected,
                 )
-
-    def test_enqueue_prompt_cache_warmup_stores_chat_reply(self):
-        gen = self._make_generator(None)
-        gen.enqueue_prompt_cache_warmup(
-            self._chat_request(),
-            self._make_gen_args(),
-            {"role": "assistant", "content": "Hi"},
-        )
-        self.assertIsNotNone(gen._prompt_cache_warmup)
-        self.assertEqual(len(gen._prompt_cache_warmup.messages), 2)
-
-    def test_run_warmup_prefills_on_partial_cache_hit(self):
-        prompt_cache = MockPromptCacheManager(["base-cache"], [7])
-        gen = self._make_generator(prompt_cache)
-        gen.model_provider.load = Mock(
-            return_value=(
-                gen.model_provider.model,
-                SequencedTokenizer(([1, 2, 3, 7, 10], [1, 2, 3, 7, 20])),
-            )
-        )
-        gen.enqueue_prompt_cache_warmup(
-            self._chat_request(),
-            self._make_gen_args(),
-            {"role": "assistant", "content": "Hi"},
-        )
-
-        with patch("mlx_lm.server.generate_step", return_value=iter(())) as gs:
-            self.assertTrue(gen._run_prompt_cache_warmup())
-
-        gs.assert_called_once()
-        self.assertEqual(prompt_cache.fetch_calls, [(self.MODEL_KEY, [1, 2, 3, 7])])
-        self.assertEqual(len(prompt_cache.insert_calls), 1)
-        _, tokens, _, checkpoint = prompt_cache.insert_calls[0]
-        self.assertEqual(tokens, [1, 2, 3, 7])
-        self.assertTrue(checkpoint)
-
-    def test_run_warmup_creates_cache_on_cold_start(self):
-        prompt_cache = MockPromptCacheManager(None, [1, 2, 3])
-        gen = self._make_generator(prompt_cache)
-        gen.model_provider.load = Mock(
-            return_value=(
-                gen.model_provider.model,
-                SequencedTokenizer(([1, 2, 3, 9], [1, 2, 3, 8])),
-            )
-        )
-        gen.enqueue_prompt_cache_warmup(
-            self._chat_request(),
-            self._make_gen_args(),
-            {"role": "assistant", "content": "Hi"},
-        )
-
-        new_cache = object()
-        with patch("mlx_lm.server.generate_step", return_value=iter(())) as gs:
-            with patch("mlx_lm.server.make_prompt_cache", return_value=new_cache):
-                gen._run_prompt_cache_warmup()
-
-        gs.assert_called_once()
-        _, call_kwargs = gs.call_args
-        self.assertIs(call_kwargs["prompt_cache"], new_cache)
-        _, _, stored_cache, checkpoint = prompt_cache.insert_calls[0]
-        self.assertIs(stored_cache, new_cache)
-        self.assertTrue(checkpoint)
-
-    def test_run_warmup_skips_generate_on_exact_cache_hit(self):
-        prompt_cache = MockPromptCacheManager(["exact-cache"], [])
-        gen = self._make_generator(prompt_cache)
-        gen.model_provider.load = Mock(
-            return_value=(
-                gen.model_provider.model,
-                SequencedTokenizer(([1, 2, 3, 9], [1, 2, 3, 8])),
-            )
-        )
-        gen.enqueue_prompt_cache_warmup(
-            self._chat_request(),
-            self._make_gen_args(),
-            {"role": "assistant", "content": "Hi"},
-        )
-
-        with patch("mlx_lm.server.generate_step", return_value=iter(())) as gs:
-            self.assertTrue(gen._run_prompt_cache_warmup())
-
-        gs.assert_not_called()
-        self.assertEqual(prompt_cache.insert_calls, [])
-
-    def test_handle_completion_enqueues_full_reasoning_for_streaming_reply(self):
-        request = self._chat_request()
-        ctx = self._make_ctx(
-            has_thinking=True,
-            prompt=[9, 1],
-        )
-        handler = self._make_handler(
-            ctx,
-            [
-                self._make_response("A", 10),
-                self._make_response("B", 11),
-                self._make_response(ctx.think_end, 12),
-                self._make_response("Hi", 13, "stop"),
-            ],
-            stream=True,
-        )
-
-        handler.handle_completion(request, [])
-
-        handler.response_generator.enqueue_prompt_cache_warmup.assert_called_once()
-        _, _, assistant_message = (
-            handler.response_generator.enqueue_prompt_cache_warmup.call_args.args
-        )
-        self.assertEqual(assistant_message["content"], "Hi")
-        self.assertEqual(assistant_message["reasoning"], "AB")
-        self.assertEqual(assistant_message["reasoning_content"], "AB")
 
 
 class TestServer(unittest.TestCase):


### PR DESCRIPTION
This PR adds a `--prompt-cache-warmup` flag for speeding up the experience of multi-turn chats in `mlx_lm.server`.

More specifically, it uses idle time in between requests to pre-compute a cache checkpoint for the _next_ turn of a chat, instead of waiting for the user message.

## Problem

Previous work on cache checkpoints didn't fully address the difficult scenarios (untrimmable SSM layers, dynamic `<think>` placement, tool result rendering, etc:

- https://github.com/ml-explore/mlx-lm/issues/903
- https://github.com/ml-explore/mlx-lm/issues/980

Models with such features _always_ miss the final checkpoint and require reprocessing the entire previous assistant turn. That's much better than starting from scratch, but too often, still means waiting on tens of thousands of tokens per turn.

## Solution

At the end of an assistant turn, we already have everything needed to calculate the next stable cache prefix. Just tokenize the history with two placeholder user messages, then compare to find the overlap. This uses the model's actual chat template instead of heuristics and should handle any supported scenario.

Then, when the batch is idle, process a new checkpoint that's guaranteed to hit as long as the user continues the chat. If a new request interrupts warmup while it's in progress, we save a checkpoint immediately. If it was a continuation, it benefits from the partial progress. If not, the new request is not held up unnecessarily.

## Caveats

- This PR focuses on supporting the simple, single-user chat experience — one warmup slot, no draft model, no distributed mode. I briefly explored integrating warmup as a different batch row type, but this would've been messy without a bigger refactor. Likewise, draft model support seemed feasible, but would've expanded the scope.

- This PR also fixes two adjacent bugs:
  1. In `process_message_content()` tool arguments could be pre-parsed dicts rather than strings in some models (Qwen 3.5 and Kimi 2.5 in my testing) and would error.
  2. `make_prompt_cache` used `self.model_provider.model` (last loaded model) instead of the model actually assigned to the current batch. This could diverge if a request for a different model was served mid-batch.  

---

I've been testing this locally with a Qwen 3.5 powered Claude Code, and it makes a huge difference. I know it's a moderately large change though, so I'm happy to test more and make any adjustments.