### PR TITLE
Fix tool call parsing for models with multi-token delimiters

### DIFF
--- a/mlx_lm/server.py
+++ b/mlx_lm/server.py
@@ -1576,16 +1576,23 @@ class APIHandler(BaseHTTPRequestHandler):
                     in_reasoning = False
                 else:
                     reasoning_text += gen.text
-            elif ctx.has_tool_calling and gen.text == ctx.tool_call_start:
-                made_tool_call = True
-                in_tool_call = True
             elif in_tool_call:
-                if gen.text == ctx.tool_call_end:
+                tool_text += gen.text
+                # Detect end tag: exact single-token match or substring in buffer
+                if gen.text == ctx.tool_call_end or ctx.tool_call_end in tool_text:
+                    tool_text = tool_text[: tool_text.index(ctx.tool_call_end)]
                     tool_calls.append(tool_text)
                     tool_text = ""
                     in_tool_call = False
-                else:
-                    tool_text += gen.text
+            elif ctx.has_tool_calling:
+                text += gen.text
+                segment += gen.text
+                # Detect start tag: exact single-token match or substring in buffer
+                if ctx.tool_call_start in text:
+                    text = text[: text.index(ctx.tool_call_start)]
+                    segment = ""
+                    made_tool_call = True
+                    in_tool_call = True
             else:
                 text += gen.text
                 segment += gen.text

--- a/mlx_lm/tokenizer_utils.py
+++ b/mlx_lm/tokenizer_utils.py
@@ -303,13 +303,17 @@ class TokenizerWrapper:
                 self._think_end_id = vocab[think_end]
                 break
 
-        # Disable tool calling if tool call tokens aren't in vocab
+        # Warn if tool call tokens aren't in vocab but keep tool calling
+        # enabled — the streaming parser uses text matching which still works
+        # for multi-token delimiters (e.g. <tool_call> tokenized as subwords)
         if (tool_call_start and tool_call_start not in vocab) or (
             tool_call_end and tool_call_end not in vocab
         ):
-            self._tool_call_start = None
-            self._tool_call_end = None
-            self._tool_parser = None
+            logging.warning(
+                f"Tool call tokens ({tool_call_start}, {tool_call_end}) not "
+                "found as single tokens in vocab. "
+                "Tool call parsing will use text matching."
+            )
 
     def apply_chat_template(self, *args, tokenize=True, **kwargs):
         if self._chat_template is not None:


### PR DESCRIPTION
## Summary

Fixes #984 — tool calling detection and parsing fails for models where `<tool_call>` / `</tool_call>` delimiters are tokenized as multiple sub-tokens rather than single special tokens.

This affects all `mlx-community/Trinity-*` models (afmoe architecture) and potentially other community conversions where special tokens weren't preserved during MLX conversion.

### Changes

- **`tokenizer_utils.py`**: Changed the vocab guard from disabling tool calling to emitting a warning. The streaming parser uses text matching which works fine for multi-token delimiters — there's no reason to disable it entirely.

- **`server.py`**: Changed the streaming tool call parser from exact single-token matching (`gen.text == ctx.tool_call_start`) to buffer-based substring matching (`ctx.tool_call_start in text`). This correctly detects `<tool_call>` even when it arrives as multiple tokens (`<`, `tool`, `_`, `call`, `>`).

### Before

```
WARNING - Received tools but model does not support tool calling.
```
Response has tool call in `content` but `tool_calls` is empty, `finish_reason` is `stop`.

### After

Tool calls are correctly parsed into structured `tool_calls` with `finish_reason: tool_calls`.

## Test plan

- [x] Tested with `mlx-community/Trinity-Mini-8bit` — tool calls correctly detected and parsed
- [x] Verified backward compatibility: models with single-token delimiters still work (exact match is a subset of substring match)
- [x] No changes to tool parser logic itself, only detection and streaming extraction