### PR TITLE
Clear cache trainer memory

### DIFF
--- a/mlx_lm/lora.py
+++ b/mlx_lm/lora.py
@@ -21,7 +21,7 @@ from .tuner.utils import (
     load_adapters,
     print_trainable_parameters,
 )
-from .utils import load, save_config
+from .utils import _parse_size, load, save_config
 
 yaml_loader = yaml.SafeLoader
 yaml_loader.add_implicit_resolver(
@@ -69,6 +69,7 @@ CONFIG_DEFAULTS = {
     "config": None,
     "grad_checkpoint": False,
     "grad_accumulation_steps": 1,
+    "clear_cache_threshold": 0,
     "lr_schedule": None,
     "lora_parameters": {"rank": 8, "dropout": 0.0, "scale": 20.0},
     "mask_prompt": False,
@@ -189,6 +190,12 @@ def build_parser():
         action="store_true",
         help="Use gradient checkpointing to reduce memory use.",
         default=None,
+    )
+    parser.add_argument(
+        "--clear-cache-threshold",
+        type=_parse_size,
+        default=0,
+        help="Clear the allocator cache between steps if it grows too large.",
     )
     parser.add_argument(
         "--report-to",

--- a/mlx_lm/server.py
+++ b/mlx_lm/server.py
@@ -42,24 +42,12 @@ from .models.cache import (
     trim_prompt_cache,
 )
 from .sample_utils import make_logits_processors, make_sampler
-from .utils import load, sharded_load
+from .utils import _parse_size, load, sharded_load
 
 
 def get_system_fingerprint():
     gpu_arch = mx.device_info()["architecture"]
     return f"{__version__}-{mx.__version__}-{platform.platform()}-{gpu_arch}"
-
-
-def parse_size(x):
-    sizes = {"M": 1e6, "G": 1e9, "MB": 1e6, "GB": 1e9, "": 1}
-    split = 0
-    for xi in x:
-        if not (xi.isdigit() or xi == "."):
-            break
-        split += 1
-    digits = float(x[:split])
-    size = (x[split:]).strip().upper()
-    return int(digits * sizes[size])
 
 
 class StopCondition(NamedTuple):
@@ -2005,7 +1993,7 @@ def main():
     )
     parser.add_argument(
         "--prompt-cache-bytes",
-        type=parse_size,
+        type=_parse_size,
         help="Maximum size in bytes of the KV caches",
     )
     parser.add_argument(

--- a/mlx_lm/tuner/trainer.py
+++ b/mlx_lm/tuner/trainer.py
@@ -17,6 +17,11 @@ from .callbacks import TrainingCallback
 from .datasets import CacheDataset
 
 
+def _clear_cache(threshold: int):
+    if mx.get_cache_memory() > threshold:
+        mx.clear_cache()
+
+
 def grad_checkpoint(layer):
     """
     Update all instances of type(layer) to use gradient checkpointing.
@@ -68,6 +73,12 @@ class TrainingArgs:
         default=1,
         metadata={
             "help": "Number of steps to accumulate gradients before applying an optimizer update."
+        },
+    )
+    clear_cache_threshold: int = field(
+        default=0,
+        metadata={
+            "help": "Clear the allocator cache between steps if it grows too large."
         },
     )
 
@@ -170,6 +181,7 @@ def evaluate(
     max_seq_length=2048,
     loss: callable = default_loss,
     iterate_batches: callable = iterate_batches,
+    clear_cache_threshold: int = 0,
 ):
     model.eval()
     all_losses = mx.array(0.0)
@@ -194,14 +206,13 @@ def evaluate(
         all_losses += losses * toks
         ntokens += toks
         mx.eval(all_losses, ntokens)
-        mx.clear_cache()
+        _clear_cache(clear_cache_threshold)
 
     all_losses = mx.distributed.all_sum(all_losses, stream=mx.cpu)
     ntokens = mx.distributed.all_sum(ntokens, stream=mx.cpu)
-    mx.eval(all_losses, ntokens)
-    mx.clear_cache()
+    avg_loss = (all_losses / ntokens).item()
 
-    return (all_losses / ntokens).item()
+    return avg_loss
 
 
 def train(
@@ -315,7 +326,7 @@ def train(
         n_tokens += toks
         steps += 1
         mx.eval(state, losses, n_tokens, grad_accum)
-        mx.clear_cache()
+        _clear_cache(args.clear_cache_threshold)
         train_time += time.perf_counter() - tic
 
         # Report training loss if needed

--- a/mlx_lm/utils.py
+++ b/mlx_lm/utils.py
@@ -57,6 +57,18 @@ MODEL_REMAPPING = {
 MAX_FILE_SIZE_GB = 5
 
 
+def _parse_size(x):
+    sizes = {"M": 1e6, "G": 1e9, "MB": 1e6, "GB": 1e9, "": 1}
+    split = 0
+    for xi in x:
+        if not (xi.isdigit() or xi == "."):
+            break
+        split += 1
+    digits = float(x[:split])
+    size = (x[split:]).strip().upper()
+    return int(digits * sizes[size])
+
+
 def _unpack_awq_weights(qweight: mx.array) -> mx.array:
     bits = 4
     pack_factor = 32 // bits


### PR DESCRIPTION
Simply adds a 'mx.clear_cache()' after each iteration of LORA training. This takes memory use (measured by `phys_footprint`) from '51.0 GiB' to '7.09 GiB' under the same conditions. MLX's native peak_memory wasn't detecting this extra usage, so it didn't immediately appear in the server - but I noticed in in mactop, so investigated + patched.