### PR TITLE
Native MTP speculative decoding (Qwen3.5/3.6 reference implementation)

### DIFF
--- a/mlx_lm/generate.py
+++ b/mlx_lm/generate.py
@@ -691,10 +691,11 @@ def mtp_generate_step(
         model_cache = cache.make_prompt_cache(model)
         mtp_cache = model.make_mtp_cache()
     else:
-        # When a pre-built cache is provided, split at backbone length
+        # Split a pre-built cache at backbone length.  If MTP entries are
+        # absent (e.g. cache created by make_prompt_cache), create them.
         n_main = len(model.layers)
         model_cache = prompt_cache[:n_main]
-        mtp_cache = prompt_cache[n_main:]
+        mtp_cache = prompt_cache[n_main:] or model.make_mtp_cache()
 
     sampler = sampler or (lambda x: mx.argmax(x, axis=-1))
 
@@ -770,7 +771,7 @@ def mtp_generate_step(
                 main_lp = lps[0]
 
                 ntoks += 1
-                yield main_tok, main_lp, False
+                yield main_tok.item(), main_lp, False
                 if ntoks >= max_tokens:
                     break
 
@@ -799,12 +800,12 @@ def mtp_generate_step(
                             c.rollback_state = None
 
                     ntoks += 1
-                    yield draft_tok, draft_lp, True
+                    yield draft_tok.item(), draft_lp, True
                     if ntoks >= max_tokens:
                         break
 
                     ntoks += 1
-                    yield bonus_tok, bonus_lp, False
+                    yield bonus_tok.item(), bonus_lp, False
                     if ntoks >= max_tokens:
                         break
 
@@ -828,7 +829,7 @@ def mtp_generate_step(
                     cache.trim_prompt_cache(mtp_cache, 1)
 
                     ntoks += 1
-                    yield verify_pred, verify_lp, False
+                    yield verify_pred.item(), verify_lp, False
                     if ntoks >= max_tokens:
                         break
 

--- a/mlx_lm/generate.py
+++ b/mlx_lm/generate.py
@@ -662,7 +662,7 @@ def mtp_generate_step(
     sampler: Optional[Callable[[mx.array], mx.array]] = None,
     logits_processors: Optional[List[Callable[[mx.array, mx.array], mx.array]]] = None,
     prompt_cache: Optional[Any] = None,
-    prefill_step_size: int = 512,
+    prefill_step_size: int = 2048,
     kv_bits: Optional[int] = None,
     kv_group_size: int = 64,
     quantized_kv_start: int = 0,
@@ -769,11 +769,14 @@ def mtp_generate_step(
         return draft_tok, draft_lp
 
     def _prefill(y):
-        while y.size > prefill_step_size:
-            model(y[:prefill_step_size][None], cache=model_cache)
+        # Leave exactly 1 token for _step_backbone: return_hidden=True keeps
+        # the hidden state [1, N, d_model] live, so N must be 1.
+        while y.size > 1:
+            n = min(prefill_step_size, y.size - 1)
+            model(y[:n][None], cache=model_cache)
             quantize_cache_fn(model_cache)
             mx.eval([c.state for c in model_cache if hasattr(c, "state")])
-            y = y[prefill_step_size:]
+            y = y[n:]
             mx.clear_cache()
         return y
 

--- a/mlx_lm/generate.py
+++ b/mlx_lm/generate.py
@@ -666,6 +666,7 @@ def mtp_generate_step(
     kv_bits: Optional[int] = None,
     kv_group_size: int = 64,
     quantized_kv_start: int = 0,
+    input_embeddings: Optional[mx.array] = None,
 ) -> Generator[Tuple[mx.array, mx.array, bool], None, None]:
     """A generator that uses the model's native MTP head for speculative decoding.
 
@@ -708,8 +709,10 @@ def mtp_generate_step(
 
     def _process_and_sample(tokens, logits):
         if logits_processors:
+            logits = logits[None]
             for processor in logits_processors:
                 logits = processor(tokens, logits)
+            logits = logits.squeeze(0)
         logprobs = logits - mx.logsumexp(logits, axis=-1, keepdims=True)
         return sampler(logprobs), logprobs
 
@@ -774,20 +777,30 @@ def mtp_generate_step(
             draft_tok, draft_lp = _process_and_sample(tokens_for_proc, mtp_logits)
         return draft_tok, draft_lp
 
-    def _prefill(y):
+    def _prefill(y, input_embeddings):
         # Leave exactly 1 token for _step_backbone: return_hidden=True keeps
         # the hidden state [1, N, d_model] live, so N must be 1.
-        while y.size > 1:
-            n = min(prefill_step_size, y.size - 1)
-            model(y[:n][None], cache=model_cache)
+        total = len(input_embeddings) if input_embeddings is not None else y.size
+        while total > 1:
+            n = min(prefill_step_size, total - 1)
+            if input_embeddings is not None:
+                model(
+                    y[:n][None],
+                    cache=model_cache,
+                    input_embeddings=input_embeddings[:n][None],
+                )
+                input_embeddings = input_embeddings[n:]
+            else:
+                model(y[:n][None], cache=model_cache)
             quantize_cache_fn(model_cache)
             mx.eval([c.state for c in model_cache if hasattr(c, "state")])
             y = y[n:]
+            total -= n
             mx.clear_cache()
         return y
 
     with mx.stream(generation_stream):
-        y = _prefill(y)
+        y = _prefill(y, input_embeddings)
 
     ntoks = 0
     draft_tok = draft_lp = None

--- a/mlx_lm/generate.py
+++ b/mlx_lm/generate.py
@@ -757,13 +757,12 @@ def mtp_generate_step(
             quantize_cache_fn(model_cache)
             nonlocal prev_tokens
             toks, lps = [], []
-            y_ctx = y if n_predict == 1 else y[: -(n_predict - 1)]
             for i in range(n_predict):
                 if logits_processors:
                     prev_tokens = (
-                        mx.concatenate([prev_tokens, y_ctx])
+                        mx.concatenate([prev_tokens, y[i : i + 1]])
                         if prev_tokens is not None
-                        else y_ctx
+                        else y[i : i + 1]
                     )
                 tok, lp = _process_and_sample(prev_tokens, logits[:, i, :].squeeze(0))
                 toks.append(tok)
@@ -777,7 +776,15 @@ def mtp_generate_step(
             mtp_logits = model.mtp_forward(hidden_last, next_ids, mtp_cache)
             quantize_cache_fn(mtp_cache)
             mtp_logits = mtp_logits[:, -1, :].squeeze(0)
-            draft_tok, draft_lp = _process_and_sample(prev_tokens, mtp_logits)
+            if logits_processors:
+                tokens_for_proc = (
+                    mx.concatenate([prev_tokens, main_tok.reshape(-1)])
+                    if prev_tokens is not None
+                    else main_tok.reshape(-1)
+                )
+            else:
+                tokens_for_proc = prev_tokens
+            draft_tok, draft_lp = _process_and_sample(tokens_for_proc, mtp_logits)
         return draft_tok, draft_lp
 
     def _prefill(y):
@@ -846,6 +853,8 @@ def mtp_generate_step(
                 y = mx.array([bonus_tok.item()], mx.uint32)
             else:
                 _rollback_draft()
+                if logits_processors and prev_tokens is not None:
+                    prev_tokens = prev_tokens[:-1]  # discard rejected draft token
                 verify_tok_id = verify_pred.item()
                 ntoks += 1
                 yield verify_tok_id, verify_lp, False

--- a/mlx_lm/generate.py
+++ b/mlx_lm/generate.py
@@ -44,6 +44,7 @@ DEFAULT_SEED = None
 DEFAULT_MODEL = "mlx-community/Llama-3.2-3B-Instruct-4bit"
 DEFAULT_QUANTIZED_KV_START = 5000
 DEFAULT_PREFILL_STEP_SIZE = 2048
+_CACHE_CLEAR_INTERVAL = 256
 
 
 def str2bool(string):
@@ -473,7 +474,7 @@ def generate_step(
             if n == max_tokens:
                 break
             yield y.item(), logprobs
-            if n % 256 == 0:
+            if n % _CACHE_CLEAR_INTERVAL == 0:
                 mx.clear_cache()
             y, logprobs = next_y, next_logprobs
             n += 1
@@ -865,6 +866,7 @@ def mtp_generate_step(
         y = _prefill(y, input_embeddings)
 
     ntoks = 0
+    last_cache_block = 0
     draft_tok = draft_lp = draft_accept_lp = draft_xtc_draw = None
 
     while ntoks < max_tokens:
@@ -964,6 +966,10 @@ def mtp_generate_step(
                 )
                 mx.eval(draft_tok)
                 y = mx.array([verify_tok_id], mx.uint32)
+        block = ntoks // _CACHE_CLEAR_INTERVAL
+        if block > last_cache_block:
+            mx.clear_cache()
+            last_cache_block = block
 
 
 def stream_generate(

--- a/mlx_lm/generate.py
+++ b/mlx_lm/generate.py
@@ -19,8 +19,8 @@ import mlx.nn as nn
 from mlx.utils import tree_reduce
 from transformers import PreTrainedTokenizer
 
-from .models import cache
 from .models.cache import (
+    MTPPromptCacheState,
     QuantizedKVCache,
     TokenBuffer,
     can_trim_prompt_cache,
@@ -765,7 +765,7 @@ def mtp_generate_step(
     cached_token_count = 0
 
     if prompt_cache is None:
-        model_cache = cache.make_prompt_cache(model)
+        model_cache = make_prompt_cache(model)
         mtp_cache = fresh_mtp_cache
     else:
         n_main = len(model.layers)
@@ -777,7 +777,7 @@ def mtp_generate_step(
 
         model_cache = list(prompt_cache[:n_main])
         tail = list(prompt_cache[n_main:])
-        if tail and isinstance(tail[-1], cache.MTPPromptCacheState):
+        if tail and isinstance(tail[-1], MTPPromptCacheState):
             prompt_state = tail.pop()
         mtp_cache = tail
 
@@ -808,7 +808,7 @@ def mtp_generate_step(
                 raise TypeError(
                     "prompt_cache must be a mutable sequence for native MTP."
                 )
-            prompt_state = cache.MTPPromptCacheState()
+            prompt_state = MTPPromptCacheState()
             prompt_cache.append(prompt_state)
         elif not prompt_state.empty():
             cached_token_count = prompt_state.num_tokens

--- a/mlx_lm/generate.py
+++ b/mlx_lm/generate.py
@@ -16,6 +16,7 @@ import mlx.nn as nn
 from mlx.utils import tree_reduce
 from transformers import PreTrainedTokenizer
 
+from .models import cache
 from .models.cache import (
     QuantizedKVCache,
     TokenBuffer,
@@ -656,6 +657,183 @@ def speculative_generate_step(
             _rewind_cache(num_draft, n)
 
 
+def mtp_generate_step(
+    prompt: mx.array,
+    model: nn.Module,
+    *,
+    max_tokens: int = 256,
+    sampler: Optional[Callable[[mx.array], mx.array]] = None,
+    logits_processors: Optional[List[Callable[[mx.array, mx.array], mx.array]]] = None,
+    prompt_cache: Optional[Any] = None,
+    prefill_step_size: int = 512,
+    kv_bits: Optional[int] = None,
+    kv_group_size: int = 64,
+    quantized_kv_start: int = 0,
+) -> Generator[Tuple[mx.array, mx.array, bool], None, None]:
+    """A generator using the model's native MTP head for speculative decoding.
+
+    Produces up to 2 tokens per forward pass:
+      - 1 backbone token (always accepted)
+      - 1 MTP draft token (accepted if the backbone agrees on the next step)
+
+    The model must expose ``mtp_forward(hidden, next_tok, mtp_cache)`` and
+    support ``return_hidden=True`` in its ``__call__``.
+
+    Yields:
+        Tuple[mx.array, mx.array, bool]: token, log-probabilities, from_draft.
+    """
+    y = prompt.astype(mx.uint32)
+    prev_tokens = None
+
+    if prompt_cache is None:
+        model_cache = cache.make_prompt_cache(model)
+        mtp_cache = model.make_mtp_cache()
+    else:
+        # When a pre-built cache is provided, split at backbone length
+        n_main = len(model.layers)
+        model_cache = prompt_cache[:n_main]
+        mtp_cache = prompt_cache[n_main:]
+
+    sampler = sampler or (lambda x: mx.argmax(x, axis=-1))
+
+    quantize_cache_fn = functools.partial(
+        maybe_quantize_kv_cache,
+        quantized_kv_start=quantized_kv_start,
+        kv_group_size=kv_group_size,
+        kv_bits=kv_bits,
+    )
+
+    def _process_and_sample(tokens, logits):
+        if logits_processors:
+            for processor in logits_processors:
+                logits = processor(tokens, logits)
+        logprobs = logits - mx.logsumexp(logits, axis=-1, keepdims=True)
+        tok = sampler(logprobs)
+        return tok, logprobs
+
+    def _step_backbone(y, n_predict=1):
+        """One backbone forward pass. Returns (tokens, logprobs, hidden)."""
+        with mx.stream(generation_stream):
+            logits, hidden = model(y[None], cache=model_cache, return_hidden=True)
+            logits = logits[:, -n_predict:, :]
+            quantize_cache_fn(model_cache)
+            nonlocal prev_tokens
+            toks, lps = [], []
+            y_ctx = y if n_predict == 1 else y[: -(n_predict - 1)]
+            for i in range(n_predict):
+                if logits_processors:
+                    prev_tokens = (
+                        mx.concatenate([prev_tokens, y_ctx])
+                        if prev_tokens is not None
+                        else y_ctx
+                    )
+                tok, lp = _process_and_sample(prev_tokens, logits[:, i, :].squeeze(0))
+                toks.append(tok)
+                lps.append(lp)
+            return mx.stack(toks), mx.stack(lps), hidden
+
+    def _step_mtp(hidden_last, main_tok):
+        """Run MTP head. Returns (draft_token, draft_logprobs)."""
+        # hidden_last: (1, 1, H), main_tok: 0-d or scalar
+        next_ids = main_tok.reshape(1, 1)
+        with mx.stream(generation_stream):
+            mtp_logits = model.mtp_forward(hidden_last, next_ids, mtp_cache)
+            quantize_cache_fn(mtp_cache)
+            mtp_logits = mtp_logits[:, -1, :].squeeze(0)
+            draft_tok, draft_lp = _process_and_sample(prev_tokens, mtp_logits)
+        return draft_tok, draft_lp
+
+    def _prefill(y):
+        while y.size > prefill_step_size:
+            model(y[:prefill_step_size][None], cache=model_cache)
+            quantize_cache_fn(model_cache)
+            mx.eval([c.state for c in model_cache if hasattr(c, "state")])
+            y = y[prefill_step_size:]
+            mx.clear_cache()
+        return y
+
+    with mx.stream(generation_stream):
+        y = _prefill(y)
+
+    ntoks = 0
+    draft_tok = None
+    draft_lp = None
+
+    try:
+        while True:
+            if draft_tok is None:
+                # No pending draft — run backbone only, then generate first draft
+                toks, lps, hidden = _step_backbone(y, n_predict=1)
+                mx.eval(toks)
+                main_tok = toks[0]
+                main_lp = lps[0]
+
+                ntoks += 1
+                yield main_tok, main_lp, False
+                if ntoks >= max_tokens:
+                    break
+
+                draft_tok, draft_lp = _step_mtp(hidden[:, -1:, :], main_tok)
+                mx.eval(draft_tok)
+                y = mx.array([main_tok.item()], mx.uint32)
+            else:
+                # Verify draft: process [y, draft_tok] through backbone together
+                y_with_draft = mx.concatenate(
+                    [y, mx.array([draft_tok.item()], mx.uint32)]
+                )
+                toks, lps, hidden = _step_backbone(y_with_draft, n_predict=2)
+                mx.eval(toks, draft_tok)
+
+                verify_pred = toks[0]   # backbone prediction after y → verify draft
+                bonus_tok = toks[1]     # backbone prediction after draft_tok
+                verify_lp = lps[0]
+                bonus_lp = lps[1]
+
+                if verify_pred.item() == draft_tok.item():
+                    # Draft accepted
+                    ntoks += 1
+                    yield draft_tok, draft_lp, True
+                    if ntoks >= max_tokens:
+                        break
+
+                    ntoks += 1
+                    yield bonus_tok, bonus_lp, False
+                    if ntoks >= max_tokens:
+                        break
+
+                    # Next draft from MTP at draft_tok's hidden state
+                    draft_tok, draft_lp = _step_mtp(hidden[:, 1:2, :], bonus_tok)
+                    mx.eval(draft_tok)
+                    y = mx.array([bonus_tok.item()], mx.uint32)
+                else:
+                    # Draft rejected — trim caches.
+                    #
+                    # Qwen3.5 is a hybrid SSM+Attention model: attention layers use
+                    # KVCache (trimmable), SSM layers use ArraysCache (not trimmable).
+                    # trim_prompt_cache() is all-or-nothing, so we trim KV entries
+                    # individually. The SSM state will retain a 1-token contamination
+                    # from the rejected draft, which is empirically negligible compared
+                    # to the sequence length but means output may differ slightly from
+                    # standard generate_step. A correct fix would require exposing
+                    # per-token intermediate SSM states from GatedDeltaNet (future work).
+                    for c in model_cache:
+                        if c.is_trimmable():
+                            c.trim(1)
+                    cache.trim_prompt_cache(mtp_cache, 1)
+
+                    ntoks += 1
+                    yield verify_pred, verify_lp, False
+                    if ntoks >= max_tokens:
+                        break
+
+                    # Next draft from MTP at y's hidden state
+                    draft_tok, draft_lp = _step_mtp(hidden[:, 0:1, :], verify_pred)
+                    mx.eval(draft_tok)
+                    y = mx.array([verify_pred.item()], mx.uint32)
+    finally:
+        pass
+
+
 def stream_generate(
     model: nn.Module,
     tokenizer: Union[PreTrainedTokenizer, TokenizerWrapper],
@@ -700,18 +878,23 @@ def stream_generate(
 
     kwargs["max_tokens"] = max_tokens
 
-    if draft_model is None:
+    if draft_model is not None:
+        kwargs.pop("max_kv_size", None)
+        kwargs.pop("prompt_progress_callback", None)
+        token_generator = speculative_generate_step(
+            prompt, model, draft_model, **kwargs
+        )
+    elif hasattr(model, "mtp_forward"):
+        kwargs.pop("max_kv_size", None)
+        kwargs.pop("prompt_progress_callback", None)
+        kwargs.pop("num_draft_tokens", None)
+        token_generator = mtp_generate_step(prompt, model, **kwargs)
+    else:
         kwargs.pop("num_draft_tokens", None)
         token_generator = generate_step(prompt, model, **kwargs)
         # from_draft always false for non-speculative generation
         token_generator = (
             (token, logprobs, False) for token, logprobs in token_generator
-        )
-    else:
-        kwargs.pop("max_kv_size", None)
-        kwargs.pop("prompt_progress_callback", None)
-        token_generator = speculative_generate_step(
-            prompt, model, draft_model, **kwargs
         )
     with wired_limit(model, [generation_stream]):
         tic = time.perf_counter()

--- a/mlx_lm/generate.py
+++ b/mlx_lm/generate.py
@@ -303,6 +303,22 @@ def maybe_quantize_kv_cache(prompt_cache, quantized_kv_start, kv_group_size, kv_
             prompt_cache[e] = c.to_quantized(group_size=kv_group_size, bits=kv_bits)
 
 
+def validate_prompt_and_embeddings(model, prompt, input_embeddings):
+    if input_embeddings is not None:
+        if not does_model_support_input_embeddings(model):
+            raise ValueError("Model does not support input embeddings.")
+        elif len(prompt) > 0 and len(prompt) != len(input_embeddings):
+            raise ValueError(
+                f"When providing input_embeddings, their sequence length ({len(input_embeddings)}) "
+                f"must match the sequence length of the prompt ({len(prompt)}), or the "
+                "prompt must be empty."
+            )
+    elif len(prompt) == 0:
+        raise ValueError(
+            "Either input_embeddings or prompt (or both) must be provided."
+        )
+
+
 def generate_step(
     prompt: mx.array,
     model: nn.Module,
@@ -350,19 +366,7 @@ def generate_step(
     Yields:
         Tuple[mx.array, mx.array]: One token and a vector of log probabilities.
     """
-    if input_embeddings is not None:
-        if not does_model_support_input_embeddings(model):
-            raise ValueError("Model does not support input embeddings.")
-        elif len(prompt) > 0 and len(prompt) != len(input_embeddings):
-            raise ValueError(
-                f"When providing input_embeddings, their sequence length ({len(input_embeddings)}) "
-                f"must match the sequence length of the prompt ({len(prompt)}), or the "
-                "prompt must be empty."
-            )
-    elif len(prompt) == 0:
-        raise ValueError(
-            "Either input_embeddings or prompt (or both) must be provided."
-        )
+    validate_prompt_and_embeddings(model, prompt, input_embeddings)
 
     tokens = None
 
@@ -688,6 +692,8 @@ def mtp_generate_step(
         Tuple[mx.array, mx.array, bool]: (token, log-probabilities, from_draft).
             ``from_draft`` is ``True`` when the token came from the MTP head.
     """
+    validate_prompt_and_embeddings(model, prompt, input_embeddings)
+
     y = prompt.astype(mx.uint32)
     prev_tokens = None
 

--- a/mlx_lm/generate.py
+++ b/mlx_lm/generate.py
@@ -658,17 +658,19 @@ def mtp_generate_step(
     kv_group_size: int = 64,
     quantized_kv_start: int = 0,
 ) -> Generator[Tuple[mx.array, mx.array, bool], None, None]:
-    """A generator using the model's native MTP head for speculative decoding.
+    """A generator that uses the model's native MTP head for speculative decoding.
 
-    Produces up to 2 tokens per forward pass:
-      - 1 backbone token (always accepted)
-      - 1 MTP draft token (accepted if the backbone agrees on the next step)
+    Each iteration runs one backbone forward pass over the current token and its
+    pending draft, then one MTP forward pass to propose the next draft.  Up to 2
+    tokens are emitted per backbone step: one always-accepted backbone token and
+    one conditionally-accepted draft token.
 
-    The model must expose ``mtp_forward(hidden, next_tok, mtp_cache)`` and
+    The model must implement ``mtp_forward(hidden, next_tok, mtp_cache)`` and
     support ``return_hidden=True`` in its ``__call__``.
 
     Yields:
-        Tuple[mx.array, mx.array, bool]: token, log-probabilities, from_draft.
+        Tuple[mx.array, mx.array, bool]: (token, log-probabilities, from_draft).
+            ``from_draft`` is ``True`` when the token came from the MTP head.
     """
     y = prompt.astype(mx.uint32)
     prev_tokens = None
@@ -699,10 +701,10 @@ def mtp_generate_step(
         tok = sampler(logprobs)
         return tok, logprobs
 
-    def _step_backbone(y, n_predict=1):
-        """One backbone forward pass. Returns (tokens, logprobs, hidden)."""
+    def _step_backbone(y, n_predict=1, n_confirmed=0):
+        """Run the backbone on ``y`` and return (tokens, logprobs, hidden)."""
         with mx.stream(generation_stream):
-            logits, hidden = model(y[None], cache=model_cache, return_hidden=True)
+            logits, hidden = model(y[None], cache=model_cache, return_hidden=True, n_confirmed=n_confirmed)
             logits = logits[:, -n_predict:, :]
             quantize_cache_fn(model_cache)
             nonlocal prev_tokens
@@ -721,8 +723,7 @@ def mtp_generate_step(
             return mx.stack(toks), mx.stack(lps), hidden
 
     def _step_mtp(hidden_last, main_tok):
-        """Run MTP head. Returns (draft_token, draft_logprobs)."""
-        # hidden_last: (1, 1, H), main_tok: 0-d or scalar
+        """Run the MTP head and return (draft_token, draft_logprobs)."""
         next_ids = main_tok.reshape(1, 1)
         with mx.stream(generation_stream):
             mtp_logits = model.mtp_forward(hidden_last, next_ids, mtp_cache)
@@ -765,11 +766,13 @@ def mtp_generate_step(
                 mx.eval(draft_tok)
                 y = mx.array([main_tok.item()], mx.uint32)
             else:
-                # Verify draft: process [y, draft_tok] through backbone together
+                # Verify draft: run backbone over [y, draft_tok].
+                # n_confirmed=1 causes GatedDeltaNet to snapshot its SSM/conv state
+                # after the confirmed token y, enabling exact rollback on rejection.
                 y_with_draft = mx.concatenate(
                     [y, mx.array([draft_tok.item()], mx.uint32)]
                 )
-                toks, lps, hidden = _step_backbone(y_with_draft, n_predict=2)
+                toks, lps, hidden = _step_backbone(y_with_draft, n_predict=2, n_confirmed=1)
                 mx.eval(toks, draft_tok)
 
                 verify_pred = toks[0]   # backbone prediction after y → verify draft
@@ -778,7 +781,11 @@ def mtp_generate_step(
                 bonus_lp = lps[1]
 
                 if verify_pred.item() == draft_tok.item():
-                    # Draft accepted
+                    # Draft accepted — discard rollback snapshots.
+                    for c in model_cache:
+                        if hasattr(c, "rollback_state"):
+                            c.rollback_state = None
+
                     ntoks += 1
                     yield draft_tok, draft_lp, True
                     if ntoks >= max_tokens:
@@ -794,18 +801,17 @@ def mtp_generate_step(
                     mx.eval(draft_tok)
                     y = mx.array([bonus_tok.item()], mx.uint32)
                 else:
-                    # Draft rejected — trim caches.
-                    #
-                    # Qwen3.5 is a hybrid SSM+Attention model: attention layers use
-                    # KVCache (trimmable), SSM layers use ArraysCache (not trimmable).
-                    # trim_prompt_cache() is all-or-nothing, so we trim KV entries
-                    # individually. The SSM state will retain a 1-token contamination
-                    # from the rejected draft, which is empirically negligible compared
-                    # to the sequence length but means output may differ slightly from
-                    # standard generate_step. A correct fix would require exposing
-                    # per-token intermediate SSM states from GatedDeltaNet (future work).
+                    # Draft rejected — roll back all caches to the state after y.
+                    # SSM layers (ArraysCache): restore the conv/ssm snapshot saved
+                    # by GatedDeltaNet after the confirmed token.
+                    # Attention layers (KVCache): trim the draft-token entry.
                     for c in model_cache:
-                        if c.is_trimmable():
+                        if hasattr(c, "rollback_state") and c.rollback_state is not None:
+                            conv_snap, ssm_snap = c.rollback_state
+                            c[0] = conv_snap
+                            c[1] = ssm_snap
+                            c.rollback_state = None
+                        elif c.is_trimmable():
                             c.trim(1)
                     cache.trim_prompt_cache(mtp_cache, 1)
 

--- a/mlx_lm/generate.py
+++ b/mlx_lm/generate.py
@@ -879,7 +879,6 @@ def mtp_generate_step(
             # n_confirmed=1 causes GatedDeltaNet to snapshot its SSM/conv state
             # after the confirmed token y, enabling exact rollback on rejection.
             y_with_draft = mx.concatenate([y, mx.array([draft_tok.item()], mx.uint32)])
-            u = mx.random.uniform()
             toks, lps, accept_lps, hidden, prev_tokens = _step_backbone(
                 y_with_draft,
                 prev_tokens,
@@ -887,6 +886,7 @@ def mtp_generate_step(
                 n_confirmed=1,
                 xtc_draw=draft_xtc_draw,
             )
+            u = mx.random.uniform()
             mx.eval(toks, draft_tok, u)
 
             verify_pred, bonus_tok = toks[0], toks[1]

--- a/mlx_lm/generate.py
+++ b/mlx_lm/generate.py
@@ -679,10 +679,11 @@ def mtp_generate_step(
         model_cache = cache.make_prompt_cache(model)
         mtp_cache = model.make_mtp_cache()
     else:
-        # When a pre-built cache is provided, split at backbone length
+        # Split a pre-built cache at backbone length.  If MTP entries are
+        # absent (e.g. cache created by make_prompt_cache), create them.
         n_main = len(model.layers)
         model_cache = prompt_cache[:n_main]
-        mtp_cache = prompt_cache[n_main:]
+        mtp_cache = prompt_cache[n_main:] or model.make_mtp_cache()
 
     sampler = sampler or (lambda x: mx.argmax(x, axis=-1))
 
@@ -758,7 +759,7 @@ def mtp_generate_step(
                 main_lp = lps[0]
 
                 ntoks += 1
-                yield main_tok, main_lp, False
+                yield main_tok.item(), main_lp, False
                 if ntoks >= max_tokens:
                     break
 
@@ -787,12 +788,12 @@ def mtp_generate_step(
                             c.rollback_state = None
 
                     ntoks += 1
-                    yield draft_tok, draft_lp, True
+                    yield draft_tok.item(), draft_lp, True
                     if ntoks >= max_tokens:
                         break
 
                     ntoks += 1
-                    yield bonus_tok, bonus_lp, False
+                    yield bonus_tok.item(), bonus_lp, False
                     if ntoks >= max_tokens:
                         break
 
@@ -816,7 +817,7 @@ def mtp_generate_step(
                     cache.trim_prompt_cache(mtp_cache, 1)
 
                     ntoks += 1
-                    yield verify_pred, verify_lp, False
+                    yield verify_pred.item(), verify_lp, False
                     if ntoks >= max_tokens:
                         break
 

--- a/mlx_lm/generate.py
+++ b/mlx_lm/generate.py
@@ -825,22 +825,24 @@ def mtp_generate_step(
         return draft_tok, draft_lp, draft_accept_lp, xtc_draw
 
     def _prefill(y, input_embeddings):
-        # Leave exactly 1 token for _step_backbone: return_hidden=True keeps
-        # the hidden state [1, N, d_model] live, so N must be 1.
+        # Leave exactly 1 token for _step_backbone so the decode loop starts clean.
         total = len(input_embeddings) if input_embeddings is not None else y.size
         while total > 1:
             n = min(prefill_step_size, total - 1)
             if input_embeddings is not None:
-                model(
+                _, hidden = model(
                     y[:n][None],
                     cache=model_cache,
+                    return_hidden=True,
                     input_embeddings=input_embeddings[:n][None],
                 )
                 input_embeddings = input_embeddings[n:]
             else:
-                model(y[:n][None], cache=model_cache)
+                _, hidden = model(y[:n][None], cache=model_cache, return_hidden=True)
+            model.mtp_forward(hidden, y[1 : n + 1][None], mtp_cache)
+            quantize_cache_fn(mtp_cache)
             quantize_cache_fn(model_cache)
-            mx.eval([c.state for c in model_cache if hasattr(c, "state")])
+            mx.eval([c.state for c in model_cache + mtp_cache if hasattr(c, "state")])
             y = y[n:]
             total -= n
             mx.clear_cache()

--- a/mlx_lm/generate.py
+++ b/mlx_lm/generate.py
@@ -873,13 +873,27 @@ def mtp_generate_step(
                 if logits_processors and prev_tokens is not None:
                     prev_tokens = prev_tokens[:-1]  # discard rejected draft token
                 verify_tok_id = verify_pred.item()
+                if not _is_greedy:
+                    # Sample from residual distribution max(p_target - p_draft, 0) / Z
+                    # (Leviathan et al. 2022 §2.3; Chen et al. 2023). Guarantees the
+                    # output marginal equals the target distribution exactly.
+                    p_target = mx.exp(verify_lp)
+                    p_draft = mx.exp(draft_lp)
+                    residual = mx.maximum(p_target - p_draft, 0.0)
+                    z = residual.sum().item()
+                    if z > 1e-8:
+                        verify_tok_id = mx.random.categorical(
+                            mx.log(residual / z + 1e-10).reshape(1, -1)
+                        ).item()
                 ntoks += 1
                 yield verify_tok_id, verify_lp, False
                 if ntoks >= max_tokens:
                     return
                 # Next draft from MTP at y's hidden state.
                 draft_tok, draft_lp = _step_mtp(
-                    hidden_at_confirmed, verify_pred, prev_tokens
+                    hidden_at_confirmed,
+                    mx.array([verify_tok_id], mx.uint32),
+                    prev_tokens,
                 )
                 mx.eval(draft_tok)
                 y = mx.array([verify_tok_id], mx.uint32)

--- a/mlx_lm/generate.py
+++ b/mlx_lm/generate.py
@@ -3,7 +3,6 @@
 import argparse
 import contextlib
 import copy
-import functools
 import json
 import math
 import sys
@@ -375,7 +374,7 @@ def generate_step(
 
     prompt_progress_callback = prompt_progress_callback or (lambda *_: None)
 
-    quantize_cache_fn = functools.partial(
+    quantize_cache_fn = partial(
         maybe_quantize_kv_cache,
         quantized_kv_start=quantized_kv_start,
         kv_group_size=kv_group_size,
@@ -533,7 +532,7 @@ def speculative_generate_step(
 
     sampler = sampler or (lambda x: mx.argmax(x, axis=-1))
 
-    quantize_cache_fn = functools.partial(
+    quantize_cache_fn = partial(
         maybe_quantize_kv_cache,
         quantized_kv_start=quantized_kv_start,
         kv_group_size=kv_group_size,
@@ -717,7 +716,7 @@ def mtp_generate_step(
         else ([], None)
     )
 
-    quantize_cache_fn = functools.partial(
+    quantize_cache_fn = partial(
         maybe_quantize_kv_cache,
         quantized_kv_start=quantized_kv_start,
         kv_group_size=kv_group_size,

--- a/mlx_lm/generate.py
+++ b/mlx_lm/generate.py
@@ -4,6 +4,7 @@ import argparse
 import contextlib
 import copy
 import functools
+import warnings
 import json
 import sys
 import time
@@ -905,6 +906,17 @@ def stream_generate(
         kwargs.pop("prompt_progress_callback", None)
         kwargs.pop("num_draft_tokens", None)
         token_generator = mtp_generate_step(prompt, model, **kwargs)
+    elif mtp:
+        warnings.warn(
+            "--mtp flag ignored: model does not have an MTP head. "
+            "Falling back to standard generation.",
+            stacklevel=2,
+        )
+        kwargs.pop("num_draft_tokens", None)
+        token_generator = generate_step(prompt, model, **kwargs)
+        token_generator = (
+            (token, logprobs, False) for token, logprobs in token_generator
+        )
     else:
         kwargs.pop("num_draft_tokens", None)
         token_generator = generate_step(prompt, model, **kwargs)

--- a/mlx_lm/generate.py
+++ b/mlx_lm/generate.py
@@ -6,7 +6,6 @@ import copy
 import functools
 import json
 import math
-import random
 import sys
 import time
 import warnings
@@ -32,7 +31,7 @@ from .models.cache import (
     TokenBuffer,
     load_prompt_cache,
 )
-from .sample_utils import make_sampler
+from .sample_utils import categorical_sampling, make_sampler, make_sampler_chain
 from .tokenizer_utils import TokenizerWrapper
 from .utils import does_model_support_input_embeddings, load
 
@@ -659,7 +658,6 @@ def mtp_generate_step(
     model: nn.Module,
     *,
     max_tokens: int = 256,
-    sampler: Optional[Callable[[mx.array], mx.array]] = None,
     logits_processors: Optional[List[Callable[[mx.array, mx.array], mx.array]]] = None,
     prompt_cache: Optional[Any] = None,
     prefill_step_size: int = 2048,
@@ -667,6 +665,14 @@ def mtp_generate_step(
     kv_group_size: int = 64,
     quantized_kv_start: int = 0,
     input_embeddings: Optional[mx.array] = None,
+    temp: float = 0.0,
+    top_p: float = 0.0,
+    top_k: int = 0,
+    min_p: float = 0.0,
+    min_tokens_to_keep: int = 1,
+    xtc_probability: float = 0.0,
+    xtc_threshold: float = 0.0,
+    xtc_special_tokens: List[int] = [],
 ) -> Generator[Tuple[mx.array, mx.array, bool], None, None]:
     """A generator that uses the model's native MTP head for speculative decoding.
 
@@ -695,10 +701,21 @@ def mtp_generate_step(
         model_cache = prompt_cache[:n_main]
         mtp_cache = prompt_cache[n_main:] or model.make_mtp_cache()
 
-    # Exact-match acceptance for greedy (sampler=None); probabilistic
-    # acceptance min(1, p_target/p_draft) for stochastic samplers.
-    _is_greedy = sampler is None
-    sampler = sampler or (lambda x: mx.argmax(x, axis=-1))
+    _is_greedy = temp == 0
+
+    _filter_chain, _xtc_cell = (
+        make_sampler_chain(
+            top_p,
+            top_k,
+            min_p,
+            min_tokens_to_keep,
+            xtc_probability,
+            xtc_threshold,
+            xtc_special_tokens,
+        )
+        if not _is_greedy
+        else ([], None)
+    )
 
     quantize_cache_fn = functools.partial(
         maybe_quantize_kv_cache,
@@ -707,14 +724,31 @@ def mtp_generate_step(
         kv_bits=kv_bits,
     )
 
-    def _process_and_sample(tokens, logits):
+    def _process_and_sample(tokens, logits, xtc_draw=None):
         if logits_processors:
             logits = logits[None]
             for processor in logits_processors:
                 logits = processor(tokens, logits)
             logits = logits.squeeze(0)
         logprobs = logits - mx.logsumexp(logits, axis=-1, keepdims=True)
-        return sampler(logprobs), logprobs
+        if _filter_chain:
+            if _xtc_cell is not None:
+                _xtc_cell[0] = xtc_draw  # None = fresh draw; mx.array = shared draw
+            masked = logprobs
+            for f in _filter_chain:
+                masked = f(masked)
+            token = categorical_sampling(masked, temp)
+            # lp_accept must reflect the same filtered distribution as token.
+            scaled = masked / temp
+            lp_accept = scaled - mx.logsumexp(scaled, axis=-1, keepdims=True)
+        elif _is_greedy:
+            token = mx.argmax(logprobs, axis=-1)
+            lp_accept = logprobs
+        else:
+            token = categorical_sampling(logprobs, temp)
+            scaled = logprobs / temp
+            lp_accept = scaled - mx.logsumexp(scaled, axis=-1, keepdims=True)
+        return token, logprobs, lp_accept
 
     def _clear_rollback():
         for c in model_cache:
@@ -737,15 +771,15 @@ def mtp_generate_step(
             elif c.is_trimmable():
                 c.trim(1)
 
-    def _step_backbone(y, prev_tokens, n_predict=1, n_confirmed=0):
-        """Run the backbone on ``y`` and return (tokens, logprobs, hidden, prev_tokens)."""
+    def _step_backbone(y, prev_tokens, n_predict=1, n_confirmed=0, xtc_draw=None):
+        """Run the backbone on ``y`` and return (tokens, logprobs, accept_lps, hidden, prev_tokens)."""
         with mx.stream(generation_stream):
             logits, hidden = model(
                 y[None], cache=model_cache, return_hidden=True, n_confirmed=n_confirmed
             )
             logits = logits[:, -n_predict:, :]
             quantize_cache_fn(model_cache)
-            toks, lps = [], []
+            toks, lps, accept_lps = [], [], []
             for i in range(n_predict):
                 if logits_processors:
                     prev_tokens = (
@@ -753,13 +787,24 @@ def mtp_generate_step(
                         if prev_tokens is not None
                         else y[i : i + 1]
                     )
-                tok, lp = _process_and_sample(prev_tokens, logits[:, i, :].squeeze(0))
+                # Pass the shared XTC draw only for position 0 (the verify position).
+                draw = xtc_draw if i == 0 else None
+                tok, lp, alp = _process_and_sample(
+                    prev_tokens, logits[:, i, :].squeeze(0), draw
+                )
                 toks.append(tok)
                 lps.append(lp)
-            return mx.stack(toks), mx.stack(lps), hidden, prev_tokens
+                accept_lps.append(alp)
+            return (
+                mx.stack(toks),
+                mx.stack(lps),
+                mx.stack(accept_lps),
+                hidden,
+                prev_tokens,
+            )
 
     def _step_mtp(hidden_last, main_tok, prev_tokens):
-        """Run the MTP head and return (draft_token, draft_logprobs)."""
+        """Run the MTP head and return (draft_token, draft_logprobs, draft_accept_lp, xtc_draw)."""
         next_ids = main_tok.reshape(1, 1)
         with mx.stream(generation_stream):
             mtp_logits = model.mtp_forward(hidden_last, next_ids, mtp_cache)
@@ -773,8 +818,12 @@ def mtp_generate_step(
                 )
             else:
                 tokens_for_proc = prev_tokens
-            draft_tok, draft_lp = _process_and_sample(tokens_for_proc, mtp_logits)
-        return draft_tok, draft_lp
+            # Draw the XTC boolean once here so the verify step can reuse it.
+            xtc_draw = mx.random.uniform() if _xtc_cell is not None else None
+            draft_tok, draft_lp, draft_accept_lp = _process_and_sample(
+                tokens_for_proc, mtp_logits, xtc_draw
+            )
+        return draft_tok, draft_lp, draft_accept_lp, xtc_draw
 
     def _prefill(y, input_embeddings):
         # Leave exactly 1 token for _step_backbone: return_hidden=True keeps
@@ -802,12 +851,14 @@ def mtp_generate_step(
         y = _prefill(y, input_embeddings)
 
     ntoks = 0
-    draft_tok = draft_lp = None
+    draft_tok = draft_lp = draft_accept_lp = draft_xtc_draw = None
 
     while ntoks < max_tokens:
         if draft_tok is None:
             # No pending draft: run backbone only, then generate first draft.
-            toks, lps, hidden, prev_tokens = _step_backbone(y, prev_tokens, n_predict=1)
+            toks, lps, accept_lps, hidden, prev_tokens = _step_backbone(
+                y, prev_tokens, n_predict=1
+            )
             mx.eval(toks)
             main_tok, main_lp = toks[0], lps[0]
             ntoks += 1
@@ -815,7 +866,9 @@ def mtp_generate_step(
             if ntoks >= max_tokens:
                 return
             hidden_at_main = hidden[:, -1:, :]
-            draft_tok, draft_lp = _step_mtp(hidden_at_main, main_tok, prev_tokens)
+            draft_tok, draft_lp, draft_accept_lp, draft_xtc_draw = _step_mtp(
+                hidden_at_main, main_tok, prev_tokens
+            )
             mx.eval(draft_tok)
             y = mx.array([main_tok.item()], mx.uint32)
         else:
@@ -823,21 +876,29 @@ def mtp_generate_step(
             # n_confirmed=1 causes GatedDeltaNet to snapshot its SSM/conv state
             # after the confirmed token y, enabling exact rollback on rejection.
             y_with_draft = mx.concatenate([y, mx.array([draft_tok.item()], mx.uint32)])
-            toks, lps, hidden, prev_tokens = _step_backbone(
-                y_with_draft, prev_tokens, n_predict=2, n_confirmed=1
+            u = mx.random.uniform()
+            toks, lps, accept_lps, hidden, prev_tokens = _step_backbone(
+                y_with_draft,
+                prev_tokens,
+                n_predict=2,
+                n_confirmed=1,
+                xtc_draw=draft_xtc_draw,
             )
-            mx.eval(toks, draft_tok)
+            mx.eval(toks, draft_tok, u)
 
             verify_pred, bonus_tok = toks[0], toks[1]
             verify_lp, bonus_lp = lps[0], lps[1]
+            verify_accept_lp = accept_lps[0]
             draft_tok_id = draft_tok.item()
 
             if _is_greedy:
                 accept = verify_pred.item() == draft_tok_id
             else:
-                # Probabilistic acceptance: min(1, p_target / p_draft).
-                log_accept = (verify_lp[draft_tok_id] - draft_lp[draft_tok_id]).item()
-                accept = log_accept >= 0 or random.random() < math.exp(log_accept)
+                # Probabilistic acceptance: min(1, p_target/p_draft) with temp-adjusted logprobs.
+                log_accept = (
+                    verify_accept_lp[draft_tok_id] - draft_accept_lp[draft_tok_id]
+                ).item()
+                accept = log_accept >= 0 or u.item() < math.exp(log_accept)
 
             hidden_at_confirmed = hidden[:, 0:1, :]
             hidden_at_draft = hidden[:, 1:2, :]
@@ -853,7 +914,9 @@ def mtp_generate_step(
                 if ntoks >= max_tokens:
                     return
                 # Next draft from MTP at draft_tok's hidden state.
-                draft_tok, draft_lp = _step_mtp(hidden_at_draft, bonus_tok, prev_tokens)
+                draft_tok, draft_lp, draft_accept_lp, draft_xtc_draw = _step_mtp(
+                    hidden_at_draft, bonus_tok, prev_tokens
+                )
                 mx.eval(draft_tok)
                 y = mx.array([bonus_tok.item()], mx.uint32)
             else:
@@ -865,8 +928,9 @@ def mtp_generate_step(
                     # Sample from residual distribution max(p_target - p_draft, 0) / Z
                     # (Leviathan et al. 2022 §2.3; Chen et al. 2023). Guarantees the
                     # output marginal equals the target distribution exactly.
-                    p_target = mx.exp(verify_lp)
-                    p_draft = mx.exp(draft_lp)
+                    # Both distributions are temperature-adjusted to match sampling.
+                    p_target = mx.exp(verify_accept_lp)
+                    p_draft = mx.exp(draft_accept_lp)
                     residual = mx.maximum(p_target - p_draft, 0.0)
                     z = residual.sum(keepdims=True)
                     dist = mx.where(z > 0, residual, p_target)
@@ -879,7 +943,7 @@ def mtp_generate_step(
                 if ntoks >= max_tokens:
                     return
                 # Next draft from MTP at y's hidden state.
-                draft_tok, draft_lp = _step_mtp(
+                draft_tok, draft_lp, draft_accept_lp, draft_xtc_draw = _step_mtp(
                     hidden_at_confirmed,
                     mx.array([verify_tok_id], mx.uint32),
                     prev_tokens,
@@ -895,6 +959,14 @@ def stream_generate(
     max_tokens: int = 256,
     draft_model: Optional[nn.Module] = None,
     mtp: bool = False,
+    temp: float = 0.0,
+    top_p: float = 0.0,
+    top_k: int = 0,
+    min_p: float = 0.0,
+    min_tokens_to_keep: int = 1,
+    xtc_probability: float = 0.0,
+    xtc_threshold: float = 0.0,
+    xtc_special_tokens: List[int] = [],
     **kwargs,
 ) -> Generator[GenerationResponse, None, None]:
     """
@@ -945,7 +1017,20 @@ def stream_generate(
         kwargs.pop("max_kv_size", None)
         kwargs.pop("prompt_progress_callback", None)
         kwargs.pop("num_draft_tokens", None)
-        token_generator = mtp_generate_step(prompt, model, **kwargs)
+        kwargs.pop("sampler", None)  # mtp_generate_step does not accept sampler=
+        token_generator = mtp_generate_step(
+            prompt,
+            model,
+            temp=temp,
+            top_p=top_p,
+            top_k=top_k,
+            min_p=min_p,
+            min_tokens_to_keep=min_tokens_to_keep,
+            xtc_probability=xtc_probability,
+            xtc_threshold=xtc_threshold,
+            xtc_special_tokens=xtc_special_tokens,
+            **kwargs,
+        )
     else:
         if mtp:
             warnings.warn(

--- a/mlx_lm/generate.py
+++ b/mlx_lm/generate.py
@@ -711,8 +711,29 @@ def mtp_generate_step(
             for processor in logits_processors:
                 logits = processor(tokens, logits)
         logprobs = logits - mx.logsumexp(logits, axis=-1, keepdims=True)
-        tok = sampler(logprobs)
-        return tok, logprobs
+        return sampler(logprobs), logprobs
+
+    def _clear_rollback():
+        for c in model_cache:
+            if hasattr(c, "rollback_state"):
+                c.rollback_state = None
+
+    def _rollback_draft():
+        """Restore caches to the state after the confirmed token.
+
+        SSM layers (ArraysCache): restore the conv/ssm snapshot saved by
+        GatedDeltaNet after the confirmed token.
+        Attention layers (KVCache): trim the draft-token entry.
+        """
+        for c in model_cache:
+            if hasattr(c, "rollback_state") and c.rollback_state is not None:
+                conv_snap, ssm_snap = c.rollback_state
+                c[0] = conv_snap
+                c[1] = ssm_snap
+                c.rollback_state = None
+            elif c.is_trimmable():
+                c.trim(1)
+        cache.trim_prompt_cache(mtp_cache, 1)
 
     def _step_backbone(y, n_predict=1, n_confirmed=0):
         """Run the backbone on ``y`` and return (tokens, logprobs, hidden)."""
@@ -760,101 +781,65 @@ def mtp_generate_step(
         y = _prefill(y)
 
     ntoks = 0
-    draft_tok = None
-    draft_lp = None
+    draft_tok = draft_lp = None
 
-    try:
-        while True:
-            if draft_tok is None:
-                # No pending draft: run backbone only, then generate first draft.
-                toks, lps, hidden = _step_backbone(y, n_predict=1)
-                mx.eval(toks)
-                main_tok = toks[0]
-                main_lp = lps[0]
+    while ntoks < max_tokens:
+        if draft_tok is None:
+            # No pending draft: run backbone only, then generate first draft.
+            toks, lps, hidden = _step_backbone(y, n_predict=1)
+            mx.eval(toks)
+            main_tok, main_lp = toks[0], lps[0]
+            ntoks += 1
+            yield main_tok.item(), main_lp, False
+            if ntoks >= max_tokens:
+                return
+            draft_tok, draft_lp = _step_mtp(hidden[:, -1:, :], main_tok)
+            mx.eval(draft_tok)
+            y = mx.array([main_tok.item()], mx.uint32)
+        else:
+            # Verify draft: run backbone over [y, draft_tok].
+            # n_confirmed=1 causes GatedDeltaNet to snapshot its SSM/conv state
+            # after the confirmed token y, enabling exact rollback on rejection.
+            y_with_draft = mx.concatenate([y, mx.array([draft_tok.item()], mx.uint32)])
+            toks, lps, hidden = _step_backbone(y_with_draft, n_predict=2, n_confirmed=1)
+            mx.eval(toks, draft_tok)
 
-                ntoks += 1
-                yield main_tok.item(), main_lp, False
-                if ntoks >= max_tokens:
-                    break
+            verify_pred, bonus_tok = toks[0], toks[1]
+            verify_lp, bonus_lp = lps[0], lps[1]
+            draft_tok_id = draft_tok.item()
 
-                draft_tok, draft_lp = _step_mtp(hidden[:, -1:, :], main_tok)
-                mx.eval(draft_tok)
-                y = mx.array([main_tok.item()], mx.uint32)
+            if _is_greedy:
+                accept = verify_pred.item() == draft_tok_id
             else:
-                # Verify draft: run backbone over [y, draft_tok].
-                # n_confirmed=1 causes GatedDeltaNet to snapshot its SSM/conv state
-                # after the confirmed token y, enabling exact rollback on rejection.
-                y_with_draft = mx.concatenate(
-                    [y, mx.array([draft_tok.item()], mx.uint32)]
-                )
-                toks, lps, hidden = _step_backbone(
-                    y_with_draft, n_predict=2, n_confirmed=1
-                )
-                mx.eval(toks, draft_tok)
+                # Probabilistic acceptance: min(1, p_target / p_draft).
+                log_accept = (verify_lp[draft_tok_id] - draft_lp[draft_tok_id]).item()
+                accept = log_accept >= 0 or random.random() < math.exp(log_accept)
 
-                verify_pred = toks[0]  # backbone prediction for y, used to verify draft
-                bonus_tok = toks[1]  # backbone prediction after draft_tok
-                verify_lp = lps[0]
-                bonus_lp = lps[1]
-
-                draft_tok_id = draft_tok.item()
-                if _is_greedy:
-                    accept = verify_pred.item() == draft_tok_id
-                else:
-                    # Probabilistic acceptance: min(1, p_target / p_draft).
-                    log_accept = (
-                        verify_lp[draft_tok_id] - draft_lp[draft_tok_id]
-                    ).item()
-                    accept = log_accept >= 0 or random.random() < math.exp(log_accept)
-                if accept:
-                    # Draft accepted: discard rollback snapshots.
-                    for c in model_cache:
-                        if hasattr(c, "rollback_state"):
-                            c.rollback_state = None
-
-                    ntoks += 1
-                    yield draft_tok.item(), draft_lp, True
-                    if ntoks >= max_tokens:
-                        break
-
-                    ntoks += 1
-                    yield bonus_tok.item(), bonus_lp, False
-                    if ntoks >= max_tokens:
-                        break
-
-                    # Next draft from MTP at draft_tok's hidden state
-                    draft_tok, draft_lp = _step_mtp(hidden[:, 1:2, :], bonus_tok)
-                    mx.eval(draft_tok)
-                    y = mx.array([bonus_tok.item()], mx.uint32)
-                else:
-                    # Draft rejected: roll back all caches to the state after y.
-                    # SSM layers (ArraysCache): restore the conv/ssm snapshot saved
-                    # by GatedDeltaNet after the confirmed token.
-                    # Attention layers (KVCache): trim the draft-token entry.
-                    for c in model_cache:
-                        if (
-                            hasattr(c, "rollback_state")
-                            and c.rollback_state is not None
-                        ):
-                            conv_snap, ssm_snap = c.rollback_state
-                            c[0] = conv_snap
-                            c[1] = ssm_snap
-                            c.rollback_state = None
-                        elif c.is_trimmable():
-                            c.trim(1)
-                    cache.trim_prompt_cache(mtp_cache, 1)
-
-                    ntoks += 1
-                    yield verify_pred.item(), verify_lp, False
-                    if ntoks >= max_tokens:
-                        break
-
-                    # Next draft from MTP at y's hidden state
-                    draft_tok, draft_lp = _step_mtp(hidden[:, 0:1, :], verify_pred)
-                    mx.eval(draft_tok)
-                    y = mx.array([verify_pred.item()], mx.uint32)
-    finally:
-        pass
+            if accept:
+                _clear_rollback()
+                ntoks += 1
+                yield draft_tok_id, draft_lp, True
+                if ntoks >= max_tokens:
+                    return
+                ntoks += 1
+                yield bonus_tok.item(), bonus_lp, False
+                if ntoks >= max_tokens:
+                    return
+                # Next draft from MTP at draft_tok's hidden state.
+                draft_tok, draft_lp = _step_mtp(hidden[:, 1:2, :], bonus_tok)
+                mx.eval(draft_tok)
+                y = mx.array([bonus_tok.item()], mx.uint32)
+            else:
+                _rollback_draft()
+                verify_tok_id = verify_pred.item()
+                ntoks += 1
+                yield verify_tok_id, verify_lp, False
+                if ntoks >= max_tokens:
+                    return
+                # Next draft from MTP at y's hidden state.
+                draft_tok, draft_lp = _step_mtp(hidden[:, 0:1, :], verify_pred)
+                mx.eval(draft_tok)
+                y = mx.array([verify_tok_id], mx.uint32)
 
 
 def stream_generate(
@@ -915,18 +900,13 @@ def stream_generate(
         kwargs.pop("prompt_progress_callback", None)
         kwargs.pop("num_draft_tokens", None)
         token_generator = mtp_generate_step(prompt, model, **kwargs)
-    elif mtp:
-        warnings.warn(
-            "--mtp flag ignored: model does not have an MTP head. "
-            "Falling back to standard generation.",
-            stacklevel=2,
-        )
-        kwargs.pop("num_draft_tokens", None)
-        token_generator = generate_step(prompt, model, **kwargs)
-        token_generator = (
-            (token, logprobs, False) for token, logprobs in token_generator
-        )
     else:
+        if mtp:
+            warnings.warn(
+                "--mtp flag ignored: model does not have an MTP head. "
+                "Falling back to standard generation.",
+                stacklevel=2,
+            )
         kwargs.pop("num_draft_tokens", None)
         token_generator = generate_step(prompt, model, **kwargs)
         # from_draft always false for non-speculative generation

--- a/mlx_lm/generate.py
+++ b/mlx_lm/generate.py
@@ -892,7 +892,6 @@ def mtp_generate_step(
             # n_confirmed=1 causes GatedDeltaNet to snapshot its SSM/conv state
             # after the confirmed token y, enabling exact rollback on rejection.
             y_with_draft = mx.concatenate([y, mx.array([draft_tok.item()], mx.uint32)])
-            u = mx.random.uniform()
             toks, lps, accept_lps, hidden, prev_tokens = _step_backbone(
                 y_with_draft,
                 prev_tokens,
@@ -900,6 +899,7 @@ def mtp_generate_step(
                 n_confirmed=1,
                 xtc_draw=draft_xtc_draw,
             )
+            u = mx.random.uniform()
             mx.eval(toks, draft_tok, u)
 
             verify_pred, bonus_tok = toks[0], toks[1]

--- a/mlx_lm/generate.py
+++ b/mlx_lm/generate.py
@@ -46,6 +46,7 @@ DEFAULT_MIN_TOKENS_TO_KEEP = 1
 DEFAULT_SEED = None
 DEFAULT_MODEL = "mlx-community/Llama-3.2-3B-Instruct-4bit"
 DEFAULT_QUANTIZED_KV_START = 5000
+_CACHE_CLEAR_INTERVAL = 256
 
 
 def str2bool(string):
@@ -462,7 +463,7 @@ def generate_step(
         if n == max_tokens:
             break
         yield y.item(), logprobs
-        if n % 256 == 0:
+        if n % _CACHE_CLEAR_INTERVAL == 0:
             mx.clear_cache()
         y, logprobs = next_y, next_logprobs
         n += 1
@@ -852,6 +853,7 @@ def mtp_generate_step(
         y = _prefill(y, input_embeddings)
 
     ntoks = 0
+    last_cache_block = 0
     draft_tok = draft_lp = draft_accept_lp = draft_xtc_draw = None
 
     while ntoks < max_tokens:
@@ -951,6 +953,10 @@ def mtp_generate_step(
                 )
                 mx.eval(draft_tok)
                 y = mx.array([verify_tok_id], mx.uint32)
+        block = ntoks // _CACHE_CLEAR_INTERVAL
+        if block > last_cache_block:
+            mx.clear_cache()
+            last_cache_block = block
 
 
 def stream_generate(

--- a/mlx_lm/generate.py
+++ b/mlx_lm/generate.py
@@ -3,7 +3,6 @@
 import argparse
 import contextlib
 import copy
-import functools
 import json
 import math
 import sys
@@ -11,6 +10,7 @@ import time
 import warnings
 from collections import deque
 from dataclasses import dataclass
+from functools import partial
 from typing import Any, Callable, Generator, List, Optional, Sequence, Tuple, Union
 
 import mlx.core as mx
@@ -379,7 +379,7 @@ def generate_step(
 
     prompt_progress_callback = prompt_progress_callback or (lambda *_: None)
 
-    quantize_cache_fn = functools.partial(
+    quantize_cache_fn = partial(
         maybe_quantize_kv_cache,
         quantized_kv_start=quantized_kv_start,
         kv_group_size=kv_group_size,
@@ -543,7 +543,7 @@ def speculative_generate_step(
 
     sampler = sampler or (lambda x: mx.argmax(x, axis=-1))
 
-    quantize_cache_fn = functools.partial(
+    quantize_cache_fn = partial(
         maybe_quantize_kv_cache,
         quantized_kv_start=quantized_kv_start,
         kv_group_size=kv_group_size,
@@ -729,7 +729,7 @@ def mtp_generate_step(
         else ([], None)
     )
 
-    quantize_cache_fn = functools.partial(
+    quantize_cache_fn = partial(
         maybe_quantize_kv_cache,
         quantized_kv_start=quantized_kv_start,
         kv_group_size=kv_group_size,

--- a/mlx_lm/generate.py
+++ b/mlx_lm/generate.py
@@ -214,6 +214,12 @@ def setup_arg_parser():
         help="Number of tokens to draft when using speculative decoding.",
         default=3,
     )
+    parser.add_argument(
+        "--mtp",
+        action="store_true",
+        help="Use native Multi-Token Prediction for speculative decoding "
+        "(requires a model with an MTP head, e.g. Qwen3.5).",
+    )
     return parser
 
 
@@ -847,6 +853,7 @@ def stream_generate(
     prompt: Union[str, mx.array, List[int]],
     max_tokens: int = 256,
     draft_model: Optional[nn.Module] = None,
+    mtp: bool = False,
     **kwargs,
 ) -> Generator[GenerationResponse, None, None]:
     """
@@ -862,6 +869,8 @@ def stream_generate(
         draft_model (Optional[nn.Module]): An optional draft model. If provided
           then speculative decoding is used. The draft model must use the same
           tokenizer as the main model. Default: ``None``.
+        mtp (bool): Use native Multi-Token Prediction for speculative
+          decoding. Requires a model with an MTP head. Default: ``False``.
         kwargs: The remaining options get passed to :func:`generate_step`.
           See :func:`generate_step` for more details.
 
@@ -891,7 +900,7 @@ def stream_generate(
         token_generator = speculative_generate_step(
             prompt, model, draft_model, **kwargs
         )
-    elif hasattr(model, "mtp_forward"):
+    elif mtp and hasattr(model, "mtp_forward"):
         kwargs.pop("max_kv_size", None)
         kwargs.pop("prompt_progress_callback", None)
         kwargs.pop("num_draft_tokens", None)
@@ -2334,6 +2343,7 @@ def main():
         quantized_kv_start=args.quantized_kv_start,
         draft_model=draft_model,
         num_draft_tokens=args.num_draft_tokens,
+        mtp=args.mtp,
     )
     if not args.verbose:
         print(response)

--- a/mlx_lm/generate.py
+++ b/mlx_lm/generate.py
@@ -678,6 +678,7 @@ def mtp_generate_step(
     kv_bits: Optional[int] = None,
     kv_group_size: int = 64,
     quantized_kv_start: int = 0,
+    input_embeddings: Optional[mx.array] = None,
 ) -> Generator[Tuple[mx.array, mx.array, bool], None, None]:
     """A generator that uses the model's native MTP head for speculative decoding.
 
@@ -720,8 +721,10 @@ def mtp_generate_step(
 
     def _process_and_sample(tokens, logits):
         if logits_processors:
+            logits = logits[None]
             for processor in logits_processors:
                 logits = processor(tokens, logits)
+            logits = logits.squeeze(0)
         logprobs = logits - mx.logsumexp(logits, axis=-1, keepdims=True)
         return sampler(logprobs), logprobs
 
@@ -786,20 +789,30 @@ def mtp_generate_step(
             draft_tok, draft_lp = _process_and_sample(tokens_for_proc, mtp_logits)
         return draft_tok, draft_lp
 
-    def _prefill(y):
+    def _prefill(y, input_embeddings):
         # Leave exactly 1 token for _step_backbone: return_hidden=True keeps
         # the hidden state [1, N, d_model] live, so N must be 1.
-        while y.size > 1:
-            n = min(prefill_step_size, y.size - 1)
-            model(y[:n][None], cache=model_cache)
+        total = len(input_embeddings) if input_embeddings is not None else y.size
+        while total > 1:
+            n = min(prefill_step_size, total - 1)
+            if input_embeddings is not None:
+                model(
+                    y[:n][None],
+                    cache=model_cache,
+                    input_embeddings=input_embeddings[:n][None],
+                )
+                input_embeddings = input_embeddings[n:]
+            else:
+                model(y[:n][None], cache=model_cache)
             quantize_cache_fn(model_cache)
             mx.eval([c.state for c in model_cache if hasattr(c, "state")])
             y = y[n:]
+            total -= n
             mx.clear_cache()
         return y
 
     with mx.stream(generation_stream):
-        y = _prefill(y)
+        y = _prefill(y, input_embeddings)
 
     ntoks = 0
     draft_tok = draft_lp = None

--- a/mlx_lm/generate.py
+++ b/mlx_lm/generate.py
@@ -5,6 +5,8 @@ import contextlib
 import copy
 import functools
 import json
+import math
+import random
 import sys
 import time
 import warnings
@@ -704,6 +706,9 @@ def mtp_generate_step(
         model_cache = prompt_cache[:n_main]
         mtp_cache = prompt_cache[n_main:] or model.make_mtp_cache()
 
+    # Exact-match acceptance for greedy (sampler=None); probabilistic
+    # acceptance min(1, p_target/p_draft) for stochastic samplers.
+    _is_greedy = sampler is None
     sampler = sampler or (lambda x: mx.argmax(x, axis=-1))
 
     quantize_cache_fn = functools.partial(
@@ -773,7 +778,7 @@ def mtp_generate_step(
     try:
         while True:
             if draft_tok is None:
-                # No pending draft — run backbone only, then generate first draft
+                # No pending draft: run backbone only, then generate first draft.
                 toks, lps, hidden = _step_backbone(y, n_predict=1)
                 mx.eval(toks)
                 main_tok = toks[0]
@@ -799,13 +804,22 @@ def mtp_generate_step(
                 )
                 mx.eval(toks, draft_tok)
 
-                verify_pred = toks[0]  # backbone prediction after y → verify draft
+                verify_pred = toks[0]  # backbone prediction for y, used to verify draft
                 bonus_tok = toks[1]  # backbone prediction after draft_tok
                 verify_lp = lps[0]
                 bonus_lp = lps[1]
 
-                if verify_pred.item() == draft_tok.item():
-                    # Draft accepted — discard rollback snapshots.
+                draft_tok_id = draft_tok.item()
+                if _is_greedy:
+                    accept = verify_pred.item() == draft_tok_id
+                else:
+                    # Probabilistic acceptance: min(1, p_target / p_draft).
+                    log_accept = (
+                        verify_lp[draft_tok_id] - draft_lp[draft_tok_id]
+                    ).item()
+                    accept = log_accept >= 0 or random.random() < math.exp(log_accept)
+                if accept:
+                    # Draft accepted: discard rollback snapshots.
                     for c in model_cache:
                         if hasattr(c, "rollback_state"):
                             c.rollback_state = None
@@ -825,7 +839,7 @@ def mtp_generate_step(
                     mx.eval(draft_tok)
                     y = mx.array([bonus_tok.item()], mx.uint32)
                 else:
-                    # Draft rejected — roll back all caches to the state after y.
+                    # Draft rejected: roll back all caches to the state after y.
                     # SSM layers (ArraysCache): restore the conv/ssm snapshot saved
                     # by GatedDeltaNet after the confirmed token.
                     # Attention layers (KVCache): trim the draft-token entry.

--- a/mlx_lm/generate.py
+++ b/mlx_lm/generate.py
@@ -816,9 +816,20 @@ def mtp_generate_step(
                 prev_tokens,
             )
 
-    def _step_mtp(hidden_last, main_tok, prev_tokens):
-        """Run the MTP head and return (draft_token, draft_logprobs, draft_accept_lp, xtc_draw)."""
-        next_ids = main_tok.reshape(1, 1)
+    def _step_mtp(hidden_last, main_tok, prev_tokens, *, cache_commit=None):
+        """Run the MTP head and return (draft_token, draft_logprobs, draft_accept_lp, xtc_draw).
+
+        cache_commit: (hidden, tok) prepended as a cache-alignment position so that the
+        accepted draft token is committed to mtp_cache in the same batched forward.
+        """
+        if cache_commit is not None:
+            align_h, align_tok = cache_commit
+            hidden_last = mx.concatenate([align_h, hidden_last], axis=1)
+            next_ids = mx.concatenate(
+                [align_tok.reshape(1, 1), main_tok.reshape(1, 1)], axis=1
+            )
+        else:
+            next_ids = main_tok.reshape(1, 1)
         with mx.stream(generation_stream):
             mtp_logits = model.mtp_forward(hidden_last, next_ids, mtp_cache)
             quantize_cache_fn(mtp_cache)
@@ -929,9 +940,13 @@ def mtp_generate_step(
                 yield bonus_tok.item(), bonus_lp, False
                 if ntoks >= max_tokens:
                     return
-                # Next draft from MTP at draft_tok's hidden state.
+                # Next draft: one batched forward aligns the cache for the
+                # accepted draft token and generates the next draft together.
                 draft_tok, draft_lp, draft_accept_lp, draft_xtc_draw = _step_mtp(
-                    hidden_at_draft, bonus_tok, prev_tokens
+                    hidden_at_draft,
+                    bonus_tok,
+                    prev_tokens,
+                    cache_commit=(hidden_at_confirmed, draft_tok),
                 )
                 mx.eval(draft_tok)
                 y = mx.array([bonus_tok.item()], mx.uint32)

--- a/mlx_lm/generate.py
+++ b/mlx_lm/generate.py
@@ -3,6 +3,7 @@
 import argparse
 import contextlib
 import copy
+import inspect
 import json
 import math
 import sys
@@ -300,6 +301,15 @@ class GenerationResponse:
     finish_reason: Optional[str] = None
 
 
+@dataclass
+class _MTPPromptFinalizePlan:
+    mtp_hidden: Optional[mx.array]
+    mtp_tokens: Optional[mx.array]
+    target_token: Optional[mx.array]
+    last_hidden: Optional[mx.array]
+    num_tokens: int
+
+
 def maybe_quantize_kv_cache(prompt_cache, quantized_kv_start, kv_group_size, kv_bits):
     if kv_bits is None:
         return
@@ -322,6 +332,19 @@ def validate_prompt_and_embeddings(model, prompt, input_embeddings):
         raise ValueError(
             "Either input_embeddings or prompt (or both) must be provided."
         )
+
+
+def _model_supports_mtp(model):
+    # Detect a loaded native MTP head without relying on method presence alone.
+    supported = getattr(model, "supports_mtp", None)
+    if supported is not None:
+        return bool(supported)
+    if not hasattr(model, "mtp_forward") or not hasattr(model, "make_mtp_cache"):
+        return False
+    try:
+        return len(model.make_mtp_cache()) > 0
+    except (AttributeError, TypeError):
+        return False
 
 
 def generate_step(
@@ -706,22 +729,94 @@ def mtp_generate_step(
         Tuple[mx.array, mx.array, bool]: (token, log-probabilities, from_draft).
             ``from_draft`` is ``True`` when the token came from the MTP head.
     """
+    if input_embeddings is not None:
+        raise ValueError(
+            "Native MTP generation does not yet support input_embeddings. "
+            "Use standard generation for embedding or multimodal inputs."
+        )
     validate_prompt_and_embeddings(model, prompt, input_embeddings)
 
+    if logits_processors:
+        unsafe_processors = [
+            type(processor).__name__
+            for processor in logits_processors
+            if not inspect.isfunction(processor)
+            and not isinstance(processor, partial)
+            and not getattr(processor, "is_stateless", False)
+        ]
+        if unsafe_processors:
+            names = ", ".join(unsafe_processors)
+            raise ValueError(
+                "Native MTP currently supports only stateless logits processors. "
+                "Use plain functions, functools.partial, or set is_stateless=True "
+                f"on a safe callable. Unsupported processor(s): {names}."
+            )
+
+    if not _model_supports_mtp(model):
+        raise ValueError("The model does not have a usable native MTP head.")
+
     y = prompt.astype(mx.uint32)
+    input_token_count = int(y.size)
     prev_tokens = None
     prompt_progress_callback = prompt_progress_callback or (lambda *_: None)
     total_prompt_tokens = y.size
+    fresh_mtp_cache = model.make_mtp_cache()
+    prompt_state = None
+    cached_token_count = 0
 
     if prompt_cache is None:
         model_cache = cache.make_prompt_cache(model)
-        mtp_cache = model.make_mtp_cache()
+        mtp_cache = fresh_mtp_cache
     else:
-        # Split a pre-built cache at backbone length.  If MTP entries are
-        # absent (e.g. cache created by make_prompt_cache), create them.
         n_main = len(model.layers)
-        model_cache = prompt_cache[:n_main]
-        mtp_cache = prompt_cache[n_main:] or model.make_mtp_cache()
+        n_mtp = len(fresh_mtp_cache)
+        if len(prompt_cache) < n_main:
+            raise ValueError(
+                "The supplied prompt_cache has fewer entries than the model backbone."
+            )
+
+        model_cache = list(prompt_cache[:n_main])
+        tail = list(prompt_cache[n_main:])
+        if tail and isinstance(tail[-1], cache.MTPPromptCacheState):
+            prompt_state = tail.pop()
+        mtp_cache = tail
+
+        if mtp_cache and len(mtp_cache) != n_mtp:
+            raise ValueError(
+                "The supplied prompt_cache contains an incompatible number of "
+                "MTP cache entries."
+            )
+
+        model_nonempty = any(not c.empty() for c in model_cache)
+        mtp_nonempty = any(not c.empty() for c in mtp_cache)
+        if not mtp_cache:
+            if model_nonempty:
+                raise ValueError(
+                    "A pre-populated native-MTP prompt_cache must include its "
+                    "MTP cache entries and boundary state."
+                )
+            mtp_cache = fresh_mtp_cache
+            prompt_cache.extend(mtp_cache)
+        elif prompt_state is None and (model_nonempty or mtp_nonempty):
+            raise ValueError(
+                "Legacy native-MTP prompt caches without boundary metadata cannot "
+                "be reused safely. Rebuild the prefix once."
+            )
+
+        if prompt_state is None:
+            if not hasattr(prompt_cache, "append"):
+                raise TypeError(
+                    "prompt_cache must be a mutable sequence for native MTP."
+                )
+            prompt_state = cache.MTPPromptCacheState()
+            prompt_cache.append(prompt_state)
+        elif not prompt_state.empty():
+            cached_token_count = prompt_state.num_tokens
+            if y.size == 0:
+                raise ValueError(
+                    "An exact native-MTP cache hit needs at least one suffix token "
+                    "to resume the one-token-lagged MTP state."
+                )
 
     _is_greedy = temp == 0
 
@@ -745,6 +840,17 @@ def mtp_generate_step(
         kv_group_size=kv_group_size,
         kv_bits=kv_bits,
     )
+
+    if prompt_state is not None and not prompt_state.empty():
+        with mx.stream(generation_stream):
+            model.mtp_forward(
+                prompt_state.last_hidden,
+                y[:1].reshape(1, 1),
+                mtp_cache,
+            )
+            quantize_cache_fn(mtp_cache)
+            mx.eval([c.state for c in mtp_cache if hasattr(c, "state")])
+        prompt_state.last_hidden = None
 
     def _process_and_sample(tokens, logits, xtc_draw=None):
         if logits_processors:
@@ -858,6 +964,58 @@ def mtp_generate_step(
             )
         return draft_tok, draft_lp, draft_accept_lp, xtc_draw
 
+    finalize_plan = None
+
+    def _sync_prompt_cache():
+        if prompt_cache is None:
+            return
+        n_main = len(model.layers)
+        n_mtp = len(mtp_cache)
+        prompt_cache[:n_main] = model_cache
+        prompt_cache[n_main : n_main + n_mtp] = mtp_cache
+        if prompt_state is not None:
+            if len(prompt_cache) == n_main + n_mtp:
+                prompt_cache.append(prompt_state)
+            else:
+                prompt_cache[n_main + n_mtp] = prompt_state
+                del prompt_cache[n_main + n_mtp + 1 :]
+
+    def _finalize_prompt_cache():
+        nonlocal finalize_plan
+        if prompt_state is None or finalize_plan is None:
+            return
+
+        plan = finalize_plan
+        last_hidden = plan.last_hidden
+        with mx.stream(generation_stream):
+            if plan.mtp_hidden is not None:
+                model.mtp_forward(plan.mtp_hidden, plan.mtp_tokens, mtp_cache)
+                quantize_cache_fn(mtp_cache)
+
+            if plan.target_token is not None:
+                _, hidden = model(
+                    plan.target_token.reshape(1, 1),
+                    cache=model_cache,
+                    return_hidden=True,
+                )
+                last_hidden = hidden[:, -1:, :]
+                quantize_cache_fn(model_cache)
+
+            if last_hidden is None:
+                raise RuntimeError(
+                    "Native MTP finalization has no boundary hidden state."
+                )
+
+            mx.eval(
+                [c.state for c in model_cache + mtp_cache if hasattr(c, "state")],
+                last_hidden,
+            )
+
+        prompt_state.last_hidden = last_hidden
+        prompt_state.num_tokens = plan.num_tokens
+        _sync_prompt_cache()
+        finalize_plan = None
+
     def _prefill(y, input_embeddings):
         # Leave exactly 1 token for _step_backbone so the decode loop starts clean.
         total = len(input_embeddings) if input_embeddings is not None else y.size
@@ -892,112 +1050,158 @@ def mtp_generate_step(
     last_cache_block = 0
     draft_tok = draft_lp = draft_accept_lp = draft_xtc_draw = None
 
-    while ntoks < max_tokens:
-        if draft_tok is None:
-            # No pending draft: run backbone only, then generate first draft.
-            toks, lps, accept_lps, hidden, prev_tokens = _step_backbone(
-                y, prev_tokens, n_predict=1
-            )
-            mx.eval(toks)
-            prompt_progress_callback(total_prompt_tokens, total_prompt_tokens)
-            main_tok, main_lp = toks[0], lps[0]
-            ntoks += 1
-            yield main_tok.item(), main_lp, False
-            if ntoks >= max_tokens:
-                return
-            hidden_at_main = hidden[:, -1:, :]
-            draft_tok, draft_lp, draft_accept_lp, draft_xtc_draw = _step_mtp(
-                hidden_at_main, main_tok, prev_tokens
-            )
-            mx.eval(draft_tok)
-            y = mx.array([main_tok.item()], mx.uint32)
-        else:
-            # Verify draft: run backbone over [y, draft_tok].
-            # n_confirmed=1 causes GatedDeltaNet to snapshot its SSM/conv state
-            # after the confirmed token y, enabling exact rollback on rejection.
-            y_with_draft = mx.concatenate([y, mx.array([draft_tok.item()], mx.uint32)])
-            toks, lps, accept_lps, hidden, prev_tokens = _step_backbone(
-                y_with_draft,
-                prev_tokens,
-                n_predict=2,
-                n_confirmed=1,
-                xtc_draw=draft_xtc_draw,
-            )
-            u = mx.random.uniform()
-            mx.eval(toks, draft_tok, u)
-
-            verify_pred, bonus_tok = toks[0], toks[1]
-            verify_lp, bonus_lp = lps[0], lps[1]
-            verify_accept_lp = accept_lps[0]
-            draft_tok_id = draft_tok.item()
-
-            if _is_greedy:
-                accept = verify_pred.item() == draft_tok_id
-            else:
-                # Probabilistic acceptance: min(1, p_target/p_draft) with temp-adjusted logprobs.
-                log_accept = (
-                    verify_accept_lp[draft_tok_id] - draft_accept_lp[draft_tok_id]
-                ).item()
-                accept = log_accept >= 0 or u.item() < math.exp(log_accept)
-
-            hidden_at_confirmed = hidden[:, 0:1, :]
-            hidden_at_draft = hidden[:, 1:2, :]
-
-            if accept:
-                _clear_rollback()
+    try:
+        while max_tokens < 0 or ntoks < max_tokens:
+            if draft_tok is None:
+                # No pending draft: run backbone only, then generate first draft.
+                toks, lps, accept_lps, hidden, prev_tokens = _step_backbone(
+                    y, prev_tokens, n_predict=1
+                )
+                mx.eval(toks)
+                prompt_progress_callback(total_prompt_tokens, total_prompt_tokens)
+                main_tok, main_lp = toks[0], lps[0]
+                hidden_at_main = hidden[:, -1:, :]
                 ntoks += 1
-                yield draft_tok_id, draft_lp, True
-                if ntoks >= max_tokens:
+                finalize_plan = _MTPPromptFinalizePlan(
+                    mtp_hidden=hidden_at_main,
+                    mtp_tokens=main_tok.reshape(1, 1),
+                    target_token=main_tok,
+                    last_hidden=None,
+                    num_tokens=cached_token_count + input_token_count + ntoks,
+                )
+                yield main_tok.item(), main_lp, False
+                if max_tokens >= 0 and ntoks >= max_tokens:
                     return
-                ntoks += 1
-                yield bonus_tok.item(), bonus_lp, False
-                if ntoks >= max_tokens:
-                    return
-                # Next draft: one batched forward aligns the cache for the
-                # accepted draft token and generates the next draft together.
+                finalize_plan = None
                 draft_tok, draft_lp, draft_accept_lp, draft_xtc_draw = _step_mtp(
-                    hidden_at_draft,
-                    bonus_tok,
-                    prev_tokens,
-                    cache_commit=(hidden_at_confirmed, draft_tok),
+                    hidden_at_main, main_tok, prev_tokens
                 )
                 mx.eval(draft_tok)
-                y = mx.array([bonus_tok.item()], mx.uint32)
+                y = mx.array([main_tok.item()], mx.uint32)
             else:
-                _rollback_draft()
-                if logits_processors and prev_tokens is not None:
-                    prev_tokens = prev_tokens[:-1]  # discard rejected draft token
-                verify_tok_id = verify_pred.item()
-                if not _is_greedy:
-                    # Sample from residual distribution max(p_target - p_draft, 0) / Z
-                    # (Leviathan et al. 2022 §2.3; Chen et al. 2023). Guarantees the
-                    # output marginal equals the target distribution exactly.
-                    # Both distributions are temperature-adjusted to match sampling.
-                    p_target = mx.exp(verify_accept_lp)
-                    p_draft = mx.exp(draft_accept_lp)
-                    residual = mx.maximum(p_target - p_draft, 0.0)
-                    z = residual.sum(keepdims=True)
-                    dist = mx.where(z > 0, residual, p_target)
-                    # categorical treats -inf log-prob as p=0.
-                    verify_tok_id = mx.random.categorical(
-                        mx.log(dist).reshape(1, -1)
+                # Verify draft: run backbone over [y, draft_tok].
+                # n_confirmed=1 causes GatedDeltaNet to snapshot its SSM/conv state
+                # after the confirmed token y, enabling exact rollback on rejection.
+                y_with_draft = mx.concatenate(
+                    [y, mx.array([draft_tok.item()], mx.uint32)]
+                )
+                toks, lps, accept_lps, hidden, prev_tokens = _step_backbone(
+                    y_with_draft,
+                    prev_tokens,
+                    n_predict=2,
+                    n_confirmed=1,
+                    xtc_draw=draft_xtc_draw,
+                )
+                u = mx.random.uniform()
+                mx.eval(toks, draft_tok, u)
+
+                verify_pred, bonus_tok = toks[0], toks[1]
+                verify_lp, bonus_lp = lps[0], lps[1]
+                verify_accept_lp = accept_lps[0]
+                draft_tok_id = draft_tok.item()
+
+                if _is_greedy:
+                    accept = verify_pred.item() == draft_tok_id
+                else:
+                    # Probabilistic acceptance: min(1, p_target/p_draft).
+                    log_accept = (
+                        verify_accept_lp[draft_tok_id] - draft_accept_lp[draft_tok_id]
                     ).item()
-                ntoks += 1
-                yield verify_tok_id, verify_lp, False
-                if ntoks >= max_tokens:
-                    return
-                # Next draft from MTP at y's hidden state.
-                draft_tok, draft_lp, draft_accept_lp, draft_xtc_draw = _step_mtp(
-                    hidden_at_confirmed,
-                    mx.array([verify_tok_id], mx.uint32),
-                    prev_tokens,
-                )
-                mx.eval(draft_tok)
-                y = mx.array([verify_tok_id], mx.uint32)
-        block = ntoks // _CACHE_CLEAR_INTERVAL
-        if block > last_cache_block:
-            mx.clear_cache()
-            last_cache_block = block
+                    accept = log_accept >= 0 or u.item() < math.exp(log_accept)
+
+                hidden_at_confirmed = hidden[:, 0:1, :]
+                hidden_at_draft = hidden[:, 1:2, :]
+
+                if accept:
+                    _clear_rollback()
+                    accepted_draft = draft_tok
+                    ntoks += 1
+                    finalize_plan = _MTPPromptFinalizePlan(
+                        mtp_hidden=hidden_at_confirmed,
+                        mtp_tokens=accepted_draft.reshape(1, 1),
+                        target_token=None,
+                        last_hidden=hidden_at_draft,
+                        num_tokens=cached_token_count + input_token_count + ntoks,
+                    )
+                    yield draft_tok_id, verify_lp, True
+                    if max_tokens >= 0 and ntoks >= max_tokens:
+                        return
+
+                    ntoks += 1
+                    finalize_plan = _MTPPromptFinalizePlan(
+                        mtp_hidden=mx.concatenate(
+                            [hidden_at_confirmed, hidden_at_draft], axis=1
+                        ),
+                        mtp_tokens=mx.concatenate(
+                            [
+                                accepted_draft.reshape(1, 1),
+                                bonus_tok.reshape(1, 1),
+                            ],
+                            axis=1,
+                        ),
+                        target_token=bonus_tok,
+                        last_hidden=None,
+                        num_tokens=cached_token_count + input_token_count + ntoks,
+                    )
+                    yield bonus_tok.item(), bonus_lp, False
+                    if max_tokens >= 0 and ntoks >= max_tokens:
+                        return
+
+                    finalize_plan = None
+                    # Next draft: one batched forward aligns the cache for the
+                    # accepted draft token and generates the next draft together.
+                    draft_tok, draft_lp, draft_accept_lp, draft_xtc_draw = _step_mtp(
+                        hidden_at_draft,
+                        bonus_tok,
+                        prev_tokens,
+                        cache_commit=(hidden_at_confirmed, accepted_draft),
+                    )
+                    mx.eval(draft_tok)
+                    y = mx.array([bonus_tok.item()], mx.uint32)
+                else:
+                    _rollback_draft()
+                    if logits_processors and prev_tokens is not None:
+                        prev_tokens = prev_tokens[:-1]  # discard rejected draft token
+                    verify_tok_id = verify_pred.item()
+                    if not _is_greedy:
+                        # Sample from residual distribution max(p_target - p_draft, 0) / Z.
+                        p_target = mx.exp(verify_accept_lp)
+                        p_draft = mx.exp(draft_accept_lp)
+                        residual = mx.maximum(p_target - p_draft, 0.0)
+                        z = residual.sum(keepdims=True)
+                        dist = mx.where(z > 0, residual, p_target)
+                        verify_tok_id = mx.random.categorical(
+                            mx.log(dist).reshape(1, -1)
+                        ).item()
+
+                    verify_tok = mx.array(verify_tok_id, mx.uint32)
+                    ntoks += 1
+                    finalize_plan = _MTPPromptFinalizePlan(
+                        mtp_hidden=hidden_at_confirmed,
+                        mtp_tokens=verify_tok.reshape(1, 1),
+                        target_token=verify_tok,
+                        last_hidden=None,
+                        num_tokens=cached_token_count + input_token_count + ntoks,
+                    )
+                    yield verify_tok_id, verify_lp, False
+                    if max_tokens >= 0 and ntoks >= max_tokens:
+                        return
+
+                    finalize_plan = None
+                    # Next draft from MTP at y's hidden state.
+                    draft_tok, draft_lp, draft_accept_lp, draft_xtc_draw = _step_mtp(
+                        hidden_at_confirmed,
+                        verify_tok,
+                        prev_tokens,
+                    )
+                    mx.eval(draft_tok)
+                    y = mx.array([verify_tok_id], mx.uint32)
+            block = ntoks // _CACHE_CLEAR_INTERVAL
+            if block > last_cache_block:
+                mx.clear_cache()
+                last_cache_block = block
+    finally:
+        _finalize_prompt_cache()
 
 
 def stream_generate(
@@ -1061,7 +1265,7 @@ def stream_generate(
         token_generator = speculative_generate_step(
             prompt, model, draft_model, **kwargs
         )
-    elif mtp and hasattr(model, "mtp_forward"):
+    elif mtp and _model_supports_mtp(model):
         kwargs.pop("max_kv_size", None)
         prompt_progress_callback = kwargs.pop("prompt_progress_callback", None)
         kwargs.pop("num_draft_tokens", None)
@@ -1094,19 +1298,34 @@ def stream_generate(
             (token, logprobs, False) for token, logprobs in token_generator
         )
     with wired_limit(model, [generation_stream]):
-        tic = time.perf_counter()
-        for n, (token, logprobs, from_draft) in enumerate(token_generator):
-            if n == 0:
-                prompt_time = time.perf_counter() - tic
-                prompt_tps = prompt.size / prompt_time
-                tic = time.perf_counter()
-            if token in tokenizer.eos_token_ids:
-                break
+        try:
+            tic = time.perf_counter()
+            for n, (token, logprobs, from_draft) in enumerate(token_generator):
+                if n == 0:
+                    prompt_time = time.perf_counter() - tic
+                    prompt_tps = prompt.size / prompt_time
+                    tic = time.perf_counter()
+                if token in tokenizer.eos_token_ids:
+                    break
 
-            detokenizer.add_token(token)
-            if (n + 1) == max_tokens:
-                break
+                detokenizer.add_token(token)
+                if (n + 1) == max_tokens:
+                    break
 
+                yield GenerationResponse(
+                    text=detokenizer.last_segment,
+                    token=token,
+                    logprobs=logprobs,
+                    from_draft=from_draft,
+                    prompt_tokens=prompt.size,
+                    prompt_tps=prompt_tps,
+                    generation_tokens=n + 1,
+                    generation_tps=(n + 1) / (time.perf_counter() - tic),
+                    peak_memory=mx.get_peak_memory() / 1e9,
+                    finish_reason=None,
+                )
+
+            detokenizer.finalize()
             yield GenerationResponse(
                 text=detokenizer.last_segment,
                 token=token,
@@ -1117,22 +1336,14 @@ def stream_generate(
                 generation_tokens=n + 1,
                 generation_tps=(n + 1) / (time.perf_counter() - tic),
                 peak_memory=mx.get_peak_memory() / 1e9,
-                finish_reason=None,
+                finish_reason=(
+                    "stop" if token in tokenizer.eos_token_ids else "length"
+                ),
             )
-
-        detokenizer.finalize()
-        yield GenerationResponse(
-            text=detokenizer.last_segment,
-            token=token,
-            logprobs=logprobs,
-            from_draft=from_draft,
-            prompt_tokens=prompt.size,
-            prompt_tps=prompt_tps,
-            generation_tokens=n + 1,
-            generation_tps=(n + 1) / (time.perf_counter() - tic),
-            peak_memory=mx.get_peak_memory() / 1e9,
-            finish_reason="stop" if token in tokenizer.eos_token_ids else "length",
-        )
+        finally:
+            close = getattr(token_generator, "close", None)
+            if close is not None:
+                close()
 
 
 def generate(
@@ -2525,6 +2736,14 @@ def main():
         draft_model=draft_model,
         num_draft_tokens=args.num_draft_tokens,
         mtp=args.mtp,
+        temp=args.temp,
+        top_p=args.top_p,
+        top_k=args.top_k,
+        min_p=args.min_p,
+        min_tokens_to_keep=args.min_tokens_to_keep,
+        xtc_probability=args.xtc_probability,
+        xtc_threshold=args.xtc_threshold,
+        xtc_special_tokens=tokenizer.encode("\n") + list(tokenizer.eos_token_ids),
     )
     if not args.verbose:
         print(response)

--- a/mlx_lm/generate.py
+++ b/mlx_lm/generate.py
@@ -880,11 +880,12 @@ def mtp_generate_step(
                     p_target = mx.exp(verify_lp)
                     p_draft = mx.exp(draft_lp)
                     residual = mx.maximum(p_target - p_draft, 0.0)
-                    z = residual.sum().item()
-                    if z > 1e-8:
-                        verify_tok_id = mx.random.categorical(
-                            mx.log(residual / z + 1e-10).reshape(1, -1)
-                        ).item()
+                    z = residual.sum(keepdims=True)
+                    dist = mx.where(z > 0, residual, p_target)
+                    # categorical treats -inf log-prob as p=0.
+                    verify_tok_id = mx.random.categorical(
+                        mx.log(dist).reshape(1, -1)
+                    ).item()
                 ntoks += 1
                 yield verify_tok_id, verify_lp, False
                 if ntoks >= max_tokens:

--- a/mlx_lm/generate.py
+++ b/mlx_lm/generate.py
@@ -745,13 +745,12 @@ def mtp_generate_step(
             quantize_cache_fn(model_cache)
             nonlocal prev_tokens
             toks, lps = [], []
-            y_ctx = y if n_predict == 1 else y[: -(n_predict - 1)]
             for i in range(n_predict):
                 if logits_processors:
                     prev_tokens = (
-                        mx.concatenate([prev_tokens, y_ctx])
+                        mx.concatenate([prev_tokens, y[i : i + 1]])
                         if prev_tokens is not None
-                        else y_ctx
+                        else y[i : i + 1]
                     )
                 tok, lp = _process_and_sample(prev_tokens, logits[:, i, :].squeeze(0))
                 toks.append(tok)
@@ -765,7 +764,15 @@ def mtp_generate_step(
             mtp_logits = model.mtp_forward(hidden_last, next_ids, mtp_cache)
             quantize_cache_fn(mtp_cache)
             mtp_logits = mtp_logits[:, -1, :].squeeze(0)
-            draft_tok, draft_lp = _process_and_sample(prev_tokens, mtp_logits)
+            if logits_processors:
+                tokens_for_proc = (
+                    mx.concatenate([prev_tokens, main_tok.reshape(-1)])
+                    if prev_tokens is not None
+                    else main_tok.reshape(-1)
+                )
+            else:
+                tokens_for_proc = prev_tokens
+            draft_tok, draft_lp = _process_and_sample(tokens_for_proc, mtp_logits)
         return draft_tok, draft_lp
 
     def _prefill(y):
@@ -834,6 +841,8 @@ def mtp_generate_step(
                 y = mx.array([bonus_tok.item()], mx.uint32)
             else:
                 _rollback_draft()
+                if logits_processors and prev_tokens is not None:
+                    prev_tokens = prev_tokens[:-1]  # discard rejected draft token
                 verify_tok_id = verify_pred.item()
                 ntoks += 1
                 yield verify_tok_id, verify_lp, False

--- a/mlx_lm/generate.py
+++ b/mlx_lm/generate.py
@@ -670,17 +670,19 @@ def mtp_generate_step(
     kv_group_size: int = 64,
     quantized_kv_start: int = 0,
 ) -> Generator[Tuple[mx.array, mx.array, bool], None, None]:
-    """A generator using the model's native MTP head for speculative decoding.
+    """A generator that uses the model's native MTP head for speculative decoding.
 
-    Produces up to 2 tokens per forward pass:
-      - 1 backbone token (always accepted)
-      - 1 MTP draft token (accepted if the backbone agrees on the next step)
+    Each iteration runs one backbone forward pass over the current token and its
+    pending draft, then one MTP forward pass to propose the next draft.  Up to 2
+    tokens are emitted per backbone step: one always-accepted backbone token and
+    one conditionally-accepted draft token.
 
-    The model must expose ``mtp_forward(hidden, next_tok, mtp_cache)`` and
+    The model must implement ``mtp_forward(hidden, next_tok, mtp_cache)`` and
     support ``return_hidden=True`` in its ``__call__``.
 
     Yields:
-        Tuple[mx.array, mx.array, bool]: token, log-probabilities, from_draft.
+        Tuple[mx.array, mx.array, bool]: (token, log-probabilities, from_draft).
+            ``from_draft`` is ``True`` when the token came from the MTP head.
     """
     y = prompt.astype(mx.uint32)
     prev_tokens = None
@@ -711,10 +713,10 @@ def mtp_generate_step(
         tok = sampler(logprobs)
         return tok, logprobs
 
-    def _step_backbone(y, n_predict=1):
-        """One backbone forward pass. Returns (tokens, logprobs, hidden)."""
+    def _step_backbone(y, n_predict=1, n_confirmed=0):
+        """Run the backbone on ``y`` and return (tokens, logprobs, hidden)."""
         with mx.stream(generation_stream):
-            logits, hidden = model(y[None], cache=model_cache, return_hidden=True)
+            logits, hidden = model(y[None], cache=model_cache, return_hidden=True, n_confirmed=n_confirmed)
             logits = logits[:, -n_predict:, :]
             quantize_cache_fn(model_cache)
             nonlocal prev_tokens
@@ -733,8 +735,7 @@ def mtp_generate_step(
             return mx.stack(toks), mx.stack(lps), hidden
 
     def _step_mtp(hidden_last, main_tok):
-        """Run MTP head. Returns (draft_token, draft_logprobs)."""
-        # hidden_last: (1, 1, H), main_tok: 0-d or scalar
+        """Run the MTP head and return (draft_token, draft_logprobs)."""
         next_ids = main_tok.reshape(1, 1)
         with mx.stream(generation_stream):
             mtp_logits = model.mtp_forward(hidden_last, next_ids, mtp_cache)
@@ -777,11 +778,13 @@ def mtp_generate_step(
                 mx.eval(draft_tok)
                 y = mx.array([main_tok.item()], mx.uint32)
             else:
-                # Verify draft: process [y, draft_tok] through backbone together
+                # Verify draft: run backbone over [y, draft_tok].
+                # n_confirmed=1 causes GatedDeltaNet to snapshot its SSM/conv state
+                # after the confirmed token y, enabling exact rollback on rejection.
                 y_with_draft = mx.concatenate(
                     [y, mx.array([draft_tok.item()], mx.uint32)]
                 )
-                toks, lps, hidden = _step_backbone(y_with_draft, n_predict=2)
+                toks, lps, hidden = _step_backbone(y_with_draft, n_predict=2, n_confirmed=1)
                 mx.eval(toks, draft_tok)
 
                 verify_pred = toks[0]   # backbone prediction after y → verify draft
@@ -790,7 +793,11 @@ def mtp_generate_step(
                 bonus_lp = lps[1]
 
                 if verify_pred.item() == draft_tok.item():
-                    # Draft accepted
+                    # Draft accepted — discard rollback snapshots.
+                    for c in model_cache:
+                        if hasattr(c, "rollback_state"):
+                            c.rollback_state = None
+
                     ntoks += 1
                     yield draft_tok, draft_lp, True
                     if ntoks >= max_tokens:
@@ -806,18 +813,17 @@ def mtp_generate_step(
                     mx.eval(draft_tok)
                     y = mx.array([bonus_tok.item()], mx.uint32)
                 else:
-                    # Draft rejected — trim caches.
-                    #
-                    # Qwen3.5 is a hybrid SSM+Attention model: attention layers use
-                    # KVCache (trimmable), SSM layers use ArraysCache (not trimmable).
-                    # trim_prompt_cache() is all-or-nothing, so we trim KV entries
-                    # individually. The SSM state will retain a 1-token contamination
-                    # from the rejected draft, which is empirically negligible compared
-                    # to the sequence length but means output may differ slightly from
-                    # standard generate_step. A correct fix would require exposing
-                    # per-token intermediate SSM states from GatedDeltaNet (future work).
+                    # Draft rejected — roll back all caches to the state after y.
+                    # SSM layers (ArraysCache): restore the conv/ssm snapshot saved
+                    # by GatedDeltaNet after the confirmed token.
+                    # Attention layers (KVCache): trim the draft-token entry.
                     for c in model_cache:
-                        if c.is_trimmable():
+                        if hasattr(c, "rollback_state") and c.rollback_state is not None:
+                            conv_snap, ssm_snap = c.rollback_state
+                            c[0] = conv_snap
+                            c[1] = ssm_snap
+                            c.rollback_state = None
+                        elif c.is_trimmable():
                             c.trim(1)
                     cache.trim_prompt_cache(mtp_cache, 1)
 

--- a/mlx_lm/generate.py
+++ b/mlx_lm/generate.py
@@ -803,9 +803,20 @@ def mtp_generate_step(
                 prev_tokens,
             )
 
-    def _step_mtp(hidden_last, main_tok, prev_tokens):
-        """Run the MTP head and return (draft_token, draft_logprobs, draft_accept_lp, xtc_draw)."""
-        next_ids = main_tok.reshape(1, 1)
+    def _step_mtp(hidden_last, main_tok, prev_tokens, *, cache_commit=None):
+        """Run the MTP head and return (draft_token, draft_logprobs, draft_accept_lp, xtc_draw).
+
+        cache_commit: (hidden, tok) prepended as a cache-alignment position so that the
+        accepted draft token is committed to mtp_cache in the same batched forward.
+        """
+        if cache_commit is not None:
+            align_h, align_tok = cache_commit
+            hidden_last = mx.concatenate([align_h, hidden_last], axis=1)
+            next_ids = mx.concatenate(
+                [align_tok.reshape(1, 1), main_tok.reshape(1, 1)], axis=1
+            )
+        else:
+            next_ids = main_tok.reshape(1, 1)
         with mx.stream(generation_stream):
             mtp_logits = model.mtp_forward(hidden_last, next_ids, mtp_cache)
             quantize_cache_fn(mtp_cache)
@@ -916,9 +927,13 @@ def mtp_generate_step(
                 yield bonus_tok.item(), bonus_lp, False
                 if ntoks >= max_tokens:
                     return
-                # Next draft from MTP at draft_tok's hidden state.
+                # Next draft: one batched forward aligns the cache for the
+                # accepted draft token and generates the next draft together.
                 draft_tok, draft_lp, draft_accept_lp, draft_xtc_draw = _step_mtp(
-                    hidden_at_draft, bonus_tok, prev_tokens
+                    hidden_at_draft,
+                    bonus_tok,
+                    prev_tokens,
+                    cache_commit=(hidden_at_confirmed, draft_tok),
                 )
                 mx.eval(draft_tok)
                 y = mx.array([bonus_tok.item()], mx.uint32)

--- a/mlx_lm/generate.py
+++ b/mlx_lm/generate.py
@@ -735,15 +735,14 @@ def mtp_generate_step(
                 c.trim(1)
         cache.trim_prompt_cache(mtp_cache, 1)
 
-    def _step_backbone(y, n_predict=1, n_confirmed=0):
-        """Run the backbone on ``y`` and return (tokens, logprobs, hidden)."""
+    def _step_backbone(y, prev_tokens, n_predict=1, n_confirmed=0):
+        """Run the backbone on ``y`` and return (tokens, logprobs, hidden, prev_tokens)."""
         with mx.stream(generation_stream):
             logits, hidden = model(
                 y[None], cache=model_cache, return_hidden=True, n_confirmed=n_confirmed
             )
             logits = logits[:, -n_predict:, :]
             quantize_cache_fn(model_cache)
-            nonlocal prev_tokens
             toks, lps = [], []
             for i in range(n_predict):
                 if logits_processors:
@@ -755,9 +754,9 @@ def mtp_generate_step(
                 tok, lp = _process_and_sample(prev_tokens, logits[:, i, :].squeeze(0))
                 toks.append(tok)
                 lps.append(lp)
-            return mx.stack(toks), mx.stack(lps), hidden
+            return mx.stack(toks), mx.stack(lps), hidden, prev_tokens
 
-    def _step_mtp(hidden_last, main_tok):
+    def _step_mtp(hidden_last, main_tok, prev_tokens):
         """Run the MTP head and return (draft_token, draft_logprobs)."""
         next_ids = main_tok.reshape(1, 1)
         with mx.stream(generation_stream):
@@ -796,14 +795,15 @@ def mtp_generate_step(
     while ntoks < max_tokens:
         if draft_tok is None:
             # No pending draft: run backbone only, then generate first draft.
-            toks, lps, hidden = _step_backbone(y, n_predict=1)
+            toks, lps, hidden, prev_tokens = _step_backbone(y, prev_tokens, n_predict=1)
             mx.eval(toks)
             main_tok, main_lp = toks[0], lps[0]
             ntoks += 1
             yield main_tok.item(), main_lp, False
             if ntoks >= max_tokens:
                 return
-            draft_tok, draft_lp = _step_mtp(hidden[:, -1:, :], main_tok)
+            hidden_at_main = hidden[:, -1:, :]
+            draft_tok, draft_lp = _step_mtp(hidden_at_main, main_tok, prev_tokens)
             mx.eval(draft_tok)
             y = mx.array([main_tok.item()], mx.uint32)
         else:
@@ -811,7 +811,9 @@ def mtp_generate_step(
             # n_confirmed=1 causes GatedDeltaNet to snapshot its SSM/conv state
             # after the confirmed token y, enabling exact rollback on rejection.
             y_with_draft = mx.concatenate([y, mx.array([draft_tok.item()], mx.uint32)])
-            toks, lps, hidden = _step_backbone(y_with_draft, n_predict=2, n_confirmed=1)
+            toks, lps, hidden, prev_tokens = _step_backbone(
+                y_with_draft, prev_tokens, n_predict=2, n_confirmed=1
+            )
             mx.eval(toks, draft_tok)
 
             verify_pred, bonus_tok = toks[0], toks[1]
@@ -825,6 +827,9 @@ def mtp_generate_step(
                 log_accept = (verify_lp[draft_tok_id] - draft_lp[draft_tok_id]).item()
                 accept = log_accept >= 0 or random.random() < math.exp(log_accept)
 
+            hidden_at_confirmed = hidden[:, 0:1, :]
+            hidden_at_draft = hidden[:, 1:2, :]
+
             if accept:
                 _clear_rollback()
                 ntoks += 1
@@ -836,7 +841,7 @@ def mtp_generate_step(
                 if ntoks >= max_tokens:
                     return
                 # Next draft from MTP at draft_tok's hidden state.
-                draft_tok, draft_lp = _step_mtp(hidden[:, 1:2, :], bonus_tok)
+                draft_tok, draft_lp = _step_mtp(hidden_at_draft, bonus_tok, prev_tokens)
                 mx.eval(draft_tok)
                 y = mx.array([bonus_tok.item()], mx.uint32)
             else:
@@ -849,7 +854,9 @@ def mtp_generate_step(
                 if ntoks >= max_tokens:
                     return
                 # Next draft from MTP at y's hidden state.
-                draft_tok, draft_lp = _step_mtp(hidden[:, 0:1, :], verify_pred)
+                draft_tok, draft_lp = _step_mtp(
+                    hidden_at_confirmed, verify_pred, prev_tokens
+                )
                 mx.eval(draft_tok)
                 y = mx.array([verify_tok_id], mx.uint32)
 

--- a/mlx_lm/generate.py
+++ b/mlx_lm/generate.py
@@ -723,8 +723,29 @@ def mtp_generate_step(
             for processor in logits_processors:
                 logits = processor(tokens, logits)
         logprobs = logits - mx.logsumexp(logits, axis=-1, keepdims=True)
-        tok = sampler(logprobs)
-        return tok, logprobs
+        return sampler(logprobs), logprobs
+
+    def _clear_rollback():
+        for c in model_cache:
+            if hasattr(c, "rollback_state"):
+                c.rollback_state = None
+
+    def _rollback_draft():
+        """Restore caches to the state after the confirmed token.
+
+        SSM layers (ArraysCache): restore the conv/ssm snapshot saved by
+        GatedDeltaNet after the confirmed token.
+        Attention layers (KVCache): trim the draft-token entry.
+        """
+        for c in model_cache:
+            if hasattr(c, "rollback_state") and c.rollback_state is not None:
+                conv_snap, ssm_snap = c.rollback_state
+                c[0] = conv_snap
+                c[1] = ssm_snap
+                c.rollback_state = None
+            elif c.is_trimmable():
+                c.trim(1)
+        cache.trim_prompt_cache(mtp_cache, 1)
 
     def _step_backbone(y, n_predict=1, n_confirmed=0):
         """Run the backbone on ``y`` and return (tokens, logprobs, hidden)."""
@@ -772,101 +793,65 @@ def mtp_generate_step(
         y = _prefill(y)
 
     ntoks = 0
-    draft_tok = None
-    draft_lp = None
+    draft_tok = draft_lp = None
 
-    try:
-        while True:
-            if draft_tok is None:
-                # No pending draft: run backbone only, then generate first draft.
-                toks, lps, hidden = _step_backbone(y, n_predict=1)
-                mx.eval(toks)
-                main_tok = toks[0]
-                main_lp = lps[0]
+    while ntoks < max_tokens:
+        if draft_tok is None:
+            # No pending draft: run backbone only, then generate first draft.
+            toks, lps, hidden = _step_backbone(y, n_predict=1)
+            mx.eval(toks)
+            main_tok, main_lp = toks[0], lps[0]
+            ntoks += 1
+            yield main_tok.item(), main_lp, False
+            if ntoks >= max_tokens:
+                return
+            draft_tok, draft_lp = _step_mtp(hidden[:, -1:, :], main_tok)
+            mx.eval(draft_tok)
+            y = mx.array([main_tok.item()], mx.uint32)
+        else:
+            # Verify draft: run backbone over [y, draft_tok].
+            # n_confirmed=1 causes GatedDeltaNet to snapshot its SSM/conv state
+            # after the confirmed token y, enabling exact rollback on rejection.
+            y_with_draft = mx.concatenate([y, mx.array([draft_tok.item()], mx.uint32)])
+            toks, lps, hidden = _step_backbone(y_with_draft, n_predict=2, n_confirmed=1)
+            mx.eval(toks, draft_tok)
 
-                ntoks += 1
-                yield main_tok.item(), main_lp, False
-                if ntoks >= max_tokens:
-                    break
+            verify_pred, bonus_tok = toks[0], toks[1]
+            verify_lp, bonus_lp = lps[0], lps[1]
+            draft_tok_id = draft_tok.item()
 
-                draft_tok, draft_lp = _step_mtp(hidden[:, -1:, :], main_tok)
-                mx.eval(draft_tok)
-                y = mx.array([main_tok.item()], mx.uint32)
+            if _is_greedy:
+                accept = verify_pred.item() == draft_tok_id
             else:
-                # Verify draft: run backbone over [y, draft_tok].
-                # n_confirmed=1 causes GatedDeltaNet to snapshot its SSM/conv state
-                # after the confirmed token y, enabling exact rollback on rejection.
-                y_with_draft = mx.concatenate(
-                    [y, mx.array([draft_tok.item()], mx.uint32)]
-                )
-                toks, lps, hidden = _step_backbone(
-                    y_with_draft, n_predict=2, n_confirmed=1
-                )
-                mx.eval(toks, draft_tok)
+                # Probabilistic acceptance: min(1, p_target / p_draft).
+                log_accept = (verify_lp[draft_tok_id] - draft_lp[draft_tok_id]).item()
+                accept = log_accept >= 0 or random.random() < math.exp(log_accept)
 
-                verify_pred = toks[0]  # backbone prediction for y, used to verify draft
-                bonus_tok = toks[1]  # backbone prediction after draft_tok
-                verify_lp = lps[0]
-                bonus_lp = lps[1]
-
-                draft_tok_id = draft_tok.item()
-                if _is_greedy:
-                    accept = verify_pred.item() == draft_tok_id
-                else:
-                    # Probabilistic acceptance: min(1, p_target / p_draft).
-                    log_accept = (
-                        verify_lp[draft_tok_id] - draft_lp[draft_tok_id]
-                    ).item()
-                    accept = log_accept >= 0 or random.random() < math.exp(log_accept)
-                if accept:
-                    # Draft accepted: discard rollback snapshots.
-                    for c in model_cache:
-                        if hasattr(c, "rollback_state"):
-                            c.rollback_state = None
-
-                    ntoks += 1
-                    yield draft_tok.item(), draft_lp, True
-                    if ntoks >= max_tokens:
-                        break
-
-                    ntoks += 1
-                    yield bonus_tok.item(), bonus_lp, False
-                    if ntoks >= max_tokens:
-                        break
-
-                    # Next draft from MTP at draft_tok's hidden state
-                    draft_tok, draft_lp = _step_mtp(hidden[:, 1:2, :], bonus_tok)
-                    mx.eval(draft_tok)
-                    y = mx.array([bonus_tok.item()], mx.uint32)
-                else:
-                    # Draft rejected: roll back all caches to the state after y.
-                    # SSM layers (ArraysCache): restore the conv/ssm snapshot saved
-                    # by GatedDeltaNet after the confirmed token.
-                    # Attention layers (KVCache): trim the draft-token entry.
-                    for c in model_cache:
-                        if (
-                            hasattr(c, "rollback_state")
-                            and c.rollback_state is not None
-                        ):
-                            conv_snap, ssm_snap = c.rollback_state
-                            c[0] = conv_snap
-                            c[1] = ssm_snap
-                            c.rollback_state = None
-                        elif c.is_trimmable():
-                            c.trim(1)
-                    cache.trim_prompt_cache(mtp_cache, 1)
-
-                    ntoks += 1
-                    yield verify_pred.item(), verify_lp, False
-                    if ntoks >= max_tokens:
-                        break
-
-                    # Next draft from MTP at y's hidden state
-                    draft_tok, draft_lp = _step_mtp(hidden[:, 0:1, :], verify_pred)
-                    mx.eval(draft_tok)
-                    y = mx.array([verify_pred.item()], mx.uint32)
-    finally:
-        pass
+            if accept:
+                _clear_rollback()
+                ntoks += 1
+                yield draft_tok_id, draft_lp, True
+                if ntoks >= max_tokens:
+                    return
+                ntoks += 1
+                yield bonus_tok.item(), bonus_lp, False
+                if ntoks >= max_tokens:
+                    return
+                # Next draft from MTP at draft_tok's hidden state.
+                draft_tok, draft_lp = _step_mtp(hidden[:, 1:2, :], bonus_tok)
+                mx.eval(draft_tok)
+                y = mx.array([bonus_tok.item()], mx.uint32)
+            else:
+                _rollback_draft()
+                verify_tok_id = verify_pred.item()
+                ntoks += 1
+                yield verify_tok_id, verify_lp, False
+                if ntoks >= max_tokens:
+                    return
+                # Next draft from MTP at y's hidden state.
+                draft_tok, draft_lp = _step_mtp(hidden[:, 0:1, :], verify_pred)
+                mx.eval(draft_tok)
+                y = mx.array([verify_tok_id], mx.uint32)
 
 
 def stream_generate(
@@ -927,18 +912,13 @@ def stream_generate(
         kwargs.pop("prompt_progress_callback", None)
         kwargs.pop("num_draft_tokens", None)
         token_generator = mtp_generate_step(prompt, model, **kwargs)
-    elif mtp:
-        warnings.warn(
-            "--mtp flag ignored: model does not have an MTP head. "
-            "Falling back to standard generation.",
-            stacklevel=2,
-        )
-        kwargs.pop("num_draft_tokens", None)
-        token_generator = generate_step(prompt, model, **kwargs)
-        token_generator = (
-            (token, logprobs, False) for token, logprobs in token_generator
-        )
     else:
+        if mtp:
+            warnings.warn(
+                "--mtp flag ignored: model does not have an MTP head. "
+                "Falling back to standard generation.",
+                stacklevel=2,
+            )
         kwargs.pop("num_draft_tokens", None)
         token_generator = generate_step(prompt, model, **kwargs)
         # from_draft always false for non-speculative generation

--- a/mlx_lm/generate.py
+++ b/mlx_lm/generate.py
@@ -682,6 +682,7 @@ def mtp_generate_step(
     kv_group_size: int = 64,
     quantized_kv_start: int = 0,
     input_embeddings: Optional[mx.array] = None,
+    prompt_progress_callback: Optional[Callable[[int, int], None]] = None,
     temp: float = 0.0,
     top_p: float = 0.0,
     top_k: int = 0,
@@ -709,6 +710,8 @@ def mtp_generate_step(
 
     y = prompt.astype(mx.uint32)
     prev_tokens = None
+    prompt_progress_callback = prompt_progress_callback or (lambda *_: None)
+    total_prompt_tokens = y.size
 
     if prompt_cache is None:
         model_cache = cache.make_prompt_cache(model)
@@ -858,6 +861,7 @@ def mtp_generate_step(
     def _prefill(y, input_embeddings):
         # Leave exactly 1 token for _step_backbone so the decode loop starts clean.
         total = len(input_embeddings) if input_embeddings is not None else y.size
+        processed = total_prompt_tokens - total
         while total > 1:
             n = min(prefill_step_size, total - 1)
             if input_embeddings is not None:
@@ -876,6 +880,8 @@ def mtp_generate_step(
             mx.eval([c.state for c in model_cache + mtp_cache if hasattr(c, "state")])
             y = y[n:]
             total -= n
+            processed += n
+            prompt_progress_callback(processed, total_prompt_tokens)
             mx.clear_cache()
         return y
 
@@ -893,6 +899,7 @@ def mtp_generate_step(
                 y, prev_tokens, n_predict=1
             )
             mx.eval(toks)
+            prompt_progress_callback(total_prompt_tokens, total_prompt_tokens)
             main_tok, main_lp = toks[0], lps[0]
             ntoks += 1
             yield main_tok.item(), main_lp, False
@@ -1056,12 +1063,13 @@ def stream_generate(
         )
     elif mtp and hasattr(model, "mtp_forward"):
         kwargs.pop("max_kv_size", None)
-        kwargs.pop("prompt_progress_callback", None)
+        prompt_progress_callback = kwargs.pop("prompt_progress_callback", None)
         kwargs.pop("num_draft_tokens", None)
         kwargs.pop("sampler", None)  # mtp_generate_step does not accept sampler=
         token_generator = mtp_generate_step(
             prompt,
             model,
+            prompt_progress_callback=prompt_progress_callback,
             temp=temp,
             top_p=top_p,
             top_k=top_k,

--- a/mlx_lm/generate.py
+++ b/mlx_lm/generate.py
@@ -6,7 +6,6 @@ import copy
 import functools
 import json
 import math
-import random
 import sys
 import time
 import warnings
@@ -28,7 +27,7 @@ from .models.cache import (
     make_prompt_cache,
     trim_prompt_cache,
 )
-from .sample_utils import make_sampler
+from .sample_utils import categorical_sampling, make_sampler, make_sampler_chain
 from .tokenizer_utils import TokenizerWrapper
 from .utils import does_model_support_input_embeddings, load
 
@@ -671,7 +670,6 @@ def mtp_generate_step(
     model: nn.Module,
     *,
     max_tokens: int = 256,
-    sampler: Optional[Callable[[mx.array], mx.array]] = None,
     logits_processors: Optional[List[Callable[[mx.array, mx.array], mx.array]]] = None,
     prompt_cache: Optional[Any] = None,
     prefill_step_size: int = 2048,
@@ -679,6 +677,14 @@ def mtp_generate_step(
     kv_group_size: int = 64,
     quantized_kv_start: int = 0,
     input_embeddings: Optional[mx.array] = None,
+    temp: float = 0.0,
+    top_p: float = 0.0,
+    top_k: int = 0,
+    min_p: float = 0.0,
+    min_tokens_to_keep: int = 1,
+    xtc_probability: float = 0.0,
+    xtc_threshold: float = 0.0,
+    xtc_special_tokens: List[int] = [],
 ) -> Generator[Tuple[mx.array, mx.array, bool], None, None]:
     """A generator that uses the model's native MTP head for speculative decoding.
 
@@ -707,10 +713,21 @@ def mtp_generate_step(
         model_cache = prompt_cache[:n_main]
         mtp_cache = prompt_cache[n_main:] or model.make_mtp_cache()
 
-    # Exact-match acceptance for greedy (sampler=None); probabilistic
-    # acceptance min(1, p_target/p_draft) for stochastic samplers.
-    _is_greedy = sampler is None
-    sampler = sampler or (lambda x: mx.argmax(x, axis=-1))
+    _is_greedy = temp == 0
+
+    _filter_chain, _xtc_cell = (
+        make_sampler_chain(
+            top_p,
+            top_k,
+            min_p,
+            min_tokens_to_keep,
+            xtc_probability,
+            xtc_threshold,
+            xtc_special_tokens,
+        )
+        if not _is_greedy
+        else ([], None)
+    )
 
     quantize_cache_fn = functools.partial(
         maybe_quantize_kv_cache,
@@ -719,14 +736,31 @@ def mtp_generate_step(
         kv_bits=kv_bits,
     )
 
-    def _process_and_sample(tokens, logits):
+    def _process_and_sample(tokens, logits, xtc_draw=None):
         if logits_processors:
             logits = logits[None]
             for processor in logits_processors:
                 logits = processor(tokens, logits)
             logits = logits.squeeze(0)
         logprobs = logits - mx.logsumexp(logits, axis=-1, keepdims=True)
-        return sampler(logprobs), logprobs
+        if _filter_chain:
+            if _xtc_cell is not None:
+                _xtc_cell[0] = xtc_draw  # None = fresh draw; mx.array = shared draw
+            masked = logprobs
+            for f in _filter_chain:
+                masked = f(masked)
+            token = categorical_sampling(masked, temp)
+            # lp_accept must reflect the same filtered distribution as token.
+            scaled = masked / temp
+            lp_accept = scaled - mx.logsumexp(scaled, axis=-1, keepdims=True)
+        elif _is_greedy:
+            token = mx.argmax(logprobs, axis=-1)
+            lp_accept = logprobs
+        else:
+            token = categorical_sampling(logprobs, temp)
+            scaled = logprobs / temp
+            lp_accept = scaled - mx.logsumexp(scaled, axis=-1, keepdims=True)
+        return token, logprobs, lp_accept
 
     def _clear_rollback():
         for c in model_cache:
@@ -749,15 +783,15 @@ def mtp_generate_step(
             elif c.is_trimmable():
                 c.trim(1)
 
-    def _step_backbone(y, prev_tokens, n_predict=1, n_confirmed=0):
-        """Run the backbone on ``y`` and return (tokens, logprobs, hidden, prev_tokens)."""
+    def _step_backbone(y, prev_tokens, n_predict=1, n_confirmed=0, xtc_draw=None):
+        """Run the backbone on ``y`` and return (tokens, logprobs, accept_lps, hidden, prev_tokens)."""
         with mx.stream(generation_stream):
             logits, hidden = model(
                 y[None], cache=model_cache, return_hidden=True, n_confirmed=n_confirmed
             )
             logits = logits[:, -n_predict:, :]
             quantize_cache_fn(model_cache)
-            toks, lps = [], []
+            toks, lps, accept_lps = [], [], []
             for i in range(n_predict):
                 if logits_processors:
                     prev_tokens = (
@@ -765,13 +799,24 @@ def mtp_generate_step(
                         if prev_tokens is not None
                         else y[i : i + 1]
                     )
-                tok, lp = _process_and_sample(prev_tokens, logits[:, i, :].squeeze(0))
+                # Pass the shared XTC draw only for position 0 (the verify position).
+                draw = xtc_draw if i == 0 else None
+                tok, lp, alp = _process_and_sample(
+                    prev_tokens, logits[:, i, :].squeeze(0), draw
+                )
                 toks.append(tok)
                 lps.append(lp)
-            return mx.stack(toks), mx.stack(lps), hidden, prev_tokens
+                accept_lps.append(alp)
+            return (
+                mx.stack(toks),
+                mx.stack(lps),
+                mx.stack(accept_lps),
+                hidden,
+                prev_tokens,
+            )
 
     def _step_mtp(hidden_last, main_tok, prev_tokens):
-        """Run the MTP head and return (draft_token, draft_logprobs)."""
+        """Run the MTP head and return (draft_token, draft_logprobs, draft_accept_lp, xtc_draw)."""
         next_ids = main_tok.reshape(1, 1)
         with mx.stream(generation_stream):
             mtp_logits = model.mtp_forward(hidden_last, next_ids, mtp_cache)
@@ -785,8 +830,12 @@ def mtp_generate_step(
                 )
             else:
                 tokens_for_proc = prev_tokens
-            draft_tok, draft_lp = _process_and_sample(tokens_for_proc, mtp_logits)
-        return draft_tok, draft_lp
+            # Draw the XTC boolean once here so the verify step can reuse it.
+            xtc_draw = mx.random.uniform() if _xtc_cell is not None else None
+            draft_tok, draft_lp, draft_accept_lp = _process_and_sample(
+                tokens_for_proc, mtp_logits, xtc_draw
+            )
+        return draft_tok, draft_lp, draft_accept_lp, xtc_draw
 
     def _prefill(y, input_embeddings):
         # Leave exactly 1 token for _step_backbone: return_hidden=True keeps
@@ -814,12 +863,14 @@ def mtp_generate_step(
         y = _prefill(y, input_embeddings)
 
     ntoks = 0
-    draft_tok = draft_lp = None
+    draft_tok = draft_lp = draft_accept_lp = draft_xtc_draw = None
 
     while ntoks < max_tokens:
         if draft_tok is None:
             # No pending draft: run backbone only, then generate first draft.
-            toks, lps, hidden, prev_tokens = _step_backbone(y, prev_tokens, n_predict=1)
+            toks, lps, accept_lps, hidden, prev_tokens = _step_backbone(
+                y, prev_tokens, n_predict=1
+            )
             mx.eval(toks)
             main_tok, main_lp = toks[0], lps[0]
             ntoks += 1
@@ -827,7 +878,9 @@ def mtp_generate_step(
             if ntoks >= max_tokens:
                 return
             hidden_at_main = hidden[:, -1:, :]
-            draft_tok, draft_lp = _step_mtp(hidden_at_main, main_tok, prev_tokens)
+            draft_tok, draft_lp, draft_accept_lp, draft_xtc_draw = _step_mtp(
+                hidden_at_main, main_tok, prev_tokens
+            )
             mx.eval(draft_tok)
             y = mx.array([main_tok.item()], mx.uint32)
         else:
@@ -835,21 +888,29 @@ def mtp_generate_step(
             # n_confirmed=1 causes GatedDeltaNet to snapshot its SSM/conv state
             # after the confirmed token y, enabling exact rollback on rejection.
             y_with_draft = mx.concatenate([y, mx.array([draft_tok.item()], mx.uint32)])
-            toks, lps, hidden, prev_tokens = _step_backbone(
-                y_with_draft, prev_tokens, n_predict=2, n_confirmed=1
+            u = mx.random.uniform()
+            toks, lps, accept_lps, hidden, prev_tokens = _step_backbone(
+                y_with_draft,
+                prev_tokens,
+                n_predict=2,
+                n_confirmed=1,
+                xtc_draw=draft_xtc_draw,
             )
-            mx.eval(toks, draft_tok)
+            mx.eval(toks, draft_tok, u)
 
             verify_pred, bonus_tok = toks[0], toks[1]
             verify_lp, bonus_lp = lps[0], lps[1]
+            verify_accept_lp = accept_lps[0]
             draft_tok_id = draft_tok.item()
 
             if _is_greedy:
                 accept = verify_pred.item() == draft_tok_id
             else:
-                # Probabilistic acceptance: min(1, p_target / p_draft).
-                log_accept = (verify_lp[draft_tok_id] - draft_lp[draft_tok_id]).item()
-                accept = log_accept >= 0 or random.random() < math.exp(log_accept)
+                # Probabilistic acceptance: min(1, p_target/p_draft) with temp-adjusted logprobs.
+                log_accept = (
+                    verify_accept_lp[draft_tok_id] - draft_accept_lp[draft_tok_id]
+                ).item()
+                accept = log_accept >= 0 or u.item() < math.exp(log_accept)
 
             hidden_at_confirmed = hidden[:, 0:1, :]
             hidden_at_draft = hidden[:, 1:2, :]
@@ -865,7 +926,9 @@ def mtp_generate_step(
                 if ntoks >= max_tokens:
                     return
                 # Next draft from MTP at draft_tok's hidden state.
-                draft_tok, draft_lp = _step_mtp(hidden_at_draft, bonus_tok, prev_tokens)
+                draft_tok, draft_lp, draft_accept_lp, draft_xtc_draw = _step_mtp(
+                    hidden_at_draft, bonus_tok, prev_tokens
+                )
                 mx.eval(draft_tok)
                 y = mx.array([bonus_tok.item()], mx.uint32)
             else:
@@ -877,8 +940,9 @@ def mtp_generate_step(
                     # Sample from residual distribution max(p_target - p_draft, 0) / Z
                     # (Leviathan et al. 2022 §2.3; Chen et al. 2023). Guarantees the
                     # output marginal equals the target distribution exactly.
-                    p_target = mx.exp(verify_lp)
-                    p_draft = mx.exp(draft_lp)
+                    # Both distributions are temperature-adjusted to match sampling.
+                    p_target = mx.exp(verify_accept_lp)
+                    p_draft = mx.exp(draft_accept_lp)
                     residual = mx.maximum(p_target - p_draft, 0.0)
                     z = residual.sum(keepdims=True)
                     dist = mx.where(z > 0, residual, p_target)
@@ -891,7 +955,7 @@ def mtp_generate_step(
                 if ntoks >= max_tokens:
                     return
                 # Next draft from MTP at y's hidden state.
-                draft_tok, draft_lp = _step_mtp(
+                draft_tok, draft_lp, draft_accept_lp, draft_xtc_draw = _step_mtp(
                     hidden_at_confirmed,
                     mx.array([verify_tok_id], mx.uint32),
                     prev_tokens,
@@ -907,6 +971,14 @@ def stream_generate(
     max_tokens: int = 256,
     draft_model: Optional[nn.Module] = None,
     mtp: bool = False,
+    temp: float = 0.0,
+    top_p: float = 0.0,
+    top_k: int = 0,
+    min_p: float = 0.0,
+    min_tokens_to_keep: int = 1,
+    xtc_probability: float = 0.0,
+    xtc_threshold: float = 0.0,
+    xtc_special_tokens: List[int] = [],
     **kwargs,
 ) -> Generator[GenerationResponse, None, None]:
     """
@@ -957,7 +1029,20 @@ def stream_generate(
         kwargs.pop("max_kv_size", None)
         kwargs.pop("prompt_progress_callback", None)
         kwargs.pop("num_draft_tokens", None)
-        token_generator = mtp_generate_step(prompt, model, **kwargs)
+        kwargs.pop("sampler", None)  # mtp_generate_step does not accept sampler=
+        token_generator = mtp_generate_step(
+            prompt,
+            model,
+            temp=temp,
+            top_p=top_p,
+            top_k=top_k,
+            min_p=min_p,
+            min_tokens_to_keep=min_tokens_to_keep,
+            xtc_probability=xtc_probability,
+            xtc_threshold=xtc_threshold,
+            xtc_special_tokens=xtc_special_tokens,
+            **kwargs,
+        )
     else:
         if mtp:
             warnings.warn(

--- a/mlx_lm/generate.py
+++ b/mlx_lm/generate.py
@@ -868,11 +868,12 @@ def mtp_generate_step(
                     p_target = mx.exp(verify_lp)
                     p_draft = mx.exp(draft_lp)
                     residual = mx.maximum(p_target - p_draft, 0.0)
-                    z = residual.sum().item()
-                    if z > 1e-8:
-                        verify_tok_id = mx.random.categorical(
-                            mx.log(residual / z + 1e-10).reshape(1, -1)
-                        ).item()
+                    z = residual.sum(keepdims=True)
+                    dist = mx.where(z > 0, residual, p_target)
+                    # categorical treats -inf log-prob as p=0.
+                    verify_tok_id = mx.random.categorical(
+                        mx.log(dist).reshape(1, -1)
+                    ).item()
                 ntoks += 1
                 yield verify_tok_id, verify_lp, False
                 if ntoks >= max_tokens:

--- a/mlx_lm/generate.py
+++ b/mlx_lm/generate.py
@@ -747,15 +747,14 @@ def mtp_generate_step(
                 c.trim(1)
         cache.trim_prompt_cache(mtp_cache, 1)
 
-    def _step_backbone(y, n_predict=1, n_confirmed=0):
-        """Run the backbone on ``y`` and return (tokens, logprobs, hidden)."""
+    def _step_backbone(y, prev_tokens, n_predict=1, n_confirmed=0):
+        """Run the backbone on ``y`` and return (tokens, logprobs, hidden, prev_tokens)."""
         with mx.stream(generation_stream):
             logits, hidden = model(
                 y[None], cache=model_cache, return_hidden=True, n_confirmed=n_confirmed
             )
             logits = logits[:, -n_predict:, :]
             quantize_cache_fn(model_cache)
-            nonlocal prev_tokens
             toks, lps = [], []
             for i in range(n_predict):
                 if logits_processors:
@@ -767,9 +766,9 @@ def mtp_generate_step(
                 tok, lp = _process_and_sample(prev_tokens, logits[:, i, :].squeeze(0))
                 toks.append(tok)
                 lps.append(lp)
-            return mx.stack(toks), mx.stack(lps), hidden
+            return mx.stack(toks), mx.stack(lps), hidden, prev_tokens
 
-    def _step_mtp(hidden_last, main_tok):
+    def _step_mtp(hidden_last, main_tok, prev_tokens):
         """Run the MTP head and return (draft_token, draft_logprobs)."""
         next_ids = main_tok.reshape(1, 1)
         with mx.stream(generation_stream):
@@ -808,14 +807,15 @@ def mtp_generate_step(
     while ntoks < max_tokens:
         if draft_tok is None:
             # No pending draft: run backbone only, then generate first draft.
-            toks, lps, hidden = _step_backbone(y, n_predict=1)
+            toks, lps, hidden, prev_tokens = _step_backbone(y, prev_tokens, n_predict=1)
             mx.eval(toks)
             main_tok, main_lp = toks[0], lps[0]
             ntoks += 1
             yield main_tok.item(), main_lp, False
             if ntoks >= max_tokens:
                 return
-            draft_tok, draft_lp = _step_mtp(hidden[:, -1:, :], main_tok)
+            hidden_at_main = hidden[:, -1:, :]
+            draft_tok, draft_lp = _step_mtp(hidden_at_main, main_tok, prev_tokens)
             mx.eval(draft_tok)
             y = mx.array([main_tok.item()], mx.uint32)
         else:
@@ -823,7 +823,9 @@ def mtp_generate_step(
             # n_confirmed=1 causes GatedDeltaNet to snapshot its SSM/conv state
             # after the confirmed token y, enabling exact rollback on rejection.
             y_with_draft = mx.concatenate([y, mx.array([draft_tok.item()], mx.uint32)])
-            toks, lps, hidden = _step_backbone(y_with_draft, n_predict=2, n_confirmed=1)
+            toks, lps, hidden, prev_tokens = _step_backbone(
+                y_with_draft, prev_tokens, n_predict=2, n_confirmed=1
+            )
             mx.eval(toks, draft_tok)
 
             verify_pred, bonus_tok = toks[0], toks[1]
@@ -837,6 +839,9 @@ def mtp_generate_step(
                 log_accept = (verify_lp[draft_tok_id] - draft_lp[draft_tok_id]).item()
                 accept = log_accept >= 0 or random.random() < math.exp(log_accept)
 
+            hidden_at_confirmed = hidden[:, 0:1, :]
+            hidden_at_draft = hidden[:, 1:2, :]
+
             if accept:
                 _clear_rollback()
                 ntoks += 1
@@ -848,7 +853,7 @@ def mtp_generate_step(
                 if ntoks >= max_tokens:
                     return
                 # Next draft from MTP at draft_tok's hidden state.
-                draft_tok, draft_lp = _step_mtp(hidden[:, 1:2, :], bonus_tok)
+                draft_tok, draft_lp = _step_mtp(hidden_at_draft, bonus_tok, prev_tokens)
                 mx.eval(draft_tok)
                 y = mx.array([bonus_tok.item()], mx.uint32)
             else:
@@ -861,7 +866,9 @@ def mtp_generate_step(
                 if ntoks >= max_tokens:
                     return
                 # Next draft from MTP at y's hidden state.
-                draft_tok, draft_lp = _step_mtp(hidden[:, 0:1, :], verify_pred)
+                draft_tok, draft_lp = _step_mtp(
+                    hidden_at_confirmed, verify_pred, prev_tokens
+                )
                 mx.eval(draft_tok)
                 y = mx.array([verify_tok_id], mx.uint32)
 

--- a/mlx_lm/generate.py
+++ b/mlx_lm/generate.py
@@ -4,10 +4,10 @@ import argparse
 import contextlib
 import copy
 import functools
-import warnings
 import json
 import sys
 import time
+import warnings
 from collections import deque
 from dataclasses import dataclass
 from typing import Any, Callable, Generator, List, Optional, Sequence, Tuple, Union
@@ -724,7 +724,9 @@ def mtp_generate_step(
     def _step_backbone(y, n_predict=1, n_confirmed=0):
         """Run the backbone on ``y`` and return (tokens, logprobs, hidden)."""
         with mx.stream(generation_stream):
-            logits, hidden = model(y[None], cache=model_cache, return_hidden=True, n_confirmed=n_confirmed)
+            logits, hidden = model(
+                y[None], cache=model_cache, return_hidden=True, n_confirmed=n_confirmed
+            )
             logits = logits[:, -n_predict:, :]
             quantize_cache_fn(model_cache)
             nonlocal prev_tokens
@@ -792,11 +794,13 @@ def mtp_generate_step(
                 y_with_draft = mx.concatenate(
                     [y, mx.array([draft_tok.item()], mx.uint32)]
                 )
-                toks, lps, hidden = _step_backbone(y_with_draft, n_predict=2, n_confirmed=1)
+                toks, lps, hidden = _step_backbone(
+                    y_with_draft, n_predict=2, n_confirmed=1
+                )
                 mx.eval(toks, draft_tok)
 
-                verify_pred = toks[0]   # backbone prediction after y → verify draft
-                bonus_tok = toks[1]     # backbone prediction after draft_tok
+                verify_pred = toks[0]  # backbone prediction after y → verify draft
+                bonus_tok = toks[1]  # backbone prediction after draft_tok
                 verify_lp = lps[0]
                 bonus_lp = lps[1]
 
@@ -826,7 +830,10 @@ def mtp_generate_step(
                     # by GatedDeltaNet after the confirmed token.
                     # Attention layers (KVCache): trim the draft-token entry.
                     for c in model_cache:
-                        if hasattr(c, "rollback_state") and c.rollback_state is not None:
+                        if (
+                            hasattr(c, "rollback_state")
+                            and c.rollback_state is not None
+                        ):
                             conv_snap, ssm_snap = c.rollback_state
                             c[0] = conv_snap
                             c[1] = ssm_snap

--- a/mlx_lm/generate.py
+++ b/mlx_lm/generate.py
@@ -210,6 +210,12 @@ def setup_arg_parser():
         help="Number of tokens to draft when using speculative decoding.",
         default=3,
     )
+    parser.add_argument(
+        "--mtp",
+        action="store_true",
+        help="Use native Multi-Token Prediction for speculative decoding "
+        "(requires a model with an MTP head, e.g. Qwen3.5).",
+    )
     return parser
 
 
@@ -835,6 +841,7 @@ def stream_generate(
     prompt: Union[str, mx.array, List[int]],
     max_tokens: int = 256,
     draft_model: Optional[nn.Module] = None,
+    mtp: bool = False,
     **kwargs,
 ) -> Generator[GenerationResponse, None, None]:
     """
@@ -850,6 +857,8 @@ def stream_generate(
         draft_model (Optional[nn.Module]): An optional draft model. If provided
           then speculative decoding is used. The draft model must use the same
           tokenizer as the main model. Default: ``None``.
+        mtp (bool): Use native Multi-Token Prediction for speculative
+          decoding. Requires a model with an MTP head. Default: ``False``.
         kwargs: The remaining options get passed to :func:`generate_step`.
           See :func:`generate_step` for more details.
 
@@ -879,7 +888,7 @@ def stream_generate(
         token_generator = speculative_generate_step(
             prompt, model, draft_model, **kwargs
         )
-    elif hasattr(model, "mtp_forward"):
+    elif mtp and hasattr(model, "mtp_forward"):
         kwargs.pop("max_kv_size", None)
         kwargs.pop("prompt_progress_callback", None)
         kwargs.pop("num_draft_tokens", None)
@@ -2370,6 +2379,7 @@ def main():
         quantized_kv_start=args.quantized_kv_start,
         draft_model=draft_model,
         num_draft_tokens=args.num_draft_tokens,
+        mtp=args.mtp,
     )
     if not args.verbose:
         print(response)

--- a/mlx_lm/generate.py
+++ b/mlx_lm/generate.py
@@ -308,6 +308,22 @@ def maybe_quantize_kv_cache(prompt_cache, quantized_kv_start, kv_group_size, kv_
             prompt_cache[e] = c.to_quantized(group_size=kv_group_size, bits=kv_bits)
 
 
+def validate_prompt_and_embeddings(model, prompt, input_embeddings):
+    if input_embeddings is not None:
+        if not does_model_support_input_embeddings(model):
+            raise ValueError("Model does not support input embeddings.")
+        elif len(prompt) > 0 and len(prompt) != len(input_embeddings):
+            raise ValueError(
+                f"When providing input_embeddings, their sequence length ({len(input_embeddings)}) "
+                f"must match the sequence length of the prompt ({len(prompt)}), or the "
+                "prompt must be empty."
+            )
+    elif len(prompt) == 0:
+        raise ValueError(
+            "Either input_embeddings or prompt (or both) must be provided."
+        )
+
+
 def generate_step(
     prompt: mx.array,
     model: nn.Module,
@@ -355,19 +371,7 @@ def generate_step(
     Yields:
         Tuple[mx.array, mx.array]: One token and a vector of log probabilities.
     """
-    if input_embeddings is not None:
-        if not does_model_support_input_embeddings(model):
-            raise ValueError("Model does not support input embeddings.")
-        elif len(prompt) > 0 and len(prompt) != len(input_embeddings):
-            raise ValueError(
-                f"When providing input_embeddings, their sequence length ({len(input_embeddings)}) "
-                f"must match the sequence length of the prompt ({len(prompt)}), or the "
-                "prompt must be empty."
-            )
-    elif len(prompt) == 0:
-        raise ValueError(
-            "Either input_embeddings or prompt (or both) must be provided."
-        )
+    validate_prompt_and_embeddings(model, prompt, input_embeddings)
 
     tokens = None
 
@@ -701,6 +705,8 @@ def mtp_generate_step(
         Tuple[mx.array, mx.array, bool]: (token, log-probabilities, from_draft).
             ``from_draft`` is ``True`` when the token came from the MTP head.
     """
+    validate_prompt_and_embeddings(model, prompt, input_embeddings)
+
     y = prompt.astype(mx.uint32)
     prev_tokens = None
 

--- a/mlx_lm/generate.py
+++ b/mlx_lm/generate.py
@@ -645,6 +645,183 @@ def speculative_generate_step(
         _rewind_cache(num_draft, n)
 
 
+def mtp_generate_step(
+    prompt: mx.array,
+    model: nn.Module,
+    *,
+    max_tokens: int = 256,
+    sampler: Optional[Callable[[mx.array], mx.array]] = None,
+    logits_processors: Optional[List[Callable[[mx.array, mx.array], mx.array]]] = None,
+    prompt_cache: Optional[Any] = None,
+    prefill_step_size: int = 512,
+    kv_bits: Optional[int] = None,
+    kv_group_size: int = 64,
+    quantized_kv_start: int = 0,
+) -> Generator[Tuple[mx.array, mx.array, bool], None, None]:
+    """A generator using the model's native MTP head for speculative decoding.
+
+    Produces up to 2 tokens per forward pass:
+      - 1 backbone token (always accepted)
+      - 1 MTP draft token (accepted if the backbone agrees on the next step)
+
+    The model must expose ``mtp_forward(hidden, next_tok, mtp_cache)`` and
+    support ``return_hidden=True`` in its ``__call__``.
+
+    Yields:
+        Tuple[mx.array, mx.array, bool]: token, log-probabilities, from_draft.
+    """
+    y = prompt.astype(mx.uint32)
+    prev_tokens = None
+
+    if prompt_cache is None:
+        model_cache = cache.make_prompt_cache(model)
+        mtp_cache = model.make_mtp_cache()
+    else:
+        # When a pre-built cache is provided, split at backbone length
+        n_main = len(model.layers)
+        model_cache = prompt_cache[:n_main]
+        mtp_cache = prompt_cache[n_main:]
+
+    sampler = sampler or (lambda x: mx.argmax(x, axis=-1))
+
+    quantize_cache_fn = functools.partial(
+        maybe_quantize_kv_cache,
+        quantized_kv_start=quantized_kv_start,
+        kv_group_size=kv_group_size,
+        kv_bits=kv_bits,
+    )
+
+    def _process_and_sample(tokens, logits):
+        if logits_processors:
+            for processor in logits_processors:
+                logits = processor(tokens, logits)
+        logprobs = logits - mx.logsumexp(logits, axis=-1, keepdims=True)
+        tok = sampler(logprobs)
+        return tok, logprobs
+
+    def _step_backbone(y, n_predict=1):
+        """One backbone forward pass. Returns (tokens, logprobs, hidden)."""
+        with mx.stream(generation_stream):
+            logits, hidden = model(y[None], cache=model_cache, return_hidden=True)
+            logits = logits[:, -n_predict:, :]
+            quantize_cache_fn(model_cache)
+            nonlocal prev_tokens
+            toks, lps = [], []
+            y_ctx = y if n_predict == 1 else y[: -(n_predict - 1)]
+            for i in range(n_predict):
+                if logits_processors:
+                    prev_tokens = (
+                        mx.concatenate([prev_tokens, y_ctx])
+                        if prev_tokens is not None
+                        else y_ctx
+                    )
+                tok, lp = _process_and_sample(prev_tokens, logits[:, i, :].squeeze(0))
+                toks.append(tok)
+                lps.append(lp)
+            return mx.stack(toks), mx.stack(lps), hidden
+
+    def _step_mtp(hidden_last, main_tok):
+        """Run MTP head. Returns (draft_token, draft_logprobs)."""
+        # hidden_last: (1, 1, H), main_tok: 0-d or scalar
+        next_ids = main_tok.reshape(1, 1)
+        with mx.stream(generation_stream):
+            mtp_logits = model.mtp_forward(hidden_last, next_ids, mtp_cache)
+            quantize_cache_fn(mtp_cache)
+            mtp_logits = mtp_logits[:, -1, :].squeeze(0)
+            draft_tok, draft_lp = _process_and_sample(prev_tokens, mtp_logits)
+        return draft_tok, draft_lp
+
+    def _prefill(y):
+        while y.size > prefill_step_size:
+            model(y[:prefill_step_size][None], cache=model_cache)
+            quantize_cache_fn(model_cache)
+            mx.eval([c.state for c in model_cache if hasattr(c, "state")])
+            y = y[prefill_step_size:]
+            mx.clear_cache()
+        return y
+
+    with mx.stream(generation_stream):
+        y = _prefill(y)
+
+    ntoks = 0
+    draft_tok = None
+    draft_lp = None
+
+    try:
+        while True:
+            if draft_tok is None:
+                # No pending draft — run backbone only, then generate first draft
+                toks, lps, hidden = _step_backbone(y, n_predict=1)
+                mx.eval(toks)
+                main_tok = toks[0]
+                main_lp = lps[0]
+
+                ntoks += 1
+                yield main_tok, main_lp, False
+                if ntoks >= max_tokens:
+                    break
+
+                draft_tok, draft_lp = _step_mtp(hidden[:, -1:, :], main_tok)
+                mx.eval(draft_tok)
+                y = mx.array([main_tok.item()], mx.uint32)
+            else:
+                # Verify draft: process [y, draft_tok] through backbone together
+                y_with_draft = mx.concatenate(
+                    [y, mx.array([draft_tok.item()], mx.uint32)]
+                )
+                toks, lps, hidden = _step_backbone(y_with_draft, n_predict=2)
+                mx.eval(toks, draft_tok)
+
+                verify_pred = toks[0]   # backbone prediction after y → verify draft
+                bonus_tok = toks[1]     # backbone prediction after draft_tok
+                verify_lp = lps[0]
+                bonus_lp = lps[1]
+
+                if verify_pred.item() == draft_tok.item():
+                    # Draft accepted
+                    ntoks += 1
+                    yield draft_tok, draft_lp, True
+                    if ntoks >= max_tokens:
+                        break
+
+                    ntoks += 1
+                    yield bonus_tok, bonus_lp, False
+                    if ntoks >= max_tokens:
+                        break
+
+                    # Next draft from MTP at draft_tok's hidden state
+                    draft_tok, draft_lp = _step_mtp(hidden[:, 1:2, :], bonus_tok)
+                    mx.eval(draft_tok)
+                    y = mx.array([bonus_tok.item()], mx.uint32)
+                else:
+                    # Draft rejected — trim caches.
+                    #
+                    # Qwen3.5 is a hybrid SSM+Attention model: attention layers use
+                    # KVCache (trimmable), SSM layers use ArraysCache (not trimmable).
+                    # trim_prompt_cache() is all-or-nothing, so we trim KV entries
+                    # individually. The SSM state will retain a 1-token contamination
+                    # from the rejected draft, which is empirically negligible compared
+                    # to the sequence length but means output may differ slightly from
+                    # standard generate_step. A correct fix would require exposing
+                    # per-token intermediate SSM states from GatedDeltaNet (future work).
+                    for c in model_cache:
+                        if c.is_trimmable():
+                            c.trim(1)
+                    cache.trim_prompt_cache(mtp_cache, 1)
+
+                    ntoks += 1
+                    yield verify_pred, verify_lp, False
+                    if ntoks >= max_tokens:
+                        break
+
+                    # Next draft from MTP at y's hidden state
+                    draft_tok, draft_lp = _step_mtp(hidden[:, 0:1, :], verify_pred)
+                    mx.eval(draft_tok)
+                    y = mx.array([verify_pred.item()], mx.uint32)
+    finally:
+        pass
+
+
 def stream_generate(
     model: nn.Module,
     tokenizer: Union[PreTrainedTokenizer, TokenizerWrapper],
@@ -689,18 +866,23 @@ def stream_generate(
 
     kwargs["max_tokens"] = max_tokens
 
-    if draft_model is None:
+    if draft_model is not None:
+        kwargs.pop("max_kv_size", None)
+        kwargs.pop("prompt_progress_callback", None)
+        token_generator = speculative_generate_step(
+            prompt, model, draft_model, **kwargs
+        )
+    elif hasattr(model, "mtp_forward"):
+        kwargs.pop("max_kv_size", None)
+        kwargs.pop("prompt_progress_callback", None)
+        kwargs.pop("num_draft_tokens", None)
+        token_generator = mtp_generate_step(prompt, model, **kwargs)
+    else:
         kwargs.pop("num_draft_tokens", None)
         token_generator = generate_step(prompt, model, **kwargs)
         # from_draft always false for non-speculative generation
         token_generator = (
             (token, logprobs, False) for token, logprobs in token_generator
-        )
-    else:
-        kwargs.pop("max_kv_size", None)
-        kwargs.pop("prompt_progress_callback", None)
-        token_generator = speculative_generate_step(
-            prompt, model, draft_model, **kwargs
         )
     with wired_limit(model, [generation_stream]):
         tic = time.perf_counter()

--- a/mlx_lm/generate.py
+++ b/mlx_lm/generate.py
@@ -5,6 +5,8 @@ import contextlib
 import copy
 import functools
 import json
+import math
+import random
 import sys
 import time
 import warnings
@@ -692,6 +694,9 @@ def mtp_generate_step(
         model_cache = prompt_cache[:n_main]
         mtp_cache = prompt_cache[n_main:] or model.make_mtp_cache()
 
+    # Exact-match acceptance for greedy (sampler=None); probabilistic
+    # acceptance min(1, p_target/p_draft) for stochastic samplers.
+    _is_greedy = sampler is None
     sampler = sampler or (lambda x: mx.argmax(x, axis=-1))
 
     quantize_cache_fn = functools.partial(
@@ -761,7 +766,7 @@ def mtp_generate_step(
     try:
         while True:
             if draft_tok is None:
-                # No pending draft — run backbone only, then generate first draft
+                # No pending draft: run backbone only, then generate first draft.
                 toks, lps, hidden = _step_backbone(y, n_predict=1)
                 mx.eval(toks)
                 main_tok = toks[0]
@@ -787,13 +792,22 @@ def mtp_generate_step(
                 )
                 mx.eval(toks, draft_tok)
 
-                verify_pred = toks[0]  # backbone prediction after y → verify draft
+                verify_pred = toks[0]  # backbone prediction for y, used to verify draft
                 bonus_tok = toks[1]  # backbone prediction after draft_tok
                 verify_lp = lps[0]
                 bonus_lp = lps[1]
 
-                if verify_pred.item() == draft_tok.item():
-                    # Draft accepted — discard rollback snapshots.
+                draft_tok_id = draft_tok.item()
+                if _is_greedy:
+                    accept = verify_pred.item() == draft_tok_id
+                else:
+                    # Probabilistic acceptance: min(1, p_target / p_draft).
+                    log_accept = (
+                        verify_lp[draft_tok_id] - draft_lp[draft_tok_id]
+                    ).item()
+                    accept = log_accept >= 0 or random.random() < math.exp(log_accept)
+                if accept:
+                    # Draft accepted: discard rollback snapshots.
                     for c in model_cache:
                         if hasattr(c, "rollback_state"):
                             c.rollback_state = None
@@ -813,7 +827,7 @@ def mtp_generate_step(
                     mx.eval(draft_tok)
                     y = mx.array([bonus_tok.item()], mx.uint32)
                 else:
-                    # Draft rejected — roll back all caches to the state after y.
+                    # Draft rejected: roll back all caches to the state after y.
                     # SSM layers (ArraysCache): restore the conv/ssm snapshot saved
                     # by GatedDeltaNet after the confirmed token.
                     # Attention layers (KVCache): trim the draft-token entry.

--- a/mlx_lm/generate.py
+++ b/mlx_lm/generate.py
@@ -748,7 +748,6 @@ def mtp_generate_step(
                 c.rollback_state = None
             elif c.is_trimmable():
                 c.trim(1)
-        cache.trim_prompt_cache(mtp_cache, 1)
 
     def _step_backbone(y, prev_tokens, n_predict=1, n_confirmed=0):
         """Run the backbone on ``y`` and return (tokens, logprobs, hidden, prev_tokens)."""

--- a/mlx_lm/generate.py
+++ b/mlx_lm/generate.py
@@ -4,10 +4,10 @@ import argparse
 import contextlib
 import copy
 import functools
-import warnings
 import json
 import sys
 import time
+import warnings
 from collections import deque
 from dataclasses import dataclass
 from functools import partial
@@ -712,7 +712,9 @@ def mtp_generate_step(
     def _step_backbone(y, n_predict=1, n_confirmed=0):
         """Run the backbone on ``y`` and return (tokens, logprobs, hidden)."""
         with mx.stream(generation_stream):
-            logits, hidden = model(y[None], cache=model_cache, return_hidden=True, n_confirmed=n_confirmed)
+            logits, hidden = model(
+                y[None], cache=model_cache, return_hidden=True, n_confirmed=n_confirmed
+            )
             logits = logits[:, -n_predict:, :]
             quantize_cache_fn(model_cache)
             nonlocal prev_tokens
@@ -780,11 +782,13 @@ def mtp_generate_step(
                 y_with_draft = mx.concatenate(
                     [y, mx.array([draft_tok.item()], mx.uint32)]
                 )
-                toks, lps, hidden = _step_backbone(y_with_draft, n_predict=2, n_confirmed=1)
+                toks, lps, hidden = _step_backbone(
+                    y_with_draft, n_predict=2, n_confirmed=1
+                )
                 mx.eval(toks, draft_tok)
 
-                verify_pred = toks[0]   # backbone prediction after y → verify draft
-                bonus_tok = toks[1]     # backbone prediction after draft_tok
+                verify_pred = toks[0]  # backbone prediction after y → verify draft
+                bonus_tok = toks[1]  # backbone prediction after draft_tok
                 verify_lp = lps[0]
                 bonus_lp = lps[1]
 
@@ -814,7 +818,10 @@ def mtp_generate_step(
                     # by GatedDeltaNet after the confirmed token.
                     # Attention layers (KVCache): trim the draft-token entry.
                     for c in model_cache:
-                        if hasattr(c, "rollback_state") and c.rollback_state is not None:
+                        if (
+                            hasattr(c, "rollback_state")
+                            and c.rollback_state is not None
+                        ):
                             conv_snap, ssm_snap = c.rollback_state
                             c[0] = conv_snap
                             c[1] = ssm_snap

--- a/mlx_lm/generate.py
+++ b/mlx_lm/generate.py
@@ -736,7 +736,6 @@ def mtp_generate_step(
                 c.rollback_state = None
             elif c.is_trimmable():
                 c.trim(1)
-        cache.trim_prompt_cache(mtp_cache, 1)
 
     def _step_backbone(y, prev_tokens, n_predict=1, n_confirmed=0):
         """Run the backbone on ``y`` and return (tokens, logprobs, hidden, prev_tokens)."""

--- a/mlx_lm/generate.py
+++ b/mlx_lm/generate.py
@@ -861,13 +861,27 @@ def mtp_generate_step(
                 if logits_processors and prev_tokens is not None:
                     prev_tokens = prev_tokens[:-1]  # discard rejected draft token
                 verify_tok_id = verify_pred.item()
+                if not _is_greedy:
+                    # Sample from residual distribution max(p_target - p_draft, 0) / Z
+                    # (Leviathan et al. 2022 §2.3; Chen et al. 2023). Guarantees the
+                    # output marginal equals the target distribution exactly.
+                    p_target = mx.exp(verify_lp)
+                    p_draft = mx.exp(draft_lp)
+                    residual = mx.maximum(p_target - p_draft, 0.0)
+                    z = residual.sum().item()
+                    if z > 1e-8:
+                        verify_tok_id = mx.random.categorical(
+                            mx.log(residual / z + 1e-10).reshape(1, -1)
+                        ).item()
                 ntoks += 1
                 yield verify_tok_id, verify_lp, False
                 if ntoks >= max_tokens:
                     return
                 # Next draft from MTP at y's hidden state.
                 draft_tok, draft_lp = _step_mtp(
-                    hidden_at_confirmed, verify_pred, prev_tokens
+                    hidden_at_confirmed,
+                    mx.array([verify_tok_id], mx.uint32),
+                    prev_tokens,
                 )
                 mx.eval(draft_tok)
                 y = mx.array([verify_tok_id], mx.uint32)

--- a/mlx_lm/generate.py
+++ b/mlx_lm/generate.py
@@ -4,6 +4,7 @@ import argparse
 import contextlib
 import copy
 import functools
+import warnings
 import json
 import sys
 import time
@@ -893,6 +894,17 @@ def stream_generate(
         kwargs.pop("prompt_progress_callback", None)
         kwargs.pop("num_draft_tokens", None)
         token_generator = mtp_generate_step(prompt, model, **kwargs)
+    elif mtp:
+        warnings.warn(
+            "--mtp flag ignored: model does not have an MTP head. "
+            "Falling back to standard generation.",
+            stacklevel=2,
+        )
+        kwargs.pop("num_draft_tokens", None)
+        token_generator = generate_step(prompt, model, **kwargs)
+        token_generator = (
+            (token, logprobs, False) for token, logprobs in token_generator
+        )
     else:
         kwargs.pop("num_draft_tokens", None)
         token_generator = generate_step(prompt, model, **kwargs)

--- a/mlx_lm/generate.py
+++ b/mlx_lm/generate.py
@@ -838,22 +838,24 @@ def mtp_generate_step(
         return draft_tok, draft_lp, draft_accept_lp, xtc_draw
 
     def _prefill(y, input_embeddings):
-        # Leave exactly 1 token for _step_backbone: return_hidden=True keeps
-        # the hidden state [1, N, d_model] live, so N must be 1.
+        # Leave exactly 1 token for _step_backbone so the decode loop starts clean.
         total = len(input_embeddings) if input_embeddings is not None else y.size
         while total > 1:
             n = min(prefill_step_size, total - 1)
             if input_embeddings is not None:
-                model(
+                _, hidden = model(
                     y[:n][None],
                     cache=model_cache,
+                    return_hidden=True,
                     input_embeddings=input_embeddings[:n][None],
                 )
                 input_embeddings = input_embeddings[n:]
             else:
-                model(y[:n][None], cache=model_cache)
+                _, hidden = model(y[:n][None], cache=model_cache, return_hidden=True)
+            model.mtp_forward(hidden, y[1 : n + 1][None], mtp_cache)
+            quantize_cache_fn(mtp_cache)
             quantize_cache_fn(model_cache)
-            mx.eval([c.state for c in model_cache if hasattr(c, "state")])
+            mx.eval([c.state for c in model_cache + mtp_cache if hasattr(c, "state")])
             y = y[n:]
             total -= n
             mx.clear_cache()

--- a/mlx_lm/generate.py
+++ b/mlx_lm/generate.py
@@ -674,7 +674,7 @@ def mtp_generate_step(
     sampler: Optional[Callable[[mx.array], mx.array]] = None,
     logits_processors: Optional[List[Callable[[mx.array, mx.array], mx.array]]] = None,
     prompt_cache: Optional[Any] = None,
-    prefill_step_size: int = 512,
+    prefill_step_size: int = 2048,
     kv_bits: Optional[int] = None,
     kv_group_size: int = 64,
     quantized_kv_start: int = 0,
@@ -781,11 +781,14 @@ def mtp_generate_step(
         return draft_tok, draft_lp
 
     def _prefill(y):
-        while y.size > prefill_step_size:
-            model(y[:prefill_step_size][None], cache=model_cache)
+        # Leave exactly 1 token for _step_backbone: return_hidden=True keeps
+        # the hidden state [1, N, d_model] live, so N must be 1.
+        while y.size > 1:
+            n = min(prefill_step_size, y.size - 1)
+            model(y[:n][None], cache=model_cache)
             quantize_cache_fn(model_cache)
             mx.eval([c.state for c in model_cache if hasattr(c, "state")])
-            y = y[prefill_step_size:]
+            y = y[n:]
             mx.clear_cache()
         return y
 

--- a/mlx_lm/models/cache.py
+++ b/mlx_lm/models/cache.py
@@ -596,6 +596,9 @@ class ArraysCache(_BaseCache):
         instance = super().__new__(cls)
         instance.left_padding = None
         instance.lengths = None
+        # Snapshot of (conv_state, ssm_state) saved after processing confirmed tokens
+        # in an MTP draft-verification step. Cleared after each step.
+        instance.rollback_state = None
         return instance
 
     def __init__(self, size, left_padding: Optional[List[int]] = None):

--- a/mlx_lm/models/cache.py
+++ b/mlx_lm/models/cache.py
@@ -592,13 +592,14 @@ class RotatingKVCache(_BaseCache):
 
 
 class ArraysCache(_BaseCache):
+    # Snapshot of (conv_state, ssm_state) saved after processing confirmed tokens
+    # in an MTP draft-verification step. Cleared after each step.
+    rollback_state: Optional[tuple] = None
+
     def __new__(cls, *args, **kwargs):
         instance = super().__new__(cls)
         instance.left_padding = None
         instance.lengths = None
-        # Snapshot of (conv_state, ssm_state) saved after processing confirmed tokens
-        # in an MTP draft-verification step. Cleared after each step.
-        instance.rollback_state = None
         return instance
 
     def __init__(self, size, left_padding: Optional[List[int]] = None):

--- a/mlx_lm/models/cache.py
+++ b/mlx_lm/models/cache.py
@@ -1497,6 +1497,47 @@ class BatchRotatingKVCache(_BaseCache):
         return self.keys.nbytes + self.values.nbytes
 
 
+class MTPPromptCacheState(_BaseCache):
+    """Serializable boundary metadata for a reusable native-MTP prompt cache.
+
+    The target cache contains ``num_tokens`` committed tokens.  The MTP-head
+    cache intentionally trails by one position because its next update needs
+    the first token of the following suffix.  ``last_hidden`` is the target
+    backbone hidden state for the final committed token and closes that gap
+    when a subsequent request supplies its first suffix token.
+    """
+
+    def __init__(self, last_hidden=None, num_tokens: int = 0):
+        self.last_hidden = last_hidden
+        self.num_tokens = num_tokens
+
+    @property
+    def state(self):
+        return [] if self.last_hidden is None else [self.last_hidden]
+
+    @state.setter
+    def state(self, value):
+        self.last_hidden = value[0] if value else None
+
+    @property
+    def meta_state(self):
+        return str(self.num_tokens)
+
+    @meta_state.setter
+    def meta_state(self, value):
+        self.num_tokens = int(value or 0)
+
+    def empty(self):
+        return self.last_hidden is None
+
+    def size(self):
+        return self.num_tokens
+
+    @property
+    def nbytes(self):
+        return 0 if self.last_hidden is None else self.last_hidden.nbytes
+
+
 class TokenBuffer:
     """A simple token buffer that can be efficiently appended to in a similar
     fashion to the KVCache.

--- a/mlx_lm/models/qwen3_5.py
+++ b/mlx_lm/models/qwen3_5.py
@@ -53,7 +53,6 @@ class TextModelArgs(BaseModelArgs):
 
     # MTP fields
     mtp_num_hidden_layers: int = 0
-    mtp_use_dedicated_embeddings: bool = False
 
     # Rope parameters
     rope_parameters: Optional[Dict[str, Union[float, str, bool, List[int]]]] = field(
@@ -134,11 +133,52 @@ class GatedDeltaNet(nn.Module):
 
         self.sharding_group = None
 
+    def _process_chunk(
+        self,
+        qkv_chunk: mx.array,
+        a_chunk: mx.array,
+        b_chunk: mx.array,
+        conv_state: mx.array,
+        ssm_state: Optional[mx.array],
+        ssm_mask: Optional[mx.array] = None,
+        lengths: Optional[mx.array] = None,
+    ):
+        B, S_chunk = qkv_chunk.shape[:2]
+        conv_in = mx.concatenate([conv_state, qkv_chunk], axis=1)
+        n_keep = self.conv_kernel_size - 1
+        if lengths is not None:
+            ends = mx.clip(lengths, 0, S_chunk)
+            positions = (ends[:, None] + mx.arange(n_keep))[..., None]
+            new_conv_state = mx.take_along_axis(conv_in, positions, axis=1)
+        else:
+            new_conv_state = mx.contiguous(conv_in[:, -n_keep:])
+        conv_out = nn.silu(self.conv1d(conv_in))
+
+        q, k, v = [
+            t.reshape(B, S_chunk, h, d)
+            for t, h, d in zip(
+                mx.split(conv_out, [self.key_dim, 2 * self.key_dim], -1),
+                [self.num_k_heads, self.num_k_heads, self.num_v_heads],
+                [self.head_k_dim, self.head_k_dim, self.head_v_dim],
+            )
+        ]
+        inv_scale = k.shape[-1] ** -0.5
+        q = (inv_scale**2) * mx.fast.rms_norm(q, None, 1e-6)
+        k = inv_scale * mx.fast.rms_norm(k, None, 1e-6)
+
+        out, new_ssm_state = gated_delta_update(
+            q, k, v, a_chunk, b_chunk,
+            self.A_log, self.dt_bias, ssm_state, ssm_mask,
+            use_kernel=not self.training,
+        )
+        return out, new_conv_state, new_ssm_state
+
     def __call__(
         self,
         inputs: mx.array,
         mask: Optional[mx.array] = None,
         cache: Optional[Any] = None,
+        n_confirmed: int = 0,
     ) -> mx.array:
         B, S, _ = inputs.shape
 
@@ -150,56 +190,39 @@ class GatedDeltaNet(nn.Module):
         b = self.in_proj_b(inputs)
         a = self.in_proj_a(inputs)
 
-        if cache is not None and cache[0] is not None:
-            conv_state = cache[0]
-        else:
-            conv_state = mx.zeros(
-                (B, self.conv_kernel_size - 1, self.conv_dim),
-                dtype=inputs.dtype,
-            )
+        conv_state = (
+            cache[0]
+            if cache is not None and cache[0] is not None
+            else mx.zeros((B, self.conv_kernel_size - 1, self.conv_dim), dtype=inputs.dtype)
+        )
+        ssm_state = cache[1] if cache else None
 
         if mask is not None:
             qkv = mx.where(mask[..., None], qkv, 0)
-        conv_input = mx.concatenate([conv_state, qkv], axis=1)
-        if cache is not None:
-            n_keep = self.conv_kernel_size - 1
-            if cache.lengths is not None:
-                ends = mx.clip(cache.lengths, 0, S)
-                positions = (ends[:, None] + mx.arange(n_keep))[..., None]
-                cache[0] = mx.take_along_axis(conv_input, positions, axis=1)
-            else:
-                cache[0] = mx.contiguous(conv_input[:, -n_keep:, :])
-        conv_out = nn.silu(self.conv1d(conv_input))
 
-        q, k, v = [
-            t.reshape(B, S, h, d)
-            for t, h, d in zip(
-                mx.split(conv_out, [self.key_dim, 2 * self.key_dim], -1),
-                [self.num_k_heads, self.num_k_heads, self.num_v_heads],
-                [self.head_k_dim, self.head_k_dim, self.head_v_dim],
+        if n_confirmed > 0 and n_confirmed < S:
+            # Process confirmed and draft tokens separately so we can snapshot the
+            # SSM/conv state between them for exact rollback on draft rejection.
+            mask_c = mask[:, :n_confirmed] if mask is not None else None
+            mask_d = mask[:, n_confirmed:] if mask is not None else None
+            out_c, conv_c, ssm_c = self._process_chunk(
+                qkv[:, :n_confirmed], a[:, :n_confirmed], b[:, :n_confirmed],
+                conv_state, ssm_state, mask_c,
             )
-        ]
-
-        state = cache[1] if cache else None
-        inv_scale = k.shape[-1] ** -0.5
-        q = (inv_scale**2) * mx.fast.rms_norm(q, None, 1e-6)
-        k = inv_scale * mx.fast.rms_norm(k, None, 1e-6)
-
-        out, state = gated_delta_update(
-            q,
-            k,
-            v,
-            a,
-            b,
-            self.A_log,
-            self.dt_bias,
-            state,
-            mask,
-            use_kernel=not self.training,
-        )
+            if cache is not None:
+                cache.rollback_state = (conv_c, ssm_c)
+            out_d, conv_f, ssm_f = self._process_chunk(
+                qkv[:, n_confirmed:], a[:, n_confirmed:], b[:, n_confirmed:],
+                conv_c, ssm_c, mask_d,
+            )
+            out = mx.concatenate([out_c, out_d], axis=1)
+        else:
+            lengths = cache.lengths if cache is not None else None
+            out, conv_f, ssm_f = self._process_chunk(qkv, a, b, conv_state, ssm_state, mask, lengths=lengths)
 
         if cache is not None:
-            cache[1] = state
+            cache[0] = conv_f
+            cache[1] = ssm_f
             cache.advance(S)
 
         out = self.norm(out, z)
@@ -235,9 +258,10 @@ class DecoderLayer(nn.Module):
         x: mx.array,
         mask: Optional[mx.array] = None,
         cache: Optional[Any] = None,
+        n_confirmed: int = 0,
     ) -> mx.array:
         if self.is_linear:
-            r = self.linear_attn(self.input_layernorm(x), mask, cache)
+            r = self.linear_attn(self.input_layernorm(x), mask, cache, n_confirmed=n_confirmed)
         else:
             r = self.self_attn(self.input_layernorm(x), mask, cache)
         h = x + r
@@ -270,18 +294,10 @@ class MTPDecoderLayer(nn.Module):
 
 
 class MTPModule(nn.Module):
-    """Multi-Token Prediction head.
+    """Multi-Token Prediction head (Qwen3.5 native speculative decoding).
 
-    Predicts the token at position t+2 given:
-      - h_t   : backbone hidden state at the last accepted position t
-      - t_main: the main model's sampled prediction for t+1
-
-    Forward:
-        fused = fc(cat([pre_fc_norm_embedding(embed(t_main)),
-                        pre_fc_norm_hidden(h_t)]))
-        → MTPDecoderLayer(s)
-        → norm
-        → (caller applies lm_head, shared with backbone)
+    Predicts token t+2 from the backbone hidden state h_t and the sampled
+    token t+1, using a shared lm_head with the backbone.
     """
 
     def __init__(self, args: TextModelArgs):
@@ -346,6 +362,7 @@ class Qwen3_5TextModel(PipelineMixin, nn.Module):
         inputs: mx.array,
         cache: Optional[Any] = None,
         input_embeddings: Optional[mx.array] = None,
+        n_confirmed: int = 0,
     ) -> mx.array:
         if input_embeddings is not None:
             hidden_states = input_embeddings
@@ -371,7 +388,8 @@ class Qwen3_5TextModel(PipelineMixin, nn.Module):
 
         for layer, c in zip(self.pipeline_layers, cache):
             mask = ssm_mask if layer.is_linear else fa_mask
-            hidden_states = layer(hidden_states, mask=mask, cache=c)
+            kw = {"n_confirmed": n_confirmed} if layer.is_linear and n_confirmed > 0 else {}
+            hidden_states = layer(hidden_states, mask=mask, cache=c, **kw)
 
         # Send to the next process in the pipeline
         if pipeline_rank != 0:
@@ -410,8 +428,9 @@ class TextModel(nn.Module):
         cache: Optional[Any] = None,
         input_embeddings: Optional[mx.array] = None,
         return_hidden: bool = False,
+        n_confirmed: int = 0,
     ) -> mx.array:
-        hidden = self.model(inputs, cache, input_embeddings=input_embeddings)
+        hidden = self.model(inputs, cache, input_embeddings=input_embeddings, n_confirmed=n_confirmed)
         if self.args.tie_word_embeddings:
             out = self.model.embed_tokens.as_linear(hidden)
         else:
@@ -540,12 +559,14 @@ class Model(nn.Module):
         cache=None,
         input_embeddings: Optional[mx.array] = None,
         return_hidden: bool = False,
+        n_confirmed: int = 0,
     ):
         return self.language_model(
             inputs,
             cache=cache,
             input_embeddings=input_embeddings,
             return_hidden=return_hidden,
+            n_confirmed=n_confirmed,
         )
 
     @property

--- a/mlx_lm/models/qwen3_5.py
+++ b/mlx_lm/models/qwen3_5.py
@@ -51,6 +51,10 @@ class TextModelArgs(BaseModelArgs):
     moe_intermediate_size: int = 0
     norm_topk_prob: bool = True
 
+    # MTP fields
+    mtp_num_hidden_layers: int = 0
+    mtp_use_dedicated_embeddings: bool = False
+
     # Rope parameters
     rope_parameters: Optional[Dict[str, Union[float, str, bool, List[int]]]] = field(
         default_factory=lambda: {
@@ -241,6 +245,79 @@ class DecoderLayer(nn.Module):
         return out
 
 
+class MTPDecoderLayer(nn.Module):
+    """Full-attention-only transformer layer for the MTP head (no GatedDeltaNet)."""
+
+    def __init__(self, args: TextModelArgs):
+        super().__init__()
+        self.self_attn = Attention(args)
+        self.input_layernorm = nn.RMSNorm(args.hidden_size, eps=args.rms_norm_eps)
+        self.post_attention_layernorm = nn.RMSNorm(args.hidden_size, eps=args.rms_norm_eps)
+        if args.num_experts > 0:
+            self.mlp = SparseMoeBlock(args)
+        else:
+            self.mlp = MLP(args.hidden_size, args.intermediate_size)
+
+    def __call__(
+        self,
+        x: mx.array,
+        mask: Optional[mx.array] = None,
+        cache: Optional[Any] = None,
+    ) -> mx.array:
+        r = self.self_attn(self.input_layernorm(x), mask, cache)
+        h = x + r
+        return h + self.mlp(self.post_attention_layernorm(h))
+
+
+class MTPModule(nn.Module):
+    """Multi-Token Prediction head.
+
+    Predicts the token at position t+2 given:
+      - h_t   : backbone hidden state at the last accepted position t
+      - t_main: the main model's sampled prediction for t+1
+
+    Forward:
+        fused = fc(cat([pre_fc_norm_embedding(embed(t_main)),
+                        pre_fc_norm_hidden(h_t)]))
+        → MTPDecoderLayer(s)
+        → norm
+        → (caller applies lm_head, shared with backbone)
+    """
+
+    def __init__(self, args: TextModelArgs):
+        super().__init__()
+        self.pre_fc_norm_hidden = nn.RMSNorm(args.hidden_size, eps=args.rms_norm_eps)
+        self.pre_fc_norm_embedding = nn.RMSNorm(args.hidden_size, eps=args.rms_norm_eps)
+        self.fc = nn.Linear(args.hidden_size * 2, args.hidden_size, bias=False)
+        self.layers = [
+            MTPDecoderLayer(args) for _ in range(args.mtp_num_hidden_layers)
+        ]
+        self.norm = nn.RMSNorm(args.hidden_size, eps=args.rms_norm_eps)
+
+    def __call__(
+        self,
+        hidden_states: mx.array,
+        next_token_ids: mx.array,
+        embed_tokens: nn.Embedding,
+        cache: Optional[Any] = None,
+    ) -> mx.array:
+        # hidden_states : (B, 1, H)  — backbone hidden at last accepted position
+        # next_token_ids: (B, 1)     — t_main (main model's prediction for t+1)
+        embeds = embed_tokens(next_token_ids)  # (B, 1, H)
+        e = self.pre_fc_norm_embedding(embeds)
+        h = self.pre_fc_norm_hidden(hidden_states)
+        fused = self.fc(mx.concatenate([e, h], axis=-1))  # (B, 1, H)
+
+        if cache is None:
+            cache = [None] * len(self.layers)
+
+        mask = create_attention_mask(fused, cache[0])
+        for layer, c in zip(self.layers, cache):
+            fused = layer(fused, mask, c)
+
+        return self.norm(fused)  # (B, 1, H)
+
+
 class Qwen3_5TextModel(PipelineMixin, nn.Module):
     def __init__(self, args: TextModelArgs):
         super().__init__()
@@ -324,19 +401,50 @@ class TextModel(nn.Module):
         self.model = Qwen3_5TextModel(args)
         if not args.tie_word_embeddings:
             self.lm_head = nn.Linear(args.hidden_size, args.vocab_size, bias=False)
+        if args.mtp_num_hidden_layers > 0:
+            self.mtp = MTPModule(args)
 
     def __call__(
         self,
         inputs: mx.array,
         cache: Optional[Any] = None,
         input_embeddings: Optional[mx.array] = None,
+        return_hidden: bool = False,
     ) -> mx.array:
-        out = self.model(inputs, cache, input_embeddings=input_embeddings)
+        hidden = self.model(inputs, cache, input_embeddings=input_embeddings)
         if self.args.tie_word_embeddings:
-            out = self.model.embed_tokens.as_linear(out)
+            out = self.model.embed_tokens.as_linear(hidden)
         else:
-            out = self.lm_head(out)
+            out = self.lm_head(hidden)
+        if return_hidden:
+            return out, hidden
         return out
+
+    def mtp_forward(
+        self,
+        hidden_states: mx.array,
+        next_token_ids: mx.array,
+        mtp_cache: Any,
+    ) -> mx.array:
+        """Run the MTP head and apply the shared lm_head.
+
+        Args:
+            hidden_states: (B, 1, H) — backbone hidden state at the last position.
+            next_token_ids: (B, 1)   — sampled main token (t_main).
+            mtp_cache: list of KVCache entries for the MTP transformer layer(s).
+
+        Returns:
+            logits: (B, 1, vocab_size)
+        """
+        mtp_out = self.mtp(
+            hidden_states,
+            next_token_ids,
+            self.model.embed_tokens,
+            mtp_cache,
+        )
+        if self.args.tie_word_embeddings:
+            return self.model.embed_tokens.as_linear(mtp_out)
+        return self.lm_head(mtp_out)
 
     @property
     def layers(self):
@@ -345,13 +453,23 @@ class TextModel(nn.Module):
     def make_cache(self):
         return [ArraysCache(size=2) if l.is_linear else KVCache() for l in self.layers]
 
+    def make_mtp_cache(self):
+        """Return a fresh list of KVCache entries for the MTP layer(s)."""
+        if hasattr(self, "mtp"):
+            return [KVCache() for _ in self.mtp.layers]
+        return []
+
     def sanitize(self, weights):
-        has_mtp_weights = any("mtp." in k for k in weights)
         has_unsanitized_conv1d = any(
             "conv1d.weight" in k and v.shape[-1] != 1 for k, v in weights.items()
         )
-        should_shift_norm_weights = has_mtp_weights or has_unsanitized_conv1d
-        weights = {k: v for k, v in weights.items() if "mtp." not in k}
+        # Norm weights need a +1 shift only in raw HF checkpoints (detected via
+        # unsanitized conv1d). Already-converted MLX models (conv1d fixed) must NOT
+        # be shifted again — even when they contain MTP weights.
+        should_shift_norm_weights = has_unsanitized_conv1d
+        # Keep MTP weights if this model has an MTP head; drop them otherwise
+        if not hasattr(self, "mtp"):
+            weights = {k: v for k, v in weights.items() if "mtp." not in k}
 
         if self.args.tie_word_embeddings:
             weights.pop("lm_head.weight", None)
@@ -362,6 +480,10 @@ class TextModel(nn.Module):
             "model.norm.weight",
             ".q_norm.weight",
             ".k_norm.weight",
+            # MTP-specific norms (not covered by the patterns above)
+            ".pre_fc_norm_hidden.weight",
+            ".pre_fc_norm_embedding.weight",
+            "mtp.norm.weight",
         )
         for k, v in weights.items():
             if "conv1d.weight" in k and v.shape[-1] != 1:
@@ -417,9 +539,13 @@ class Model(nn.Module):
         inputs: mx.array,
         cache=None,
         input_embeddings: Optional[mx.array] = None,
+        return_hidden: bool = False,
     ):
         return self.language_model(
-            inputs, cache=cache, input_embeddings=input_embeddings
+            inputs,
+            cache=cache,
+            input_embeddings=input_embeddings,
+            return_hidden=return_hidden,
         )
 
     @property
@@ -559,6 +685,19 @@ class Model(nn.Module):
                 shard_inplace(
                     layer.mlp.switch_mlp.up_proj, "all-to-sharded", group=group
                 )
+
+    def mtp_forward(
+        self,
+        hidden_states: mx.array,
+        next_token_ids: mx.array,
+        mtp_cache: Any,
+    ) -> mx.array:
+        """Delegate to language_model.mtp_forward. See TextModel.mtp_forward."""
+        return self.language_model.mtp_forward(hidden_states, next_token_ids, mtp_cache)
+
+    def make_mtp_cache(self):
+        """Return fresh KVCache entries for the MTP layer(s)."""
+        return self.language_model.make_mtp_cache()
 
     @property
     def layers(self):

--- a/mlx_lm/models/qwen3_5.py
+++ b/mlx_lm/models/qwen3_5.py
@@ -545,9 +545,6 @@ class TextModel(nn.Module):
         def predicate(path, _):
             if path.endswith("mlp.gate") or path.endswith("shared_expert_gate"):
                 return {"group_size": 64, "bits": 8}
-            # Keep the MTP fusion projection in full precision.
-            if path.endswith("mtp.fc"):
-                return False
             return True
 
         if self.args.num_experts <= 0 and self.args.mtp_num_hidden_layers <= 0:

--- a/mlx_lm/models/qwen3_5.py
+++ b/mlx_lm/models/qwen3_5.py
@@ -471,12 +471,12 @@ class TextModel(nn.Module):
         """Run the MTP head and apply the shared lm_head.
 
         Args:
-            hidden_states: Backbone pre-norm hidden state, shape (B, 1, H).
-            next_token_ids: Sampled main token ids, shape (B, 1).
+            hidden_states: Backbone pre-norm hidden state (B, N, H). N=1 during decode, N>1 during prompt prefill.
+            next_token_ids: Next token ids, shape (B, N).
             mtp_cache: KVCache entries for the MTP transformer layers.
 
         Returns:
-            logits of shape (B, 1, vocab_size).
+            logits of shape (B, N, vocab_size).
         """
         mtp_out = self.mtp(
             hidden_states,

--- a/mlx_lm/models/qwen3_5.py
+++ b/mlx_lm/models/qwen3_5.py
@@ -167,8 +167,15 @@ class GatedDeltaNet(nn.Module):
         k = inv_scale * mx.fast.rms_norm(k, None, 1e-6)
 
         out, new_ssm_state = gated_delta_update(
-            q, k, v, a_chunk, b_chunk,
-            self.A_log, self.dt_bias, ssm_state, ssm_mask,
+            q,
+            k,
+            v,
+            a_chunk,
+            b_chunk,
+            self.A_log,
+            self.dt_bias,
+            ssm_state,
+            ssm_mask,
             use_kernel=not self.training,
         )
         return out, new_conv_state, new_ssm_state
@@ -193,7 +200,9 @@ class GatedDeltaNet(nn.Module):
         conv_state = (
             cache[0]
             if cache is not None and cache[0] is not None
-            else mx.zeros((B, self.conv_kernel_size - 1, self.conv_dim), dtype=inputs.dtype)
+            else mx.zeros(
+                (B, self.conv_kernel_size - 1, self.conv_dim), dtype=inputs.dtype
+            )
         )
         ssm_state = cache[1] if cache else None
 
@@ -206,19 +215,29 @@ class GatedDeltaNet(nn.Module):
             mask_c = mask[:, :n_confirmed] if mask is not None else None
             mask_d = mask[:, n_confirmed:] if mask is not None else None
             out_c, conv_c, ssm_c = self._process_chunk(
-                qkv[:, :n_confirmed], a[:, :n_confirmed], b[:, :n_confirmed],
-                conv_state, ssm_state, mask_c,
+                qkv[:, :n_confirmed],
+                a[:, :n_confirmed],
+                b[:, :n_confirmed],
+                conv_state,
+                ssm_state,
+                mask_c,
             )
             if cache is not None:
                 cache.rollback_state = (conv_c, ssm_c)
             out_d, conv_f, ssm_f = self._process_chunk(
-                qkv[:, n_confirmed:], a[:, n_confirmed:], b[:, n_confirmed:],
-                conv_c, ssm_c, mask_d,
+                qkv[:, n_confirmed:],
+                a[:, n_confirmed:],
+                b[:, n_confirmed:],
+                conv_c,
+                ssm_c,
+                mask_d,
             )
             out = mx.concatenate([out_c, out_d], axis=1)
         else:
             lengths = cache.lengths if cache is not None else None
-            out, conv_f, ssm_f = self._process_chunk(qkv, a, b, conv_state, ssm_state, mask, lengths=lengths)
+            out, conv_f, ssm_f = self._process_chunk(
+                qkv, a, b, conv_state, ssm_state, mask, lengths=lengths
+            )
 
         if cache is not None:
             cache[0] = conv_f
@@ -261,7 +280,9 @@ class DecoderLayer(nn.Module):
         n_confirmed: int = 0,
     ) -> mx.array:
         if self.is_linear:
-            r = self.linear_attn(self.input_layernorm(x), mask, cache, n_confirmed=n_confirmed)
+            r = self.linear_attn(
+                self.input_layernorm(x), mask, cache, n_confirmed=n_confirmed
+            )
         else:
             r = self.self_attn(self.input_layernorm(x), mask, cache)
         h = x + r
@@ -276,7 +297,9 @@ class MTPDecoderLayer(nn.Module):
         super().__init__()
         self.self_attn = Attention(args)
         self.input_layernorm = nn.RMSNorm(args.hidden_size, eps=args.rms_norm_eps)
-        self.post_attention_layernorm = nn.RMSNorm(args.hidden_size, eps=args.rms_norm_eps)
+        self.post_attention_layernorm = nn.RMSNorm(
+            args.hidden_size, eps=args.rms_norm_eps
+        )
         if args.num_experts > 0:
             self.mlp = SparseMoeBlock(args)
         else:
@@ -305,9 +328,7 @@ class MTPModule(nn.Module):
         self.pre_fc_norm_hidden = nn.RMSNorm(args.hidden_size, eps=args.rms_norm_eps)
         self.pre_fc_norm_embedding = nn.RMSNorm(args.hidden_size, eps=args.rms_norm_eps)
         self.fc = nn.Linear(args.hidden_size * 2, args.hidden_size, bias=False)
-        self.layers = [
-            MTPDecoderLayer(args) for _ in range(args.mtp_num_hidden_layers)
-        ]
+        self.layers = [MTPDecoderLayer(args) for _ in range(args.mtp_num_hidden_layers)]
         self.norm = nn.RMSNorm(args.hidden_size, eps=args.rms_norm_eps)
 
     def __call__(
@@ -388,7 +409,11 @@ class Qwen3_5TextModel(PipelineMixin, nn.Module):
 
         for layer, c in zip(self.pipeline_layers, cache):
             mask = ssm_mask if layer.is_linear else fa_mask
-            kw = {"n_confirmed": n_confirmed} if layer.is_linear and n_confirmed > 0 else {}
+            kw = (
+                {"n_confirmed": n_confirmed}
+                if layer.is_linear and n_confirmed > 0
+                else {}
+            )
             hidden_states = layer(hidden_states, mask=mask, cache=c, **kw)
 
         # Send to the next process in the pipeline
@@ -430,7 +455,9 @@ class TextModel(nn.Module):
         return_hidden: bool = False,
         n_confirmed: int = 0,
     ) -> mx.array:
-        hidden = self.model(inputs, cache, input_embeddings=input_embeddings, n_confirmed=n_confirmed)
+        hidden = self.model(
+            inputs, cache, input_embeddings=input_embeddings, n_confirmed=n_confirmed
+        )
         normed = self.model.norm(hidden)
         if self.args.tie_word_embeddings:
             out = self.model.embed_tokens.as_linear(normed)

--- a/mlx_lm/models/qwen3_5.py
+++ b/mlx_lm/models/qwen3_5.py
@@ -517,6 +517,11 @@ class TextModel(nn.Module):
         # Keep MTP weights if this model has an MTP head; drop them otherwise
         if not hasattr(self, "mtp"):
             weights = {k: v for k, v in weights.items() if "mtp." not in k}
+        elif not any("mtp." in k for k in weights):
+            raise ValueError(
+                "Config specifies mtp_num_hidden_layers > 0 but the model weights "
+                "contain no MTP parameters. Set mtp_num_hidden_layers=0 to disable MTP."
+            )
 
         if self.args.tie_word_embeddings:
             weights.pop("lm_head.weight", None)

--- a/mlx_lm/models/qwen3_5.py
+++ b/mlx_lm/models/qwen3_5.py
@@ -197,13 +197,13 @@ class GatedDeltaNet(nn.Module):
         b = self.in_proj_b(inputs)
         a = self.in_proj_a(inputs)
 
-        conv_state = (
-            cache[0]
-            if cache is not None and cache[0] is not None
-            else mx.zeros(
-                (B, self.conv_kernel_size - 1, self.conv_dim), dtype=inputs.dtype
+        if cache is not None and cache[0] is not None:
+            conv_state = cache[0]
+        else:
+            conv_state = mx.zeros(
+                (B, self.conv_kernel_size - 1, self.conv_dim),
+                dtype=inputs.dtype,
             )
-        )
         ssm_state = cache[1] if cache else None
 
         if mask is not None:
@@ -338,8 +338,6 @@ class MTPModule(nn.Module):
         embed_tokens: nn.Embedding,
         cache: Optional[Any] = None,
     ) -> mx.array:
-        # hidden_states : (B, 1, H)  — backbone hidden at last accepted position
-        # next_token_ids: (B, 1)     — t_main (main model's prediction for t+1)
         embeds = embed_tokens(next_token_ids)  # (B, 1, H)
         e = self.pre_fc_norm_embedding(embeds)
         h = self.pre_fc_norm_hidden(hidden_states)
@@ -409,12 +407,9 @@ class Qwen3_5TextModel(PipelineMixin, nn.Module):
 
         for layer, c in zip(self.pipeline_layers, cache):
             mask = ssm_mask if layer.is_linear else fa_mask
-            kw = (
-                {"n_confirmed": n_confirmed}
-                if layer.is_linear and n_confirmed > 0
-                else {}
+            hidden_states = layer(
+                hidden_states, mask=mask, cache=c, n_confirmed=n_confirmed
             )
-            hidden_states = layer(hidden_states, mask=mask, cache=c, **kw)
 
         # Send to the next process in the pipeline
         if pipeline_rank != 0:
@@ -476,12 +471,12 @@ class TextModel(nn.Module):
         """Run the MTP head and apply the shared lm_head.
 
         Args:
-            hidden_states: (B, 1, H) — backbone hidden state at the last position.
-            next_token_ids: (B, 1)   — sampled main token (t_main).
-            mtp_cache: list of KVCache entries for the MTP transformer layer(s).
+            hidden_states: Backbone pre-norm hidden state, shape (B, 1, H).
+            next_token_ids: Sampled main token ids, shape (B, 1).
+            mtp_cache: KVCache entries for the MTP transformer layers.
 
         Returns:
-            logits: (B, 1, vocab_size)
+            logits of shape (B, 1, vocab_size).
         """
         mtp_out = self.mtp(
             hidden_states,
@@ -511,8 +506,8 @@ class TextModel(nn.Module):
             "conv1d.weight" in k and v.shape[-1] != 1 for k, v in weights.items()
         )
         # Norm weights need a +1 shift only in raw HF checkpoints (detected via
-        # unsanitized conv1d). Already-converted MLX models (conv1d fixed) must NOT
-        # be shifted again — even when they contain MTP weights.
+        # unsanitized conv1d). Already-converted MLX models must not be shifted
+        # again, even when they contain MTP weights.
         should_shift_norm_weights = has_unsanitized_conv1d
         # Keep MTP weights if this model has an MTP head; drop them otherwise
         if not hasattr(self, "mtp"):

--- a/mlx_lm/models/qwen3_5.py
+++ b/mlx_lm/models/qwen3_5.py
@@ -408,7 +408,7 @@ class Qwen3_5TextModel(PipelineMixin, nn.Module):
                 : hidden_states.shape[0]
             ]
 
-        return self.norm(hidden_states)
+        return hidden_states
 
 
 class TextModel(nn.Module):
@@ -431,12 +431,13 @@ class TextModel(nn.Module):
         n_confirmed: int = 0,
     ) -> mx.array:
         hidden = self.model(inputs, cache, input_embeddings=input_embeddings, n_confirmed=n_confirmed)
+        normed = self.model.norm(hidden)
         if self.args.tie_word_embeddings:
-            out = self.model.embed_tokens.as_linear(hidden)
+            out = self.model.embed_tokens.as_linear(normed)
         else:
-            out = self.lm_head(hidden)
+            out = self.lm_head(normed)
         if return_hidden:
-            return out, hidden
+            return out, hidden  # pre-norm hidden for MTP head
         return out
 
     def mtp_forward(
@@ -514,14 +515,16 @@ class TextModel(nn.Module):
 
     @property
     def quant_predicate(self):
-        if self.args.num_experts <= 0:
-            return None
-
         def predicate(path, _):
             if path.endswith("mlp.gate") or path.endswith("shared_expert_gate"):
                 return {"group_size": 64, "bits": 8}
+            # Keep the MTP fusion projection in full precision.
+            if path.endswith("mtp.fc"):
+                return False
             return True
 
+        if self.args.num_experts <= 0 and self.args.mtp_num_hidden_layers <= 0:
+            return None
         return predicate
 
     @property

--- a/mlx_lm/models/qwen3_5.py
+++ b/mlx_lm/models/qwen3_5.py
@@ -1,5 +1,6 @@
 # Copyright © 2026 Apple Inc.
 
+import warnings
 from dataclasses import dataclass, field
 from typing import Any, Dict, List, Optional, Union
 
@@ -462,6 +463,10 @@ class TextModel(nn.Module):
             return out, hidden  # pre-norm hidden for MTP head
         return out
 
+    @property
+    def supports_mtp(self):
+        return hasattr(self, "mtp")
+
     def mtp_forward(
         self,
         hidden_states: mx.array,
@@ -478,6 +483,8 @@ class TextModel(nn.Module):
         Returns:
             logits of shape (B, N, vocab_size).
         """
+        if not self.supports_mtp:
+            raise ValueError("This checkpoint does not contain native MTP weights.")
         mtp_out = self.mtp(
             hidden_states,
             next_token_ids,
@@ -502,17 +509,31 @@ class TextModel(nn.Module):
         return []
 
     def sanitize(self, weights):
+        has_mtp_weights = any("mtp." in k for k in weights)
         has_unsanitized_conv1d = any(
             "conv1d.weight" in k and v.shape[-1] != 1 for k, v in weights.items()
         )
+        # Norm weights need a +1 shift only in raw HF checkpoints (detected via
+        # unsanitized conv1d). Already-converted MLX models must not be shifted
+        # again, even when they contain MTP weights.
+        should_shift_norm_weights = has_unsanitized_conv1d
         # Keep MTP weights if this model has an MTP head; drop them otherwise
         if not hasattr(self, "mtp"):
             weights = {k: v for k, v in weights.items() if "mtp." not in k}
-        elif not any("mtp." in k for k in weights):
-            raise ValueError(
-                "Config specifies mtp_num_hidden_layers > 0 but the model weights "
-                "contain no MTP parameters. Set mtp_num_hidden_layers=0 to disable MTP."
+        elif not has_mtp_weights:
+            # Some converted checkpoints retain mtp_num_hidden_layers in config
+            # even though conversion stripped the MTP tensors. Keep ordinary
+            # autoregressive loading compatible, but retain the specific diagnosis
+            # that the checkpoint config and packaged tensors disagree.
+            warnings.warn(
+                "Checkpoint configuration declares an MTP head, but no MTP tensors "
+                "were found. MTP has been disabled; the checkpoint may be "
+                "incorrectly converted or packaged.",
+                UserWarning,
+                stacklevel=2,
             )
+            del self.mtp
+            self.args.mtp_num_hidden_layers = 0
 
         if self.args.tie_word_embeddings:
             weights.pop("lm_head.weight", None)
@@ -531,7 +552,7 @@ class TextModel(nn.Module):
         for k, v in weights.items():
             if "conv1d.weight" in k and v.shape[-1] != 1:
                 weights[k] = v.moveaxis(2, 1)
-            if has_unsanitized_conv1d and any(k.endswith(sfx) for sfx in norm_keys):
+            if should_shift_norm_weights and any(k.endswith(sfx) for sfx in norm_keys):
                 if v.ndim == 1:
                     weights[k] = v + 1.0
         return weights
@@ -729,6 +750,10 @@ class Model(nn.Module):
                 shard_inplace(
                     layer.mlp.switch_mlp.up_proj, "all-to-sharded", group=group
                 )
+
+    @property
+    def supports_mtp(self):
+        return self.language_model.supports_mtp
 
     def mtp_forward(
         self,

--- a/mlx_lm/models/qwen3_5.py
+++ b/mlx_lm/models/qwen3_5.py
@@ -51,6 +51,10 @@ class TextModelArgs(BaseModelArgs):
     moe_intermediate_size: int = 0
     norm_topk_prob: bool = True
 
+    # MTP fields
+    mtp_num_hidden_layers: int = 0
+    mtp_use_dedicated_embeddings: bool = False
+
     # Rope parameters
     rope_parameters: Optional[Dict[str, Union[float, str, bool, List[int]]]] = field(
         default_factory=lambda: {
@@ -241,6 +245,79 @@ class DecoderLayer(nn.Module):
         return out
 
 
+class MTPDecoderLayer(nn.Module):
+    """Full-attention-only transformer layer for the MTP head (no GatedDeltaNet)."""
+
+    def __init__(self, args: TextModelArgs):
+        super().__init__()
+        self.self_attn = Attention(args)
+        self.input_layernorm = nn.RMSNorm(args.hidden_size, eps=args.rms_norm_eps)
+        self.post_attention_layernorm = nn.RMSNorm(args.hidden_size, eps=args.rms_norm_eps)
+        if args.num_experts > 0:
+            self.mlp = SparseMoeBlock(args)
+        else:
+            self.mlp = MLP(args.hidden_size, args.intermediate_size)
+
+    def __call__(
+        self,
+        x: mx.array,
+        mask: Optional[mx.array] = None,
+        cache: Optional[Any] = None,
+    ) -> mx.array:
+        r = self.self_attn(self.input_layernorm(x), mask, cache)
+        h = x + r
+        return h + self.mlp(self.post_attention_layernorm(h))
+
+
+class MTPModule(nn.Module):
+    """Multi-Token Prediction head.
+
+    Predicts the token at position t+2 given:
+      - h_t   : backbone hidden state at the last accepted position t
+      - t_main: the main model's sampled prediction for t+1
+
+    Forward:
+        fused = fc(cat([pre_fc_norm_embedding(embed(t_main)),
+                        pre_fc_norm_hidden(h_t)]))
+        → MTPDecoderLayer(s)
+        → norm
+        → (caller applies lm_head, shared with backbone)
+    """
+
+    def __init__(self, args: TextModelArgs):
+        super().__init__()
+        self.pre_fc_norm_hidden = nn.RMSNorm(args.hidden_size, eps=args.rms_norm_eps)
+        self.pre_fc_norm_embedding = nn.RMSNorm(args.hidden_size, eps=args.rms_norm_eps)
+        self.fc = nn.Linear(args.hidden_size * 2, args.hidden_size, bias=False)
+        self.layers = [
+            MTPDecoderLayer(args) for _ in range(args.mtp_num_hidden_layers)
+        ]
+        self.norm = nn.RMSNorm(args.hidden_size, eps=args.rms_norm_eps)
+
+    def __call__(
+        self,
+        hidden_states: mx.array,
+        next_token_ids: mx.array,
+        embed_tokens: nn.Embedding,
+        cache: Optional[Any] = None,
+    ) -> mx.array:
+        # hidden_states : (B, 1, H)  — backbone hidden at last accepted position
+        # next_token_ids: (B, 1)     — t_main (main model's prediction for t+1)
+        embeds = embed_tokens(next_token_ids)  # (B, 1, H)
+        e = self.pre_fc_norm_embedding(embeds)
+        h = self.pre_fc_norm_hidden(hidden_states)
+        fused = self.fc(mx.concatenate([e, h], axis=-1))  # (B, 1, H)
+
+        if cache is None:
+            cache = [None] * len(self.layers)
+
+        mask = create_attention_mask(fused, cache[0])
+        for layer, c in zip(self.layers, cache):
+            fused = layer(fused, mask, c)
+
+        return self.norm(fused)  # (B, 1, H)
+
+
 class Qwen3_5TextModel(PipelineMixin, nn.Module):
     def __init__(self, args: TextModelArgs):
         super().__init__()
@@ -324,19 +401,50 @@ class TextModel(nn.Module):
         self.model = Qwen3_5TextModel(args)
         if not args.tie_word_embeddings:
             self.lm_head = nn.Linear(args.hidden_size, args.vocab_size, bias=False)
+        if args.mtp_num_hidden_layers > 0:
+            self.mtp = MTPModule(args)
 
     def __call__(
         self,
         inputs: mx.array,
         cache: Optional[Any] = None,
         input_embeddings: Optional[mx.array] = None,
+        return_hidden: bool = False,
     ) -> mx.array:
-        out = self.model(inputs, cache, input_embeddings=input_embeddings)
+        hidden = self.model(inputs, cache, input_embeddings=input_embeddings)
         if self.args.tie_word_embeddings:
-            out = self.model.embed_tokens.as_linear(out)
+            out = self.model.embed_tokens.as_linear(hidden)
         else:
-            out = self.lm_head(out)
+            out = self.lm_head(hidden)
+        if return_hidden:
+            return out, hidden
         return out
+
+    def mtp_forward(
+        self,
+        hidden_states: mx.array,
+        next_token_ids: mx.array,
+        mtp_cache: Any,
+    ) -> mx.array:
+        """Run the MTP head and apply the shared lm_head.
+
+        Args:
+            hidden_states: (B, 1, H) — backbone hidden state at the last position.
+            next_token_ids: (B, 1)   — sampled main token (t_main).
+            mtp_cache: list of KVCache entries for the MTP transformer layer(s).
+
+        Returns:
+            logits: (B, 1, vocab_size)
+        """
+        mtp_out = self.mtp(
+            hidden_states,
+            next_token_ids,
+            self.model.embed_tokens,
+            mtp_cache,
+        )
+        if self.args.tie_word_embeddings:
+            return self.model.embed_tokens.as_linear(mtp_out)
+        return self.lm_head(mtp_out)
 
     @property
     def layers(self):
@@ -345,11 +453,19 @@ class TextModel(nn.Module):
     def make_cache(self):
         return [ArraysCache(size=2) if l.is_linear else KVCache() for l in self.layers]
 
+    def make_mtp_cache(self):
+        """Return a fresh list of KVCache entries for the MTP layer(s)."""
+        if hasattr(self, "mtp"):
+            return [KVCache() for _ in self.mtp.layers]
+        return []
+
     def sanitize(self, weights):
         has_unsanitized_conv1d = any(
             "conv1d.weight" in k and v.shape[-1] != 1 for k, v in weights.items()
         )
-        weights = {k: v for k, v in weights.items() if "mtp." not in k}
+        # Keep MTP weights if this model has an MTP head; drop them otherwise
+        if not hasattr(self, "mtp"):
+            weights = {k: v for k, v in weights.items() if "mtp." not in k}
 
         if self.args.tie_word_embeddings:
             weights.pop("lm_head.weight", None)
@@ -360,6 +476,10 @@ class TextModel(nn.Module):
             "model.norm.weight",
             ".q_norm.weight",
             ".k_norm.weight",
+            # MTP-specific norms (not covered by the patterns above)
+            ".pre_fc_norm_hidden.weight",
+            ".pre_fc_norm_embedding.weight",
+            "mtp.norm.weight",
         )
         for k, v in weights.items():
             if "conv1d.weight" in k and v.shape[-1] != 1:
@@ -415,9 +535,13 @@ class Model(nn.Module):
         inputs: mx.array,
         cache=None,
         input_embeddings: Optional[mx.array] = None,
+        return_hidden: bool = False,
     ):
         return self.language_model(
-            inputs, cache=cache, input_embeddings=input_embeddings
+            inputs,
+            cache=cache,
+            input_embeddings=input_embeddings,
+            return_hidden=return_hidden,
         )
 
     @property
@@ -557,6 +681,19 @@ class Model(nn.Module):
                 shard_inplace(
                     layer.mlp.switch_mlp.up_proj, "all-to-sharded", group=group
                 )
+
+    def mtp_forward(
+        self,
+        hidden_states: mx.array,
+        next_token_ids: mx.array,
+        mtp_cache: Any,
+    ) -> mx.array:
+        """Delegate to language_model.mtp_forward. See TextModel.mtp_forward."""
+        return self.language_model.mtp_forward(hidden_states, next_token_ids, mtp_cache)
+
+    def make_mtp_cache(self):
+        """Return fresh KVCache entries for the MTP layer(s)."""
+        return self.language_model.make_mtp_cache()
 
     @property
     def layers(self):

--- a/mlx_lm/models/qwen3_5.py
+++ b/mlx_lm/models/qwen3_5.py
@@ -53,7 +53,6 @@ class TextModelArgs(BaseModelArgs):
 
     # MTP fields
     mtp_num_hidden_layers: int = 0
-    mtp_use_dedicated_embeddings: bool = False
 
     # Rope parameters
     rope_parameters: Optional[Dict[str, Union[float, str, bool, List[int]]]] = field(
@@ -134,11 +133,52 @@ class GatedDeltaNet(nn.Module):
 
         self.sharding_group = None
 
+    def _process_chunk(
+        self,
+        qkv_chunk: mx.array,
+        a_chunk: mx.array,
+        b_chunk: mx.array,
+        conv_state: mx.array,
+        ssm_state: Optional[mx.array],
+        ssm_mask: Optional[mx.array] = None,
+        lengths: Optional[mx.array] = None,
+    ):
+        B, S_chunk = qkv_chunk.shape[:2]
+        conv_in = mx.concatenate([conv_state, qkv_chunk], axis=1)
+        n_keep = self.conv_kernel_size - 1
+        if lengths is not None:
+            ends = mx.clip(lengths, 0, S_chunk)
+            positions = (ends[:, None] + mx.arange(n_keep))[..., None]
+            new_conv_state = mx.take_along_axis(conv_in, positions, axis=1)
+        else:
+            new_conv_state = mx.contiguous(conv_in[:, -n_keep:])
+        conv_out = nn.silu(self.conv1d(conv_in))
+
+        q, k, v = [
+            t.reshape(B, S_chunk, h, d)
+            for t, h, d in zip(
+                mx.split(conv_out, [self.key_dim, 2 * self.key_dim], -1),
+                [self.num_k_heads, self.num_k_heads, self.num_v_heads],
+                [self.head_k_dim, self.head_k_dim, self.head_v_dim],
+            )
+        ]
+        inv_scale = k.shape[-1] ** -0.5
+        q = (inv_scale**2) * mx.fast.rms_norm(q, None, 1e-6)
+        k = inv_scale * mx.fast.rms_norm(k, None, 1e-6)
+
+        out, new_ssm_state = gated_delta_update(
+            q, k, v, a_chunk, b_chunk,
+            self.A_log, self.dt_bias, ssm_state, ssm_mask,
+            use_kernel=not self.training,
+        )
+        return out, new_conv_state, new_ssm_state
+
     def __call__(
         self,
         inputs: mx.array,
         mask: Optional[mx.array] = None,
         cache: Optional[Any] = None,
+        n_confirmed: int = 0,
     ) -> mx.array:
         B, S, _ = inputs.shape
 
@@ -150,56 +190,39 @@ class GatedDeltaNet(nn.Module):
         b = self.in_proj_b(inputs)
         a = self.in_proj_a(inputs)
 
-        if cache is not None and cache[0] is not None:
-            conv_state = cache[0]
-        else:
-            conv_state = mx.zeros(
-                (B, self.conv_kernel_size - 1, self.conv_dim),
-                dtype=inputs.dtype,
-            )
+        conv_state = (
+            cache[0]
+            if cache is not None and cache[0] is not None
+            else mx.zeros((B, self.conv_kernel_size - 1, self.conv_dim), dtype=inputs.dtype)
+        )
+        ssm_state = cache[1] if cache else None
 
         if mask is not None:
             qkv = mx.where(mask[..., None], qkv, 0)
-        conv_input = mx.concatenate([conv_state, qkv], axis=1)
-        if cache is not None:
-            n_keep = self.conv_kernel_size - 1
-            if cache.lengths is not None:
-                ends = mx.clip(cache.lengths, 0, S)
-                positions = (ends[:, None] + mx.arange(n_keep))[..., None]
-                cache[0] = mx.take_along_axis(conv_input, positions, axis=1)
-            else:
-                cache[0] = mx.contiguous(conv_input[:, -n_keep:, :])
-        conv_out = nn.silu(self.conv1d(conv_input))
 
-        q, k, v = [
-            t.reshape(B, S, h, d)
-            for t, h, d in zip(
-                mx.split(conv_out, [self.key_dim, 2 * self.key_dim], -1),
-                [self.num_k_heads, self.num_k_heads, self.num_v_heads],
-                [self.head_k_dim, self.head_k_dim, self.head_v_dim],
+        if n_confirmed > 0 and n_confirmed < S:
+            # Process confirmed and draft tokens separately so we can snapshot the
+            # SSM/conv state between them for exact rollback on draft rejection.
+            mask_c = mask[:, :n_confirmed] if mask is not None else None
+            mask_d = mask[:, n_confirmed:] if mask is not None else None
+            out_c, conv_c, ssm_c = self._process_chunk(
+                qkv[:, :n_confirmed], a[:, :n_confirmed], b[:, :n_confirmed],
+                conv_state, ssm_state, mask_c,
             )
-        ]
-
-        state = cache[1] if cache else None
-        inv_scale = k.shape[-1] ** -0.5
-        q = (inv_scale**2) * mx.fast.rms_norm(q, None, 1e-6)
-        k = inv_scale * mx.fast.rms_norm(k, None, 1e-6)
-
-        out, state = gated_delta_update(
-            q,
-            k,
-            v,
-            a,
-            b,
-            self.A_log,
-            self.dt_bias,
-            state,
-            mask,
-            use_kernel=not self.training,
-        )
+            if cache is not None:
+                cache.rollback_state = (conv_c, ssm_c)
+            out_d, conv_f, ssm_f = self._process_chunk(
+                qkv[:, n_confirmed:], a[:, n_confirmed:], b[:, n_confirmed:],
+                conv_c, ssm_c, mask_d,
+            )
+            out = mx.concatenate([out_c, out_d], axis=1)
+        else:
+            lengths = cache.lengths if cache is not None else None
+            out, conv_f, ssm_f = self._process_chunk(qkv, a, b, conv_state, ssm_state, mask, lengths=lengths)
 
         if cache is not None:
-            cache[1] = state
+            cache[0] = conv_f
+            cache[1] = ssm_f
             cache.advance(S)
 
         out = self.norm(out, z)
@@ -235,9 +258,10 @@ class DecoderLayer(nn.Module):
         x: mx.array,
         mask: Optional[mx.array] = None,
         cache: Optional[Any] = None,
+        n_confirmed: int = 0,
     ) -> mx.array:
         if self.is_linear:
-            r = self.linear_attn(self.input_layernorm(x), mask, cache)
+            r = self.linear_attn(self.input_layernorm(x), mask, cache, n_confirmed=n_confirmed)
         else:
             r = self.self_attn(self.input_layernorm(x), mask, cache)
         h = x + r
@@ -270,18 +294,10 @@ class MTPDecoderLayer(nn.Module):
 
 
 class MTPModule(nn.Module):
-    """Multi-Token Prediction head.
+    """Multi-Token Prediction head (Qwen3.5 native speculative decoding).
 
-    Predicts the token at position t+2 given:
-      - h_t   : backbone hidden state at the last accepted position t
-      - t_main: the main model's sampled prediction for t+1
-
-    Forward:
-        fused = fc(cat([pre_fc_norm_embedding(embed(t_main)),
-                        pre_fc_norm_hidden(h_t)]))
-        → MTPDecoderLayer(s)
-        → norm
-        → (caller applies lm_head, shared with backbone)
+    Predicts token t+2 from the backbone hidden state h_t and the sampled
+    token t+1, using a shared lm_head with the backbone.
     """
 
     def __init__(self, args: TextModelArgs):
@@ -346,6 +362,7 @@ class Qwen3_5TextModel(PipelineMixin, nn.Module):
         inputs: mx.array,
         cache: Optional[Any] = None,
         input_embeddings: Optional[mx.array] = None,
+        n_confirmed: int = 0,
     ) -> mx.array:
         if input_embeddings is not None:
             hidden_states = input_embeddings
@@ -371,7 +388,8 @@ class Qwen3_5TextModel(PipelineMixin, nn.Module):
 
         for layer, c in zip(self.pipeline_layers, cache):
             mask = ssm_mask if layer.is_linear else fa_mask
-            hidden_states = layer(hidden_states, mask=mask, cache=c)
+            kw = {"n_confirmed": n_confirmed} if layer.is_linear and n_confirmed > 0 else {}
+            hidden_states = layer(hidden_states, mask=mask, cache=c, **kw)
 
         # Send to the next process in the pipeline
         if pipeline_rank != 0:
@@ -410,8 +428,9 @@ class TextModel(nn.Module):
         cache: Optional[Any] = None,
         input_embeddings: Optional[mx.array] = None,
         return_hidden: bool = False,
+        n_confirmed: int = 0,
     ) -> mx.array:
-        hidden = self.model(inputs, cache, input_embeddings=input_embeddings)
+        hidden = self.model(inputs, cache, input_embeddings=input_embeddings, n_confirmed=n_confirmed)
         if self.args.tie_word_embeddings:
             out = self.model.embed_tokens.as_linear(hidden)
         else:
@@ -536,12 +555,14 @@ class Model(nn.Module):
         cache=None,
         input_embeddings: Optional[mx.array] = None,
         return_hidden: bool = False,
+        n_confirmed: int = 0,
     ):
         return self.language_model(
             inputs,
             cache=cache,
             input_embeddings=input_embeddings,
             return_hidden=return_hidden,
+            n_confirmed=n_confirmed,
         )
 
     @property

--- a/mlx_lm/models/qwen3_5.py
+++ b/mlx_lm/models/qwen3_5.py
@@ -513,10 +513,6 @@ class TextModel(nn.Module):
         has_unsanitized_conv1d = any(
             "conv1d.weight" in k and v.shape[-1] != 1 for k, v in weights.items()
         )
-        # Norm weights need a +1 shift only in raw HF checkpoints (detected via
-        # unsanitized conv1d). Already-converted MLX models must not be shifted
-        # again, even when they contain MTP weights.
-        should_shift_norm_weights = has_unsanitized_conv1d
         # Keep MTP weights if this model has an MTP head; drop them otherwise
         if not hasattr(self, "mtp"):
             weights = {k: v for k, v in weights.items() if "mtp." not in k}
@@ -552,7 +548,7 @@ class TextModel(nn.Module):
         for k, v in weights.items():
             if "conv1d.weight" in k and v.shape[-1] != 1:
                 weights[k] = v.moveaxis(2, 1)
-            if should_shift_norm_weights and any(k.endswith(sfx) for sfx in norm_keys):
+            if has_unsanitized_conv1d and any(k.endswith(sfx) for sfx in norm_keys):
                 if v.ndim == 1:
                     weights[k] = v + 1.0
         return weights

--- a/mlx_lm/models/qwen3_5.py
+++ b/mlx_lm/models/qwen3_5.py
@@ -513,6 +513,11 @@ class TextModel(nn.Module):
         # Keep MTP weights if this model has an MTP head; drop them otherwise
         if not hasattr(self, "mtp"):
             weights = {k: v for k, v in weights.items() if "mtp." not in k}
+        elif not any("mtp." in k for k in weights):
+            raise ValueError(
+                "Config specifies mtp_num_hidden_layers > 0 but the model weights "
+                "contain no MTP parameters. Set mtp_num_hidden_layers=0 to disable MTP."
+            )
 
         if self.args.tie_word_embeddings:
             weights.pop("lm_head.weight", None)

--- a/mlx_lm/models/qwen3_5.py
+++ b/mlx_lm/models/qwen3_5.py
@@ -541,9 +541,6 @@ class TextModel(nn.Module):
         def predicate(path, _):
             if path.endswith("mlp.gate") or path.endswith("shared_expert_gate"):
                 return {"group_size": 64, "bits": 8}
-            # Keep the MTP fusion projection in full precision.
-            if path.endswith("mtp.fc"):
-                return False
             return True
 
         if self.args.num_experts <= 0 and self.args.mtp_num_hidden_layers <= 0:

--- a/mlx_lm/models/qwen3_5.py
+++ b/mlx_lm/models/qwen3_5.py
@@ -408,7 +408,7 @@ class Qwen3_5TextModel(PipelineMixin, nn.Module):
                 : hidden_states.shape[0]
             ]
 
-        return self.norm(hidden_states)
+        return hidden_states
 
 
 class TextModel(nn.Module):
@@ -431,12 +431,13 @@ class TextModel(nn.Module):
         n_confirmed: int = 0,
     ) -> mx.array:
         hidden = self.model(inputs, cache, input_embeddings=input_embeddings, n_confirmed=n_confirmed)
+        normed = self.model.norm(hidden)
         if self.args.tie_word_embeddings:
-            out = self.model.embed_tokens.as_linear(hidden)
+            out = self.model.embed_tokens.as_linear(normed)
         else:
-            out = self.lm_head(hidden)
+            out = self.lm_head(normed)
         if return_hidden:
-            return out, hidden
+            return out, hidden  # pre-norm hidden for MTP head
         return out
 
     def mtp_forward(
@@ -510,14 +511,16 @@ class TextModel(nn.Module):
 
     @property
     def quant_predicate(self):
-        if self.args.num_experts <= 0:
-            return None
-
         def predicate(path, _):
             if path.endswith("mlp.gate") or path.endswith("shared_expert_gate"):
                 return {"group_size": 64, "bits": 8}
+            # Keep the MTP fusion projection in full precision.
+            if path.endswith("mtp.fc"):
+                return False
             return True
 
+        if self.args.num_experts <= 0 and self.args.mtp_num_hidden_layers <= 0:
+            return None
         return predicate
 
     @property

--- a/mlx_lm/models/qwen3_5.py
+++ b/mlx_lm/models/qwen3_5.py
@@ -197,13 +197,13 @@ class GatedDeltaNet(nn.Module):
         b = self.in_proj_b(inputs)
         a = self.in_proj_a(inputs)
 
-        conv_state = (
-            cache[0]
-            if cache is not None and cache[0] is not None
-            else mx.zeros(
-                (B, self.conv_kernel_size - 1, self.conv_dim), dtype=inputs.dtype
+        if cache is not None and cache[0] is not None:
+            conv_state = cache[0]
+        else:
+            conv_state = mx.zeros(
+                (B, self.conv_kernel_size - 1, self.conv_dim),
+                dtype=inputs.dtype,
             )
-        )
         ssm_state = cache[1] if cache else None
 
         if mask is not None:
@@ -338,8 +338,6 @@ class MTPModule(nn.Module):
         embed_tokens: nn.Embedding,
         cache: Optional[Any] = None,
     ) -> mx.array:
-        # hidden_states : (B, 1, H)  — backbone hidden at last accepted position
-        # next_token_ids: (B, 1)     — t_main (main model's prediction for t+1)
         embeds = embed_tokens(next_token_ids)  # (B, 1, H)
         e = self.pre_fc_norm_embedding(embeds)
         h = self.pre_fc_norm_hidden(hidden_states)
@@ -409,12 +407,9 @@ class Qwen3_5TextModel(PipelineMixin, nn.Module):
 
         for layer, c in zip(self.pipeline_layers, cache):
             mask = ssm_mask if layer.is_linear else fa_mask
-            kw = (
-                {"n_confirmed": n_confirmed}
-                if layer.is_linear and n_confirmed > 0
-                else {}
+            hidden_states = layer(
+                hidden_states, mask=mask, cache=c, n_confirmed=n_confirmed
             )
-            hidden_states = layer(hidden_states, mask=mask, cache=c, **kw)
 
         # Send to the next process in the pipeline
         if pipeline_rank != 0:
@@ -476,12 +471,12 @@ class TextModel(nn.Module):
         """Run the MTP head and apply the shared lm_head.
 
         Args:
-            hidden_states: (B, 1, H) — backbone hidden state at the last position.
-            next_token_ids: (B, 1)   — sampled main token (t_main).
-            mtp_cache: list of KVCache entries for the MTP transformer layer(s).
+            hidden_states: Backbone pre-norm hidden state, shape (B, 1, H).
+            next_token_ids: Sampled main token ids, shape (B, 1).
+            mtp_cache: KVCache entries for the MTP transformer layers.
 
         Returns:
-            logits: (B, 1, vocab_size)
+            logits of shape (B, 1, vocab_size).
         """
         mtp_out = self.mtp(
             hidden_states,

--- a/mlx_lm/models/qwen3_5_moe.py
+++ b/mlx_lm/models/qwen3_5_moe.py
@@ -20,6 +20,31 @@ class ModelArgs(BaseModelArgs):
         return super().from_dict(params)
 
 
+def _unfuse_experts(weights, prefix):
+    """Split fused gate_up_proj into per-projection switch_mlp weights (Qwen3.6 format)."""
+    gate_up_key = f"{prefix}.experts.gate_up_proj"
+    if gate_up_key not in weights:
+        return
+    gate_up = weights.pop(gate_up_key)
+    mid = gate_up.shape[-2] // 2
+    weights[f"{prefix}.switch_mlp.gate_proj.weight"] = gate_up[..., :mid, :]
+    weights[f"{prefix}.switch_mlp.up_proj.weight"] = gate_up[..., mid:, :]
+    weights[f"{prefix}.switch_mlp.down_proj.weight"] = weights.pop(
+        f"{prefix}.experts.down_proj"
+    )
+
+
+def _stack_per_expert(weights, prefix, num_experts):
+    """Stack per-expert weights into switch_mlp format (Qwen3.5 format)."""
+    for n in ("gate_proj", "up_proj", "down_proj"):
+        weights[f"{prefix}.switch_mlp.{n}.weight"] = mx.stack(
+            [
+                weights.pop(f"{prefix}.experts.{e}.{n}.weight")
+                for e in range(num_experts)
+            ]
+        )
+
+
 class Model(Qwen3_5Model):
 
     def sanitize(self, weights):
@@ -29,42 +54,27 @@ class Model(Qwen3_5Model):
                 continue
             if key.startswith("model.language_model"):
                 key = key.replace("model.language_model", "language_model.model")
-            elif key.startswith("language_model."):
-                pass
-            else:
+            elif not key.startswith("language_model."):
                 key = "language_model." + key
             new_weights[key] = value
 
+        # Backbone MoE layers always use fused gate_up_proj (both Qwen3.5 and Qwen3.6).
         for l in range(self.language_model.args.num_hidden_layers):
-            prefix = f"language_model.model.layers.{l}.mlp"
-            gate_up_key = f"{prefix}.experts.gate_up_proj"
-            if gate_up_key in new_weights:
-                gate_up = new_weights.pop(gate_up_key)
-                mid = gate_up.shape[-2] // 2
-                new_weights[f"{prefix}.switch_mlp.gate_proj.weight"] = gate_up[
-                    ..., :mid, :
-                ]
-                new_weights[f"{prefix}.switch_mlp.up_proj.weight"] = gate_up[
-                    ..., mid:, :
-                ]
-                new_weights[f"{prefix}.switch_mlp.down_proj.weight"] = new_weights.pop(
-                    f"{prefix}.experts.down_proj"
-                )
+            _unfuse_experts(new_weights, f"language_model.model.layers.{l}.mlp")
 
-        # Stack per-expert MTP weights into switch_mlp format.
-        # MTP layers use unfused per-expert weights (experts.{i}.gate_proj etc)
-        # unlike backbone layers which use fused gate_up_proj.
+        # MTP layers: fused format (Qwen3.6) or per-expert format (Qwen3.5).
+        # Detect format once from the first layer and apply uniformly.
         mtp_num = getattr(self.language_model.args, "mtp_num_hidden_layers", 0)
-        num_experts = self.language_model.args.num_experts
-        for layer_idx in range(mtp_num):
-            prefix = f"language_model.mtp.layers.{layer_idx}.mlp"
-            test_key = f"{prefix}.experts.0.gate_proj.weight"
-            if test_key in new_weights:
-                for n in ["gate_proj", "up_proj", "down_proj"]:
-                    to_join = [
-                        new_weights.pop(f"{prefix}.experts.{e}.{n}.weight")
-                        for e in range(num_experts)
-                    ]
-                    new_weights[f"{prefix}.switch_mlp.{n}.weight"] = mx.stack(to_join)
+        if mtp_num > 0:
+            num_experts = self.language_model.args.num_experts
+            mtp_is_fused = (
+                "language_model.mtp.layers.0.mlp.experts.gate_up_proj" in new_weights
+            )
+            for layer_idx in range(mtp_num):
+                prefix = f"language_model.mtp.layers.{layer_idx}.mlp"
+                if mtp_is_fused:
+                    _unfuse_experts(new_weights, prefix)
+                else:
+                    _stack_per_expert(new_weights, prefix, num_experts)
 
         return self.language_model.sanitize(new_weights)

--- a/mlx_lm/models/qwen3_5_moe.py
+++ b/mlx_lm/models/qwen3_5_moe.py
@@ -2,6 +2,8 @@
 
 from dataclasses import dataclass
 
+import mlx.core as mx
+
 from .base import BaseModelArgs
 from .qwen3_5 import Model as Qwen3_5Model
 
@@ -48,5 +50,21 @@ class Model(Qwen3_5Model):
                 new_weights[f"{prefix}.switch_mlp.down_proj.weight"] = new_weights.pop(
                     f"{prefix}.experts.down_proj"
                 )
+
+        # Stack per-expert MTP weights into switch_mlp format.
+        # MTP layers use unfused per-expert weights (experts.{i}.gate_proj etc)
+        # unlike backbone layers which use fused gate_up_proj.
+        mtp_num = getattr(self.language_model.args, "mtp_num_hidden_layers", 0)
+        num_experts = self.language_model.args.num_experts
+        for l in range(mtp_num):
+            prefix = f"language_model.mtp.layers.{l}.mlp"
+            test_key = f"{prefix}.experts.0.gate_proj.weight"
+            if test_key in new_weights:
+                for n in ["gate_proj", "up_proj", "down_proj"]:
+                    to_join = [
+                        new_weights.pop(f"{prefix}.experts.{e}.{n}.weight")
+                        for e in range(num_experts)
+                    ]
+                    new_weights[f"{prefix}.switch_mlp.{n}.weight"] = mx.stack(to_join)
 
         return self.language_model.sanitize(new_weights)

--- a/mlx_lm/models/qwen3_5_moe.py
+++ b/mlx_lm/models/qwen3_5_moe.py
@@ -56,8 +56,8 @@ class Model(Qwen3_5Model):
         # unlike backbone layers which use fused gate_up_proj.
         mtp_num = getattr(self.language_model.args, "mtp_num_hidden_layers", 0)
         num_experts = self.language_model.args.num_experts
-        for l in range(mtp_num):
-            prefix = f"language_model.mtp.layers.{l}.mlp"
+        for layer_idx in range(mtp_num):
+            prefix = f"language_model.mtp.layers.{layer_idx}.mlp"
             test_key = f"{prefix}.experts.0.gate_proj.weight"
             if test_key in new_weights:
                 for n in ["gate_proj", "up_proj", "down_proj"]:

--- a/mlx_lm/models/qwen3_5_moe.py
+++ b/mlx_lm/models/qwen3_5_moe.py
@@ -65,11 +65,11 @@ class Model(Qwen3_5Model):
         # MTP layers: fused format (Qwen3.6) or per-expert format (Qwen3.5).
         # Detect format once from the first layer and apply uniformly.
         mtp_num = getattr(self.language_model.args, "mtp_num_hidden_layers", 0)
-        if mtp_num > 0:
+        fused_key = "language_model.mtp.layers.0.mlp.experts.gate_up_proj"
+        per_expert_key = "language_model.mtp.layers.0.mlp.experts.0.gate_proj.weight"
+        if mtp_num > 0 and (fused_key in new_weights or per_expert_key in new_weights):
             num_experts = self.language_model.args.num_experts
-            mtp_is_fused = (
-                "language_model.mtp.layers.0.mlp.experts.gate_up_proj" in new_weights
-            )
+            mtp_is_fused = fused_key in new_weights
             for layer_idx in range(mtp_num):
                 prefix = f"language_model.mtp.layers.{layer_idx}.mlp"
                 if mtp_is_fused:

--- a/mlx_lm/sample_utils.py
+++ b/mlx_lm/sample_utils.py
@@ -2,9 +2,40 @@
 
 import math
 from functools import partial
-from typing import Callable, Dict, List, Optional
+from typing import Callable, Dict, List, Optional, Tuple
 
 import mlx.core as mx
+
+
+def make_sampler_chain(
+    top_p: float = 0.0,
+    top_k: int = 0,
+    min_p: float = 0.0,
+    min_tokens_to_keep: int = 1,
+    xtc_probability: float = 0.0,
+    xtc_threshold: float = 0.0,
+    xtc_special_tokens: List[int] = [],
+) -> Tuple[List[Callable[[mx.array], mx.array]], Optional[List]]:
+    """Return (filter_chain, xtc_cell) for use in mtp_generate_step.
+
+    xtc_cell is a mutable [uniform_draw] slot; set it before running the chain
+    to share the XTC boolean across draft and verify steps. None when XTC is off.
+    """
+    _xtc_cell: Optional[List] = [None] if xtc_probability > 0.0 else None
+    chain: List[Callable[[mx.array], mx.array]] = []
+    if top_p > 0 and top_p < 1.0:
+        chain.append(lambda x: apply_top_p(x, top_p))
+    if min_p != 0.0:
+        chain.append(lambda x: apply_min_p(x, min_p, min_tokens_to_keep))
+    if xtc_probability > 0.0:
+        chain.append(
+            lambda x: apply_xtc(
+                x, xtc_probability, xtc_threshold, xtc_special_tokens, _xtc_cell[0]
+            )
+        )
+    if top_k > 0:
+        chain.append(lambda x: apply_top_k(x, top_k))
+    return chain, _xtc_cell
 
 
 def make_sampler(
@@ -47,17 +78,15 @@ def make_sampler(
         return lambda x: mx.argmax(x, axis=-1)
 
     # Create sampler chain
-    sampling_methods = []
-    if top_p > 0 and top_p < 1.0:
-        sampling_methods.append(lambda x: apply_top_p(x, top_p))
-    if min_p != 0.0:
-        sampling_methods.append(lambda x: apply_min_p(x, min_p, min_tokens_to_keep))
-    if xtc_probability > 0.0:
-        sampling_methods.append(
-            lambda x: apply_xtc(x, xtc_probability, xtc_threshold, xtc_special_tokens)
-        )
-    if top_k > 0:
-        sampling_methods.append(lambda x: apply_top_k(x, top_k))
+    sampling_methods, _ = make_sampler_chain(
+        top_p,
+        top_k,
+        min_p,
+        min_tokens_to_keep,
+        xtc_probability,
+        xtc_threshold,
+        xtc_special_tokens,
+    )
 
     # Apply the sampling methods
     def sampler(logprobs):
@@ -243,6 +272,7 @@ def apply_xtc(
     xtc_probability: float,
     xtc_threshold: float,
     xtc_special_tokens: List[int],
+    p_draw: Optional[mx.array] = None,
 ) -> mx.array:
     """
     Apply XTC sampling to the logits.
@@ -252,6 +282,9 @@ def apply_xtc(
         xtc_probability (float): Probability of XTC sampling to happen for each token
         xtc_threshold (float): The threshold the probs need to reach for being sampled.
         special_tokens_ids (list(int)): List of special tokens IDs to be excluded from XTC sampling.
+        p_draw (mx.array, optional): Pre-drawn uniform; if None, draws fresh.
+            Pass the same draw to draft and verify steps to share the XTC
+            apply/skip decision across both forward passes.
     """
     if not (0 <= xtc_threshold <= 0.5):
         raise ValueError(
@@ -267,8 +300,9 @@ def apply_xtc(
     if xtc_special_tokens:
         mask[..., xtc_special_tokens] = False
 
+    draw = mx.random.uniform(0, 1) if p_draw is None else p_draw
     return mx.where(
-        mx.random.uniform(0, 1) > xtc_probability,
+        draw > xtc_probability,
         logits,
         mx.where(mask, -mx.inf, logits),
     )

--- a/mlx_lm/sample_utils.py
+++ b/mlx_lm/sample_utils.py
@@ -2,9 +2,40 @@
 
 import math
 from functools import partial
-from typing import Callable, Dict, List, Optional
+from typing import Callable, Dict, List, Optional, Tuple
 
 import mlx.core as mx
+
+
+def make_sampler_chain(
+    top_p: float = 0.0,
+    top_k: int = 0,
+    min_p: float = 0.0,
+    min_tokens_to_keep: int = 1,
+    xtc_probability: float = 0.0,
+    xtc_threshold: float = 0.0,
+    xtc_special_tokens: List[int] = [],
+) -> Tuple[List[Callable[[mx.array], mx.array]], Optional[List]]:
+    """Return (filter_chain, xtc_cell) for use in mtp_generate_step.
+
+    xtc_cell is a mutable [uniform_draw] slot; set it before running the chain
+    to share the XTC boolean across draft and verify steps. None when XTC is off.
+    """
+    _xtc_cell: Optional[List] = [None] if xtc_probability > 0.0 else None
+    chain: List[Callable[[mx.array], mx.array]] = []
+    if top_p > 0 and top_p < 1.0:
+        chain.append(lambda x: apply_top_p(x, top_p))
+    if min_p != 0.0:
+        chain.append(lambda x: apply_min_p(x, min_p, min_tokens_to_keep))
+    if xtc_probability > 0.0:
+        chain.append(
+            lambda x: apply_xtc(
+                x, xtc_probability, xtc_threshold, xtc_special_tokens, _xtc_cell[0]
+            )
+        )
+    if top_k > 0:
+        chain.append(lambda x: apply_top_k(x, top_k))
+    return chain, _xtc_cell
 
 
 def make_sampler(
@@ -47,17 +78,15 @@ def make_sampler(
         return lambda x: mx.argmax(x, axis=-1)
 
     # Create sampler chain
-    sampling_methods = []
-    if top_p > 0 and top_p < 1.0:
-        sampling_methods.append(lambda x: apply_top_p(x, top_p))
-    if min_p != 0.0:
-        sampling_methods.append(lambda x: apply_min_p(x, min_p, min_tokens_to_keep))
-    if xtc_probability > 0.0:
-        sampling_methods.append(
-            lambda x: apply_xtc(x, xtc_probability, xtc_threshold, xtc_special_tokens)
-        )
-    if top_k > 0:
-        sampling_methods.append(lambda x: apply_top_k(x, top_k))
+    sampling_methods, _ = make_sampler_chain(
+        top_p,
+        top_k,
+        min_p,
+        min_tokens_to_keep,
+        xtc_probability,
+        xtc_threshold,
+        xtc_special_tokens,
+    )
 
     # Apply the sampling methods
     def sampler(logprobs):
@@ -243,6 +272,7 @@ def apply_xtc(
     xtc_probability: float,
     xtc_threshold: float,
     xtc_special_tokens: List[int],
+    p_draw: Optional[mx.array] = None,
 ) -> mx.array:
     """
     Apply XTC sampling to the logits.
@@ -252,6 +282,9 @@ def apply_xtc(
         xtc_probability (float): Probability of XTC sampling to happen for each token
         xtc_threshold (float): The threshold the probs need to reach for being sampled.
         special_tokens_ids (list(int)): List of special tokens IDs to be excluded from XTC sampling.
+        p_draw (mx.array, optional): Pre-drawn uniform; if None, draws fresh.
+            Pass the same draw to draft and verify steps to share the XTC
+            apply/skip decision across both forward passes.
     """
     if not (0 <= xtc_threshold <= 0.5):
         raise ValueError(
@@ -269,8 +302,9 @@ def apply_xtc(
     if xtc_special_tokens:
         mask[..., xtc_special_tokens] = False
 
+    draw = mx.random.uniform(0, 1) if p_draw is None else p_draw
     return mx.where(
-        mx.random.uniform(0, 1) > xtc_probability,
+        draw > xtc_probability,
         logits,
         mx.where(mask, -mx.inf, logits),
     )

--- a/mlx_lm/server.py
+++ b/mlx_lm/server.py
@@ -378,6 +378,10 @@ class ModelProvider:
         return self.model, self.tokenizer
 
 
+def _xtc_special_tokens(tokenizer):
+    return tokenizer.encode("\n") + list(tokenizer.eos_token_ids)
+
+
 def _make_sampler(args, tokenizer):
     return make_sampler(
         args.sampling.temperature,
@@ -386,7 +390,7 @@ def _make_sampler(args, tokenizer):
         min_p=args.sampling.min_p,
         xtc_probability=args.sampling.xtc_probability,
         xtc_threshold=args.sampling.xtc_threshold,
-        xtc_special_tokens=tokenizer.encode("\n") + list(tokenizer.eos_token_ids),
+        xtc_special_tokens=_xtc_special_tokens(tokenizer),
     )
 
 
@@ -939,6 +943,13 @@ class ResponseGenerator:
                 prompt_progress_callback=progress,
                 prefill_step_size=self.cli_args.prefill_step_size,
                 mtp=getattr(self.cli_args, "mtp", False),
+                temp=args.sampling.temperature,
+                top_p=args.sampling.top_p,
+                top_k=args.sampling.top_k,
+                min_p=args.sampling.min_p,
+                xtc_probability=args.sampling.xtc_probability,
+                xtc_threshold=args.sampling.xtc_threshold,
+                xtc_special_tokens=_xtc_special_tokens(tokenizer),
             ):
                 finish_reason = gen.finish_reason
 

--- a/mlx_lm/server.py
+++ b/mlx_lm/server.py
@@ -360,8 +360,11 @@ class ModelProvider:
         self.model = model
         self.tokenizer = tokenizer
         self.draft_model = draft_model
-        # MTP speculative decoding requires single-sequence generation.
-        if hasattr(model, "mtp_forward"):
+        # MTP speculative decoding uses single-sequence generation
+        # (draft/verify loop is incompatible with batch generation).
+        # TODO: dynamically switch between MTP (1 request) and
+        # BatchGenerator (>= 2 concurrent requests).
+        if self.cli_args.mtp and hasattr(model, "mtp_forward"):
             is_batchable = False
         self.is_batchable = is_batchable
 
@@ -934,6 +937,7 @@ class ResponseGenerator:
                 num_draft_tokens=args.num_draft_tokens,
                 prompt_progress_callback=progress,
                 prefill_step_size=self.cli_args.prefill_step_size,
+                mtp=getattr(self.cli_args, "mtp", False),
             ):
                 finish_reason = gen.finish_reason
 
@@ -1855,6 +1859,12 @@ def main():
         "--pipeline",
         action="store_true",
         help="Use pipelining instead of tensor parallelism",
+    )
+    parser.add_argument(
+        "--mtp",
+        action="store_true",
+        help="Use native Multi-Token Prediction for speculative decoding "
+        "(requires a model with an MTP head, e.g. Qwen3.5).",
     )
     args = parser.parse_args()
     if mx.metal.is_available():

--- a/mlx_lm/server.py
+++ b/mlx_lm/server.py
@@ -360,8 +360,11 @@ class ModelProvider:
         self.model = model
         self.tokenizer = tokenizer
         self.draft_model = draft_model
-        # MTP speculative decoding requires single-sequence generation.
-        if hasattr(model, "mtp_forward"):
+        # MTP speculative decoding uses single-sequence generation
+        # (draft/verify loop is incompatible with batch generation).
+        # TODO: dynamically switch between MTP (1 request) and
+        # BatchGenerator (>= 2 concurrent requests).
+        if self.cli_args.mtp and hasattr(model, "mtp_forward"):
             is_batchable = False
         self.is_batchable = is_batchable
 
@@ -934,6 +937,7 @@ class ResponseGenerator:
                 num_draft_tokens=args.num_draft_tokens,
                 prompt_progress_callback=progress,
                 prefill_step_size=self.cli_args.prefill_step_size,
+                mtp=getattr(self.cli_args, "mtp", False),
             ):
                 finish_reason = gen.finish_reason
 
@@ -1852,6 +1856,12 @@ def main():
         "--pipeline",
         action="store_true",
         help="Use pipelining instead of tensor parallelism",
+    )
+    parser.add_argument(
+        "--mtp",
+        action="store_true",
+        help="Use native Multi-Token Prediction for speculative decoding "
+        "(requires a model with an MTP head, e.g. Qwen3.5).",
     )
     args = parser.parse_args()
     if mx.metal.is_available():

--- a/mlx_lm/server.py
+++ b/mlx_lm/server.py
@@ -360,12 +360,6 @@ class ModelProvider:
         self.model = model
         self.tokenizer = tokenizer
         self.draft_model = draft_model
-        # MTP speculative decoding uses single-sequence generation
-        # (draft/verify loop is incompatible with batch generation).
-        # TODO: dynamically switch between MTP (1 request) and
-        # BatchGenerator (>= 2 concurrent requests).
-        if self.cli_args.mtp and hasattr(model, "mtp_forward"):
-            is_batchable = False
         self.is_batchable = is_batchable
 
     def load_default(self):
@@ -752,7 +746,14 @@ class ResponseGenerator:
                         rqueue.put(e)
                         continue
 
-                    if not self._is_batchable(args):
+                    # Prefer single-sequence MTP when the queue is empty;
+                    # fall back to BatchGenerator when requests are queued.
+                    mtp_active = getattr(self.cli_args, "mtp", False) and hasattr(
+                        model, "mtp_forward"
+                    )
+                    if not self._is_batchable(args) or (
+                        mtp_active and self.requests.empty()
+                    ):
                         self._serve_single((rqueue, request, args))
                         continue
 

--- a/mlx_lm/server.py
+++ b/mlx_lm/server.py
@@ -36,11 +36,12 @@ from .generate import (
     BatchGenerator,
     StopSequenceMatcher,
     TextStateMachine,
+    _model_supports_mtp,
     make_stop_matcher,
     make_text_state_machine,
     stream_generate,
 )
-from .models.cache import LRUPromptCache, make_prompt_cache
+from .models.cache import LRUPromptCache, MTPPromptCacheState, make_prompt_cache
 from .sample_utils import make_logits_processors, make_sampler
 from .utils import _parse_size, load, sharded_load
 
@@ -750,14 +751,12 @@ class ResponseGenerator:
                         rqueue.put(e)
                         continue
 
-                    # Prefer single-sequence MTP when the queue is empty;
-                    # fall back to BatchGenerator when requests are queued.
-                    mtp_active = getattr(self.cli_args, "mtp", False) and hasattr(
-                        model, "mtp_forward"
+                    # Native MTP is currently single-sequence only. Keep routing
+                    # deterministic instead of racing a best-effort queue check.
+                    mtp_active = getattr(self.cli_args, "mtp", False) and (
+                        _model_supports_mtp(model)
                     )
-                    if not self._is_batchable(args) or (
-                        mtp_active and self.requests.empty()
-                    ):
+                    if not self._is_batchable(args) or mtp_active:
                         self._serve_single((rqueue, request, args))
                         continue
 
@@ -921,6 +920,24 @@ class ResponseGenerator:
             cache, rest = self.prompt_cache.fetch_nearest_cache(
                 self.model_provider.model_key, prompt
             )
+            mtp_active = getattr(self.cli_args, "mtp", False) and (
+                _model_supports_mtp(model)
+            )
+            # A reusable native-MTP entry contains target caches, the MTP-head
+            # caches, and one boundary record holding the final target hidden state.
+            # Exact hits have no suffix token with which to resume the lagged MTP
+            # state, so they are rebuilt rather than replayed unsafely.
+            if mtp_active and cache is not None:
+                expected = len(model.layers) + len(model.make_mtp_cache()) + 1
+                valid_mtp_cache = (
+                    len(cache) == expected
+                    and isinstance(cache[-1], MTPPromptCacheState)
+                    and not cache[-1].empty()
+                    and len(rest) > 0
+                )
+                if not valid_mtp_cache:
+                    cache = None
+                    rest = prompt
             ctx.prompt_cache_count = len(prompt) - len(rest)
             cache_key = prompt[:]
             if cache is None:

--- a/mlx_lm/server.py
+++ b/mlx_lm/server.py
@@ -360,6 +360,9 @@ class ModelProvider:
         self.model = model
         self.tokenizer = tokenizer
         self.draft_model = draft_model
+        # MTP speculative decoding requires single-sequence generation.
+        if hasattr(model, "mtp_forward"):
+            is_batchable = False
         self.is_batchable = is_batchable
 
     def load_default(self):

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -647,6 +647,7 @@ class TestModels(unittest.TestCase):
         }
         hf_norm_key = "model.language_model.layers.0.input_layernorm.weight"
         mlx_norm_key = "language_model.model.layers.0.input_layernorm.weight"
+        hf_conv1d_key = "model.language_model.layers.0.linear_attn.conv1d.weight"
 
         for model_type, hf_mtp_key in (
             ("qwen3_5", "mtp.fc.weights"),
@@ -663,11 +664,14 @@ class TestModels(unittest.TestCase):
 
             base = mx.arange(8, dtype=mx.float32)
 
-            # Simulate convert sanitize on HF-style keys.
+            # Simulate convert sanitize on HF-style keys. The norm shift is only
+            # triggered by an unsanitized (PyTorch-layout) conv1d weight, not by
+            # the presence of MTP weights alone.
             converted = model.sanitize(
                 {
                     hf_norm_key: base,
                     hf_mtp_key: mx.zeros((1,), dtype=mx.float32),
+                    hf_conv1d_key: mx.zeros((4, 1, 3), dtype=mx.float32),
                 }
             )
             self.assertIn(mlx_norm_key, converted)

--- a/tests/test_mtp.py
+++ b/tests/test_mtp.py
@@ -1,0 +1,182 @@
+import importlib
+import unittest
+
+import mlx.core as mx
+from mlx_lm.models.cache import make_prompt_cache
+from mlx_lm.generate import generate_step, mtp_generate_step
+
+
+def _make_qwen3_5_mtp_model():
+    """Create a tiny Qwen3.5 model with an MTP head for testing."""
+    module = importlib.import_module("mlx_lm.models.qwen3_5")
+    args = module.ModelArgs.from_dict(
+        {
+            "model_type": "qwen3_5",
+            "text_config": {
+                "model_type": "qwen3_5",
+                "hidden_size": 64,
+                "intermediate_size": 128,
+                "num_hidden_layers": 4,
+                "num_attention_heads": 4,
+                "num_key_value_heads": 2,
+                "vocab_size": 256,
+                "linear_num_value_heads": 2,
+                "linear_num_key_heads": 2,
+                "linear_key_head_dim": 16,
+                "linear_value_head_dim": 16,
+                "linear_conv_kernel_dim": 3,
+                "full_attention_interval": 2,
+                "tie_word_embeddings": True,
+                "rms_norm_eps": 1e-5,
+                "head_dim": 32,
+                "rope_theta": 1000.0,
+                "partial_rotary_factor": 0.5,
+                "max_position_embeddings": 128,
+                "mtp_num_hidden_layers": 1,
+            },
+        }
+    )
+    model = module.Model(args)
+    model.set_dtype(mx.float32)
+    mx.eval(model.parameters())
+    return model
+
+
+class TestMTP(unittest.TestCase):
+    """Tests for native MTP (Multi-Token Prediction) speculative decoding.
+
+    Uses a tiny synthetic Qwen3.5 model (4 layers, hidden=64, vocab=256)
+    with mtp_num_hidden_layers=1 and full_attention_interval=2, giving a
+    mix of GatedDeltaNet (SSM) and full-attention layers.
+
+    Not tested here (would require a real tokenizer loaded from HF):
+    - stream_generate() with mtp=True/False flag dispatch
+    - Server integration (--mtp flag, is_batchable)
+    """
+
+    @classmethod
+    def setUpClass(cls):
+        cls.model = _make_qwen3_5_mtp_model()
+
+    def test_mtp_module_exists(self):
+        """Model with mtp_num_hidden_layers=1 should have MTP head."""
+        self.assertTrue(hasattr(self.model, "mtp_forward"))
+        self.assertTrue(hasattr(self.model, "make_mtp_cache"))
+        lm = self.model.language_model
+        self.assertTrue(hasattr(lm, "mtp"))
+        self.assertEqual(len(lm.mtp.layers), 1)
+
+    def test_make_mtp_cache(self):
+        """make_mtp_cache should return one KVCache per MTP layer."""
+        mtp_cache = self.model.make_mtp_cache()
+        self.assertEqual(len(mtp_cache), 1)
+        self.assertTrue(mtp_cache[0].is_trimmable())
+
+    def test_return_hidden(self):
+        """return_hidden=True should return (logits, hidden) with correct shapes."""
+        inputs = mx.array([[0, 1, 2]])
+        cache = make_prompt_cache(self.model)
+        out, hidden = self.model(inputs, cache=cache, return_hidden=True)
+        self.assertEqual(out.shape, (1, 3, 256))
+        self.assertEqual(hidden.shape, (1, 3, 64))
+
+    def test_mtp_forward_shape(self):
+        """mtp_forward should produce logits of shape (B, 1, vocab)."""
+        hidden = mx.random.normal((1, 1, 64))
+        next_ids = mx.array([[5]])
+        mtp_cache = self.model.make_mtp_cache()
+        logits = self.model.mtp_forward(hidden, next_ids, mtp_cache)
+        self.assertEqual(logits.shape, (1, 1, 256))
+
+    def test_hidden_is_pre_norm(self):
+        """Hidden states returned with return_hidden should be pre-norm.
+
+        This verifies the fix for double normalization: the backbone returns
+        pre-norm hidden states, and the final norm is applied only before
+        lm_head (not before the MTP head).
+        """
+        lm = self.model.language_model
+        inputs = mx.array([[0, 1, 2]])
+        cache = make_prompt_cache(self.model)
+
+        _, hidden = lm(inputs, cache=cache, return_hidden=True)
+
+        # Apply the final norm manually and check it changes the values.
+        normed = lm.model.norm(hidden)
+        self.assertFalse(mx.allclose(hidden, normed, atol=1e-5).item())
+
+    def test_quant_predicate_excludes_mtp_fc(self):
+        """quant_predicate should exclude mtp.fc from quantization."""
+        lm = self.model.language_model
+        predicate = lm.quant_predicate
+        self.assertIsNotNone(predicate)
+        # mtp.fc should not be quantized
+        self.assertFalse(predicate("mtp.fc", None))
+        # Regular layers should be quantized
+        self.assertTrue(predicate("layers.0.mlp.gate_proj", None))
+
+    def test_mtp_generate_identity(self):
+        """mtp_generate_step should produce the same greedy tokens as generate_step.
+
+        This is the most important correctness test: it proves that the
+        draft/verify loop, SSM state rollback on rejection, and MTP cache
+        management are all correct.  Any bug in these would cause the MTP
+        path to diverge from standard generation.
+        """
+        prompt = mx.array([0, 1, 2, 3], dtype=mx.uint32)
+        n_tokens = 10
+
+        def greedy(logprobs):
+            return mx.argmax(logprobs, axis=-1)
+
+        # Standard generation
+        std_cache = make_prompt_cache(self.model)
+        std_tokens = []
+        for i, (tok, _) in enumerate(
+            generate_step(prompt, self.model, sampler=greedy, prompt_cache=std_cache)
+        ):
+            std_tokens.append(int(tok))
+            if i + 1 >= n_tokens:
+                break
+
+        # MTP generation
+        mtp_tokens = []
+        for tok, _, _ in mtp_generate_step(
+            prompt, self.model, sampler=greedy, max_tokens=n_tokens
+        ):
+            mtp_tokens.append(int(tok))
+            if len(mtp_tokens) >= n_tokens:
+                break
+
+        self.assertEqual(
+            std_tokens,
+            mtp_tokens,
+            f"Token mismatch: std={std_tokens}, mtp={mtp_tokens}",
+        )
+
+    def test_mtp_generate_runs(self):
+        """mtp_generate_step should complete without errors.
+
+        Exercises the full end-to-end path: prefill, backbone forward with
+        return_hidden, MTP draft generation, verification with n_confirmed,
+        SSM rollback on rejection, and MTP cache trimming.
+        """
+        prompt = mx.array([0, 1, 2, 3], dtype=mx.uint32)
+        n_tokens = 10
+
+        def greedy(logprobs):
+            return mx.argmax(logprobs, axis=-1)
+
+        tokens = []
+        for tok, _, _ in mtp_generate_step(
+            prompt, self.model, sampler=greedy, max_tokens=n_tokens
+        ):
+            tokens.append(int(tok))
+            if len(tokens) >= n_tokens:
+                break
+
+        self.assertEqual(len(tokens), n_tokens)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_mtp.py
+++ b/tests/test_mtp.py
@@ -2,8 +2,9 @@ import importlib
 import unittest
 
 import mlx.core as mx
-from mlx_lm.models.cache import make_prompt_cache
+
 from mlx_lm.generate import generate_step, mtp_generate_step
+from mlx_lm.models.cache import make_prompt_cache
 
 
 def _make_qwen3_5_mtp_model():

--- a/tests/test_mtp.py
+++ b/tests/test_mtp.py
@@ -171,6 +171,92 @@ class TestMTP(unittest.TestCase):
 
         self.assertEqual(len(tokens), n_tokens)
 
+    def test_mtp_generate_identity_with_logits_processor(self):
+        """mtp_generate_step must produce the same greedy tokens as generate_step
+        when a context-sensitive stateless processor is applied.
+
+        A processor that boosts (tokens[-1] + 1) % vocab biases sampling based on
+        the last token.  Incorrect prev_tokens management in the verify pass would
+        cause the bonus token or the token after a rejection to be sampled with
+        the wrong bias, producing a sequence that diverges from serial generation.
+        """
+        prompt = mx.array([0, 1, 2, 3], dtype=mx.uint32)
+        n_tokens = 10
+
+        def context_processor(tokens, logits):
+            if tokens is None or tokens.size == 0:
+                return logits
+            target = (int(tokens[-1].item()) + 1) % logits.shape[-1]
+            # 1D boost broadcasts correctly for both (vocab,) and (1, vocab) logits.
+            boost = mx.zeros(logits.shape[-1])
+            return logits + boost.at[target].add(10.0)
+
+        std_cache = make_prompt_cache(self.model)
+        std_tokens = []
+        for i, (tok, _) in enumerate(
+            generate_step(
+                prompt,
+                self.model,
+                prompt_cache=std_cache,
+                logits_processors=[context_processor],
+            )
+        ):
+            std_tokens.append(int(tok))
+            if i + 1 >= n_tokens:
+                break
+
+        mtp_tokens = []
+        for tok, _, _ in mtp_generate_step(
+            prompt,
+            self.model,
+            max_tokens=n_tokens,
+            logits_processors=[context_processor],
+        ):
+            mtp_tokens.append(int(tok))
+            if len(mtp_tokens) >= n_tokens:
+                break
+
+        self.assertEqual(std_tokens, mtp_tokens)
+
+    def test_mtp_processor_prev_tokens_correct_at_draft_step(self):
+        """The processor must see the just-sampled backbone token as tokens[-1]
+        when the MTP head runs, not the preceding input token.
+
+        A forcing processor logs tokens[-1] on every call.  When tokens[-1] equals
+        the last prompt token (3) it applies a large boost to token 4, guaranteeing
+        the backbone samples token 4 regardless of model weights.  The second
+        processor call comes from the MTP head: if the token context is correct it
+        sees 4; if stale it sees 3 again.
+        """
+        # Last prompt token is 3; the forcing processor boosts token 4 when it
+        # sees 3, so the backbone deterministically samples T0 = 4 regardless of weights.
+        prompt = mx.array([0, 1, 2, 3], dtype=mx.uint32)
+
+        logged: list[int] = []
+
+        def forcing_processor(tokens, logits):
+            if tokens is not None and tokens.size > 0:
+                last = int(tokens[-1].item())
+                logged.append(last)
+                if last == 3:
+                    boost = mx.zeros(logits.shape[-1])
+                    return logits + boost.at[4].add(1000.0)
+            return logits
+
+        for _tok, _, _ in mtp_generate_step(
+            prompt,
+            self.model,
+            max_tokens=2,
+            logits_processors=[forcing_processor],
+        ):
+            pass
+
+        # First call (backbone): context is the last prompt token.
+        self.assertGreaterEqual(len(logged), 2)
+        self.assertEqual(logged[0], 3)
+        # Second call (MTP head): context must be T0 = 4, not the prompt token.
+        self.assertEqual(logged[1], 4)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_mtp.py
+++ b/tests/test_mtp.py
@@ -127,24 +127,19 @@ class TestMTP(unittest.TestCase):
         prompt = mx.array([0, 1, 2, 3], dtype=mx.uint32)
         n_tokens = 10
 
-        def greedy(logprobs):
-            return mx.argmax(logprobs, axis=-1)
-
-        # Standard generation
+        # Standard generation, greedy (default sampler is argmax).
         std_cache = make_prompt_cache(self.model)
         std_tokens = []
         for i, (tok, _) in enumerate(
-            generate_step(prompt, self.model, sampler=greedy, prompt_cache=std_cache)
+            generate_step(prompt, self.model, prompt_cache=std_cache)
         ):
             std_tokens.append(int(tok))
             if i + 1 >= n_tokens:
                 break
 
-        # MTP generation
+        # MTP generation, greedy (sampler=None uses exact-match acceptance).
         mtp_tokens = []
-        for tok, _, _ in mtp_generate_step(
-            prompt, self.model, sampler=greedy, max_tokens=n_tokens
-        ):
+        for tok, _, _ in mtp_generate_step(prompt, self.model, max_tokens=n_tokens):
             mtp_tokens.append(int(tok))
             if len(mtp_tokens) >= n_tokens:
                 break
@@ -155,22 +150,20 @@ class TestMTP(unittest.TestCase):
             f"Token mismatch: std={std_tokens}, mtp={mtp_tokens}",
         )
 
-    def test_mtp_generate_runs(self):
-        """mtp_generate_step should complete without errors.
+    def test_mtp_probabilistic_acceptance_completes(self):
+        """mtp_generate_step should complete without errors with a stochastic sampler.
 
-        Exercises the full end-to-end path: prefill, backbone forward with
-        return_hidden, MTP draft generation, verification with n_confirmed,
-        SSM rollback on rejection, and MTP cache trimming.
+        Exercises the probabilistic acceptance path: min(1, p_target / p_draft).
         """
         prompt = mx.array([0, 1, 2, 3], dtype=mx.uint32)
         n_tokens = 10
 
-        def greedy(logprobs):
-            return mx.argmax(logprobs, axis=-1)
+        def stochastic(logprobs):
+            return mx.random.categorical(logprobs)
 
         tokens = []
         for tok, _, _ in mtp_generate_step(
-            prompt, self.model, sampler=greedy, max_tokens=n_tokens
+            prompt, self.model, sampler=stochastic, max_tokens=n_tokens
         ):
             tokens.append(int(tok))
             if len(tokens) >= n_tokens:

--- a/tests/test_mtp.py
+++ b/tests/test_mtp.py
@@ -257,6 +257,41 @@ class TestMTP(unittest.TestCase):
         # Second call (MTP head): context must be T0 = 4, not the prompt token.
         self.assertEqual(logged[1], 4)
 
+    def test_mtp_rejection_residual_sampling(self):
+        """On rejection at temp>0, the emitted token must be sampled from the
+        residual distribution max(p_target - p_draft, 0) / Z, not the backbone
+        argmax. The argmax is deterministic for a fixed model state, so rejection
+        tokens would always be identical. Residual sampling produces a
+        distribution, so tokens must vary across runs.
+
+        Using max_tokens=1 yields exactly one token per run: the accepted draft
+        (from_draft=True) or the rejection token (from_draft=False). This avoids
+        conflating rejection tokens with bonus tokens (also from_draft=False).
+        """
+        prompt = mx.array([0, 1, 2, 3], dtype=mx.uint32)
+
+        def stochastic(logprobs):
+            return mx.random.categorical(logprobs)
+
+        rejection_tokens: list[int] = []
+        for _ in range(60):
+            for tok, _, from_draft in mtp_generate_step(
+                prompt, self.model, sampler=stochastic, max_tokens=1
+            ):
+                if not from_draft:
+                    rejection_tokens.append(int(tok))
+
+        self.assertGreaterEqual(
+            len(rejection_tokens),
+            5,
+            "Too few rejection events observed; increase n_runs",
+        )
+        self.assertGreater(
+            len(set(rejection_tokens)),
+            1,
+            "Rejection tokens are always identical, argmax bug likely present",
+        )
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_mtp.py
+++ b/tests/test_mtp.py
@@ -153,23 +153,24 @@ class TestMTP(unittest.TestCase):
     def test_mtp_probabilistic_acceptance_completes(self):
         """mtp_generate_step should complete without errors with a stochastic sampler.
 
-        Exercises the probabilistic acceptance path: min(1, p_target / p_draft).
+        Exercises the probabilistic acceptance path: min(1, p_target / p_draft),
+        both with bare temp (no filters) and with top_k applied.
         """
         prompt = mx.array([0, 1, 2, 3], dtype=mx.uint32)
         n_tokens = 10
 
-        def stochastic(logprobs):
-            return mx.random.categorical(logprobs)
-
-        tokens = []
-        for tok, _, _ in mtp_generate_step(
-            prompt, self.model, sampler=stochastic, max_tokens=n_tokens
-        ):
-            tokens.append(int(tok))
-            if len(tokens) >= n_tokens:
-                break
-
-        self.assertEqual(len(tokens), n_tokens)
+        for kwargs in [
+            {"temp": 0.7},
+            {"temp": 0.7, "top_k": 10},
+        ]:
+            tokens = []
+            for tok, _, _ in mtp_generate_step(
+                prompt, self.model, max_tokens=n_tokens, **kwargs
+            ):
+                tokens.append(int(tok))
+                if len(tokens) >= n_tokens:
+                    break
+            self.assertEqual(len(tokens), n_tokens, f"kwargs={kwargs}")
 
     def test_mtp_generate_identity_with_logits_processor(self):
         """mtp_generate_step must produce the same greedy tokens as generate_step
@@ -257,6 +258,31 @@ class TestMTP(unittest.TestCase):
         # Second call (MTP head): context must be T0 = 4, not the prompt token.
         self.assertEqual(logged[1], 4)
 
+    def _collect_rejection_tokens(self, n_runs=60, **kwargs):
+        """Run mtp_generate_step n_runs times with max_tokens=1 and return all
+        rejection tokens (from_draft=False)."""
+        prompt = mx.array([0, 1, 2, 3], dtype=mx.uint32)
+        rejection_tokens: list[int] = []
+        for _ in range(n_runs):
+            for tok, _, from_draft in mtp_generate_step(
+                prompt, self.model, max_tokens=1, **kwargs
+            ):
+                if not from_draft:
+                    rejection_tokens.append(int(tok))
+        return rejection_tokens
+
+    def _assert_residual_varies(self, rejection_tokens, label=""):
+        self.assertGreaterEqual(
+            len(rejection_tokens),
+            5,
+            f"{label}Too few rejection events observed; increase n_runs",
+        )
+        self.assertGreater(
+            len(set(rejection_tokens)),
+            1,
+            f"{label}Rejection tokens are always identical, argmax bug likely present",
+        )
+
     def test_mtp_rejection_residual_sampling(self):
         """On rejection at temp>0, the emitted token must be sampled from the
         residual distribution max(p_target - p_draft, 0) / Z, not the backbone
@@ -268,29 +294,7 @@ class TestMTP(unittest.TestCase):
         (from_draft=True) or the rejection token (from_draft=False). This avoids
         conflating rejection tokens with bonus tokens (also from_draft=False).
         """
-        prompt = mx.array([0, 1, 2, 3], dtype=mx.uint32)
-
-        def stochastic(logprobs):
-            return mx.random.categorical(logprobs)
-
-        rejection_tokens: list[int] = []
-        for _ in range(60):
-            for tok, _, from_draft in mtp_generate_step(
-                prompt, self.model, sampler=stochastic, max_tokens=1
-            ):
-                if not from_draft:
-                    rejection_tokens.append(int(tok))
-
-        self.assertGreaterEqual(
-            len(rejection_tokens),
-            5,
-            "Too few rejection events observed; increase n_runs",
-        )
-        self.assertGreater(
-            len(set(rejection_tokens)),
-            1,
-            "Rejection tokens are always identical, argmax bug likely present",
-        )
+        self._assert_residual_varies(self._collect_rejection_tokens(temp=1.0))
 
 
 if __name__ == "__main__":

--- a/tests/test_mtp.py
+++ b/tests/test_mtp.py
@@ -106,16 +106,6 @@ class TestMTP(unittest.TestCase):
         normed = lm.model.norm(hidden)
         self.assertFalse(mx.allclose(hidden, normed, atol=1e-5).item())
 
-    def test_quant_predicate_excludes_mtp_fc(self):
-        """quant_predicate should exclude mtp.fc from quantization."""
-        lm = self.model.language_model
-        predicate = lm.quant_predicate
-        self.assertIsNotNone(predicate)
-        # mtp.fc should not be quantized
-        self.assertFalse(predicate("mtp.fc", None))
-        # Regular layers should be quantized
-        self.assertTrue(predicate("layers.0.mlp.gate_proj", None))
-
     def test_mtp_generate_identity(self):
         """mtp_generate_step should produce the same greedy tokens as generate_step.
 

--- a/tests/test_mtp.py
+++ b/tests/test_mtp.py
@@ -140,6 +140,29 @@ class TestMTP(unittest.TestCase):
             f"Token mismatch: std={std_tokens}, mtp={mtp_tokens}",
         )
 
+    def test_mtp_prompt_progress_callback(self):
+        """prompt_progress_callback must fire during prefill and reach
+        (total, total) once the last prompt token has been processed."""
+        prompt = mx.array(list(range(20)), dtype=mx.uint32)
+        calls = []
+
+        def progress_callback(processed: int, total: int) -> None:
+            calls.append((processed, total))
+
+        for _, _, _ in mtp_generate_step(
+            prompt,
+            self.model,
+            max_tokens=1,
+            prefill_step_size=5,
+            prompt_progress_callback=progress_callback,
+        ):
+            pass
+
+        self.assertTrue(len(calls) > 0)
+        total = len(prompt)
+        self.assertTrue(all(t == total for _, t in calls))
+        self.assertEqual(calls[-1], (total, total))
+
     def test_mtp_probabilistic_acceptance_completes(self):
         """mtp_generate_step should complete without errors with a stochastic sampler.
 

--- a/tests/test_mtp.py
+++ b/tests/test_mtp.py
@@ -394,7 +394,9 @@ class TestMTP(unittest.TestCase):
         self.assertEqual(state.num_tokens, expected_tokens)
         self.assertEqual(state.last_hidden.shape, (1, 1, 64))
 
-        target_attention = next(c for c in prompt_cache[:n_main] if c.is_trimmable())
+        target_attention = next(
+            c for c in prompt_cache[:n_main] if hasattr(c, "offset")
+        )
         mtp_attention = prompt_cache[n_main]
         self.assertEqual(target_attention.offset, expected_tokens)
         self.assertEqual(mtp_attention.offset, expected_tokens - 1)

--- a/tests/test_mtp.py
+++ b/tests/test_mtp.py
@@ -1,10 +1,18 @@
 import importlib
+import itertools
+import tempfile
 import unittest
+import warnings
 
 import mlx.core as mx
 
 from mlx_lm.generate import generate_step, mtp_generate_step
-from mlx_lm.models.cache import make_prompt_cache
+from mlx_lm.models.cache import (
+    MTPPromptCacheState,
+    load_prompt_cache,
+    make_prompt_cache,
+    save_prompt_cache,
+)
 
 
 def _make_qwen3_5_mtp_model():
@@ -43,6 +51,32 @@ def _make_qwen3_5_mtp_model():
     return model
 
 
+def _make_qwen3_5_moe_mtp_model():
+    module = importlib.import_module("mlx_lm.models.qwen3_5_moe")
+    args = module.ModelArgs.from_dict(
+        {
+            "model_type": "qwen3_5_moe",
+            "text_config": {
+                "model_type": "qwen3_5_moe",
+                "hidden_size": 32,
+                "intermediate_size": 64,
+                "num_hidden_layers": 1,
+                "num_attention_heads": 4,
+                "num_key_value_heads": 2,
+                "vocab_size": 64,
+                "full_attention_interval": 1,
+                "head_dim": 8,
+                "num_experts": 2,
+                "num_experts_per_tok": 1,
+                "moe_intermediate_size": 16,
+                "shared_expert_intermediate_size": 16,
+                "mtp_num_hidden_layers": 1,
+            },
+        }
+    )
+    return module.Model(args)
+
+
 class TestMTP(unittest.TestCase):
     """Tests for native MTP (Multi-Token Prediction) speculative decoding.
 
@@ -72,6 +106,34 @@ class TestMTP(unittest.TestCase):
         mtp_cache = self.model.make_mtp_cache()
         self.assertEqual(len(mtp_cache), 1)
         self.assertTrue(mtp_cache[0].is_trimmable())
+
+    def test_missing_mtp_weights_disable_head(self):
+        model = _make_qwen3_5_mtp_model()
+        self.assertTrue(model.supports_mtp)
+        with warnings.catch_warnings(record=True) as caught:
+            warnings.simplefilter("always")
+            model.sanitize({})
+        self.assertTrue(
+            any(
+                "configuration declares an MTP head" in str(item.message)
+                and "no MTP tensors" in str(item.message)
+                for item in caught
+            )
+        )
+        self.assertFalse(model.supports_mtp)
+        self.assertEqual(model.make_mtp_cache(), [])
+
+    def test_missing_mtp_moe_weights_do_not_crash(self):
+        model = _make_qwen3_5_moe_mtp_model()
+        self.assertTrue(model.supports_mtp)
+        model.sanitize({})
+        self.assertFalse(model.supports_mtp)
+
+    def test_mtp_rejects_input_embeddings(self):
+        prompt = mx.array([0, 1], dtype=mx.uint32)
+        embeddings = mx.zeros((2, 64))
+        with self.assertRaisesRegex(ValueError, "input_embeddings"):
+            next(mtp_generate_step(prompt, self.model, input_embeddings=embeddings))
 
     def test_return_hidden(self):
         """return_hidden=True should return (logits, hidden) with correct shapes."""
@@ -185,6 +247,56 @@ class TestMTP(unittest.TestCase):
                     break
             self.assertEqual(len(tokens), n_tokens, f"kwargs={kwargs}")
 
+    def test_mtp_infinite_max_tokens(self):
+        prompt = mx.array([0, 1, 2, 3], dtype=mx.uint32)
+        tokens = list(
+            itertools.islice(
+                mtp_generate_step(prompt, self.model, max_tokens=-1),
+                3,
+            )
+        )
+        self.assertEqual(len(tokens), 3)
+
+    def test_mtp_extends_fresh_prompt_cache(self):
+        prompt = mx.array([0, 1, 2, 3], dtype=mx.uint32)
+        prompt_cache = make_prompt_cache(self.model)
+        n_main = len(prompt_cache)
+        generator = mtp_generate_step(
+            prompt,
+            self.model,
+            max_tokens=1,
+            prompt_cache=prompt_cache,
+        )
+        next(generator)
+        generator.close()
+        self.assertEqual(len(prompt_cache), n_main + 2)
+
+    def test_mtp_rejects_unaligned_populated_prompt_cache(self):
+        prompt_cache = make_prompt_cache(self.model)
+        self.model(mx.array([[0, 1]], dtype=mx.uint32), cache=prompt_cache)
+        with self.assertRaisesRegex(ValueError, "MTP cache entries and boundary state"):
+            next(
+                mtp_generate_step(
+                    mx.array([2, 3], dtype=mx.uint32),
+                    self.model,
+                    prompt_cache=prompt_cache,
+                )
+            )
+
+    def test_mtp_rejects_stateful_logits_processor(self):
+        class StatefulProcessor:
+            def __call__(self, tokens, logits):
+                return logits
+
+        with self.assertRaisesRegex(ValueError, "stateless logits processors"):
+            next(
+                mtp_generate_step(
+                    mx.array([0, 1, 2, 3], dtype=mx.uint32),
+                    self.model,
+                    logits_processors=[StatefulProcessor()],
+                )
+            )
+
     def test_mtp_generate_identity_with_logits_processor(self):
         """mtp_generate_step must produce the same greedy tokens as generate_step
         when a context-sensitive stateless processor is applied.
@@ -270,6 +382,117 @@ class TestMTP(unittest.TestCase):
         self.assertEqual(logged[0], 3)
         # Second call (MTP head): context must be T0 = 4, not the prompt token.
         self.assertEqual(logged[1], 4)
+
+    def _assert_transactional_prompt_cache(self, prompt_cache, expected_tokens):
+        n_main = len(self.model.layers)
+        n_mtp = len(self.model.make_mtp_cache())
+        self.assertEqual(len(prompt_cache), n_main + n_mtp + 1)
+
+        state = prompt_cache[-1]
+        self.assertIsInstance(state, MTPPromptCacheState)
+        self.assertFalse(state.empty())
+        self.assertEqual(state.num_tokens, expected_tokens)
+        self.assertEqual(state.last_hidden.shape, (1, 1, 64))
+
+        target_attention = next(c for c in prompt_cache[:n_main] if c.is_trimmable())
+        mtp_attention = prompt_cache[n_main]
+        self.assertEqual(target_attention.offset, expected_tokens)
+        self.assertEqual(mtp_attention.offset, expected_tokens - 1)
+
+    def test_mtp_prompt_cache_finalizes_at_length_boundary(self):
+        prompt = mx.array([0, 1, 2, 3], dtype=mx.uint32)
+        prompt_cache = make_prompt_cache(self.model)
+
+        output = list(
+            mtp_generate_step(
+                prompt,
+                self.model,
+                max_tokens=1,
+                prompt_cache=prompt_cache,
+            )
+        )
+        self.assertEqual(len(output), 1)
+        self._assert_transactional_prompt_cache(prompt_cache, len(prompt) + 1)
+
+    def test_mtp_prompt_cache_finalizes_on_generator_close(self):
+        prompt = mx.array([0, 1, 2, 3], dtype=mx.uint32)
+        prompt_cache = make_prompt_cache(self.model)
+        generator = mtp_generate_step(
+            prompt,
+            self.model,
+            max_tokens=10,
+            prompt_cache=prompt_cache,
+        )
+
+        next(generator)
+        generator.close()
+        self._assert_transactional_prompt_cache(prompt_cache, len(prompt) + 1)
+
+    def test_mtp_prompt_cache_reuse_matches_uncached_generation(self):
+        prompt = mx.array([0, 1, 2, 3], dtype=mx.uint32)
+        suffix = [10, 11]
+        prompt_cache = make_prompt_cache(self.model)
+
+        first_turn = [
+            int(token)
+            for token, _, _ in mtp_generate_step(
+                prompt,
+                self.model,
+                max_tokens=3,
+                prompt_cache=prompt_cache,
+            )
+        ]
+        transcript = prompt.tolist() + first_turn
+
+        cached_tokens = [
+            int(token)
+            for token, _, _ in mtp_generate_step(
+                mx.array(suffix, dtype=mx.uint32),
+                self.model,
+                max_tokens=6,
+                prompt_cache=prompt_cache,
+            )
+        ]
+        uncached_tokens = [
+            int(token)
+            for token, _, _ in mtp_generate_step(
+                mx.array(transcript + suffix, dtype=mx.uint32),
+                self.model,
+                max_tokens=6,
+            )
+        ]
+
+        self.assertEqual(cached_tokens, uncached_tokens)
+        self._assert_transactional_prompt_cache(
+            prompt_cache,
+            len(transcript) + len(suffix) + len(cached_tokens),
+        )
+
+    def test_mtp_prompt_cache_state_round_trip(self):
+        prompt = mx.array([0, 1, 2, 3], dtype=mx.uint32)
+        prompt_cache = make_prompt_cache(self.model)
+        list(
+            mtp_generate_step(
+                prompt,
+                self.model,
+                max_tokens=2,
+                prompt_cache=prompt_cache,
+            )
+        )
+
+        with tempfile.TemporaryDirectory() as directory:
+            path = f"{directory}/mtp-cache.safetensors"
+            save_prompt_cache(path, prompt_cache)
+            loaded = load_prompt_cache(path)
+
+        self.assertIsInstance(loaded[-1], MTPPromptCacheState)
+        self.assertEqual(loaded[-1].num_tokens, prompt_cache[-1].num_tokens)
+        self.assertTrue(
+            mx.allclose(
+                loaded[-1].last_hidden,
+                prompt_cache[-1].last_hidden,
+            ).item()
+        )
 
     def _collect_rejection_tokens(self, n_runs=60, **kwargs):
         """Run mtp_generate_step n_runs times with max_tokens=1 and return all


### PR DESCRIPTION
## Summary

Qwen3.5 checkpoints ship with a built-in Multi-Token Prediction head (`mtp_num_hidden_layers: 1` in config) that predicts token t+2 from the backbone hidden state at t and the embedding of token t+1. This PR adds support for using it as a native speculative decoding mechanism. No separate draft model needed, at minimal extra compute (1 extra transformer layer).

## Changes

- **`mlx_lm/generate.py`**: MTP generation loop with draft/verify and probabilistic acceptance, `--mtp` CLI flag
- **`mlx_lm/models/cache.py`**: `rollback_state` slot for conv/SSM snapshot on draft rejection
- **`mlx_lm/sample_utils.py`**: `p_draw` parameter added to `apply_xtc` to share the XTC draw across draft and verify
- **`mlx_lm/models/qwen3_5.py`**: MTP head module, `self.norm` moved to `TextModel` to expose pre-norm hidden states for MTP, `n_confirmed` parameter for SSM rollback, `sanitize`: norm +1 shift now triggered only on raw HF checkpoints (unsanitized conv1d), not on presence of MTP weights, and MoE gate weights at 8-bit group=64
- **`mlx_lm/models/qwen3_5_moe.py`**: MTP checkpoint sanitization for MoE variants + handling both Qwen3.5 and Qwen3.6 (fused `gate_up_proj`)
- **`mlx_lm/server.py`**: `--mtp` flag, dynamic MTP/batch switching + fix `xtc_special_tokens` construction
- **`tests/test_mtp.py`**: 10 unit tests

## How it works

Each backbone forward pass returns both logits and pre-norm hidden states. The MTP head fuses `pre_fc_norm_hidden(h_t)` and `pre_fc_norm_embedding(embed(t+1))` via a linear projection, runs one full-attention transformer layer, and produces draft logits through the shared `lm_head`.

The generation loop verifies drafts by feeding `[confirmed_tok, draft_tok]` to the backbone with `n_confirmed=1`. This causes `GatedDeltaNet` to snapshot its conv/SSM state after the confirmed token. On acceptance, both tokens are emitted. On rejection, the SSM state is rolled back to the snapshot and KV caches are trimmed.

## Results (Qwen3.6-27B 4-bit, M4 Pro)

Pooled tok/s, 3 runs × 8 prompts, conditions interleaved. See [bench_mtp.py](https://gist.github.com/AirRunner/e3aafd4de78c2cba4f4e233261cd64f2).

*Acceptance is reported as A/V (drafts accepted / drafts proposed), the standard speculative decoding metric. The benchmark script also reports `A/(V+A)` (~46% for Qwen3.6-27B at temp=0.6), which equals `A/V ÷ (1 + A/V)` and is used in some implementations.*

| Condition | Tok/s | Speedup | Accept (A/V) |
|---|---|---|---|
| Baseline | 15.7 | 1.00x | — |
| MTP temp=0 | 24.6 | **1.57x** | 88.3% |
| MTP temp=0.6 | 24.0 | **1.53x** | 84.8% |
| MTP temp=1.0 | 23.5 | **1.50x** | 80.5% |

Identity check: greedy MTP output == standard `generate_step` output.

## Usage

```bash
mlx_lm.generate --model <path> --mtp
mlx_lm.server   --model <path> --mtp
```

## Checkpoint conversion

This requires a checkpoint converted with MTP weights (the default `sanitize()` previously stripped them). Re-convert from HF with this branch to preserve `mtp.*` weights.

**Note on M1/M2:** M1 and M2 lack [native BF16 GPU support](https://news.ycombinator.com/item?id=36575443) (`MTLDataType.bfloat` requires Apple8+). If you choose not to quantise `mtp.fc` on M1/M2, you need to add the flag the flag `--dtype float16` to the convert command. Without it, MTP may drastically slow down on M1 despite positive acceptance rates.

## BatchGenerator

**Dynamic MTP/batch switching**: the server now auto-switches based on `self.requests.empty()`: MTP for solo requests and `BatchGenerator` for concurrent ones. Is a best-effort queue check the right approach, or is there a preferred pattern in the server architecture?

> Addressed in [feat/mtp-batched](https://github.com/AirRunner/mlx-lm/tree/feat/mtp-batched) where `GenerationBatch` supports MTP natively for B > 1

## Future work

### DRY refactor + SamplerConfig

A follow-up PR independent of MTP would address:

1. Code duplication across the now three generator functions:
- `_prefill` logic: 3 variants across `generate_step`, `speculative_generate_step`, and `mtp_generate_step`
- `_process_and_sample`: almost same pattern in `speculative_generate_step` and `mtp_generate_step`
- `quantize_cache_fn = functools.partial(...)`: same pattern in all three

2. `SamplerConfig`: currently `mtp_generate_step` cannot accept a pre-built `sampler=` callable and produce correct acceptance logprobs simultaneously. A `sampler` today returns only a token, but for MTP the acceptance criterion also needs the log-probability distribution the token was drawn from. The fix is a richer sampler interface that returns `(token, lp_distribution)`, allowing both `generate_step` and `mtp_generate_step` to share the same interface without passing a dozen individual parameters.

Beyond DRY, `SamplerConfig` unlocks a potential performance gain: sparse residual sampling.
On rejection at `temp > 0`, the current implementation samples from `max(p_target - p_draft, 0) / Z` over the full vocabulary (151K-token for Qwen3.5, 580 µs/call). With `top_k > 0`, the sampler already computes a top-k partition over the vocabulary, so exposing those indices lets the rejection path work on a K-token support instead.
Without a `SamplerConfig`, re-running argpartition specifically for the rejection path is slower or equal to the full-vocab path.

### Batched MTP

This PR brings MTP for the solo request path only.
However, per-sequence selective rollback (restore SSM state + trim KV only for rejected sequences) is already implemented in [`AirRunner/mlx-lm · feat/mtp-batched`](https://github.com/AirRunner/mlx-lm/tree/feat/mtp-batched), left out of this PR to keep the diff reviewable.

### Depth > 1 (`mtp_depth`)

Generic depth>1 speculation is implemented in [`feat/mtp-depth`](https://github.com/AirRunner/mlx-lm/tree/feat/mtp-depth), initially left out of this PR since earlier benchmarks showed depth=2 losing to depth=1 (small-M verify cost growing faster than the acceptance gain).

That verify cost jump seems to have shrunk with `qmv_wide` ([mlx#3764](https://github.com/ml-explore/mlx/pull/3764), mlx 0.32.0+), a preliminary re-check has depth=2 edging out depth=1 for the first time.

## Test plan

- Unit tests (10/10 passing) — module existence, cache creation, shapes, pre-norm hidden states, quant predicate, generation identity, end-to-end
- Manual validation on Qwen3.5-27B, Qwen3.5-0.8B and Qwen3.5-35B-A3B (all 4-bit)

Relates to #872 — cc @janhilgard

---

## Update - probabilistic acceptance and MoE benchmarks

Integrated probabilistic draft acceptance with two cases:

1. **Greedy** (`temp == 0`): exact-match acceptance, mathematically correct for deterministic argmax sampling
2. **Stochastic** (`temp > 0`): `min(1, p_target / p_draft)`: recovers greedy acceptance level at any temperature

#### Benchmarks on M4 Pro, with 8 diverse prompts:

A reproducible benchmark script is available: [bench_mtp.py](https://gist.github.com/AirRunner/e3aafd4de78c2cba4f4e233261cd64f2)

**Qwen3.5-27B 4-bit**

| | Tok/s | Speedup | Acceptance (A/V) |
|---|---|---|---|
| No MTP | 15.3 | 1.00x | — |
| MTP, temp=0 | 24.0 | **1.57x** | 85.2% |
| MTP, temp=0.6, exact match | 22.7 | 1.49x | 75.4% |
| MTP, temp=0.6, probabilistic | 22.9 | **1.51x** | 85.2% |

**Qwen3.5-35B-A3B 4-bit**

| | Tok/s | Speedup | Acceptance (A/V) |
|---|---|---|---|
| No MTP | 85.3 | 1.00x | — |
| MTP, temp=0 | 87.9 | **1.04x** | 85.2% |
| MTP, temp=0.6, exact match | 84.5 | 0.98x | 78.6% |
| MTP, temp=0.6, probabilistic | 86.5 | **1.03x** | 85.2% |

On M4 Pro MoE speedup is marginal regardless of acceptance rate. MTP benefit scales with baseline decode time, so at 85 tok/s (3B active params) the MTP overhead is proportionally too large to yield meaningful speedup. With probabilistic acceptance, acceptance rates are consistent with the dense model (~85%).

### Bandwidth model

The cross-hardware speedup variation is explained by `speedup = (1+p) / (β+δ)`, where `p` is the per-round acceptance probability, `β = T_verify_backbone / T_baseline`, and `δ = T_mtp_head / T_baseline`. Full derivation and per-component bandwidth estimates in [this comment](https://github.com/ml-explore/mlx-lm/pull/990#issuecomment-4277270662).

For reference:
- @Thump604's MoE results (M2 Ultra, 8-bit, temp=0, exact match): 35B-A3B 1.11x, 122B-A10B 1.09x.
- @sammcj results (M5 Max, 4-bit, temp=0): 9B +11.3%, 27B +35.5%, 122B +12.4%.
- @Anionex results (M5 Pro, 4-bit, temp=0): 27B +31.4%, 79.5% acceptance (A/V).