### PR TITLE
Strip whitespace from tool call function names

### DIFF
--- a/mlx_lm/tool_parsers/glm47.py
+++ b/mlx_lm/tool_parsers/glm47.py
@@ -12,7 +12,7 @@ from typing import Any
 
 import regex as re
 
-_func_name_regex = re.compile(r"^(.*?)<arg_key>", re.DOTALL)
+_func_name_regex = re.compile(r"^(.*?)\s*<arg_key>", re.DOTALL)
 _func_arg_regex = re.compile(
     r"<arg_key>(.*?)</arg_key>(?:\\n|\s)*<arg_value>(.*?)</arg_value>",
     re.DOTALL,


### PR DESCRIPTION
Some models (e.g. GLM-4.5-Air) emit tool call function names with trailing newlines, causing OpenAI-compatible clients to fail with "tool not found" errors.