### PR TITLE
Fix/prefix cache hybrid models

### DIFF
--- a/mlx_lm/models/cache.py
+++ b/mlx_lm/models/cache.py
@@ -538,12 +538,18 @@ class RotatingKVCache(_BaseCache):
         )
 
     def is_trimmable(self):
-        return self.offset < self.max_size
+        return True
 
     def trim(self, n):
         n = min(self.offset, n)
-        self.offset -= n
-        self._idx -= n
+        if n >= self.max_size or n == self.offset:
+            self.keys = None
+            self.values = None
+            self.offset = 0
+            self._idx = 0
+        else:
+            self.offset -= n
+            self._idx = (self._idx - n) % self.max_size
         return n
 
     def to_quantized(self, group_size: int = 64, bits: int = 4) -> QuantizedKVCache:
@@ -1240,12 +1246,19 @@ class BatchRotatingKVCache(_BaseCache):
         self.rotated = bool(v[3])
 
     def is_trimmable(self):
-        return self._offset < self.max_size
+        return True
 
     def trim(self, n):
         n = min(self._offset, n)
-        self._offset -= n
-        self._idx -= n
+        if n >= self.max_size or n == self._offset:
+            self.keys = None
+            self.values = None
+            self._offset = 0
+            self._idx = 0
+            self.rotated = False
+        else:
+            self._offset -= n
+            self._idx = (self._idx - n) % self.max_size
         self.offset -= n
         return n
 

--- a/mlx_lm/models/cache.py
+++ b/mlx_lm/models/cache.py
@@ -1359,6 +1359,8 @@ class BatchRotatingKVCache(_BaseCache):
 
     def extract(self, idx):
         cache = RotatingKVCache(self.max_size)
+        if self.keys is None:
+            return cache
         padding = self.left_padding[idx].item()
         offset = self.offset[idx].item()
         cache.keys = self.keys[idx : idx + 1]

--- a/mlx_lm/models/cache.py
+++ b/mlx_lm/models/cache.py
@@ -541,8 +541,9 @@ class RotatingKVCache(_BaseCache):
         return True
 
     def trim(self, n):
-        n = min(self.offset, n)
-        if n >= self.max_size or n == self.offset:
+        effective = min(self.offset, self.max_size)
+        n = min(effective, n)
+        if n == effective:
             self.keys = None
             self.values = None
             self.offset = 0
@@ -1252,8 +1253,9 @@ class BatchRotatingKVCache(_BaseCache):
         return True
 
     def trim(self, n):
-        n = min(self._offset, n)
-        if n >= self.max_size or n == self._offset:
+        effective = min(self._offset, self.max_size)
+        n = min(effective, n)
+        if n == effective:
             self.keys = None
             self.values = None
             self._offset = 0

--- a/mlx_lm/models/cache.py
+++ b/mlx_lm/models/cache.py
@@ -548,8 +548,11 @@ class RotatingKVCache(_BaseCache):
             self.offset = 0
             self._idx = 0
         else:
-            self.offset -= n
-            self._idx = (self._idx - n) % self.max_size
+            new_size = effective - n
+            self.keys = self._temporal_order(self.keys)[..., :new_size, :]
+            self.values = self._temporal_order(self.values)[..., :new_size, :]
+            self.offset = new_size
+            self._idx = new_size
         return n
 
     def to_quantized(self, group_size: int = 64, bits: int = 4) -> QuantizedKVCache:
@@ -1257,8 +1260,12 @@ class BatchRotatingKVCache(_BaseCache):
             self._idx = 0
             self.rotated = False
         else:
-            self._offset -= n
-            self._idx = (self._idx - n) % self.max_size
+            new_size = effective - n
+            self._temporal_order()
+            self.keys = self.keys[..., :new_size, :]
+            self.values = self.values[..., :new_size, :]
+            self._offset = new_size
+            self._idx = new_size
         self.offset -= n
         return n
 

--- a/mlx_lm/models/cache.py
+++ b/mlx_lm/models/cache.py
@@ -413,6 +413,7 @@ class RotatingKVCache(_BaseCache):
         self.keys = None
         self.values = None
         self.offset = 0
+        self._offset = 0
         self.max_size = max_size
         self._idx = 0
 
@@ -432,7 +433,7 @@ class RotatingKVCache(_BaseCache):
         """
         if self._idx == v.shape[2]:
             return v
-        elif self._idx < self.offset:
+        elif self._idx < self._offset:
             return mx.concatenate(
                 [
                     v[..., : self.keep, :],
@@ -461,6 +462,7 @@ class RotatingKVCache(_BaseCache):
             self.keys = self._trim(trim_size, self.keys, keys)
             self.values = self._trim(trim_size, self.values, values)
         self.offset += keys.shape[2]
+        self._offset += keys.shape[2]
         self._idx = self.keys.shape[2]
         return self.keys, self.values
 
@@ -468,7 +470,7 @@ class RotatingKVCache(_BaseCache):
         # May not have hit the max size yet, so potentially
         # keep growing the cache
         B, n_kv_heads, S, k_head_dim = keys.shape
-        prev = self.offset
+        prev = self._offset
         if self.keys is None or (
             prev >= self.keys.shape[2] and self.keys.shape[2] < self.max_size
         ):
@@ -500,11 +502,15 @@ class RotatingKVCache(_BaseCache):
         self.keys[..., self._idx : self._idx + S, :] = keys
         self.values[..., self._idx : self._idx + S, :] = values
         self.offset += S
+        self._offset += S
         self._idx += S
 
         # If the buffer is not full, slice off the end
-        if self.offset < self.max_size:
-            return self.keys[..., : self.offset, :], self.values[..., : self.offset, :]
+        if self._offset < self.max_size:
+            return (
+                self.keys[..., : self._offset, :],
+                self.values[..., : self._offset, :],
+            )
         return self.keys, self.values
 
     def update_and_fetch(self, keys, values):
@@ -513,12 +519,15 @@ class RotatingKVCache(_BaseCache):
         return self._update_concat(keys, values)
 
     def size(self):
-        return min(self.offset, self.max_size)
+        return min(self._offset, self.max_size)
 
     @property
     def state(self):
-        if self.offset < self.keys.shape[2]:
-            return self.keys[..., : self.offset, :], self.values[..., : self.offset, :]
+        if self._offset < self.keys.shape[2]:
+            return (
+                self.keys[..., : self._offset, :],
+                self.values[..., : self._offset, :],
+            )
         else:
             return self.keys, self.values
 
@@ -528,32 +537,36 @@ class RotatingKVCache(_BaseCache):
 
     @property
     def meta_state(self):
-        return tuple(map(str, (self.keep, self.max_size, self.offset, self._idx)))
+        return tuple(
+            map(str, (self.keep, self.max_size, self.offset, self._offset, self._idx))
+        )
 
     @meta_state.setter
     def meta_state(self, v):
-        self.keep, self.max_size, self.offset, self._idx = map(
-            int,
-            v,
-        )
+        if len(v) == 4:
+            self.keep, self.max_size, self.offset, self._idx = map(int, v)
+            self._offset = min(self.offset, self.max_size)
+        else:
+            self.keep, self.max_size, self.offset, self._offset, self._idx = map(int, v)
 
     def is_trimmable(self):
         return True
 
     def trim(self, n):
-        effective = min(self.offset, self.max_size)
+        effective = min(self._offset, self.max_size)
         n = min(effective, n)
         if n == effective:
             self.keys = None
             self.values = None
-            self.offset = 0
+            self._offset = 0
             self._idx = 0
         else:
             new_size = effective - n
             self.keys = self._temporal_order(self.keys)[..., :new_size, :]
             self.values = self._temporal_order(self.values)[..., :new_size, :]
-            self.offset = new_size
+            self._offset = new_size
             self._idx = new_size
+        self.offset -= n
         return n
 
     def to_quantized(self, group_size: int = 64, bits: int = 4) -> QuantizedKVCache:
@@ -564,7 +577,7 @@ class RotatingKVCache(_BaseCache):
     ):
         if N > 1:
             window_size = window_size or self.max_size
-            offset = min(self.max_size - 1, self.offset)
+            offset = min(self.max_size - 1, self._offset)
             if offset + N > window_size or return_array:
                 return create_causal_mask(N, offset, window_size=window_size)
             else:
@@ -573,12 +586,12 @@ class RotatingKVCache(_BaseCache):
             if window_size is None:
                 return None
             # May need a mask for when window_size < max_size
-            if self.offset >= window_size and self.max_size > window_size:
+            if self._offset >= window_size and self.max_size > window_size:
                 idx = self._idx
                 if idx >= self.max_size:
                     idx = 0
-                if self.offset < self.max_size:
-                    mask_size = self.offset + 1
+                if self._offset < self.max_size:
+                    mask_size = self._offset + 1
                 else:
                     mask_size = self.max_size
                 mask = mx.arange(mask_size) >= (mask_size - window_size)
@@ -1359,6 +1372,7 @@ class BatchRotatingKVCache(_BaseCache):
         cache.values = mx.contiguous(cache.values[:, :, padding : cache._idx])
         cache.offset = offset
         cache._idx = cache.keys.shape[2]
+        cache._offset = cache.keys.shape[2]
         return cache
 
     @classmethod

--- a/mlx_lm/server.py
+++ b/mlx_lm/server.py
@@ -294,11 +294,12 @@ class LRUPromptCache:
         if result.longer is not None and result.common_prefix > short_length:
             cache_entry = self._get(result.model, result.longer)
             if can_trim_prompt_cache(cache_entry.prompt_cache):
-                cache = copy.deepcopy(cache_entry.prompt_cache)
                 prefix = min(len(tokens) - 1, result.common_prefix)
                 num_to_trim = len(result.longer) - prefix
-                trim_prompt_cache(cache, num_to_trim)
-                return cache, tokens[prefix:]
+                cache = copy.deepcopy(cache_entry.prompt_cache)
+                trimmed = trim_prompt_cache(cache, num_to_trim)
+                if trimmed >= num_to_trim:
+                    return cache, tokens[prefix:]
 
         if short_length > 0:
             cache_entry = self._get(result.model, result.shorter)
@@ -308,6 +309,7 @@ class LRUPromptCache:
 
     def insert_cache(self, model, tokens, prompt_cache, checkpoint: bool = False):
         is_trimmable = can_trim_prompt_cache(prompt_cache)
+        max_trimmable = min(c.size() for c in prompt_cache) if is_trimmable else 0
 
         if model not in self._cache:
             self._cache[model] = {}
@@ -316,9 +318,10 @@ class LRUPromptCache:
             if tok not in current:
                 current[tok] = {}
             if is_trimmable and "cache" in current:
-                self._n_bytes -= current["cache"].nbytes
-                del current["cache"]
-                self._lru.remove(model, tokens[:i])
+                if len(tokens) - i <= max_trimmable:
+                    self._n_bytes -= current["cache"].nbytes
+                    del current["cache"]
+                    self._lru.remove(model, tokens[:i])
             current = current[tok]
 
         if "cache" in current:

--- a/tests/test_prompt_cache.py
+++ b/tests/test_prompt_cache.py
@@ -241,14 +241,13 @@ class TestPromptCache(unittest.TestCase):
         num_trimmed = trim_prompt_cache(cache, 4)
         self.assertEqual(num_trimmed, 4)
 
-        # Can't trim fixed-size KV cache after processing
-        # more than max_kv_size tokens
+        # Trimming is still possible after the cache has wrapped
         for c in cache:
             x = mx.random.uniform(shape=(1, 8, 10, 4))
             c.update_and_fetch(x, x)
 
         num_trimmed = trim_prompt_cache(cache, 4)
-        self.assertEqual(num_trimmed, 0)
+        self.assertEqual(num_trimmed, 4)
 
         cache = [QuantizedKVCache() for _ in range(2)]
         for c in cache:


### PR DESCRIPTION
Fixes the prompt cache trimming failure for sliding window models (e.g., Gemma 3, GPT-OSS) reported in #980.

### The Bug
Currently, `RotatingKVCache` and `BatchRotatingKVCache` fail to trim as soon as the sequence length exceeds the window size (when `offset >= max_size` and the buffer wraps around). Because `can_trim_prompt_cache` requires *all* layers to be trimmable, a single wrapped rotating cache forces the server to drop the entire prompt and trigger a full recompute on divergent-suffix requests (like tool calls in agentic workloads).

### The Fix
This PR enables trimming for wrapped rotating caches by aligning the architecture of `RotatingKVCache` to match `BatchRotatingKVCache`:

* **Separation of Physical vs Logical Offset:** `RotatingKVCache` previously used a single `offset` for both the physical buffer size and the absolute sequence position (RoPE). Trimming a wrapped buffer broke RoPE embeddings. We introduced `_offset` to track the physical tensor size (used for attention masks/slicing) while keeping `offset` as the absolute chronological position (used for RoPE generation).
* **Buffer Linearization:** `trim(n)` now physically unrolls the ring buffer into temporal order via `_temporal_order()` and slices off the most recent tokens.
* **API Contract Consistency:** `trim(n)` now correctly clips the physical deletion to the available history (`min(_offset, n)`) but strictly rolls back the absolute `offset` by `n` to ensure all transformer layers remain perfectly synchronized in time.

### Note on Mamba/SSM (ArraysCache)
This PR strictly addresses rotating KV caches. It does *not* touch `ArraysCache` (Qwen 3.5 / Mamba).
Since Mamba's recurrent state is an incompressible mathematical hash of the sequence, we cannot simply "trim" it chronologically. Forcing a local state reset for Mamba layers while keeping Attention layers intact would cause the model to silently hallucinate (as the server would only pass the new suffix tokens to an empty Mamba layer). Fixing Mamba prefix-caching requires a server-side checkpointing approach in `LRUPromptCache` at the prefix boundary, which is out of scope for this specific cache-level fix.

### Testing
* Ran the reproduction script provided in #980 locally using a sliding window model (`gpt-oss`).
* Verified that divergent-suffix requests now successfully trim the cache and skip the full prompt recompute, yielding the expected inference speedup.
* Measured KL Divergence between full-recompute and trimmed-generation to guarantee that the `_offset` vs `offset` separation accurately preserves RoPE positional embeddings (KL ~ 0.1).
* Passed local `pytest tests/` for regression checks.

### [UPDATE]
Thanks for @dae report

Slowdown happened because server.py assumed is_trimmable=True meaning cache could be trimmed back infinitely. With a ring buffer, this caused the server to aggressively delete valid intermediate caches, only to realize later it couldn't actually trim the longer cache back that far.

I've updated the PR to make the server aware of physical buffer limits:

`server.py` (insert_cache): Only evict intermediate caches if the trim distance fits within the physical buffer (`<= min(c.size() for c in prompt_cache)`). This keeps shorter prefixes alive as fallbacks.

`server.py` (fetch_nearest_cache): Explicitly check the result of trim_prompt_cache. If it fails to remove the requested amount of tokens, discard and fallback to a shorter cache instead of returning a broken state.

`cache.py` (extract): Added a quick keys is None guard to prevent TypeErrors during batch merging after evictions.