### PR TITLE
fix rotating kv cache merge with wrapped _idx

### DIFF
--- a/mlx_lm/models/cache.py
+++ b/mlx_lm/models/cache.py
@@ -1361,8 +1361,9 @@ class BatchRotatingKVCache(_BaseCache):
         for i, (p, c) in enumerate(zip(padding, caches)):
             if c.keys is None:
                 continue
-            keys[i : i + 1, :, p : p + c._idx] = c._temporal_order(c.keys)
-            values[i : i + 1, :, p : p + c._idx] = c._temporal_order(c.values)
+            n = c.size()
+            keys[i : i + 1, :, p : p + n] = c._temporal_order(c.keys)
+            values[i : i + 1, :, p : p + n] = c._temporal_order(c.values)
 
         cache = cls(caches[0].max_size, padding)
         cache.keys = keys

--- a/tests/test_prompt_cache.py
+++ b/tests/test_prompt_cache.py
@@ -29,7 +29,6 @@ HF_MODEL_PATH = "mlx-community/Qwen1.5-0.5B-Chat-4bit"
 
 
 class TestPromptCache(unittest.TestCase):
-
     @classmethod
     def setUpClass(cls):
         cls.test_dir_fid = tempfile.TemporaryDirectory()
@@ -661,6 +660,35 @@ class TestPromptCache(unittest.TestCase):
         c2.update_and_fetch(kv, kv)
         c_out = KVCache.merge((c1, c2))
         self.assertEqual(c_out.keys.shape, (2, 4, 4, 4))
+
+    def test_merge_rotating_caches_different_offsets(self):
+        max_size = 8
+        H, D = 2, 4
+
+        # c1: short prompt (4 tokens), no rotation
+        c1 = RotatingKVCache(max_size=max_size)
+        k1 = mx.ones((1, H, 4, D))
+        c1.update_and_fetch(k1, k1)
+        self.assertEqual(c1.offset, 4)
+        self.assertEqual(c1._idx, 4)
+        self.assertEqual(c1.size(), 4)
+
+        # c2: long prompt that fills the buffer then wraps with single-token
+        # updates, so _idx wraps around and diverges from size()
+        c2 = RotatingKVCache(max_size=max_size)
+        k2 = mx.full((1, H, max_size, D), 2.0)
+        c2.update_and_fetch(k2, k2)
+        for _ in range(4):
+            k_step = mx.full((1, H, 1, D), 3.0)
+            c2.update_and_fetch(k_step, k_step)
+        self.assertEqual(c2.offset, 12)
+        self.assertEqual(c2.size(), max_size)
+        self.assertTrue(c2._idx < c2.size())  # _idx has wrapped
+
+        # this would crash before the fix with a shape mismatch
+        merged = RotatingKVCache.merge([c1, c2])
+        self.assertEqual(merged.keys.shape, (2, H, max_size, D))
+        self.assertEqual(merged.values.shape, (2, H, max_size, D))
 
     def test_window_mask_with_full_kv_cache(self):
         c = KVCache()


### PR DESCRIPTION
fixes #983.

`BatchRotatingKVCache.merge()` uses `c._idx` to size the target slice when
copying temporally-reordered keys/values. but `_idx` is the circular buffer
write cursor, not the number of valid tokens. after the buffer wraps (offset >
max_size), `_idx` resets and can be much smaller than the actual valid length.

`_temporal_order()` always returns data with sequence length `c.size()`
(`min(offset, max_size)`), so the slice width needs to match that.

the crash shows up when the server batches concurrent requests with different
prompt lengths - a short request has a small unwrapped cache while a long
request has a wrapped cache with a different `_idx`, and the merge hits a shape
mismatch.

added a test that merges a wrapped and unwrapped cache to cover this case.