### PR TITLE
avoid mutating input in SuScaledRoPE and YarnRoPE

### DIFF
--- a/mlx_lm/models/rope_utils.py
+++ b/mlx_lm/models/rope_utils.py
@@ -58,6 +58,7 @@ class SuScaledRoPE(nn.Module):
         self._scale = long_mscale or (1.0 if factor <= 1.0 else default_scale(factor))
 
     def __call__(self, x, offset: Union[int, mx.array] = 0):
+        x = x[...]
         x[..., : self.dim] = self._scale * x[..., : self.dim]
         return mx.fast.rope(
             x,
@@ -71,7 +72,6 @@ class SuScaledRoPE(nn.Module):
 
 
 class Llama3RoPE(nn.Module):
-
     def __init__(
         self,
         dims: int,
@@ -183,6 +183,7 @@ class YarnRoPE(nn.Module):
 
     def __call__(self, x, offset=0):
         if self.mscale != 1.0:
+            x = x[...]
             x[..., : self.dims] = self.mscale * x[..., : self.dims]
         return mx.fast.rope(
             x,

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -238,6 +238,32 @@ class TestModels(unittest.TestCase):
         )
         self.assertTrue(isinstance(rope, rope_utils.Llama3RoPE))
 
+    def test_su_scaled_rope_no_mutation(self):
+        rope = rope_utils.SuScaledRoPE(
+            dims=8,
+            max_position_embeddings=131072,
+            original_max_position_embeddings=4096,
+            long_factor=[1.0] * 4,
+        )
+        x = mx.ones((1, 2, 4, 8))
+        x_before = x[0, 0, 0, 0].item()
+        rope(x)
+        mx.eval(x)
+        self.assertEqual(x[0, 0, 0, 0].item(), x_before)
+
+    def test_yarn_rope_no_mutation(self):
+        rope = rope_utils.YarnRoPE(
+            dims=8,
+            scaling_factor=2.0,
+            mscale=1.0,
+            mscale_all_dim=0,
+        )
+        x = mx.ones((1, 2, 4, 8))
+        x_before = x[0, 0, 0, 0].item()
+        rope(x)
+        mx.eval(x)
+        self.assertEqual(x[0, 0, 0, 0].item(), x_before)
+
     def test_quantized_sdpa(self):
         cache = KVCache()
 

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -246,10 +246,9 @@ class TestModels(unittest.TestCase):
             long_factor=[1.0] * 4,
         )
         x = mx.ones((1, 2, 4, 8))
-        x_before = x[0, 0, 0, 0].item()
         rope(x)
         mx.eval(x)
-        self.assertEqual(x[0, 0, 0, 0].item(), x_before)
+        self.assertTrue((x == 1).all())
 
     def test_yarn_rope_no_mutation(self):
         rope = rope_utils.YarnRoPE(
@@ -259,10 +258,9 @@ class TestModels(unittest.TestCase):
             mscale_all_dim=0,
         )
         x = mx.ones((1, 2, 4, 8))
-        x_before = x[0, 0, 0, 0].item()
         rope(x)
         mx.eval(x)
-        self.assertEqual(x[0, 0, 0, 0].item(), x_before)
+        self.assertTrue((x == 1).all())
 
     def test_quantized_sdpa(self):
         cache = KVCache()


### PR DESCRIPTION
fixes #939.

`SuScaledRoPE.__call__` and `YarnRoPE.__call__` scale the input with
in-place assignment (`x[..., :dim] = scale * x[..., :dim]`), which
mutates the caller's tensor. this can cause subtle bugs when the same
tensor is reused downstream (e.g. residual connections).

copies the input with `x[...]` before the in-place update, per
@angeloskath's suggestion. also fixed the same pattern in `YarnRoPE`
which had the identical issue.

checked all other RoPE classes and model files in the repo -
`DeepseekV2YarnRotaryEmbedding` already does `self.mscale * x` (no
mutation), and no other in-place scaling patterns exist.

added tests for both classes verifying the input is not mutated.