### PR TITLE
fall back to ast.literal_eval for malformed JSON in qwen3_coder tool parser

### DIFF
--- a/mlx_lm/tool_parsers/qwen3_coder.py
+++ b/mlx_lm/tool_parsers/qwen3_coder.py
@@ -4,6 +4,7 @@
 Modified from:
 https://huggingface.co/Qwen/Qwen3-Coder-30B-A3B-Instruct/blob/main/qwen3coder_tool_parser.py
 """
+
 import ast
 import json
 from typing import Any, Optional
@@ -70,7 +71,10 @@ def _convert_param_value(param_value: str, param_name: str, param_config: dict) 
             or param_type.startswith("dict")
             or param_type.startswith("list")
         ):
-            return json.loads(param_value)
+            try:
+                return json.loads(param_value)
+            except json.JSONDecodeError:
+                return ast.literal_eval(param_value)
 
         return ast.literal_eval(param_value)
 

--- a/tests/test_tool_parsing.py
+++ b/tests/test_tool_parsing.py
@@ -15,7 +15,6 @@ from mlx_lm.tool_parsers import (
 
 
 class TestToolParsing(unittest.TestCase):
-
     def test_parsers(self):
         test_cases = [
             ("call:multiply{a:12234585,b:48838483920}", function_gemma),
@@ -148,6 +147,49 @@ class TestToolParsing(unittest.TestCase):
                     "arguments": {"location": "London"},
                 }
                 self.assertEqual(tool_call, expected)
+
+    def test_qwen3_coder_single_quoted_params(self):
+        tools = [
+            {
+                "type": "function",
+                "function": {
+                    "name": "search",
+                    "parameters": {
+                        "type": "object",
+                        "properties": {
+                            "filters": {"type": "object"},
+                            "tags": {"type": "array"},
+                        },
+                    },
+                },
+            }
+        ]
+
+        # single-quoted dict (python-style, not valid JSON)
+        test_case = (
+            "<function=search>"
+            "<parameter=filters>{'category': 'books', 'in_stock': True}</parameter>"
+            "<parameter=tags>['fiction', 'new']</parameter>"
+            "</function>"
+        )
+        tool_call = qwen3_coder.parse_tool_call(test_case, tools)
+        self.assertEqual(tool_call["name"], "search")
+        self.assertEqual(
+            tool_call["arguments"]["filters"],
+            {"category": "books", "in_stock": True},
+        )
+        self.assertEqual(tool_call["arguments"]["tags"], ["fiction", "new"])
+
+        # valid JSON (double-quoted) should still work
+        test_case = (
+            "<function=search>"
+            '<parameter=filters>{"category": "books"}</parameter>'
+            '<parameter=tags>["fiction", "new"]</parameter>'
+            "</function>"
+        )
+        tool_call = qwen3_coder.parse_tool_call(test_case, tools)
+        self.assertEqual(tool_call["arguments"]["filters"], {"category": "books"})
+        self.assertEqual(tool_call["arguments"]["tags"], ["fiction", "new"])
 
     def test_kimi_k2(self):
         # Single tool call


### PR DESCRIPTION
fixes #912.

`_convert_param_value` calls `json.loads()` for object/array/dict/list
parameter types, which crashes with `JSONDecodeError` when the model
outputs python-style single-quoted literals like `{'key': 'value'}`
instead of valid JSON.

wraps the `json.loads()` in a try/except and falls back to
`ast.literal_eval()`, which already exists in the function as a
catch-all and handles python-style literals correctly. this matches the
upstream vLLM reference implementation which has the same fallback.

added a test covering both single-quoted (python-style) and
double-quoted (valid JSON) object/array parameters.