### PR TITLE
Inserting logits processors into BatchGenerator in batch_generate

### DIFF
--- a/mlx_lm/generate.py
+++ b/mlx_lm/generate.py
@@ -1337,7 +1337,6 @@ def batch_generate(
     max_tokens: Union[int, List[int]] = 128,
     verbose: bool = False,
     return_prompt_caches: bool = False,
-    logits_processors: Optional[List[Callable[[mx.array, mx.array], mx.array]]] = None,
     **kwargs,
 ) -> BatchResponse:
     """
@@ -1356,8 +1355,6 @@ def batch_generate(
           can be per prompt if a list is provided.
        return_prompt_caches (bool): Return the prompt caches in the batch
           responses. Default: ``False``.
-       logits_processors (List[Callable[[mx.array, mx.array], mx.array]], optional):
-          A list of functions that take tokens and logits and return the processed logits. Default: ``None``.
        kwargs: The remaining options get passed to :obj:`BatchGenerator`.
           See :obj:`BatchGenerator` for more details.
     """
@@ -1372,9 +1369,7 @@ def batch_generate(
     if verbose:
         print(f"[batch_generate] Finished processing 0/{num_samples} ...", end="\r")
 
-    uids = gen.insert(
-        prompts, max_tokens, caches=prompt_caches, logits_processors=logits_procssors
-    )
+    uids = gen.insert(prompts, max_tokens, caches=prompt_caches)
     results = {uid: [] for uid in uids}
     prompt_caches = {}
     while responses := gen.next():


### PR DESCRIPTION
Tiny change: `logits_processors` are currently included in the signature in `generate.batch_generate()` but were unused. To actually use them in `BatchGenerator`, they need to be included when inserting prompts. This PR does that.

P.s. I said I'd do this a long time ago (https://github.com/ml-explore/mlx-lm/pull/845). Apologies for the delay, life hit hard and got in the way.