### PR TITLE
Supporting delay in mlx_lm benchmark

### DIFF
--- a/mlx_lm/benchmark.py
+++ b/mlx_lm/benchmark.py
@@ -67,7 +67,7 @@ def setup_arg_parser():
         default=2048,
         help="Step size for prefill processing (default: 2048)",
     )
-    parser.add_arugment(
+    parser.add_argument(
         "--delay",
         type=int,
         default=0,


### PR DESCRIPTION
fixes #1009 

Added an optional argument to `mlx_lm.benchmark.py` named `delay` which controls cooldown delay between consecutive benchmark runs. This is useful when running benchmarks on passively-cooled MacBook Airs, which otherwise significantly throttle performance and thus degrade benchmark results.

---
Edit: I also tried out running the same benchmark with and without delay, and I think the results show that cool-down can make quite a difference (running Qwen2.5-7b-Instruct-4bit, with 2048 prompt length and 2048 generation length, on a MacBook Air M4 with 24GB of RAM):

Without delay (command: `mlx_lm benchmark --model mlx-community/Qwen2.5-7b-Instruct-4bit -n 5 -p 2048 -g 2048 --delay 0`):
```
Timing with prompt_tokens=2048, generation_tokens=2048, batch_size=1.
Trial 1:  prompt_tps=204.832, generation_tps=21.086, peak_memory=5.114
Trial 2:  prompt_tps=137.867, generation_tps=18.929, peak_memory=5.114
Trial 3:  prompt_tps=153.996, generation_tps=18.775, peak_memory=5.114
Trial 4:  prompt_tps=162.618, generation_tps=17.456, peak_memory=5.115
Trial 5:  prompt_tps=149.155, generation_tps=18.051, peak_memory=5.115
Averages: prompt_tps=161.694, generation_tps=18.859, peak_memory=5.114
```

With delay (120s) (command: `mlx_lm benchmark --model mlx-community/Qwen2.5-7b-Instruct-4bit -n 5 -p 2048 -g 2048 --delay 120`):
```
Running warmup..
Timing with prompt_tokens=2048, generation_tokens=2048, batch_size=1.
Trial 1:  prompt_tps=200.729, generation_tps=21.146, peak_memory=5.114
Trial 2:  prompt_tps=203.119, generation_tps=21.440, peak_memory=5.114
Trial 3:  prompt_tps=193.286, generation_tps=21.239, peak_memory=5.114
Trial 4:  prompt_tps=201.892, generation_tps=21.806, peak_memory=5.115
Trial 5:  prompt_tps=207.449, generation_tps=20.508, peak_memory=5.115
Averages: prompt_tps=201.295, generation_tps=21.228, peak_memory=5.114
```

The run without delay clearly shows a significant drop in both prompt and generation TPS after the first trial, which is not occuring when running with a delay (where we observe a steady prompt and generation TPS).