### PR TITLE
Fix missing cache advance from qwen 3.5

### DIFF
--- a/mlx_lm/models/qwen3_5.py
+++ b/mlx_lm/models/qwen3_5.py
@@ -189,6 +189,7 @@ class GatedDeltaNet(nn.Module):
 
         if cache is not None:
             cache[1] = state
+            cache.advance(S)
 
         out = self.norm(out, z)
         out = self.out_proj(out.reshape(B, S, -1))


### PR DESCRIPTION
As title. The side-effects from this bug would only be visible during batched generation unfortunately...