### PR TITLE
Fix SSM dt clamp default for Nemotron-H

### DIFF
--- a/mlx_lm/models/nemotron_h.py
+++ b/mlx_lm/models/nemotron_h.py
@@ -61,8 +61,8 @@ class ModelArgs(BaseModelArgs):
     _block_type_to_char = {"mamba": "M", "attention": "*", "moe": "E", "mlp": "-"}
 
     def __post_init__(self):
-        if self.time_step_limit is None and self.time_step_min is not None:
-            self.time_step_limit = (self.time_step_min, float("inf"))
+        if self.time_step_limit is None:
+            self.time_step_limit = (0.0, float("inf"))
 
         # Normalize to hybrid_override_pattern (single-char list)
         if self.hybrid_override_pattern is None and self.layers_block_type is not None:


### PR DESCRIPTION
Fix that removes incorrect lower bound clamping on SSM time steps for Nemotron-H, which negatively affects output quality. This also matches the HF reference. Results from tests below (4-bit versions):

seq_len=4096, 25 samples, tulu-3-sft-mixture

| Model | PPL (before) | PPL (after) | Delta | KL div |
|---|---|---|---|---|
| **Nano 4B** | 4.864 | 4.845 | -0.019 | 0.006 |
| **Nano 30B** | 3.987 | 3.946 | -0.041 | 0.034 |
| **Super 120B** | 3.439 | 3.363 | -0.076 | 0.046 |

seq_len=4096, 25 samples, calibration_v5.txt

  | Model | PPL (before) | PPL (after) | Delta |
  |---|---|---|---|
  | **Nano 4B** | 9.983 | 9.886 | -0.097 |
  | **Nano 30B** | 6.673 | 6.513 | -0.159 |
  | **Super 120B** | 5.563 | 5.203 | -0.361 |