### PR TITLE
Fix A_log precision in mamba.py

### DIFF
--- a/mlx_lm/models/mamba.py
+++ b/mlx_lm/models/mamba.py
@@ -133,7 +133,7 @@ class MambaBlock(nn.Module):
         conv_out = self.conv1d(x_full)
         new_conv_cache = x_full[:, -(K - 1) :, :]
         x = nn.silu(conv_out)
-        A = -mx.exp(self.A_log)
+        A = -mx.exp(self.A_log.astype(mx.float32))
         current_state = state_cache
         y = []
         for t in range(T):


### PR DESCRIPTION
fixes #565.

mamba.py computes mx.exp(self.A_log) without casting to float32 first. When the model is loaded in bf16, the exponential loses precision and logprobs diverge from HuggingFace. mamba2.py, plamo2.py, and gated_delta.py all cast A_log to float32 at the usage site. Apply the same pattern here.