### PR TITLE
Fix CacheDataset.itemlen returning wrong length

### DIFF
--- a/mlx_lm/tuner/datasets.py
+++ b/mlx_lm/tuner/datasets.py
@@ -161,7 +161,7 @@ class CacheDataset:
         self._proc_data = [None] * len(data)
 
     def itemlen(self, idx: int):
-        return len(self._data[idx])
+        return len(self[idx][0])
 
     def __getitem__(self, idx: int):
         if self._proc_data[idx] is None:


### PR DESCRIPTION
fixes #596.

CacheDataset.itemlen calls len(self._data[idx]) which returns the number of dict keys (always 1 for ChatDataset), not the actual token count. Length-based batch sorting in the trainer is effectively disabled because every item looks the same length.

Changed to len(self[idx][0]) which processes the item through the tokenizer and returns the real sequence length.