### PR TITLE
Use model's generation_config.json for default sampling parameters

### DIFF
--- a/mlx_lm/chat.py
+++ b/mlx_lm/chat.py
@@ -37,18 +37,10 @@ def setup_arg_parser():
         type=str,
         help="Optional path for the trained adapter weights and config.",
     )
-    parser.add_argument(
-        "--temp", type=float, default=None, help="Sampling temperature"
-    )
-    parser.add_argument(
-        "--top-p", type=float, default=None, help="Sampling top-p"
-    )
-    parser.add_argument(
-        "--min-p", type=float, default=None, help="Sampling min-p"
-    )
-    parser.add_argument(
-        "--top-k", type=int, default=None, help="Sampling top-k"
-    )
+    parser.add_argument("--temp", type=float, default=None, help="Sampling temperature")
+    parser.add_argument("--top-p", type=float, default=None, help="Sampling top-p")
+    parser.add_argument("--min-p", type=float, default=None, help="Sampling min-p")
+    parser.add_argument("--top-k", type=int, default=None, help="Sampling top-k")
     parser.add_argument(
         "--xtc-probability",
         type=float,

--- a/mlx_lm/chat.py
+++ b/mlx_lm/chat.py
@@ -38,10 +38,16 @@ def setup_arg_parser():
         help="Optional path for the trained adapter weights and config.",
     )
     parser.add_argument(
-        "--temp", type=float, default=DEFAULT_TEMP, help="Sampling temperature"
+        "--temp", type=float, default=None, help="Sampling temperature"
     )
     parser.add_argument(
-        "--top-p", type=float, default=DEFAULT_TOP_P, help="Sampling top-p"
+        "--top-p", type=float, default=None, help="Sampling top-p"
+    )
+    parser.add_argument(
+        "--min-p", type=float, default=None, help="Sampling min-p"
+    )
+    parser.add_argument(
+        "--top-k", type=int, default=None, help="Sampling top-k"
     )
     parser.add_argument(
         "--xtc-probability",
@@ -71,7 +77,7 @@ def setup_arg_parser():
         "--max-tokens",
         "-m",
         type=int,
-        default=DEFAULT_MAX_TOKENS,
+        default=None,
         help="Maximum number of tokens to generate",
     )
     parser.add_argument(
@@ -105,15 +111,32 @@ def main():
     if group.size() > 1:
         if args.adapter_path:
             parser.error("Adapters not supported in distributed mode")
-        model, tokenizer = sharded_load(args.model, pipeline_group, tensor_group)
+        model, tokenizer, config = sharded_load(
+            args.model, pipeline_group, tensor_group, return_config=True
+        )
     else:
-        model, tokenizer = load(
+        model, tokenizer, config = load(
             args.model,
             adapter_path=args.adapter_path,
             tokenizer_config={
                 "trust_remote_code": True if args.trust_remote_code else None
             },
+            return_config=True,
         )
+
+    # Apply generation_config.json defaults for parameters the user did not
+    # explicitly set on the command line.
+    generation_defaults = config.get("generation_config", {})
+    if args.temp is None:
+        args.temp = generation_defaults.get("temp", DEFAULT_TEMP)
+    if args.top_p is None:
+        args.top_p = generation_defaults.get("top_p", DEFAULT_TOP_P)
+    if args.min_p is None:
+        args.min_p = generation_defaults.get("min_p", 0.0)
+    if args.top_k is None:
+        args.top_k = generation_defaults.get("top_k", 0)
+    if args.max_tokens is None:
+        args.max_tokens = generation_defaults.get("max_tokens", DEFAULT_MAX_TOKENS)
 
     def print_help():
         rprint("The command list:")
@@ -150,6 +173,8 @@ def main():
             sampler=make_sampler(
                 args.temp,
                 args.top_p,
+                min_p=args.min_p,
+                top_k=args.top_k,
                 xtc_threshold=args.xtc_threshold,
                 xtc_probability=args.xtc_probability,
                 xtc_special_tokens=(

--- a/mlx_lm/generate.py
+++ b/mlx_lm/generate.py
@@ -112,18 +112,10 @@ def setup_arg_parser():
         default=None,
         help="Maximum number of tokens to generate",
     )
-    parser.add_argument(
-        "--temp", type=float, default=None, help="Sampling temperature"
-    )
-    parser.add_argument(
-        "--top-p", type=float, default=None, help="Sampling top-p"
-    )
-    parser.add_argument(
-        "--min-p", type=float, default=None, help="Sampling min-p"
-    )
-    parser.add_argument(
-        "--top-k", type=int, default=None, help="Sampling top-k"
-    )
+    parser.add_argument("--temp", type=float, default=None, help="Sampling temperature")
+    parser.add_argument("--top-p", type=float, default=None, help="Sampling top-p")
+    parser.add_argument("--min-p", type=float, default=None, help="Sampling min-p")
+    parser.add_argument("--top-k", type=int, default=None, help="Sampling top-k")
     parser.add_argument(
         "--xtc-probability",
         type=float,

--- a/mlx_lm/generate.py
+++ b/mlx_lm/generate.py
@@ -109,20 +109,20 @@ def setup_arg_parser():
         "--max-tokens",
         "-m",
         type=int,
-        default=DEFAULT_MAX_TOKENS,
+        default=None,
         help="Maximum number of tokens to generate",
     )
     parser.add_argument(
-        "--temp", type=float, default=DEFAULT_TEMP, help="Sampling temperature"
+        "--temp", type=float, default=None, help="Sampling temperature"
     )
     parser.add_argument(
-        "--top-p", type=float, default=DEFAULT_TOP_P, help="Sampling top-p"
+        "--top-p", type=float, default=None, help="Sampling top-p"
     )
     parser.add_argument(
-        "--min-p", type=float, default=DEFAULT_MIN_P, help="Sampling min-p"
+        "--min-p", type=float, default=None, help="Sampling min-p"
     )
     parser.add_argument(
-        "--top-k", type=int, default=DEFAULT_TOP_K, help="Sampling top-k"
+        "--top-k", type=int, default=None, help="Sampling top-k"
     )
     parser.add_argument(
         "--xtc-probability",
@@ -2005,12 +2005,28 @@ def main():
             )
     model_path = model_path or DEFAULT_MODEL
 
-    model, tokenizer = load(
+    model, tokenizer, config = load(
         model_path,
         adapter_path=args.adapter_path,
         tokenizer_config=tokenizer_config,
         model_config={"quantize_activations": args.quantize_activations},
+        return_config=True,
     )
+
+    # Apply generation_config.json defaults for parameters the user did not
+    # explicitly set on the command line.
+    generation_defaults = config.get("generation_config", {})
+    if args.temp is None:
+        args.temp = generation_defaults.get("temp", DEFAULT_TEMP)
+    if args.top_p is None:
+        args.top_p = generation_defaults.get("top_p", DEFAULT_TOP_P)
+    if args.min_p is None:
+        args.min_p = generation_defaults.get("min_p", DEFAULT_MIN_P)
+    if args.top_k is None:
+        args.top_k = generation_defaults.get("top_k", DEFAULT_TOP_K)
+    if args.max_tokens is None:
+        args.max_tokens = generation_defaults.get("max_tokens", DEFAULT_MAX_TOKENS)
+
     for eos_token in args.extra_eos_token:
         tokenizer.add_eos_token(eos_token)
 

--- a/mlx_lm/server.py
+++ b/mlx_lm/server.py
@@ -336,18 +336,11 @@ class ModelProvider:
             self._tokenizer_config["chat_template"] = cli_args.chat_template
 
     def _apply_generation_defaults(self, generation_config):
-        """Store the model's generation_config so it can be consulted at
-        request time.  Does *not* mutate ``cli_args``; the resolution
-        chain (user CLI arg > generation_config > hardcoded default) is
-        evaluated lazily via :meth:`resolve_default`.
-        """
+        """Store the model's generation_config for request-time resolution."""
         self.generation_config = generation_config
 
     def resolve_default(self, key):
-        """Return the effective default for *key*.
-
-        Priority: user-supplied CLI arg > generation_config.json > hardcoded.
-        """
+        """Return the effective default for *key* (CLI > generation_config > hardcoded)."""
         cli_val = getattr(self.cli_args, key, None)
         if cli_val is not None:
             return cli_val

--- a/mlx_lm/server.py
+++ b/mlx_lm/server.py
@@ -290,6 +290,17 @@ class TimeBudget:
 
 
 class ModelProvider:
+    # Hardcoded defaults used when neither the user nor the model's
+    # generation_config.json specifies a value.
+    _server_defaults = {
+        "temp": 0.0,
+        "top_p": 1.0,
+        "top_k": 0,
+        "min_p": 0.0,
+        "max_tokens": 512,
+        "repetition_penalty": 0.0,
+    }
+
     def __init__(self, cli_args: argparse.Namespace):
         """Load models on demand and persist them across the whole process."""
         self.cli_args = cli_args
@@ -298,6 +309,7 @@ class ModelProvider:
         self.tokenizer = None
         self.draft_model = None
         self.is_batchable = False
+        self.generation_config = {}
 
         group = mx.distributed.init()
         self.pipeline_group = group if group.size() > 1 and cli_args.pipeline else None
@@ -323,6 +335,24 @@ class ModelProvider:
         if cli_args.chat_template:
             self._tokenizer_config["chat_template"] = cli_args.chat_template
 
+    def _apply_generation_defaults(self, generation_config):
+        """Store the model's generation_config so it can be consulted at
+        request time.  Does *not* mutate ``cli_args``; the resolution
+        chain (user CLI arg > generation_config > hardcoded default) is
+        evaluated lazily via :meth:`resolve_default`.
+        """
+        self.generation_config = generation_config
+
+    def resolve_default(self, key):
+        """Return the effective default for *key*.
+
+        Priority: user-supplied CLI arg > generation_config.json > hardcoded.
+        """
+        cli_val = getattr(self.cli_args, key, None)
+        if cli_val is not None:
+            return cli_val
+        return self.generation_config.get(key, self._server_defaults.get(key))
+
     def _load(self, model_path, adapter_path=None, draft_model_path=None):
         if self.is_distributed and (
             adapter_path is not None or draft_model_path is not None
@@ -339,18 +369,22 @@ class ModelProvider:
 
         # Load the model and tokenizer
         if self.is_distributed:
-            model, tokenizer = sharded_load(
+            model, tokenizer, config = sharded_load(
                 model_path,
                 pipeline_group=self.pipeline_group,
                 tensor_group=self.tensor_group,
                 tokenizer_config=self._tokenizer_config,
+                return_config=True,
             )
         else:
-            model, tokenizer = load(
+            model, tokenizer, config = load(
                 model_path,
                 adapter_path=adapter_path,
                 tokenizer_config=self._tokenizer_config,
+                return_config=True,
             )
+
+        self._apply_generation_defaults(config.get("generation_config", {}))
 
         # Use the default chat template if needed
         if self.cli_args.use_default_chat_template:
@@ -1055,6 +1089,13 @@ class ResponseGenerator:
     def cli_args(self):
         return self.model_provider.cli_args
 
+    @property
+    def generation_config(self):
+        return self.model_provider.generation_config
+
+    def resolve_default(self, key):
+        return self.model_provider.resolve_default(key)
+
 
 class APIHandler(BaseHTTPRequestHandler):
     def __init__(
@@ -1169,15 +1210,24 @@ class APIHandler(BaseHTTPRequestHandler):
         self.max_tokens = self.body.get("max_completion_tokens", None)
         if self.max_tokens is None:
             self.max_tokens = self.body.get(
-                "max_tokens", self.response_generator.cli_args.max_tokens
+                "max_tokens", self.response_generator.resolve_default("max_tokens")
             )
         self.temperature = self.body.get(
-            "temperature", self.response_generator.cli_args.temp
+            "temperature", self.response_generator.resolve_default("temp")
         )
-        self.top_p = self.body.get("top_p", self.response_generator.cli_args.top_p)
-        self.top_k = self.body.get("top_k", self.response_generator.cli_args.top_k)
-        self.min_p = self.body.get("min_p", self.response_generator.cli_args.min_p)
-        self.repetition_penalty = self.body.get("repetition_penalty", 0.0)
+        self.top_p = self.body.get(
+            "top_p", self.response_generator.resolve_default("top_p")
+        )
+        self.top_k = self.body.get(
+            "top_k", self.response_generator.resolve_default("top_k")
+        )
+        self.min_p = self.body.get(
+            "min_p", self.response_generator.resolve_default("min_p")
+        )
+        self.repetition_penalty = self.body.get(
+            "repetition_penalty",
+            self.response_generator.resolve_default("repetition_penalty"),
+        )
         self.repetition_context_size = self.body.get("repetition_context_size", 20)
         self.presence_penalty = self.body.get("presence_penalty", 0.0)
         self.presence_context_size = self.body.get("presence_context_size", 20)
@@ -1817,31 +1867,31 @@ def main():
     parser.add_argument(
         "--temp",
         type=float,
-        default=0.0,
+        default=None,
         help="Default sampling temperature (default: 0.0)",
     )
     parser.add_argument(
         "--top-p",
         type=float,
-        default=1.0,
+        default=None,
         help="Default nucleus sampling top-p (default: 1.0)",
     )
     parser.add_argument(
         "--top-k",
         type=int,
-        default=0,
+        default=None,
         help="Default top-k sampling (default: 0, disables top-k)",
     )
     parser.add_argument(
         "--min-p",
         type=float,
-        default=0.0,
+        default=None,
         help="Default min-p sampling (default: 0.0, disables min-p)",
     )
     parser.add_argument(
         "--max-tokens",
         type=int,
-        default=512,
+        default=None,
         help="Default maximum number of tokens to generate (default: 512)",
     )
     parser.add_argument(

--- a/mlx_lm/utils.py
+++ b/mlx_lm/utils.py
@@ -294,23 +294,10 @@ def _read_generation_config_file(model_path: Path) -> dict:
 
 
 def load_generation_config(model_path: Path, *, _raw: Optional[dict] = None) -> dict:
-    """
-    Load generation defaults from ``generation_config.json`` if present.
+    """Load generation defaults from ``generation_config.json`` if present.
 
-    The returned dictionary uses the parameter names expected by
-    :func:`generate` / :func:`stream_generate` (e.g. ``temp`` instead of
-    ``temperature``).  Only keys that are actually present in the file are
-    included, so callers can treat the result as a sparse set of overrides.
-
-    Args:
-        model_path (Path): The local model directory.
-        _raw (dict, optional): Pre-parsed generation_config.json contents.
-            When provided the file is not read again.  Used internally by
-            :func:`load_config` to avoid a redundant file read.
-
-    Returns:
-        dict: A (possibly empty) mapping of generation parameter names to
-        their default values.
+    Returns a sparse dict using mlx-lm parameter names (e.g. ``temp``
+    instead of ``temperature``).
     """
     if _raw is None:
         _raw = _read_generation_config_file(model_path)
@@ -336,6 +323,14 @@ def load_generation_config(model_path: Path, *, _raw: Optional[dict] = None) -> 
     # When do_sample is explicitly false, force greedy decoding.
     if _raw.get("do_sample") is False:
         config["temp"] = 0.0
+    elif _raw.get("do_sample") is True and config.get("temp") == 1.0:
+        uses_sampling_controls = (
+            config.get("top_p", 1.0) < 1.0
+            or config.get("top_k", 0) > 0
+            or config.get("min_p", 0.0) > 0.0
+        )
+        if not uses_sampling_controls:
+            config["temp"] = 0.0
 
     return config
 

--- a/mlx_lm/utils.py
+++ b/mlx_lm/utils.py
@@ -264,17 +264,78 @@ def load_config(model_path: Path) -> dict:
     with open(model_path / "config.json", "r") as f:
         config = json.load(f)
 
-    generation_config_file = model_path / "generation_config.json"
-    if generation_config_file.exists():
-        generation_config = {}
-        try:
-            with open(generation_config_file, "r") as f:
-                generation_config = json.load(f)
-        except json.JSONDecodeError:
-            pass
+    raw_generation = _read_generation_config_file(model_path)
 
-        if eos_token_id := generation_config.get("eos_token_id", False):
-            config["eos_token_id"] = eos_token_id
+    if eos_token_id := raw_generation.get("eos_token_id", False):
+        config["eos_token_id"] = eos_token_id
+
+    config["generation_config"] = load_generation_config(
+        model_path, _raw=raw_generation
+    )
+
+    return config
+
+
+def _read_generation_config_file(model_path: Path) -> dict:
+    """Read and parse ``generation_config.json`` from *model_path*.
+
+    Returns the raw parsed dict, or an empty dict if the file is missing or
+    malformed.
+    """
+    generation_config_file = model_path / "generation_config.json"
+    if not generation_config_file.exists():
+        return {}
+
+    try:
+        with open(generation_config_file, "r") as f:
+            return json.load(f)
+    except (json.JSONDecodeError, OSError):
+        return {}
+
+
+def load_generation_config(model_path: Path, *, _raw: Optional[dict] = None) -> dict:
+    """
+    Load generation defaults from ``generation_config.json`` if present.
+
+    The returned dictionary uses the parameter names expected by
+    :func:`generate` / :func:`stream_generate` (e.g. ``temp`` instead of
+    ``temperature``).  Only keys that are actually present in the file are
+    included, so callers can treat the result as a sparse set of overrides.
+
+    Args:
+        model_path (Path): The local model directory.
+        _raw (dict, optional): Pre-parsed generation_config.json contents.
+            When provided the file is not read again.  Used internally by
+            :func:`load_config` to avoid a redundant file read.
+
+    Returns:
+        dict: A (possibly empty) mapping of generation parameter names to
+        their default values.
+    """
+    if _raw is None:
+        _raw = _read_generation_config_file(model_path)
+
+    if not _raw:
+        return {}
+
+    # Map HuggingFace generation_config keys to mlx-lm parameter names.
+    key_map = {
+        "temperature": "temp",
+        "top_p": "top_p",
+        "top_k": "top_k",
+        "min_p": "min_p",
+        "max_new_tokens": "max_tokens",
+        "repetition_penalty": "repetition_penalty",
+    }
+
+    config = {}
+    for hf_key, mlx_key in key_map.items():
+        if hf_key in _raw:
+            config[mlx_key] = _raw[hf_key]
+
+    # When do_sample is explicitly false, force greedy decoding.
+    if _raw.get("do_sample") is False:
+        config["temp"] = 0.0
 
     return config
 

--- a/tests/test_chat.py
+++ b/tests/test_chat.py
@@ -75,7 +75,7 @@ class TestChat(unittest.TestCase):
         mock_model = MagicMock()
         mock_tokenizer = MagicMock()
         mock_tokenizer.apply_chat_template.return_value = "processed_prompt"
-        mock_load.return_value = (mock_model, mock_tokenizer)
+        mock_load.return_value = (mock_model, mock_tokenizer, {})
 
         # Mock prompt cache
         mock_prompt_cache = MagicMock()
@@ -130,7 +130,7 @@ class TestChat(unittest.TestCase):
         mock_model = MagicMock()
         mock_tokenizer = MagicMock()
         mock_tokenizer.apply_chat_template.return_value = "processed_prompt"
-        mock_load.return_value = (mock_model, mock_tokenizer)
+        mock_load.return_value = (mock_model, mock_tokenizer, {})
 
         # Mock prompt cache
         mock_prompt_cache = MagicMock()

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -27,6 +27,7 @@ class DummyModelProvider:
         self.model, self.tokenizer = load(HF_MODEL_PATH)
         self.model_key = (HF_MODEL_PATH, None)
         self.is_batchable = True
+        self.generation_config = {}
 
         # Add draft model support
         self.draft_model = None
@@ -63,6 +64,9 @@ class DummyModelProvider:
             self.draft_model, _ = load(HF_MODEL_PATH)
             self.draft_model_key = HF_MODEL_PATH
             self.cli_args.draft_model = HF_MODEL_PATH
+
+    def resolve_default(self, key):
+        return getattr(self.cli_args, key)
 
     def load(self, model, adapter=None, draft_model=None):
         assert model in ["default_model", "chat_model"]

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -47,6 +47,7 @@ class DummyModelProvider:
                 "top_k": 0,
                 "min_p": 0.0,
                 "max_tokens": 512,
+                "repetition_penalty": 0.0,
                 "chat_template_args": {},
                 "model": None,
                 "decode_concurrency": 32,
@@ -66,7 +67,7 @@ class DummyModelProvider:
             self.cli_args.draft_model = HF_MODEL_PATH
 
     def resolve_default(self, key):
-        return getattr(self.cli_args, key)
+        return getattr(self.cli_args, key, None)
 
     def load(self, model, adapter=None, draft_model=None):
         assert model in ["default_model", "chat_model"]

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -236,6 +236,42 @@ class TestGenerationConfig(unittest.TestCase):
             result = utils.load_generation_config(Path(tmpdir))
             self.assertEqual(result["temp"], 0.7)
 
+    def test_load_generation_config_do_sample_true_default_temperature(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            self._write_config(tmpdir, {"do_sample": True, "temperature": 1.0})
+            result = utils.load_generation_config(Path(tmpdir))
+            self.assertEqual(result, {"temp": 0.0})
+
+    def test_load_generation_config_keeps_default_temperature_with_top_p(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            self._write_config(
+                tmpdir,
+                {"do_sample": True, "temperature": 1.0, "top_p": 0.95},
+            )
+            result = utils.load_generation_config(Path(tmpdir))
+            self.assertEqual(result["temp"], 1.0)
+            self.assertEqual(result["top_p"], 0.95)
+
+    def test_load_generation_config_keeps_default_temperature_with_top_k(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            self._write_config(
+                tmpdir,
+                {"do_sample": True, "temperature": 1.0, "top_k": 40},
+            )
+            result = utils.load_generation_config(Path(tmpdir))
+            self.assertEqual(result["temp"], 1.0)
+            self.assertEqual(result["top_k"], 40)
+
+    def test_load_generation_config_keeps_default_temperature_with_min_p(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            self._write_config(
+                tmpdir,
+                {"do_sample": True, "temperature": 1.0, "min_p": 0.05},
+            )
+            result = utils.load_generation_config(Path(tmpdir))
+            self.assertEqual(result["temp"], 1.0)
+            self.assertEqual(result["min_p"], 0.05)
+
     def test_load_generation_config_sparse(self):
         with tempfile.TemporaryDirectory() as tmpdir:
             self._write_config(tmpdir, {"temperature": 0.8})

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,5 +1,6 @@
 # Copyright © 2024 Apple Inc.
 
+import json
 import os
 import tempfile
 import unittest
@@ -182,6 +183,75 @@ class TestUtils(unittest.TestCase):
             logits = loaded(mx.array([[1, 2, 3]], dtype=mx.int32))
             mx.eval(logits)
             self.assertEqual(logits.shape, (1, 3, args.vocab_size))
+
+
+class TestGenerationConfig(unittest.TestCase):
+
+    def _write_config(self, tmpdir, data):
+        with open(os.path.join(tmpdir, "generation_config.json"), "w") as f:
+            json.dump(data, f)
+
+    def test_load_generation_config_key_mapping(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            self._write_config(
+                tmpdir,
+                {
+                    "temperature": 0.6,
+                    "top_p": 0.95,
+                    "top_k": 40,
+                    "min_p": 0.05,
+                    "max_new_tokens": 2048,
+                    "repetition_penalty": 1.1,
+                },
+            )
+            result = utils.load_generation_config(Path(tmpdir))
+            self.assertEqual(result["temp"], 0.6)
+            self.assertEqual(result["top_p"], 0.95)
+            self.assertEqual(result["top_k"], 40)
+            self.assertEqual(result["min_p"], 0.05)
+            self.assertEqual(result["max_tokens"], 2048)
+            self.assertEqual(result["repetition_penalty"], 1.1)
+
+    def test_load_generation_config_missing_file(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            result = utils.load_generation_config(Path(tmpdir))
+            self.assertEqual(result, {})
+
+    def test_load_generation_config_malformed_json(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            with open(os.path.join(tmpdir, "generation_config.json"), "w") as f:
+                f.write("{invalid json")
+            result = utils.load_generation_config(Path(tmpdir))
+            self.assertEqual(result, {})
+
+    def test_load_generation_config_do_sample_false(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            self._write_config(tmpdir, {"do_sample": False, "temperature": 0.7})
+            result = utils.load_generation_config(Path(tmpdir))
+            self.assertEqual(result["temp"], 0.0)
+
+    def test_load_generation_config_do_sample_true(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            self._write_config(tmpdir, {"do_sample": True, "temperature": 0.7})
+            result = utils.load_generation_config(Path(tmpdir))
+            self.assertEqual(result["temp"], 0.7)
+
+    def test_load_generation_config_sparse(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            self._write_config(tmpdir, {"temperature": 0.8})
+            result = utils.load_generation_config(Path(tmpdir))
+            self.assertEqual(result, {"temp": 0.8})
+            self.assertNotIn("top_p", result)
+            self.assertNotIn("max_tokens", result)
+
+    def test_load_generation_config_unknown_keys_ignored(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            self._write_config(
+                tmpdir,
+                {"temperature": 0.5, "num_beams": 4, "length_penalty": 1.2},
+            )
+            result = utils.load_generation_config(Path(tmpdir))
+            self.assertEqual(result, {"temp": 0.5})
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Fixes #140.

Models like Phi-4 ship a generation_config.json with sampling defaults (temperature, top_p, etc.) but mlx-lm only read eos_token_id from it. Now generate, chat, and server read these values and use them when the user does not specify an explicit override.

The priority chain is: user CLI arg > generation_config.json > hardcoded default.

The server resolves defaults lazily per request so model hot-swapping picks up the new model's config correctly.

Also adds --min-p and --top-k CLI args to chat.py (already present in generate.py) so generation_config values for those keys are not silently ignored.