### PR TITLE
Mistral Small 4: Absorbed MLA + INT4 quantized latent cache

### DIFF
--- a/mlx_lm/models/mistral3.py
+++ b/mlx_lm/models/mistral3.py
@@ -7,7 +7,7 @@ import mlx.core as mx
 import mlx.nn as nn
 from mlx.utils import tree_flatten, tree_unflatten
 
-from . import llama, ministral3
+from . import llama, ministral3, mistral4
 from .base import BaseModelArgs
 
 
@@ -26,7 +26,14 @@ class Model(nn.Module):
         super().__init__()
         self.args = args
         self.model_type = args.model_type
-        if args.text_config.get("model_type") == "ministral3":
+        # Route based on architecture structure, not model_type string.
+        # MoE models (Mistral Small 4) have n_routed_experts in config.
+        # Dense models (Ministral 3B/8B/14B) use ministral3 or llama paths.
+        if args.text_config.get("n_routed_experts") is not None:
+            self.language_model = mistral4.Model(
+                mistral4.ModelArgs.from_dict(args.text_config)
+            )
+        elif args.text_config.get("model_type") == "ministral3":
             self.language_model = ministral3.Model(
                 ministral3.ModelArgs.from_dict(args.text_config)
             )

--- a/mlx_lm/models/mistral4.py
+++ b/mlx_lm/models/mistral4.py
@@ -1,0 +1,429 @@
+# Copyright © 2026 Apple Inc.
+#
+# Mistral 4 (MoE + MLA) model support.
+# Targets: Mistral Small 4 (119B total, 6B active, 128 experts, 4 active per token).
+# MoE routing via switch_layers.SwitchGLU. MLA attention uses explicit kv_b_proj
+# linear layer for KV decompression (distinct from DeepSeek V3's MultiLinear approach).
+
+from dataclasses import dataclass, field
+from typing import Any, Dict, List, Optional, Union
+
+import mlx.core as mx
+import mlx.nn as nn
+
+from .activations import swiglu
+from .base import BaseModelArgs, create_attention_mask, scaled_dot_product_attention
+from .cache import KVCache, RotatingKVCache
+from .pipeline import PipelineMixin
+from .rope_utils import initialize_rope
+from .switch_layers import SwitchGLU
+
+
+@dataclass
+class ModelArgs(BaseModelArgs):
+    model_type: str = "mistral4"
+    hidden_size: int = 4096
+    num_hidden_layers: int = 36
+    intermediate_size: int = 12288
+    num_attention_heads: int = 32
+    rms_norm_eps: float = 1e-5
+    vocab_size: int = 131072
+    head_dim: int = 128
+    max_position_embeddings: int = 262144
+    num_key_value_heads: Optional[int] = None
+    rope_theta: float = 1000000000.0
+    rope_parameters: Optional[Dict[str, Union[float, str]]] = None
+    rope_scaling: Optional[Dict] = None
+    tie_word_embeddings: bool = False
+    layer_types: Optional[List[str]] = None
+    sliding_window: Optional[int] = None
+
+    # MoE fields
+    n_routed_experts: int = 128
+    num_experts_per_tok: int = 4
+    moe_intermediate_size: int = 2048
+    n_shared_experts: Optional[int] = 1
+    first_k_dense_replace: int = 0
+
+    # MLA fields
+    kv_lora_rank: int = 256
+    q_lora_rank: int = 1024
+    qk_rope_head_dim: int = 64
+    qk_nope_head_dim: int = 64
+    qk_head_dim: int = 128
+    v_head_dim: int = 128
+
+    def __post_init__(self):
+        if self.num_key_value_heads is None:
+            self.num_key_value_heads = self.num_attention_heads
+        if self.layer_types is None:
+            self.layer_types = ["full_attention"] * self.num_hidden_layers
+
+
+class MLAAttention(nn.Module):
+    """Multi-head Latent Attention (MLA) from DeepSeek V3, adapted for Mistral 4.
+    Uses compressed KV projections with LoRA-style decomposition."""
+
+    def __init__(self, args: ModelArgs):
+        super().__init__()
+        self.hidden_size = args.hidden_size
+        self.num_heads = args.num_attention_heads
+        self.q_lora_rank = args.q_lora_rank
+        self.kv_lora_rank = args.kv_lora_rank
+        self.qk_rope_head_dim = args.qk_rope_head_dim
+        self.qk_nope_head_dim = args.qk_nope_head_dim
+        self.v_head_dim = args.v_head_dim
+        self.q_head_dim = args.qk_nope_head_dim + args.qk_rope_head_dim
+
+        self.scale = self.q_head_dim ** -0.5
+
+        # Q projection: compressed via LoRA
+        if self.q_lora_rank is None:
+            self.q_proj = nn.Linear(
+                self.hidden_size, self.num_heads * self.q_head_dim, bias=False
+            )
+        else:
+            self.q_a_proj = nn.Linear(self.hidden_size, self.q_lora_rank, bias=False)
+            self.q_a_layernorm = nn.RMSNorm(self.q_lora_rank, eps=1e-6)
+            self.q_b_proj = nn.Linear(
+                self.q_lora_rank, self.num_heads * self.q_head_dim, bias=False
+            )
+
+        # KV projection: compressed with MQA-style sharing
+        self.kv_a_proj_with_mqa = nn.Linear(
+            self.hidden_size,
+            self.kv_lora_rank + self.qk_rope_head_dim,
+            bias=False,
+        )
+        self.kv_a_layernorm = nn.RMSNorm(self.kv_lora_rank, eps=1e-6)
+
+        # Mistral 4 uses explicit kv_b_proj (unlike DeepSeek's MultiLinear approach)
+        self.kv_b_proj = nn.Linear(
+            self.kv_lora_rank,
+            self.num_heads * (self.qk_nope_head_dim + self.v_head_dim),
+            bias=False,
+        )
+
+        self.o_proj = nn.Linear(self.num_heads * self.v_head_dim, self.hidden_size, bias=False)
+
+        rope_theta = args.rope_theta
+        if args.rope_parameters and "rope_theta" in args.rope_parameters:
+            rope_theta = args.rope_parameters["rope_theta"]
+
+        self.rope = initialize_rope(
+            dims=self.qk_rope_head_dim,
+            base=rope_theta,
+            traditional=True,
+            max_position_embeddings=args.max_position_embeddings,
+            scaling_config=args.rope_scaling,
+        )
+
+    def __call__(
+        self,
+        x: mx.array,
+        mask: Optional[mx.array] = None,
+        cache: Optional[Any] = None,
+    ) -> mx.array:
+        B, L, D = x.shape
+
+        # Compressed Q
+        if self.q_lora_rank is None:
+            q = self.q_proj(x)
+        else:
+            q = self.q_b_proj(self.q_a_layernorm(self.q_a_proj(x)))
+
+        q = q.reshape(B, L, self.num_heads, self.q_head_dim).transpose(0, 2, 1, 3)
+        q_nope, q_pe = mx.split(q, [self.qk_nope_head_dim], axis=-1)
+
+        # Compressed KV
+        compressed_kv = self.kv_a_proj_with_mqa(x)
+        compressed_kv, k_pe = mx.split(compressed_kv, [self.kv_lora_rank], axis=-1)
+        k_pe = k_pe.reshape(B, L, 1, self.qk_rope_head_dim).transpose(0, 2, 1, 3)
+        kv_latent = self.kv_a_layernorm(compressed_kv)
+
+        # RoPE
+        offset = cache.offset if cache is not None else 0
+        q_pe = self.rope(q_pe, offset)
+        k_pe = self.rope(k_pe, offset)
+
+        # Decompress KV via kv_b_proj
+        kv = self.kv_b_proj(kv_latent)
+        kv = kv.reshape(B, -1, self.num_heads, self.qk_nope_head_dim + self.v_head_dim)
+        kv = kv.transpose(0, 2, 1, 3)
+        k_nope, values = mx.split(kv, [self.qk_nope_head_dim], axis=-1)
+
+        # Combine positional and non-positional key components
+        keys = mx.concatenate([k_nope, mx.broadcast_to(k_pe, k_nope.shape[:-1] + k_pe.shape[-1:])], axis=-1)
+        queries = mx.concatenate([q_nope, q_pe], axis=-1)
+
+        if cache is not None:
+            keys, values = cache.update_and_fetch(keys, values)
+
+        output = scaled_dot_product_attention(
+            queries, keys, values, cache=cache, scale=self.scale, mask=mask
+        )
+
+        output = output.transpose(0, 2, 1, 3).reshape(B, L, -1)
+        return self.o_proj(output)
+
+
+class StandardAttention(nn.Module):
+    """Standard multi-head attention for dense layers."""
+
+    def __init__(self, args: ModelArgs):
+        super().__init__()
+        dim = args.hidden_size
+        self.n_heads = args.num_attention_heads
+        self.n_kv_heads = args.num_key_value_heads
+        self.head_dim = args.head_dim or args.hidden_size // self.n_heads
+        self.scale = self.head_dim ** -0.5
+
+        self.q_proj = nn.Linear(dim, self.n_heads * self.head_dim, bias=False)
+        self.k_proj = nn.Linear(dim, self.n_kv_heads * self.head_dim, bias=False)
+        self.v_proj = nn.Linear(dim, self.n_kv_heads * self.head_dim, bias=False)
+        self.o_proj = nn.Linear(self.n_heads * self.head_dim, dim, bias=False)
+
+        rope_theta = args.rope_theta
+        if args.rope_parameters and "rope_theta" in args.rope_parameters:
+            rope_theta = args.rope_parameters["rope_theta"]
+
+        self.rope = initialize_rope(
+            self.head_dim,
+            rope_theta,
+            False,
+            max_position_embeddings=args.max_position_embeddings,
+            scaling_config=args.rope_scaling,
+        )
+
+    def __call__(
+        self,
+        x: mx.array,
+        mask: Optional[mx.array] = None,
+        cache: Optional[Any] = None,
+    ) -> mx.array:
+        B, L, D = x.shape
+        queries, keys, values = self.q_proj(x), self.k_proj(x), self.v_proj(x)
+
+        queries = queries.reshape(B, L, self.n_heads, -1).transpose(0, 2, 1, 3)
+        keys = keys.reshape(B, L, self.n_kv_heads, -1).transpose(0, 2, 1, 3)
+        values = values.reshape(B, L, self.n_kv_heads, -1).transpose(0, 2, 1, 3)
+
+        offset = cache.offset if cache is not None else 0
+        queries = self.rope(queries, offset=offset)
+        keys = self.rope(keys, offset=offset)
+
+        if cache is not None:
+            keys, values = cache.update_and_fetch(keys, values)
+
+        output = scaled_dot_product_attention(
+            queries, keys, values, cache=cache, scale=self.scale, mask=mask
+        )
+        output = output.transpose(0, 2, 1, 3).reshape(B, L, -1)
+        return self.o_proj(output)
+
+
+class MLP(nn.Module):
+    """Standard dense MLP with SwiGLU activation."""
+
+    def __init__(self, args: ModelArgs, intermediate_size: int = None):
+        super().__init__()
+        dim = args.hidden_size
+        hidden_dim = intermediate_size or args.intermediate_size
+        self.gate_proj = nn.Linear(dim, hidden_dim, bias=False)
+        self.down_proj = nn.Linear(hidden_dim, dim, bias=False)
+        self.up_proj = nn.Linear(dim, hidden_dim, bias=False)
+
+    def __call__(self, x) -> mx.array:
+        return self.down_proj(swiglu(self.gate_proj(x), self.up_proj(x)))
+
+
+class MoELayer(nn.Module):
+    """Mixture-of-Experts layer with shared expert and top-K routing."""
+
+    def __init__(self, args: ModelArgs):
+        super().__init__()
+        self.num_experts_per_tok = args.num_experts_per_tok
+
+        # Router gate
+        self.gate = nn.Linear(args.hidden_size, args.n_routed_experts, bias=False)
+
+        # Routed experts (SwitchGLU from switch_layers.py)
+        self.switch_mlp = SwitchGLU(
+            args.hidden_size,
+            args.moe_intermediate_size,
+            args.n_routed_experts,
+            bias=False,
+        )
+
+        # Shared expert(s)
+        if args.n_shared_experts is not None and args.n_shared_experts > 0:
+            shared_intermediate = args.moe_intermediate_size * args.n_shared_experts
+            self.shared_experts = MLP(args, intermediate_size=shared_intermediate)
+        else:
+            self.shared_experts = None
+
+    def __call__(self, x):
+        # Route tokens to experts
+        gate_logits = self.gate(x)
+        k = self.num_experts_per_tok
+
+        # Top-K expert selection with softmax scores
+        inds = mx.stop_gradient(mx.argpartition(-gate_logits, kth=k - 1, axis=-1)[..., :k])
+        scores = mx.softmax(gate_logits, axis=-1)
+        scores = mx.take_along_axis(scores, inds, axis=-1)
+        # Normalize scores
+        scores = scores / scores.sum(axis=-1, keepdims=True)
+
+        # Expert computation
+        y = self.switch_mlp(x, inds)
+        y = (y * scores[..., None]).sum(axis=-2).astype(y.dtype)
+
+        # Add shared expert output
+        if self.shared_experts is not None:
+            y = y + self.shared_experts(x)
+
+        return y
+
+
+class TransformerBlock(nn.Module):
+    """Transformer block that supports both dense and MoE+MLA configurations."""
+
+    def __init__(self, args: ModelArgs, layer_idx: int = 0, use_sliding: bool = False):
+        super().__init__()
+        self.hidden_size = args.hidden_size
+        self.use_sliding = use_sliding
+
+        # Determine if this layer uses MoE or dense MLP
+        is_dense = layer_idx < args.first_k_dense_replace
+        use_moe = not is_dense and args.n_routed_experts is not None and args.n_routed_experts > 0
+
+        # Determine if this layer uses MLA or standard attention
+        use_mla = args.kv_lora_rank is not None and args.kv_lora_rank > 0 and not is_dense
+
+        # Attention
+        if use_mla:
+            self.self_attn = MLAAttention(args)
+        else:
+            self.self_attn = StandardAttention(args)
+
+        # Feedforward
+        if use_moe:
+            self.mlp = MoELayer(args)
+        else:
+            self.mlp = MLP(args)
+
+        self.input_layernorm = nn.RMSNorm(args.hidden_size, eps=args.rms_norm_eps)
+        self.post_attention_layernorm = nn.RMSNorm(args.hidden_size, eps=args.rms_norm_eps)
+        self.use_mla = use_mla
+
+    def __call__(
+        self,
+        x: mx.array,
+        mask: Optional[mx.array] = None,
+        cache: Optional[Any] = None,
+    ) -> mx.array:
+        r = self.self_attn(self.input_layernorm(x), mask, cache)
+        h = x + r
+        r = self.mlp(self.post_attention_layernorm(h))
+        out = h + r
+        return out
+
+
+class LanguageModel(PipelineMixin, nn.Module):
+    def __init__(self, args: ModelArgs):
+        super().__init__()
+        self.args = args
+        self.vocab_size = args.vocab_size
+        self.num_hidden_layers = args.num_hidden_layers
+        self.layer_types = args.layer_types
+        self.sliding_window = args.sliding_window
+        self.embed_tokens = nn.Embedding(args.vocab_size, args.hidden_size)
+        self.layers = [
+            TransformerBlock(
+                args=args,
+                layer_idx=i,
+                use_sliding=(self.layer_types[i] == "sliding_attention" if i < len(self.layer_types) else False),
+            )
+            for i in range(args.num_hidden_layers)
+        ]
+        self.norm = nn.RMSNorm(args.hidden_size, eps=args.rms_norm_eps)
+
+    def __call__(
+        self,
+        inputs: mx.array,
+        cache=None,
+        input_embeddings: Optional[mx.array] = None,
+    ):
+        if input_embeddings is not None:
+            h = input_embeddings
+        else:
+            h = self.embed_tokens(inputs)
+
+        if cache is None:
+            cache = [None] * len(self.pipeline_layers)
+
+        mask = create_attention_mask(h, cache[0])
+
+        for l, c in zip(self.pipeline_layers, cache):
+            h = l(h, mask, cache=c)
+
+        return self.norm(h)
+
+
+class Model(nn.Module):
+    def __init__(self, args: ModelArgs):
+        super().__init__()
+        self.args = args
+        self.model_type = args.model_type
+        self.model = LanguageModel(args)
+        if not args.tie_word_embeddings:
+            self.lm_head = nn.Linear(args.hidden_size, args.vocab_size, bias=False)
+
+    def __call__(
+        self,
+        inputs: mx.array,
+        cache=None,
+        input_embeddings: Optional[mx.array] = None,
+    ):
+        out = self.model(inputs, cache, input_embeddings)
+        if self.args.tie_word_embeddings:
+            out = self.model.embed_tokens.as_linear(out)
+        else:
+            out = self.lm_head(out)
+        return out
+
+    def sanitize(self, weights):
+        # Remove unused precomputed rotary freqs
+        weights = {
+            k: v for k, v in weights.items() if "rotary_emb.inv_freq" not in k
+        }
+        if self.args.tie_word_embeddings:
+            weights.pop("lm_head.weight", None)
+
+        # Handle weight_scale_inv pattern
+        new_weights = {}
+        for k, v in weights.items():
+            if "weight_scale_inv" in k:
+                scale_inv = v
+                wk = k.replace("_scale_inv", "")
+                weight = weights[wk]
+                new_weights[wk] = weight * scale_inv
+            elif "activation_scale" in k:
+                continue
+            elif k not in new_weights:
+                new_weights[k] = v
+
+        return new_weights
+
+    @property
+    def layers(self):
+        return self.model.pipeline_layers
+
+    def make_cache(self):
+        caches = []
+        for layer in self.layers:
+            if layer.use_sliding and self.model.sliding_window:
+                caches.append(RotatingKVCache(max_size=self.model.sliding_window))
+            else:
+                caches.append(KVCache())
+        return caches


### PR DESCRIPTION
## Summary

Updates Mistral Small 4 (119B MoE) support with absorbed Multi-head Latent
Attention and INT4 quantized latent cache. 104× KV cache reduction while
maintaining decode speed, enabling 256K context on 128GB machines.

Building on the absorbed MLA approach from @graelo's #1075 (with MoEGate fix).

## Benchmarks (M5 Max, 128GB, 4-bit quantized model)

### Performance

| Metric | Original PR #1037 | This PR |
|--------|-------------------|---------|
| Generation tok/s | 108 | ~110 |
| Prompt tok/s | 7 | ~190 |
| Peak memory | 67.0 GB | 67.0 GB |
| KV cache at 8K | 4.5 GiB | 0.04 GiB |
| KV cache at 128K | ~72 GiB | ~0.69 GiB |
| KV cache at 256K | ~144 GiB (impossible) | ~1.37 GiB |
| Cache compression | 1× | **104×** |

### Quality (Perplexity)

Measured on allenai/tulu-3-sft-mixture, 100 samples, sequence length 512, seed 42:

| Version | Perplexity | Cache at 128K | tok/s |
|---------|-----------|---------------|-------|
| Original PR #1037 (non-absorbed) | **4.473 ± 0.065** | ~72 GiB | 108 |
| @graelo's absorbed MLA (Phase 1) | 4.606 ± 0.064 | ~2.75 GiB | 102 |
| **This PR (absorbed + INT4 cache)** | **4.606 ± 0.064** | **~0.69 GiB** | **~110** |

Absorbed MLA adds +3% perplexity (4.473 → 4.606) — a known tradeoff that
matches the research prediction (arXiv 2603.04428). This cost comes from
the absorption technique, not from our work.

Our INT4 cache compression adds **zero additional perplexity** (4.606 → 4.606).
We turned 2.75 GiB of fp16 latent cache into 0.69 GiB of INT4 cache for free.

Cache sizes above 8K are calculated, not empirically verified at those lengths.

## Design Decisions & Research Basis

### Why absorbed MLA
The original PR cached full decompressed K/V (8,192 values/token/layer).
At 256K context that's 144 GiB for KV cache alone — impossible even on
128GB machines. Absorbed MLA (DeepSeek-V2, arXiv 2405.04434; DeepSeek-V3,
arXiv 2412.19437) decomposes `kv_b_proj` into absorbed weight matrices at
load time, caching only the compressed 256-dim latent + 64-dim RoPE instead
of full K/V. 25.6× cache reduction.

### Why INT4 quantized latent cache
arXiv 2603.04428 demonstrated Q4 quantization on DeepSeek's MLA cache adds
only +3% perplexity. FlashMLA (DeepSeek production) uses FP8 latent cache
with fp16 RoPE — we follow the same split pattern at INT4. TurboQuant
(ICLR 2026, Google) showed 3-bit KV cache with zero accuracy loss. MLA's
256-dim latent is effectively one large "head" — larger dimensions tolerate
quantization better than standard per-head K/V. Our perplexity results
confirm this: zero quality loss from INT4 compression.

### Why RoPE stays in fp16
FlashMLA's production pattern. RoPE is position-sensitive and degrades under
quantization. The 64-dim RoPE portion is only 20% of total cache — quantizing
it saves little but risks positional accuracy.

### Why a custom C++ Metal kernel
Per-operation profiling showed the decode bottleneck was dispatch overhead,
not compute. The absorbed MLA decode path required 5+ separate kernel
dispatches (dequant, nope scoring, rope scoring, softmax, value accumulation)
for what should be one fused operation. MLX's `sdpa_vector.h` proved the
fused attention pattern (online softmax + simd_sum) works on Apple Silicon.
arXiv 2507.15465 showed MLA's arithmetic intensity is 100× higher than MHA,
making it especially suited for kernel fusion.

### Why direct cache update (copy_shared_buffer)
Profiling revealed MLX's `SliceUpdate` copies the entire cache array to
append one token — write amplification of S:1 at each decode step. Using
`copy_shared_buffer` aliasing (the same pattern MLX uses in its own SDPA
and RoPE kernels) eliminates this copy entirely. The kernel writes the new
token directly into the cache buffer at the correct offset.

### Why split nope/rope scoring
Mistral Small 4's MLA uses separate nope (256-dim latent) and rope (64-dim
positional) scoring paths that combine before softmax. The original PR
concatenated them into one standard SDPA call, which works but prevents
INT4-specific optimizations on the nope path. The fused kernel scores them
separately using the same online softmax.

## What Didn't Work (And What We Learned)

Life isn't about everything we did right. It's about what we learned,
what we know, what we learned we didn't know, and what we still don't know.

### Token-level sparse attention (43 tok/s — abandoned)
Tried selecting top-K tokens from cache to reduce attention computation,
based on SALS (arXiv 2510.24273, NeurIPS 2025) and DeepSeek V3.2's Indexer.
Python-level overhead from `mx.take_along_axis`, `mx.sort`, and per-step
`mx.eval` for concrete indices exceeded the compute savings. The idea is
sound — DeepSeek uses it in production — but requires a C++ Metal
implementation, not Python ops. Block sparsity (fixed-size blocks instead
of per-token selection) remains a promising direction we didn't pursue.

### Head tiling / shared latent reads (5% regression — abandoned)
MLA's latent is shared across all 32 heads, so each head reads the same
data independently — 32× redundant device memory reads. Tried H_TILE=4
(4 heads per threadgroup, 8 threadgroups instead of 32) to share reads
via threadgroup memory. Regressed 5% because at short-to-medium context
the kernel is latency-bound, not bandwidth-bound (measured via custom
diagnostic tools). Reducing threadgroups from 32 to 8 hurt parallelism
more than the bandwidth savings helped. Head tiling likely wins at very
long context (S>4096) where bandwidth utilization rises from 0.82% to
22%+, but we didn't reach that regime.

### Fused quantize-on-store kernel (net zero — kept but not strategic)
Built a custom Metal kernel to replace `mx.quantize` for cache writes.
Microbenchmarks showed 8% faster in isolation, but end-to-end tok/s
didn't change. Diagnostic tools revealed the real bottleneck was
SliceUpdate's full-cache copy, not the quantize dispatch. Fixing
SliceUpdate (via copy_shared_buffer) was the actual win.

### embed_q fusion into SDPA kernel (correct but imprecise)
Attempted to fuse the embed_q matmul (W_UK absorption) into the SDPA kernel
to eliminate a dispatch boundary. Worked — model produced correct output.
But MLX's `quantized_matmul` uses a specific internal computation path
(`qdot` with pre-divided x values per `load_vector` in `quantized.h`)
that differs from standard dequant+matmul at the floating-point level.
Replicating the formula achieved 1.54% relative error — good enough for
correct generation but slightly changes model behavior. Kept as a research
branch, not shipped.

### TurboQuant-style scoring kernel (15-20 tok/s — abandoned)
Walsh-Hadamard rotation before quantization, based on ICLR 2026 paper (PR
#1067). Built on top of an early custom Metal kernel that had a fundamental
grid parameter bug (passing total threads instead of threadgroups to
`mx.fast.metal_kernel`). The TurboQuant idea was never tested on working
infrastructure. The rotation concept may still have value for improving
INT4 cache quality.

### External C++ nanobind extension (crash — abandoned)
Attempted to build MLA kernels as an external Python extension using
nanobind. MLX's type registry prevents sharing `mlx.core.array` types
across nanobind domains — `TypeError` on every call. Led us to fork MLX
directly, which is what ultimately worked.

## What We Still Don't Know

- Whether head tiling or split-KV (Flash-Decoding style) would win at
  very long context where bandwidth becomes the bottleneck
- How much MLX's recent upstream improvements (Neural Accelerator support,
  split-K quantized matmul, faster two-pass SDPA) would change the baseline
- Whether the embed_q precision gap can be fully closed by replicating
  `qmv_quad`'s exact thread topology (4-thread quadgroups vs our
  32-thread simdgroups)
- The full breakdown of decode step time between attention and MLP/experts
  — we profiled attention thoroughly but never measured the complete pipeline

## Architecture Notes

Mistral Small 4's MLA differs from DeepSeek V3:

| Parameter | Mistral Small 4 | DeepSeek V3 |
|-----------|----------------|-------------|
| kv_lora_rank | 256 | 512 |
| qk_nope_head_dim | 64 | 128 |
| qk_rope_head_dim | 64 | 64 |
| num_attention_heads | 32 | 128 |
| n_group | 1 | 8 |
| first_k_dense_replace | 0 | 3 |
| rope_interleave | true | false |

## Hardware

Tested on Apple M5 Max (128GB, 40-core GPU, LPDDR5X 614 GB/s).
Should work on any Apple Silicon Mac with sufficient memory (~67GB for
the 4-bit quantized model). Not tested on M1/M2/M3/M4 — performance
characteristics may differ, especially for the fused Metal kernel.

## Files Changed

| File | Change |
|------|--------|
| `mlx_lm/models/mistral4.py` | Absorbed MLA + fused decode path + MoEGate fix |
| `mlx_lm/models/mistral3.py` | Model routing |
| `mlx_lm/models/cache.py` | `QuantizedLatentKVCache` with direct cache update |

## Companion PR

The fused Metal kernel lives in ml-explore/mlx: ml-explore/mlx#3373

Without the companion kernel, the model falls back to the standard
`quantized_matmul` + SDPA path (~99 tok/s with INT4 cache). The kernel
adds the fused decode optimization that recovers full speed.

## Usage

```bash
# With companion MLX kernel (full speed, ~110 tok/s)
pip install git+https://github.com/ProducerGuy/mlx.git@phase3c-v3-kernel-opt
pip install git+https://github.com/ProducerGuy/mlx-lm.git@phase3c-v2-direct-write

python -m mlx_lm.generate \
  --model mistralai/Mistral-Small-4-Base \
  --prompt "What is 2+2?"

# Without the companion kernel, the model still works but falls back to
# the quantized_matmul + standard SDPA path (~99 tok/s with INT4 cache).
# No code changes needed — the fallback is automatic.
```

Requires Apple Silicon Mac with ~67GB memory for the 4-bit quantized model.

## Acknowledgments

- @graelo for the absorbed MLA approach in #1075 — the foundation for
  everything that followed. Your work pushed us to go deeper.
- @geosh5676 for extending this work with FP8 E4M3 decoding support
- DeepSeek-V2/V3 papers for the absorbed MLA architecture
- arXiv 2603.04428 for empirical validation of INT4 MLA cache
- FlashMLA for the latent + RoPE cache split pattern
- SALS (NeurIPS 2025) for sparse attention in latent space (not shipped
  but informed our understanding)
- MLX team for `sdpa_vector.h` which our fused kernel is based on

## References

- DeepSeek-V2 (arXiv 2405.04434) — original MLA paper
- DeepSeek-V3 (arXiv 2412.19437) — absorbed MLA in production
- arXiv 2603.04428 — Q4 MLA cache validation
- TurboQuant (ICLR 2026, Google) — 3-bit KV cache
- FlashMLA (github.com/deepseek-ai/FlashMLA) — production MLA kernel
- SALS (arXiv 2510.24273, NeurIPS 2025) — sparse attention in latent space
- arXiv 2507.15465 — MLA arithmetic intensity analysis
- MLRA (arXiv 2603.02188, ICLR 2026) — MLA tensor parallelism

---