### PR TITLE
skip xtc sampling when threshold is zero

### DIFF
--- a/mlx_lm/sample_utils.py
+++ b/mlx_lm/sample_utils.py
@@ -52,7 +52,7 @@ def make_sampler(
         sampling_methods.append(lambda x: apply_top_p(x, top_p))
     if min_p != 0.0:
         sampling_methods.append(lambda x: apply_min_p(x, min_p, min_tokens_to_keep))
-    if xtc_probability > 0.0:
+    if xtc_probability > 0.0 and xtc_threshold > 0.0:
         sampling_methods.append(
             lambda x: apply_xtc(x, xtc_probability, xtc_threshold, xtc_special_tokens)
         )

--- a/tests/test_sample_utils.py
+++ b/tests/test_sample_utils.py
@@ -2,7 +2,13 @@ import unittest
 
 import mlx.core as mx
 
-from mlx_lm.sample_utils import apply_min_p, apply_top_k, apply_top_p, apply_xtc
+from mlx_lm.sample_utils import (
+    apply_min_p,
+    apply_top_k,
+    apply_top_p,
+    apply_xtc,
+    make_sampler,
+)
 
 
 class TestSampleUtils(unittest.TestCase):
@@ -115,6 +121,25 @@ class TestSampleUtils(unittest.TestCase):
         probs = mx.array([[0.4, 0.3, 0.15, 0.15]])
         new_probs = mx.softmax(apply_xtc(mx.log(probs), 0, 0.1, [0]), -1)
         self.assertTrue(mx.allclose(new_probs, probs))
+
+    def test_xtc_threshold_zero_disables(self):
+        # threshold=0.0 should not activate XTC even with probability=1.0
+        # apply_xtc with threshold=0.0 and probability=1.0 would mask all
+        # tokens except the least probable. make_sampler should skip XTC
+        # entirely when threshold=0.0, leaving logits unchanged.
+        probs = mx.array([[0.4, 0.3, 0.15, 0.15]])
+        logits = mx.log(probs)
+        result = apply_xtc(logits, 1.0, 0.0, [])
+        # apply_xtc itself still masks (it doesn't have the gate)
+        self.assertTrue(mx.any(result == -mx.inf))
+
+        # but make_sampler should not even call apply_xtc
+        sampler = make_sampler(temp=1.0, xtc_probability=1.0, xtc_threshold=0.0)
+        # with temp=1.0 and no XTC, sampler is just categorical_sampling.
+        # verify it doesn't crash and produces a valid token
+        token = sampler(logits)
+        mx.eval(token)
+        self.assertTrue(0 <= token.item() < 4)
 
     def test_presence_penalty(self):
         from mlx_lm.sample_utils import make_presence_penalty


### PR DESCRIPTION
fixes #1036.

`make_sampler()` activates XTC when `xtc_probability > 0.0` but doesn't
check `xtc_threshold`. with the default `threshold=0.0`, all softmax
probabilities pass the threshold, so `apply_xtc()` masks everything
except the least probable token.

added `xtc_threshold > 0.0` to the activation gate so threshold zero
disables XTC, consistent with how probability zero already does.