### PR TITLE
Add KV cache quantization args to server

### DIFF
--- a/mlx_lm/server.py
+++ b/mlx_lm/server.py
@@ -1047,6 +1047,9 @@ class ResponseGenerator:
                 num_draft_tokens=args.num_draft_tokens,
                 prompt_progress_callback=progress,
                 prefill_step_size=self.cli_args.prefill_step_size,
+                kv_bits=self.cli_args.kv_bits,
+                kv_group_size=self.cli_args.kv_group_size,
+                quantized_kv_start=self.cli_args.quantized_kv_start,
             ):
                 rqueue.put(
                     Response(
@@ -2011,6 +2014,24 @@ def main():
         type=int,
         default=2048,
         help="Step size for prefill processing (default: 2048)",
+    )
+    parser.add_argument(
+        "--kv-bits",
+        type=int,
+        default=None,
+        help="Number of bits for KV cache quantization (e.g. 8 for q8). Default: None (no quantization)",
+    )
+    parser.add_argument(
+        "--kv-group-size",
+        type=int,
+        default=64,
+        help="Group size for KV cache quantization (default: 64)",
+    )
+    parser.add_argument(
+        "--quantized-kv-start",
+        type=int,
+        default=0,
+        help="Step at which to begin KV cache quantization (default: 0)",
     )
     parser.add_argument(
         "--prompt-cache-size",


### PR DESCRIPTION
Closes #1043 

Expose --kv-bits, --kv-group-size, and --quantized-kv-start CLI arguments and wire them through to the generate call in ResponseGenerator. Not applied to BatchGenerator.