### PR TITLE
fix tokenizer regex issue with Mistral-based models

### DIFF
--- a/mlx_lm/tokenizer_utils.py
+++ b/mlx_lm/tokenizer_utils.py
@@ -532,7 +532,7 @@ def load(
     chat_template = None
 
     tokenizer = AutoTokenizer.from_pretrained(
-        model_path, **(tokenizer_config_extra or {})
+        model_path, fix_mistral_regex=True, **(tokenizer_config_extra or {})
     )
 
     tokenizer_config = tokenizer.init_kwargs


### PR DESCRIPTION
## Summary
- Add `fix_mistral_regex=True` to `AutoTokenizer.from_pretrained` call in `tokenizer_utils.py` to fix incorrect regex pattern that leads to incorrect tokenization

## Test plan
- Load the affected tokenizer (e.g., `Jackrong/MLX-Qwen3.5-4B-Claude-4.6-Opus-Reasoning-Distilled-v2-bf16`) and verify the warning no longer appears

## Related
- Discussion: https://huggingface.co/mistralai/Mistral-Small-3.1-24B-Instruct-2503/discussions/84#69121093e8b480e709447d5e

🤖 Generated with [Claude Code](https://claude.com/claude-code)