### PR TITLE
Fix gated delta kernel precision

### DIFF
--- a/mlx_lm/models/gated_delta.py
+++ b/mlx_lm/models/gated_delta.py
@@ -59,37 +59,44 @@ def _make_gated_delta_kernel(has_mask=False, vectorized=False):
         {g_setup}
         auto beta_ = beta + b_idx * T * Hv;
 
-        for (int t = 0; t < T; ++t) {{
-          if ({mask_source}) {{
-            float kv_mem = 0.0f;
-            for (int i = 0; i < n_per_t; ++i) {{
-              auto s_idx = n_per_t * dk_idx + i;
-              state[i] = state[i] * {g_access};
-              kv_mem += state[i] * k_[s_idx];
-            }}
-            kv_mem = simd_sum(kv_mem);
-
-            auto delta = (v_[dv_idx] - kv_mem) * beta_[hv_idx];
-
-            float out = 0.0f;
-            for (int i = 0; i < n_per_t; ++i) {{
-              auto s_idx = n_per_t * dk_idx + i;
-              state[i] = state[i] + k_[s_idx] * delta;
-              out += state[i] * q_[s_idx];
-            }}
-            out = simd_sum(out);
-            if (thread_index_in_simdgroup == 0) {{
-              y[dv_idx] = static_cast<InT>(out);
-            }}
-          }}
-          // Increment data pointers to next time step
-          q_ += Hk * Dk;
-          k_ += Hk * Dk;
-          v_ += Hv * Dv;
-          y += Hv * Dv;
-          {g_advance}
-          beta_ += Hv;
+        #define BODY() {{ \
+            float kv_mem = 0.0f, kv_c = 0.0f; \
+            for (int i = 0; i < n_per_t; ++i) {{ \
+              auto s_idx = n_per_t * dk_idx + i; \
+              state[i] *= {g_access}; \
+              auto p = state[i] * k_[s_idx]; \
+              auto a = p - kv_c; \
+              auto b = kv_mem + a; \
+              kv_c = (b - kv_mem) - a; \
+              kv_mem = b; \
+            }} \
+            kv_mem = simd_sum(kv_mem); \
+            auto delta = (v_[dv_idx] - kv_mem) * beta_[hv_idx]; \
+            float out = 0.0f; \
+            for (int i = 0; i < n_per_t; ++i) {{ \
+              auto s_idx = n_per_t * dk_idx + i; \
+              state[i] += k_[s_idx] * delta; \
+              out += state[i] * q_[s_idx]; \
+            }} \
+            out = simd_sum(out); \
+            if (thread_index_in_simdgroup == 0) \
+              y[dv_idx] = static_cast<InT>(out); \
         }}
+        #define ADV() q_ += Hk * Dk; k_ += Hk * Dk; v_ += Hv * Dv; y += Hv * Dv; {g_advance} beta_ += Hv;
+
+        int t = 0;
+        for (; t + 3 < T; t += 4) {{
+          if ({mask_source}) BODY() ADV()
+          if ({"mask[b_idx * T + t + 1]" if has_mask else "true"}) BODY() ADV()
+          if ({"mask[b_idx * T + t + 2]" if has_mask else "true"}) BODY() ADV()
+          if ({"mask[b_idx * T + t + 3]" if has_mask else "true"}) BODY() ADV()
+        }}
+        for (; t < T; ++t) {{
+          if ({mask_source}) BODY()
+          ADV()
+        }}
+        #undef BODY
+        #undef ADV
         for (int i = 0; i < n_per_t; ++i) {{
           auto s_idx = n_per_t * dk_idx + i;
           o_state[s_idx] = static_cast<StT>(state[i]);


### PR DESCRIPTION
Adds Kahan compensation and unrolls loops. Fixes #1061

mlx-community/Qwen3.5-35B-A3B-4bit

| Context | Before pp | After pp | Δ pp | Before tg | After tg | Δ tg | Before Mem | After Mem | Δ Mem |       
  |---------|----------|---------|------|----------|---------|------|-----------|----------|-------|             
  | 0.5k | 2040.1 | 2039.2 | -0.0% | 82.1 | 83.6 | +1.8% | 20.24 GB | 20.24 GB | 0.0% |                          
  | 1k | 2574.4 | 2551.9 | -0.9% | 81.7 | 84.1 | +2.9% | 20.57 GB | 20.57 GB | 0.0% |                            
  | 2k | 2830.8 | 2818.4 | -0.4% | 82.2 | 85.8 | +4.4% | 21.40 GB | 21.40 GB | 0.0% |                            
  | 4k | 2905.8 | 2889.3 | -0.6% | 85.0 | 84.8 | -0.3% | 21.66 GB | 21.65 GB | 0.0% |                            
  | 8k | 2845.5 | 2827.4 | -0.6% | 84.2 | 84.3 | +0.2% | 22.02 GB | 22.02 GB | 0.0% |                            
  | 16k | 2627.5 | 2614.6 | -0.5% | 83.3 | 84.1 | +1.0% | 22.70 GB | 22.70 GB | 0.0% |                           
  | 32k | 2245.7 | 2235.4 | -0.5% | 80.3 | 79.9 | -0.4% | 23.96 GB | 23.96 GB | 0.0% |                           
  | **Avg** | **2581.4** | **2568.0** | **-0.5%** | **82.7** | **83.8** | **+1.4%** | | | |                      
  | **PPL** | **4.14** | **4.14** | **0.0%** | | | | | | | 