### PR TITLE
chore: Use `json-repair` for `json_tools` tool-call parsing

### DIFF
--- a/mlx_lm/tool_parsers/json_tools.py
+++ b/mlx_lm/tool_parsers/json_tools.py
@@ -1,6 +1,6 @@
 # Copyright © 2025 Apple Inc.
 
-import json
+import json_repair
 
 tool_call_start = "<tool_call>"
 
@@ -8,4 +8,4 @@ tool_call_end = "</tool_call>"
 
 
 def parse_tool_call(text, tools=None):
-    return json.loads(text.strip())
+    return json_repair.loads(text.strip())

--- a/setup.py
+++ b/setup.py
@@ -31,6 +31,7 @@ setup(
         "protobuf",
         "pyyaml",
         "jinja2",
+        "json-repair",
     ],
     packages=[
         "mlx_lm",

--- a/setup.py
+++ b/setup.py
@@ -31,7 +31,7 @@ setup(
         "protobuf",
         "pyyaml",
         "jinja2",
-        "json-repair",
+        "json-repair>=0.58.7",
     ],
     packages=[
         "mlx_lm",

--- a/tests/test_tool_parsing.py
+++ b/tests/test_tool_parsing.py
@@ -148,6 +148,74 @@ class TestToolParsing(unittest.TestCase):
                 }
                 self.assertEqual(tool_call, expected)
 
+    def test_json_tools_repairs_malformed_json(self):
+        tools_multiply = [
+            {
+                "type": "function",
+                "function": {
+                    "name": "multiply",
+                    "description": "Multiply two numbers.",
+                    "parameters": {
+                        "type": "object",
+                        "required": ["a", "b"],
+                        "properties": {
+                            "a": {"type": "number", "description": "a is a number"},
+                            "b": {"type": "number", "description": "b is a number"},
+                        },
+                    },
+                },
+            }
+        ]
+        expected_multiply = {
+            "name": "multiply",
+            "arguments": {"a": 12234585, "b": 48838483920},
+        }
+        malformed_multiply = [
+            (
+                "trailing_comma",
+                '{"name": "multiply", "arguments": {"a": 12234585, "b": 48838483920,},}',
+            ),
+            (
+                "single_quoted",
+                "{'name': 'multiply', 'arguments': {'a': 12234585, 'b': 48838483920}}",
+            ),
+        ]
+        for label, text in malformed_multiply:
+            with self.subTest(case=label):
+                self.assertEqual(
+                    json_tools.parse_tool_call(text, tools_multiply),
+                    expected_multiply,
+                )
+
+        tools_temp = [
+            {
+                "type": "function",
+                "function": {
+                    "name": "get_current_temperature",
+                    "description": "Get the current temperature.",
+                    "parameters": {
+                        "type": "object",
+                        "required": ["location"],
+                        "properties": {
+                            "location": {"type": "str", "description": "The location."},
+                        },
+                    },
+                },
+            }
+        ]
+        expected_temp = {
+            "name": "get_current_temperature",
+            "arguments": {"location": "London"},
+        }
+        text = (
+            '{"name": "get_current_temperature", '
+            '"arguments": {"location": "London",},}'
+        )
+        self.assertEqual(
+            json_tools.parse_tool_call(text, tools_temp),
+            expected_temp,
+        )
+
     def test_qwen3_coder_single_quoted_params(self):
         tools = [
             {


### PR DESCRIPTION
## Summary

The `json_tools` parser now uses `json_repair.loads()` instead of strict JSON parsing so common LLM mistakes (trailing commas, single-quoted strings, etc.) still produce usable tool calls.

## Motivation

Chat templates that emit a JSON object inside `<tool_call>` often get invalid JSON from the model (I encountered this issue frequently when using `mlx-community/Qwen3.5-27B-Claude-4.6-Opus-Distilled-MLX-4bit`). `json.loads` fails on those outputs; `json-repair` is aimed at repairing that kind of text.

## Changes

- `mlx_lm/tool_parsers/json_tools.py`: `parse_tool_call` parses the stripped payload with json_repair.loads.
- `setup.py`: Declare dependency `json-repair>=0.58.7` (latest version).
- `tests/test_tool_parsing.py`: Add `test_json_tools_repairs_malformed_json` covering trailing commas and single-quoted JSON for the multiply and temperature fixtures. Existing `test_parsers` cases still assert valid JSON for `json_tools`.

## Tradeoffs

Parsing is more lenient than before: some malformed text may be repaired into a JSON object instead of raising, which could occasionally yield unexpected `name / arguments`. That is usually acceptable for tool-call extraction but is a behavioral change from strict `json.loads`.

## Testing

```shell
python -m unittest tests.test_tool_parsing
```