### PR TITLE
feat: add KV cache quantization args to server

### DIFF
--- a/mlx_lm/server.py
+++ b/mlx_lm/server.py
@@ -757,6 +757,8 @@ class ResponseGenerator:
             return False
         if args.seed is not None:
             return False
+        if getattr(self.cli_args, "kv_bits", None) is not None:
+            return False
 
         return True
 
@@ -1035,6 +1037,11 @@ class ResponseGenerator:
                     cache += make_prompt_cache(self.model_provider.draft_model)
 
             # Process the prompt and generate tokens
+            kv_kwargs = {}
+            if getattr(self.cli_args, "kv_bits", None) is not None:
+                kv_kwargs["kv_bits"] = self.cli_args.kv_bits
+                kv_kwargs["kv_group_size"] = self.cli_args.kv_group_size
+                kv_kwargs["quantized_kv_start"] = self.cli_args.quantized_kv_start
             for gen in stream_generate(
                 model=model,
                 tokenizer=tokenizer,
@@ -1047,6 +1054,7 @@ class ResponseGenerator:
                 num_draft_tokens=args.num_draft_tokens,
                 prompt_progress_callback=progress,
                 prefill_step_size=self.cli_args.prefill_step_size,
+                **kv_kwargs,
             ):
                 rqueue.put(
                     Response(
@@ -2011,6 +2019,24 @@ def main():
         type=int,
         default=2048,
         help="Step size for prefill processing (default: 2048)",
+    )
+    parser.add_argument(
+        "--kv-bits",
+        type=int,
+        default=None,
+        help="Number of bits for KV cache quantization. None means no quantization.",
+    )
+    parser.add_argument(
+        "--kv-group-size",
+        type=int,
+        default=64,
+        help="Group size for KV cache quantization (default: 64)",
+    )
+    parser.add_argument(
+        "--quantized-kv-start",
+        type=int,
+        default=0,
+        help="Step to begin quantizing the KV cache (default: 0)",
     )
     parser.add_argument(
         "--prompt-cache-size",


### PR DESCRIPTION
## Summary

- Adds `--kv-bits`, `--kv-group-size`, and `--quantized-kv-start` CLI arguments to `mlx_lm.server`
- Wires these through to `stream_generate` → `generate_step`, which already supports KV cache quantization
- Disables batching when `kv_bits` is set since `BatchQuantizedKVCache` does not exist yet

Closes #1043.

## Motivation

KV cache quantization has been available via `mlx_lm.generate` CLI (`--kv-bits`) since v0.22, but the server has no way to enable it. Users running long-context inference through the OpenAI-compatible API cannot reduce KV cache memory usage.

## Changes

**`mlx_lm/server.py`** (26 lines added):
- Three new CLI arguments in `main()`: `--kv-bits` (int, default None), `--kv-group-size` (int, default 64), `--quantized-kv-start` (int, default 0)
- In `_serve_single`: constructs `kv_kwargs` dict and passes to `stream_generate` via `**kv_kwargs`
- In `_is_batchable`: returns `False` when `kv_bits` is set (batched quantized cache NYI)

## Test plan

- [x] `python -m mlx_lm.server --model mlx-community/Qwen2.5-0.5B-Instruct-4bit --kv-bits 4` starts without error
- [x] Sending a request generates correct output
- [x] Without `--kv-bits`, behavior is unchanged
- [x] With `--kv-bits`, batching is correctly disabled (sequential path used)

🤖 Generated with [Claude Code](https://claude.com/claude-code)