### PR TITLE
Fix RoPE precision for long context (>262K)

### DIFF
--- a/mlx_lm/models/qwen3_next.py
+++ b/mlx_lm/models/qwen3_next.py
@@ -143,12 +143,16 @@ class Qwen3NextAttention(nn.Module):
         )
 
         if cache is not None:
-            queries = self.rope(queries, offset=cache.offset)
-            keys = self.rope(keys, offset=cache.offset)
+            queries = self.rope(
+                queries.astype(mx.float32), offset=cache.offset
+            ).astype(queries.dtype)
+            keys = self.rope(
+                keys.astype(mx.float32), offset=cache.offset
+            ).astype(keys.dtype)
             keys, values = cache.update_and_fetch(keys, values)
         else:
-            queries = self.rope(queries)
-            keys = self.rope(keys)
+            queries = self.rope(queries.astype(mx.float32)).astype(queries.dtype)
+            keys = self.rope(keys.astype(mx.float32)).astype(keys.dtype)
 
         output = scaled_dot_product_attention(
             queries, keys, values, cache=cache, scale=self.scale, mask=mask


### PR DESCRIPTION
## Summary
- Cast Q/K to FP32 before RoPE rotation in `qwen3_next.py`
- Prevents position embedding collapse at >262K tokens
- No behavioral change at short context

## Problem
RoPE frequencies are computed in FP32 (`mx.arange(..., dtype=mx.float32)`) but rotation operates at input dtype (FP16). At positions beyond 262K, the delta between high-frequency embedding components falls below FP16 epsilon (~6e-8). Adjacent token positions become numerically identical, destroying the model's ability to distinguish them.

## Fix
Cast Q/K to FP32 before `self.rope()`, cast back to model dtype after. 6-line change, 4 call sites (cached and uncached paths).

## Impact
- All Qwen3.5 models using `Qwen3NextAttention` (4B, 27B, 35B, 122B)
- Prerequisite for YaRN-based context extension beyond 262K
- Zero performance impact at short context (FP32 cast is negligible)

## Test plan
- [ ] Basic generation test (no crash, coherent output)
- [ ] Needle-in-haystack at 384K with and without fix