### PR TITLE
fix(gpt_oss): handle BF16 expert weights in sanitize

### DIFF
--- a/mlx_lm/models/gpt_oss.py
+++ b/mlx_lm/models/gpt_oss.py
@@ -247,11 +247,15 @@ class Model(nn.Module):
         new_weights = {}
         for k, v in weights.items():
             if "gate_up_proj" in k and "bias" not in k:
+                is_prequantized = "_blocks" in k or "_scales" in k
                 if "_blocks" in k:
                     v = v.view(mx.uint32).flatten(-2)
                     k = k.replace("_blocks", ".weight")
                 if "_scales" in k:
                     k = k.replace("_scales", ".scales")
+                if not is_prequantized and "experts" in k:
+                    k = k + ".weight"
+                    v = v.swapaxes(-1, -2)
                 new_weights[k.replace("gate_up_proj", "gate_proj")] = mx.contiguous(
                     v[..., ::2, :]
                 )
@@ -259,11 +263,15 @@ class Model(nn.Module):
                     v[..., 1::2, :]
                 )
             elif "down_proj" in k and "bias" not in k:
+                is_prequantized = "_blocks" in k or "_scales" in k
                 if "_blocks" in k:
                     v = v.view(mx.uint32).flatten(-2)
                     k = k.replace("_blocks", ".weight")
                 if "_scales" in k:
                     k = k.replace("_scales", ".scales")
+                if not is_prequantized and "experts" in k:
+                    k = k + ".weight"
+                    v = v.swapaxes(-1, -2)
                 new_weights[k] = v
             elif "gate_up_proj_bias" in k:
                 new_weights[k.replace("gate_up_proj_bias", "gate_proj.bias")] = (


### PR DESCRIPTION
## Summary

Fixes `mlx_lm.convert` failing on BF16 gpt_oss models (e.g. `chromadb/context-1`) with:
```
ValueError: Received 72 parameters not in model
```

The `sanitize` method handled pre-quantized (MXFP4) expert weights but not raw BF16 weights from HuggingFace.

## Changes

Two fixes for BF16 expert weights (8 lines added, 0 removed):

1. **Add `.weight` suffix** — BF16 keys like `experts.gate_up_proj` lack the `.weight` suffix that `SwitchLinear` expects. Added when no `_blocks`/`_scales` suffix is present.

2. **Transpose weights** — BF16 expert weights are stored as `[E, input_dims, output_dims]` (PyTorch's `state @ weight` convention), but MLX's `SwitchLinear` expects `[E, output_dims, input_dims]`. Added `swapaxes(-1, -2)` for BF16 path.

The pre-quantized (MXFP4) code path is unchanged.

## Test

```bash
mlx_lm.convert --model chromadb/context-1 -q --q-bits 6 --q-group-size 64 --mlx-path context-1-6bit
```

Before: `ValueError: Received 72 parameters not in model`

After:
```
Prompt: 93 tokens, 186 tokens-per-sec
Generation: 46 tokens, 127 tokens-per-sec
Peak memory: 17.018 GB
```

Fixes #1079