### PR TITLE
Move mx.eval out of per-weight loop in GPTQ quantization

### DIFF
--- a/mlx_lm/quant/gptq.py
+++ b/mlx_lm/quant/gptq.py
@@ -125,8 +125,8 @@ def gptq_quantize(
 
                 W[..., k : k + j] -= e @ Hinv[k : k + 1, k : k + j]
                 err[..., k : k + 1] = e
-                mx.eval(err, W)
 
+            mx.eval(err, W)
             W[..., j:] -= err @ Hinv[i:j, j:]
 
         # Quantize with the given scales and biases


### PR DESCRIPTION
## Summary

Reduce GPU synchronization frequency in GPTQ quantization by evaluating once per group instead of once per weight element, yielding 16-30% faster quantization.

## Problem

In `gptq_quantize`, `mx.eval(err, W)` is called inside the innermost loop (per weight element). With `group_size=64`, this forces 64 GPU/CPU synchronization points per group. For a model with 196 quantizable layers and thousands of weight columns, this results in hundreds of thousands of unnecessary syncs.

## Solution

Move `mx.eval(err, W)` from inside the per-weight loop to after the group loop completes. The GPTQ error propagation (`W[..., k:k+j] -= e @ Hinv[...]`) still accumulates correctly within the lazy computation graph — MLX handles the dependencies. The eval is only needed before the cross-group update (`W[..., j:] -= err @ Hinv[i:j, j:]`).

One-line change: move `mx.eval(err, W)` down by one indentation level.

## Results

Benchmarked on MacBook Air M4 (16GB), `bits=4, group_size=64, num_samples=32`:

| Model | Before | After | Speedup | Peak Memory |
|---|---|---|---|---|
| Qwen3-0.6B (196 layers) | 208.0s | 146.0s | **-29.8%** | 5.53 GB (same) |
| Qwen3-1.7B (196 layers) | 1526.2s | 1285.2s | **-15.8%** | 14.36 GB (same) |

No change in quantization output quality — the mathematical operations are identical, only the evaluation timing differs.