### PR TITLE
fix: adaptive prefill step for long-context inference on Apple Silicon

### DIFF
--- a/mlx_lm/generate.py
+++ b/mlx_lm/generate.py
@@ -425,7 +425,20 @@ def generate_step(
         prompt_progress_callback(prompt_processed_tokens, total_prompt_tokens)
         while total_prompt_tokens - prompt_processed_tokens > 1:
             remaining = (total_prompt_tokens - prompt_processed_tokens) - 1
-            n_to_process = min(prefill_step_size, remaining)
+            # Adaptive prefill step: GPU watchdog kills command buffers that
+            # exceed ~5s. Each step runs the full model forward (all layers
+            # including chunked SDPA) in one command buffer. Cost per eval
+            # grows with cached tokens. Scale step inversely to keep each
+            # eval under the watchdog. Mid-primitive command buffer commits
+            # are NOT safe (triggers Metal driver AGXMetalG14X coalescing
+            # assertion — mlx#3216 class bug), so this is the only lever.
+            effective_step = prefill_step_size
+            if prompt_processed_tokens > 65536:
+                effective_step = max(
+                    128,
+                    int(prefill_step_size * 65536 / prompt_processed_tokens),
+                )
+            n_to_process = min(effective_step, remaining)
             _model_call(
                 input_tokens=prompt[:n_to_process][None],
                 input_embeddings=(


### PR DESCRIPTION
## Summary

Scale `prefill_step_size` inversely with cached token count when past 65K tokens, preventing GPU watchdog kills during long-context prefill on Apple Silicon.

## Problem

Each prefill step runs the full model forward pass in a single Metal command buffer. As the KV cache grows, each step takes longer. Metal's GPU watchdog kills command buffers exceeding ~5 seconds. Without adaptive scaling, prompts beyond ~65K tokens crash:

```
IOGPU: Command buffer exceeded walltime for context
```

This affects all models on Apple Silicon at long context, but is most acute on large models (122B+) where per-step cost is already high.

## Fix

When `prompt_processed_tokens > 65536`, scale the effective step size inversely:

```python
effective_step = max(128, int(prefill_step_size * 65536 / prompt_processed_tokens))
```

This keeps each command buffer under the watchdog limit. At 128K context, step shrinks from 2048 to ~1024. At 256K, ~512. Floor of 128 ensures progress.

No behavioral change for contexts under 65K. The adaptive scaling is a continuous function, not a hard threshold.

## Results

Tested on M2 Ultra 128GB with Qwen3.5-122B-A10B-VLM-MTP-5bit:

| Context | Before | After |
|---------|--------|-------|
| 32K | works | works (unchanged) |
| 64K | works | works (unchanged) |
| 128K | GPU watchdog kill | works (step adapts to ~1024) |
| 256K+ | crash | works (with YaRN rope scaling) |

## Test plan

- [x] 32K context: no behavior change
- [x] 128K context: prefill completes without watchdog kill
- [x] 256K+ with YaRN: prefill completes
- [x] 14-line change, single file