### PR TITLE
perf: reduce peak memory when loading AutoAWQ/GPTQ models

### DIFF
--- a/mlx_lm/utils.py
+++ b/mlx_lm/utils.py
@@ -155,6 +155,13 @@ def _transform_awq_weights(
             new_weights[f"{prefix}.biases"] = biases.astype(scales.dtype)
             model_dtype = scales.dtype
 
+            # Materialize results and release source weights per layer
+            mx.eval(weight, scales, new_weights[f"{prefix}.biases"])
+            del weights[f"{prefix}.qweight"]
+            if qzeros_key in weights:
+                del weights[qzeros_key]
+            del weights[scales_key]
+
         elif not any(
             key.endswith(suffix) for suffix in [".qweight", ".qzeros", ".scales"]
         ):


### PR DESCRIPTION
Fixes #1121

## Summary

Reduce peak memory by 41-48% when loading models in AutoAWQ/AutoGPTQ format by materializing transformed weights and releasing source tensors per layer, instead of accumulating all intermediates in the lazy computation graph.

Tested on 3 models / 3 architectures. Output is bit-identical.

## The problem

`_transform_awq_weights` converts packed weights from AutoAWQ/GPTQ format to MLX format. For each layer, it unpacks 4-bit weights into 32-bit (8x expansion), transposes, and repacks. With MLX's lazy evaluation, the intermediate arrays for all layers accumulate in the computation graph before being materialized at once.

For a model with `L` layers, each with intermediate overhead `O`:

- **Current peak** = `model_final + L * O`

This means a 13B model that occupies 7.4 GB in its final form requires 14.4 GB during loading — the extra 7 GB are intermediates from all layers sitting in the graph simultaneously.

## The fix

After transforming each layer, immediately materialize the results and release the source tensors:

```python
new_weights[f"{prefix}.weight"] = weight
new_weights[f"{prefix}.scales"] = scales
new_weights[f"{prefix}.biases"] = biases.astype(scales.dtype)
model_dtype = scales.dtype

# Materialize results and release source weights per layer
mx.eval(weight, scales, new_weights[f"{prefix}.biases"])
del weights[f"{prefix}.qweight"]
if qzeros_key in weights:
    del weights[qzeros_key]
del weights[scales_key]
```

This bounds the overhead to one layer's intermediates at a time:

- **New peak** = `model_final + 1 * O`

## Results

Tested on MacBook Air M4 (16 GB).

### Peak memory (3 models, 3 architectures)

| Model | Arch | Final size | Before | After | Reduction |
|---|---|---|---|---|---|
| TheBloke/Llama-2-7B-AWQ | Llama | 3.97 GB | 8.67 GB | 4.59 GB | **-47%** |
| TheBloke/Mistral-7B-v0.1-AWQ | Mistral | 4.23 GB | 10.04 GB | 5.20 GB | **-48%** |
| TheBloke/CodeLlama-13B-AWQ | CodeLlama | 7.40 GB | 14.37 GB | 8.54 GB | **-41%** |

### Output correctness

Generation output is **bit-identical** before and after the change on all 3 models (same prompt, same seed, character-by-character comparison).

### Load time

Loading is slightly slower due to per-layer `mx.eval` calls:

| Model | Before | After | Delta |
|---|---|---|---|
| Llama-2-7B-AWQ | 6.0 s | 6.6 s | +0.6 s |
| CodeLlama-13B-AWQ | 10.4 s | 15.1 s | +4.7 s |

This is a one-time cost that trades seconds for gigabytes of freed memory — the difference between a model fitting in RAM or not.

## Test plan

- [x] Full test suite passes (175/175)
- [x] `pre-commit` clean
- [x] Output bit-identical on 3 models / 3 architectures (Llama, Mistral, CodeLlama)
- [x] Peak memory reduced 41-48% on all tested models