### PR TITLE
feat: memory-aware auto-config + BatchQuantizedKVCache for batched quantized KV

### DIFF
--- a/mlx_lm/generate.py
+++ b/mlx_lm/generate.py
@@ -30,6 +30,7 @@ from .models import cache
 from .models.cache import (
     ArraysCache,
     BatchKVCache,
+    BatchQuantizedKVCache,
     BatchRotatingKVCache,
     CacheList,
     KVCache,
@@ -834,7 +835,7 @@ class BatchStats:
     peak_memory: float = 0
 
 
-def _make_cache(model, left_padding, max_kv_size):
+def _make_cache(model, left_padding, max_kv_size, kv_bits=None, kv_group_size=64):
     """
     Convert a list of regular caches into their corresponding
     batch-aware caches.
@@ -842,7 +843,15 @@ def _make_cache(model, left_padding, max_kv_size):
 
     def to_batch_cache(c):
         if type(c) is KVCache:
+            if kv_bits is not None and getattr(c, "quantizable", True):
+                return BatchQuantizedKVCache(
+                    left_padding, group_size=kv_group_size, bits=kv_bits
+                )
             return BatchKVCache(left_padding)
+        elif type(c) is QuantizedKVCache:
+            return BatchQuantizedKVCache(
+                left_padding, group_size=c.group_size, bits=c.bits
+            )
         elif isinstance(c, ArraysCache):
             c.left_padding = mx.array(left_padding)
             return c
@@ -862,6 +871,13 @@ def _make_cache(model, left_padding, max_kv_size):
         if max_kv_size is not None:
             return [
                 BatchRotatingKVCache(max_kv_size, left_padding) for _ in model.layers
+            ]
+        if kv_bits is not None:
+            return [
+                BatchQuantizedKVCache(
+                    left_padding, group_size=kv_group_size, bits=kv_bits
+                )
+                for _ in model.layers
             ]
         return [BatchKVCache(left_padding) for _ in model.layers]
 

--- a/mlx_lm/generate.py
+++ b/mlx_lm/generate.py
@@ -207,6 +207,13 @@ def setup_arg_parser():
         default=DEFAULT_QUANTIZED_KV_START,
     )
     parser.add_argument(
+        "--auto-config",
+        action="store_true",
+        help="Automatically configure KV cache settings based on available memory. "
+        "Overrides --kv-bits and --max-kv-size if set.",
+        default=False,
+    )
+    parser.add_argument(
         "--draft-model",
         type=str,
         help="A model to be used for speculative decoding.",
@@ -2041,6 +2048,24 @@ def main():
         xtc_threshold=args.xtc_threshold,
         xtc_special_tokens=tokenizer.encode("\n") + list(tokenizer.eos_token_ids),
     )
+    # Apply auto-config if requested
+    kv_bits = args.kv_bits
+    kv_group_size = args.kv_group_size
+    max_kv_size = args.max_kv_size
+    quantized_kv_start = args.quantized_kv_start
+
+    if getattr(args, "auto_config", False):
+        from .memory_config import auto_configure, describe_config
+
+        config = auto_configure(model)
+        if config.kv_bits is not None:
+            kv_bits = config.kv_bits
+            kv_group_size = config.kv_group_size
+        if config.max_kv_size is not None:
+            max_kv_size = config.max_kv_size
+        if args.verbose:
+            print(f"[auto-config] {describe_config(config)}")
+
     response = generate(
         model,
         tokenizer,
@@ -2048,11 +2073,11 @@ def main():
         max_tokens=args.max_tokens,
         verbose=args.verbose,
         sampler=sampler,
-        max_kv_size=args.max_kv_size,
+        max_kv_size=max_kv_size,
         prompt_cache=prompt_cache if using_cache else None,
-        kv_bits=args.kv_bits,
-        kv_group_size=args.kv_group_size,
-        quantized_kv_start=args.quantized_kv_start,
+        kv_bits=kv_bits,
+        kv_group_size=kv_group_size,
+        quantized_kv_start=quantized_kv_start,
         draft_model=draft_model,
         num_draft_tokens=args.num_draft_tokens,
     )

--- a/mlx_lm/memory_config.py
+++ b/mlx_lm/memory_config.py
@@ -1,0 +1,214 @@
+"""
+Memory-aware inference auto-configuration for Apple Silicon.
+
+Detects available unified memory and configures optimal KV cache settings
+to maximize context length without OOM. Designed for 32GB machines where
+memory is the primary constraint.
+
+Usage:
+    from mlx_lm.memory_config import auto_configure
+
+    config = auto_configure(model)
+    # config.kv_bits, config.max_kv_size, config.estimated_max_context, etc.
+"""
+
+from dataclasses import dataclass, field
+from typing import List, Optional
+
+import mlx.core as mx
+import mlx.nn as nn
+
+
+@dataclass
+class InferenceConfig:
+    """Recommended inference settings based on available memory."""
+
+    kv_bits: Optional[int] = None  # None (FP16), 4, or 8
+    kv_group_size: int = 64
+    max_kv_size: Optional[int] = None  # None = unlimited, or rotating cache size
+    quantized_kv_start: int = 0  # layers to keep FP16 before quantizing
+    estimated_max_context: int = 0  # max tokens before OOM
+    headroom_gb: float = 0.0  # estimated free memory at max context
+    warnings: List[str] = field(default_factory=list)
+
+
+def _model_bytes(model: nn.Module) -> int:
+    """Estimate model weight size in bytes."""
+    total = 0
+    for _, v in nn.utils.tree_flatten(model.parameters()):
+        if isinstance(v, mx.array):
+            total += v.nbytes
+    return total
+
+
+def _kv_bytes_per_token(model: nn.Module, bits: Optional[int] = None) -> float:
+    """Estimate KV cache bytes per token across all layers.
+
+    For FP16: 2 * num_kv_heads * head_dim * 2 bytes * num_layers
+    For quantized: adjusted by bits/16 ratio plus scale/bias overhead
+    """
+    args = getattr(model, "args", None)
+    if args is None:
+        # Fallback: try to infer from first layer
+        layer = model.layers[0]
+        for attr in ("self_attn", "attention", "attn"):
+            attn = getattr(layer, attr, None)
+            if attn is not None:
+                break
+        else:
+            return 0
+
+        num_kv_heads = getattr(attn, "n_kv_heads", getattr(attn, "num_kv_heads", 8))
+        head_dim = getattr(attn, "head_dim", 128)
+    else:
+        num_kv_heads = getattr(args, "num_key_value_heads", getattr(args, "num_kv_heads", 8))
+        head_dim = getattr(args, "head_dim", None)
+        if head_dim is None:
+            hidden = getattr(args, "hidden_size", 4096)
+            num_heads = getattr(args, "num_attention_heads", 32)
+            head_dim = hidden // num_heads
+
+    num_layers = len(model.layers)
+
+    # 2 for keys + values, 2 bytes per float16 element
+    fp16_per_token = 2 * num_kv_heads * head_dim * 2 * num_layers
+
+    if bits is None:
+        return fp16_per_token
+
+    # Quantized: data is packed, plus per-group scales and biases
+    group_size = 64
+    el_per_int = 32 // bits  # elements packed per uint32
+    data_bytes = num_kv_heads * head_dim / el_per_int * 4  # uint32 = 4 bytes
+    groups = num_kv_heads * head_dim / group_size
+    scale_bias_bytes = groups * 2 * 2  # scales + biases, float16 each
+
+    quant_per_layer = 2 * (data_bytes + scale_bias_bytes)  # keys + values
+    return quant_per_layer * num_layers
+
+
+def auto_configure(
+    model: nn.Module,
+    target_context: Optional[int] = None,
+    memory_budget_fraction: float = 0.85,
+) -> InferenceConfig:
+    """
+    Automatically configure inference settings based on available memory.
+
+    Args:
+        model: Loaded MLX model
+        target_context: Desired context length (None = maximize)
+        memory_budget_fraction: Fraction of recommended working set to use
+
+    Returns:
+        InferenceConfig with recommended settings
+    """
+    info = mx.device_info()
+    total_memory = info.get("memory_size", 32 * 1024**3)
+    recommended = info.get("max_recommended_working_set_size", total_memory * 0.75)
+    budget = int(recommended * memory_budget_fraction)
+
+    model_size = _model_bytes(model)
+    active = mx.get_active_memory()
+    overhead = 512 * 1024 * 1024  # 512MB buffer for activations, framework, etc.
+
+    available_for_kv = budget - model_size - overhead
+    if available_for_kv < 0:
+        available_for_kv = 0
+
+    config = InferenceConfig()
+    total_gb = total_memory / 1024**3
+    model_gb = model_size / 1024**3
+    avail_gb = available_for_kv / 1024**3
+
+    # Try configurations from least to most aggressive
+    candidates = [
+        (None, "FP16"),
+        (8, "8-bit"),
+        (4, "4-bit"),
+    ]
+
+    # Compute max context for each option
+    options = []
+    for bits, label in candidates:
+        bpt = _kv_bytes_per_token(model, bits)
+        if bpt > 0:
+            max_ctx = int(available_for_kv / bpt)
+            options.append((bits, label, max_ctx, bpt))
+
+    if not options:
+        config.warnings.append(
+            f"Model ({model_gb:.1f}GB) may not fit in memory ({total_gb:.0f}GB)"
+        )
+        config.kv_bits = 4
+        config.estimated_max_context = 0
+        return config
+
+    if target_context is not None:
+        # Find least aggressive option that meets target
+        chosen = None
+        for bits, label, max_ctx, bpt in options:
+            if max_ctx >= target_context:
+                chosen = (bits, max_ctx, bpt)
+                break
+
+        if chosen is not None:
+            config.kv_bits = chosen[0]
+            config.estimated_max_context = target_context
+            config.headroom_gb = (available_for_kv - target_context * chosen[2]) / 1024**3
+        else:
+            # Can't meet target — use most aggressive and report actual max
+            bits, label, max_ctx, bpt = options[-1]
+            config.kv_bits = bits
+            config.estimated_max_context = max_ctx
+            config.headroom_gb = 0
+            config.warnings.append(
+                f"Cannot fit {target_context:,} tokens. "
+                f"Max with {label} KV: {max_ctx:,} tokens."
+            )
+    else:
+        # No target: pick least aggressive option with >= 16K context
+        config.kv_bits = options[-1][0]  # default to most aggressive
+        config.estimated_max_context = options[-1][2]
+
+        for bits, label, max_ctx, bpt in options:
+            if max_ctx >= 16384:
+                config.kv_bits = bits
+                config.estimated_max_context = max_ctx
+                break
+
+    # If even 4-bit can't handle a reasonable context, suggest rotating cache
+    if config.estimated_max_context < 4096:
+        config.max_kv_size = max(config.estimated_max_context, 2048)
+        config.warnings.append(
+            f"Limited to {config.max_kv_size} token context window "
+            f"(rotating cache). Model uses {model_gb:.1f}GB of {total_gb:.0f}GB."
+        )
+
+    # Warn if tight
+    if config.estimated_max_context < 8192:
+        config.warnings.append(
+            f"Memory constrained: ~{config.estimated_max_context:,} max tokens. "
+            f"Consider a smaller model for long-context tasks."
+        )
+
+    return config
+
+
+def describe_config(config: InferenceConfig) -> str:
+    """Human-readable description of the configuration."""
+    lines = []
+    if config.kv_bits is None:
+        lines.append("KV cache: FP16 (no quantization)")
+    else:
+        lines.append(f"KV cache: {config.kv_bits}-bit quantized (group_size={config.kv_group_size})")
+
+    lines.append(f"Estimated max context: {config.estimated_max_context:,} tokens")
+
+    if config.max_kv_size is not None:
+        lines.append(f"Rotating cache: {config.max_kv_size:,} tokens (oldest context dropped)")
+
+    for w in config.warnings:
+        lines.append(f"Warning: {w}")
+
+    return "\n".join(lines)

--- a/mlx_lm/models/cache.py
+++ b/mlx_lm/models/cache.py
@@ -7,7 +7,7 @@ from typing import Any, Dict, List, Optional
 
 import mlx.core as mx
 import mlx.nn as nn
-from mlx.utils import tree_flatten, tree_map, tree_unflatten
+from mlx.utils import tree_flatten, tree_map, tree_reduce, tree_unflatten
 
 from .base import create_causal_mask
 

--- a/mlx_lm/models/cache.py
+++ b/mlx_lm/models/cache.py
@@ -314,6 +314,10 @@ class QuantizedKVCache(_BaseCache):
     def make_mask(self, *args, **kwargs):
         return create_attention_mask(*args, offset=self.offset, **kwargs)
 
+    @classmethod
+    def merge(cls, caches):
+        return BatchQuantizedKVCache.merge(caches)
+
     def empty(self):
         return self.keys is None
 
@@ -1095,6 +1099,285 @@ class BatchKVCache(_BaseCache):
         if self.keys is None:
             return 0
         return self.keys.nbytes + self.values.nbytes
+
+
+class BatchQuantizedKVCache(_BaseCache):
+    """Batched quantized KV cache for concurrent request serving.
+
+    Stores keys and values in quantized format (uint32 packed data +
+    per-group scales and biases) to reduce memory during batched inference.
+    Returns quantized 3-tuples from update_and_fetch() for use with
+    quantized_scaled_dot_product_attention().
+    """
+
+    step = 256
+
+    def __init__(self, left_padding: List[int], group_size: int = 64, bits: int = 8):
+        self.left_padding = mx.array(left_padding)
+        self._offset = mx.array([-l for l in left_padding])
+        self._idx = 0
+        self.group_size = group_size
+        self.bits = bits
+
+        # Quantized storage: 3-tuples of (data, scales, biases) or None
+        self.keys = None
+        self.values = None
+        self._right_padding = None
+
+    @property
+    def offset(self):
+        return self._offset + 0
+
+    @offset.setter
+    def offset(self, v):
+        self._offset = v
+
+    def _init_quant_buffer(self, B, n_kv_heads, n_steps, dim, dtype):
+        el_per_int = 32 // self.bits
+        return (
+            mx.zeros((B, n_kv_heads, n_steps, dim // el_per_int), dtype=mx.uint32),
+            mx.zeros((B, n_kv_heads, n_steps, dim // self.group_size), dtype=dtype),
+            mx.zeros((B, n_kv_heads, n_steps, dim // self.group_size), dtype=dtype),
+        )
+
+    def _expand_quant_buffer(self, buf, B, n_kv_heads, n_steps):
+        return tuple(
+            mx.concatenate(
+                [b, mx.zeros((B, n_kv_heads, n_steps, b.shape[-1]), dtype=b.dtype)],
+                axis=2,
+            )
+            for b in buf
+        )
+
+    def update_and_fetch(self, keys, values):
+        B, n_kv_heads, num_steps, k_head_dim = keys.shape
+        v_head_dim = values.shape[-1]
+        prev = self._idx
+
+        if self.keys is None or (prev + num_steps) > self.keys[0].shape[2]:
+            new_steps = (self.step + num_steps - 1) // self.step * self.step
+            if self.keys is not None:
+                if prev % self.step != 0:
+                    self.keys = tree_map(lambda x: x[..., :prev, :], self.keys)
+                    self.values = tree_map(lambda x: x[..., :prev, :], self.values)
+                self.keys = self._expand_quant_buffer(
+                    self.keys, B, n_kv_heads, new_steps
+                )
+                self.values = self._expand_quant_buffer(
+                    self.values, B, n_kv_heads, new_steps
+                )
+            else:
+                self.keys = self._init_quant_buffer(
+                    B, n_kv_heads, new_steps, k_head_dim, keys.dtype
+                )
+                self.values = self._init_quant_buffer(
+                    B, n_kv_heads, new_steps, v_head_dim, values.dtype
+                )
+
+        self._offset = self._offset + num_steps
+        self._idx += num_steps
+
+        q_keys = mx.quantize(keys, group_size=self.group_size, bits=self.bits)
+        q_values = mx.quantize(values, group_size=self.group_size, bits=self.bits)
+        for i in range(3):
+            self.keys[i][..., prev : self._idx, :] = q_keys[i]
+            self.values[i][..., prev : self._idx, :] = q_values[i]
+
+        return tree_map(
+            lambda x: x[..., : self._idx, :], (self.keys, self.values)
+        )
+
+    def prepare(self, *, left_padding=None, lengths=None, right_padding=None):
+        if left_padding is not None:
+            if self.keys is not None:
+                raise ValueError(
+                    "Left padding can only be added to an empty BatchQuantizedKVCache"
+                )
+            left_padding = mx.array(left_padding)
+            self.left_padding += left_padding
+            self._offset = self._offset - left_padding
+
+        if right_padding is not None and max(right_padding) > 0:
+            self._right_padding = mx.array(right_padding)
+
+    def finalize(self):
+        if self._right_padding is not None:
+            padding = self._right_padding
+            self.keys = tree_map(
+                lambda x: dynamic_roll(x, padding[:, None], axis=2), self.keys
+            )
+            self.values = tree_map(
+                lambda x: dynamic_roll(x, padding[:, None], axis=2), self.values
+            )
+            self._offset = self._offset - padding
+            self.left_padding += padding
+            self._right_padding = None
+
+    @property
+    def state(self):
+        k, v = self.keys, self.values
+        if self._idx < k[0].shape[2]:
+            k = tree_map(lambda x: x[..., : self._idx, :], k)
+            v = tree_map(lambda x: x[..., : self._idx, :], v)
+        return k, v, self._offset, self.left_padding
+
+    @state.setter
+    def state(self, v):
+        self.keys, self.values, self._offset, self.left_padding = v
+        self._idx = self.keys[0].shape[2]
+
+    def is_trimmable(self):
+        return True
+
+    def trim(self, n):
+        n = min(self._idx, n)
+        self._idx -= n
+        self._offset = self._offset - n
+        return n
+
+    def make_mask(self, N: int, return_array: bool = False, **kwargs):
+        return create_causal_mask(
+            N, offset=self._idx, left_padding=self.left_padding, **kwargs
+        )
+
+    def filter(self, batch_indices):
+        if self.keys is not None:
+            self.keys = tree_map(lambda x: x[batch_indices], self.keys)
+            self.values = tree_map(lambda x: x[batch_indices], self.values)
+        self._offset = self._offset[batch_indices]
+        self.left_padding = self.left_padding[batch_indices]
+
+        min_left_pad = self.left_padding.min().item()
+        if min_left_pad > 0:
+            if self.keys is not None:
+                self.keys = tree_map(
+                    lambda x: x[..., min_left_pad:, :], self.keys
+                )
+                self.values = tree_map(
+                    lambda x: x[..., min_left_pad:, :], self.values
+                )
+            self._idx -= min_left_pad
+            self.left_padding -= min_left_pad
+
+    def extend(self, other):
+        if self.keys is None and other.keys is None:
+            self.left_padding = mx.concatenate(
+                [self.left_padding, other.left_padding]
+            )
+            self._offset = mx.concatenate([self._offset, other._offset])
+            return
+
+        max_idx = max(self._idx, other._idx)
+
+        def pad_quant(c):
+            k, v = c.keys, c.values
+            if k is None:
+                return None, None, c.left_padding
+            left = max_idx - c._idx
+            k = tree_map(
+                lambda x: mx.pad(x, [(0, 0)] * (x.ndim - 2) + [(left, 0), (0, 0)]),
+                k,
+            ) if left > 0 else k
+            v = tree_map(
+                lambda x: mx.pad(x, [(0, 0)] * (x.ndim - 2) + [(left, 0), (0, 0)]),
+                v,
+            ) if left > 0 else v
+            return k, v, c.left_padding + left
+
+        sk, sv, slp = pad_quant(self)
+        ok, ov, olp = pad_quant(other)
+
+        if sk is not None and ok is not None:
+            self.keys = tree_map(lambda a, b: mx.concatenate([a, b]), sk, ok)
+            self.values = tree_map(lambda a, b: mx.concatenate([a, b]), sv, ov)
+        elif sk is not None:
+            self.keys, self.values = sk, sv
+        else:
+            self.keys, self.values = ok, ov
+
+        self.left_padding = mx.concatenate([slp, olp])
+        self._offset = mx.concatenate([self._offset, other._offset])
+        self._idx = max_idx
+
+    def extract(self, idx):
+        cache = QuantizedKVCache(group_size=self.group_size, bits=self.bits)
+        padding = self.left_padding[idx].item()
+        cache.keys = tree_map(
+            lambda x: mx.contiguous(x[idx : idx + 1, :, padding : self._idx]),
+            self.keys,
+        )
+        cache.values = tree_map(
+            lambda x: mx.contiguous(x[idx : idx + 1, :, padding : self._idx]),
+            self.values,
+        )
+        cache.offset = cache.keys[0].shape[2]
+        return cache
+
+    @classmethod
+    def merge(cls, caches):
+        offsets = [c.offset for c in caches]
+        lengths = [c.offset for c in caches]
+        max_length = max(lengths)
+
+        if max_length == 0:
+            return cls(
+                [0] * len(caches),
+                group_size=caches[0].group_size,
+                bits=caches[0].bits,
+            )
+
+        padding = [max_length - l for l in lengths]
+        B = len(caches)
+
+        # Get shapes from first non-empty cache
+        ref = next(c for c in caches if c.keys is not None)
+        n_kv_heads = ref.keys[0].shape[1]
+        k_dim_packed = ref.keys[0].shape[3]
+        v_dim_packed = ref.values[0].shape[3]
+        k_dim_scale = ref.keys[1].shape[3]
+        v_dim_scale = ref.values[1].shape[3]
+        dt = ref.keys[1].dtype
+        group_size = ref.group_size
+        bits = ref.bits
+
+        def make_buf(dim_packed, dim_scale):
+            return (
+                mx.zeros((B, n_kv_heads, max_length, dim_packed), dtype=mx.uint32),
+                mx.zeros((B, n_kv_heads, max_length, dim_scale), dtype=dt),
+                mx.zeros((B, n_kv_heads, max_length, dim_scale), dtype=dt),
+            )
+
+        keys = make_buf(k_dim_packed, k_dim_scale)
+        values = make_buf(v_dim_packed, v_dim_scale)
+
+        for i, (p, l, c) in enumerate(zip(padding, lengths, caches)):
+            if c.keys is None:
+                continue
+            for j in range(3):
+                keys[j][i : i + 1, :, p : p + l] = c.keys[j][..., :l, :]
+                values[j][i : i + 1, :, p : p + l] = c.values[j][..., :l, :]
+
+        cache = cls(padding, group_size=group_size, bits=bits)
+        cache.keys = keys
+        cache.values = values
+        cache._offset = mx.array(offsets)
+        cache._idx = max_length
+
+        return cache
+
+    def size(self):
+        return self._idx
+
+    def empty(self):
+        return self.keys is None
+
+    @property
+    def nbytes(self):
+        if self.keys is None:
+            return 0
+        return tree_reduce(
+            lambda a, x: a + x.nbytes, (self.keys, self.values), 0
+        )
 
 
 class BatchRotatingKVCache(_BaseCache):

--- a/mlx_lm/rps/__init__.py
+++ b/mlx_lm/rps/__init__.py
@@ -1,0 +1,26 @@
+"""Residual Precision Streaming (RPS) for memory-efficient LLM inference.
+
+Enables running larger models on smaller hardware by decomposing weights
+into a low-bit base (always in memory) and a quantized residual that
+boosts precision on demand.
+
+Example:
+    # Convert a model
+    from mlx_lm.rps import convert, load_rps
+
+    convert("mlx-community/Llama-3.1-70B-4bit",
+            base_output="./llama-70b-rps-base",
+            residual_output="./llama-70b-rps-residuals")
+
+    # Load and generate
+    model, tokenizer = load_rps(
+        "./llama-70b-rps-base",
+        "./llama-70b-rps-residuals",
+        tier=2,
+    )
+"""
+
+from .config import RPSConfig
+from .convert import convert, compute_residuals
+from .linear import RPSLinear
+from .loader import load_rps

--- a/mlx_lm/rps/benchmark.py
+++ b/mlx_lm/rps/benchmark.py
@@ -1,0 +1,148 @@
+"""End-to-end RPS benchmark: FP16 → 3-bit base + residuals → generate.
+
+Compares:
+1. Original FP16 quality (reference)
+2. Standard 4-bit quantization
+3. Standard 3-bit quantization
+4. RPS: 3-bit base + 2-bit residuals on all projections
+5. RPS Tier 2: 3-bit base + 2-bit residuals on v_proj + down_proj only
+"""
+
+import sys
+import time
+
+import mlx.core as mx
+import mlx.nn as nn
+
+
+def benchmark_rps(model_path: str, prompt: str = "Explain quantum computing in simple terms.", max_tokens: int = 100):
+    from mlx_lm import load, generate
+    from mlx_lm.rps.linear import RPSLinear
+    from mlx_lm.rps.convert import compute_residuals
+
+    results = {}
+
+    # --- FP16 baseline ---
+    print("=== FP16 (reference) ===")
+    model, tok = load(model_path)
+    generate(model, tok, prompt="Hi", max_tokens=3, verbose=False)
+    t0 = time.perf_counter()
+    out = generate(model, tok, prompt=prompt, max_tokens=max_tokens, verbose=False)
+    t1 = time.perf_counter()
+    toks = len(tok.encode(out))
+    speed = toks / (t1 - t0)
+    mem = mx.get_active_memory() / 1024**3
+    print(f"  {speed:.1f} tok/s, {mem:.1f} GB")
+    print(f"  {out[:200]}")
+    results["fp16"] = (speed, out)
+
+    # Collect FP16 weights for all projections
+    fp16_weights = {}
+    for li, layer in enumerate(model.layers):
+        attn = layer.self_attn
+        mlp = layer.mlp
+        for an, parent in [("q_proj", attn), ("k_proj", attn), ("v_proj", attn),
+                           ("o_proj", attn), ("gate_proj", mlp), ("up_proj", mlp),
+                           ("down_proj", mlp)]:
+            proj = getattr(parent, an, None)
+            if proj is None or not hasattr(proj, "weight"):
+                continue
+            w = proj.weight
+            if isinstance(proj, nn.QuantizedLinear):
+                w = mx.dequantize(w, proj.scales, proj.biases,
+                                  group_size=proj.group_size, bits=proj.bits)
+            mx.eval(w)
+            fp16_weights[(li, an)] = w.astype(mx.float16)
+
+    def _test_config(label, base_bits, tier2_keys=None):
+        """Apply RPS with given config and benchmark."""
+        nonlocal model, tok
+        del model
+        mx.clear_cache()
+        model, tok = load(model_path)
+
+        for li, layer in enumerate(model.layers):
+            attn = layer.self_attn
+            mlp = layer.mlp
+            for an, parent in [("q_proj", attn), ("k_proj", attn), ("v_proj", attn),
+                               ("o_proj", attn), ("gate_proj", mlp), ("up_proj", mlp),
+                               ("down_proj", mlp)]:
+                proj = getattr(parent, an, None)
+                if proj is None:
+                    continue
+                w = fp16_weights.get((li, an))
+                if w is None:
+                    continue
+
+                if tier2_keys is None:
+                    # Standard quantization (no RPS)
+                    bq, bs, bb = mx.quantize(w, group_size=64, bits=base_bits)
+                    mx.eval(bq, bs, bb)
+                    if isinstance(proj, nn.QuantizedLinear):
+                        proj.weight = bq
+                        proj.scales = bs
+                        proj.biases = bb
+                        proj.bits = base_bits
+                        proj.group_size = 64
+                    else:
+                        new_proj = nn.QuantizedLinear(
+                            w.shape[1], w.shape[0], group_size=64, bits=base_bits
+                        )
+                        new_proj.weight = bq
+                        new_proj.scales = bs
+                        new_proj.biases = bb
+                        setattr(parent, an, new_proj)
+                else:
+                    # RPS
+                    (bq, bs, bb, rq, rs, rb, _, _) = compute_residuals(
+                        w, base_bits=base_bits, residual_bits=2
+                    )
+                    mx.eval(bq, bs, bb, rq, rs, rb)
+                    rps = RPSLinear(proj) if isinstance(proj, nn.QuantizedLinear) else RPSLinear(
+                        nn.QuantizedLinear(w.shape[1], w.shape[0], group_size=64, bits=base_bits)
+                    )
+                    rps.weight = bq
+                    rps.scales = bs
+                    rps.biases = bb
+                    rps.bits = base_bits
+                    rps.group_size = 64
+                    if tier2_keys == "all" or an in tier2_keys:
+                        rps.attach_residual(rq, rs, rb, r_bits=2, r_group_size=64)
+                    setattr(parent, an, rps)
+        mx.eval()
+
+        print(f"\n=== {label} ===")
+        generate(model, tok, prompt="Hi", max_tokens=3, verbose=False)
+        t0 = time.perf_counter()
+        out = generate(model, tok, prompt=prompt, max_tokens=max_tokens, verbose=False)
+        t1 = time.perf_counter()
+        toks = len(tok.encode(out))
+        speed = toks / (t1 - t0)
+        mem = mx.get_active_memory() / 1024**3
+        print(f"  {speed:.1f} tok/s, {mem:.1f} GB")
+        print(f"  {out[:200]}")
+        results[label] = (speed, out)
+
+    # --- Standard quantization baselines ---
+    _test_config("4-bit standard", base_bits=4)
+    _test_config("3-bit standard", base_bits=3)
+
+    # --- RPS configurations ---
+    _test_config("RPS 3+2 (all projections)", base_bits=3, tier2_keys="all")
+    _test_config("RPS 3+2 (v_proj+down_proj)", base_bits=3, tier2_keys={"v_proj", "down_proj"})
+    _test_config("RPS 3+2 (attention only)", base_bits=3, tier2_keys={"q_proj", "k_proj", "v_proj", "o_proj"})
+
+    # --- Summary ---
+    print("\n" + "=" * 60)
+    print("SUMMARY")
+    print("=" * 60)
+    for label, (speed, out) in results.items():
+        quality = "OK" if len(out.strip()) > 20 and out.strip()[-1] != out.strip()[-10] else "DEGRADED"
+        print(f"  {label:35s}  {speed:6.1f} tok/s  {quality}")
+
+    return results
+
+
+if __name__ == "__main__":
+    model_path = sys.argv[1] if len(sys.argv) > 1 else "/tmp/qwen2.5-3b-fp16"
+    benchmark_rps(model_path)

--- a/mlx_lm/rps/config.py
+++ b/mlx_lm/rps/config.py
@@ -1,0 +1,30 @@
+"""Configuration for Residual Precision Streaming."""
+
+from dataclasses import dataclass, field
+from typing import List, Optional
+
+
+@dataclass
+class RPSConfig:
+    """Residual Precision Streaming configuration.
+
+    Controls how model weights are decomposed into base + residual tiers
+    for memory-efficient inference on constrained hardware.
+    """
+
+    base_bits: int = 2
+    base_group_size: int = 64
+    residual_bits: int = 2
+    residual_group_size: int = 64
+
+    # Weight suffixes whose residuals are kept in RAM (Tier 2)
+    tier2_keys: List[str] = field(
+        default_factory=lambda: ["v_proj", "down_proj"]
+    )
+
+    # Tier 3: stream remaining residuals from SSD
+    tier3_enabled: bool = False
+    tier3_prefetch_depth: int = 2
+
+    # Path to residual safetensors on disk
+    residual_path: Optional[str] = None

--- a/mlx_lm/rps/convert.py
+++ b/mlx_lm/rps/convert.py
@@ -1,0 +1,236 @@
+"""Convert a model to Residual Precision Streaming format.
+
+Takes a source model (FP16 or quantized) and produces:
+1. Base model: 2-bit quantized (standard mlx-lm format)
+2. Residuals: per-layer 2-bit quantized deltas (base → original)
+"""
+
+import json
+import shutil
+from pathlib import Path
+from typing import Optional
+
+import mlx.core as mx
+import mlx.nn as nn
+
+from .config import RPSConfig
+
+
+def _dequantize_layer_weight(layer_module) -> Optional[mx.array]:
+    """Dequantize a QuantizedLinear layer's weight to float16."""
+    if not isinstance(layer_module, nn.QuantizedLinear):
+        return None
+    w = mx.dequantize(
+        layer_module.weight,
+        layer_module.scales,
+        layer_module.biases,
+        group_size=layer_module.group_size,
+        bits=layer_module.bits,
+    )
+    return w
+
+
+def compute_residuals(
+    original_weight: mx.array,
+    base_bits: int = 2,
+    base_group_size: int = 64,
+    residual_bits: int = 2,
+    residual_group_size: int = 64,
+):
+    """Compute quantized residual between original and base-quantized weight.
+
+    Returns:
+        (base_q, base_scales, base_biases,
+         res_q, res_scales, res_biases,
+         mse_base, mse_with_residual)
+    """
+    w = original_weight.astype(mx.float16)
+
+    # Base quantization
+    base_q, base_s, base_b = mx.quantize(
+        w, group_size=base_group_size, bits=base_bits
+    )
+    w_base = mx.dequantize(base_q, base_s, base_b,
+                            group_size=base_group_size, bits=base_bits)
+
+    # Residual = original - base approximation
+    residual = w - w_base
+
+    # Quantize the residual
+    res_q, res_s, res_b = mx.quantize(
+        residual, group_size=residual_group_size, bits=residual_bits
+    )
+    w_residual = mx.dequantize(res_q, res_s, res_b,
+                                group_size=residual_group_size, bits=residual_bits)
+
+    # Measure improvement
+    mse_base = mx.mean((w - w_base) ** 2).item()
+    mse_combined = mx.mean((w - w_base - w_residual) ** 2).item()
+
+    return (
+        base_q, base_s, base_b,
+        res_q, res_s, res_b,
+        mse_base, mse_combined,
+    )
+
+
+def convert(
+    model_path: str,
+    base_output: str,
+    residual_output: str,
+    config: Optional[RPSConfig] = None,
+    verbose: bool = True,
+):
+    """Convert a model to RPS format.
+
+    Args:
+        model_path: HuggingFace model ID or local path
+        base_output: Directory for base 2-bit model
+        residual_output: Directory for residual files
+        config: RPS configuration (defaults used if None)
+        verbose: Print progress
+    """
+    from mlx_lm import load
+
+    if config is None:
+        config = RPSConfig()
+
+    if verbose:
+        print(f"Loading model: {model_path}")
+    model, tokenizer = load(model_path)
+
+    base_dir = Path(base_output)
+    res_dir = Path(residual_output)
+    base_dir.mkdir(parents=True, exist_ok=True)
+    res_dir.mkdir(parents=True, exist_ok=True)
+
+    total_mse_base = 0
+    total_mse_combined = 0
+    n_weights = 0
+
+    num_layers = len(model.layers)
+    for layer_idx in range(num_layers):
+        layer = model.layers[layer_idx]
+        layer_residuals = {}
+
+        # Find all quantized linear projections
+        targets = []
+        for attr in ("self_attn", "attention", "attn"):
+            attn = getattr(layer, attr, None)
+            if attn is not None:
+                for proj in ("q_proj", "k_proj", "v_proj", "o_proj"):
+                    m = getattr(attn, proj, None)
+                    if m is not None:
+                        targets.append((f"{attr}.{proj}", m))
+                break
+        mlp = getattr(layer, "mlp", None)
+        if mlp is not None:
+            for proj in ("gate_proj", "up_proj", "down_proj"):
+                m = getattr(mlp, proj, None)
+                if m is not None:
+                    targets.append((f"mlp.{proj}", m))
+
+        if verbose:
+            print(f"\nLayer {layer_idx}/{num_layers}:")
+
+        for name, module in targets:
+            if not isinstance(module, nn.QuantizedLinear):
+                continue
+
+            # Get original weight (dequantize from source quantization)
+            w_original = _dequantize_layer_weight(module)
+            if w_original is None:
+                continue
+            mx.eval(w_original)
+
+            # Compute base + residual
+            (base_q, base_s, base_b,
+             res_q, res_s, res_b,
+             mse_base, mse_combined) = compute_residuals(
+                w_original,
+                base_bits=config.base_bits,
+                base_group_size=config.base_group_size,
+                residual_bits=config.residual_bits,
+                residual_group_size=config.residual_group_size,
+            )
+            mx.eval(base_q, base_s, base_b, res_q, res_s, res_b)
+
+            # Update the model's base weights in-place
+            module.weight = base_q
+            module.scales = base_s
+            module.biases = base_b
+            module.bits = config.base_bits
+            module.group_size = config.base_group_size
+
+            # Store residuals
+            layer_residuals[f"{name}.weight"] = res_q
+            layer_residuals[f"{name}.scales"] = res_s
+            layer_residuals[f"{name}.biases"] = res_b
+
+            improvement = (1 - mse_combined / max(mse_base, 1e-10)) * 100
+            total_mse_base += mse_base
+            total_mse_combined += mse_combined
+            n_weights += 1
+
+            if verbose:
+                print(f"  {name}: MSE {mse_base:.6f} → {mse_combined:.6f} "
+                      f"({improvement:.0f}% reduction)")
+
+            del w_original
+
+        # Save layer residuals
+        if layer_residuals:
+            res_path = res_dir / f"residual-layer-{layer_idx:02d}.safetensors"
+            mx.save_safetensors(str(res_path), layer_residuals)
+
+        mx.eval()
+
+    # Save base model
+    if verbose:
+        print(f"\nSaving base model to {base_dir}...")
+
+    # Copy tokenizer and config files
+    from huggingface_hub import snapshot_download
+    src = Path(model_path) if Path(model_path).exists() else Path(
+        snapshot_download(model_path)
+    )
+    for fname in ("tokenizer.json", "tokenizer_config.json", "config.json",
+                   "special_tokens_map.json", "chat_template.jinja",
+                   "tokenizer.model"):
+        src_file = src / fname
+        if src_file.exists():
+            shutil.copy2(src_file, base_dir / fname)
+
+    # Save quantized weights
+    weights = dict(nn.utils.tree_flatten(model.parameters()))
+    mx.save_safetensors(str(base_dir / "model.safetensors"), weights)
+
+    # Update config with quantization info
+    config_path = base_dir / "config.json"
+    if config_path.exists():
+        with open(config_path) as f:
+            model_config = json.load(f)
+        model_config["quantization"] = {
+            "group_size": config.base_group_size,
+            "bits": config.base_bits,
+        }
+        with open(config_path, "w") as f:
+            json.dump(model_config, f, indent=2)
+
+    # Save RPS config
+    rps_meta = {
+        "base_bits": config.base_bits,
+        "base_group_size": config.base_group_size,
+        "residual_bits": config.residual_bits,
+        "residual_group_size": config.residual_group_size,
+        "tier2_keys": config.tier2_keys,
+        "num_layers": num_layers,
+    }
+    with open(res_dir / "rps_config.json", "w") as f:
+        json.dump(rps_meta, f, indent=2)
+
+    if verbose and n_weights > 0:
+        overall = (1 - total_mse_combined / max(total_mse_base, 1e-10)) * 100
+        print(f"\nDone! Overall MSE reduction: {overall:.0f}%")
+        print(f"Base model: {base_dir}")
+        print(f"Residuals: {res_dir}")

--- a/mlx_lm/rps/linear.py
+++ b/mlx_lm/rps/linear.py
@@ -1,0 +1,96 @@
+"""RPSLinear: QuantizedLinear with optional residual precision boost."""
+
+from typing import Optional
+
+import mlx.core as mx
+import mlx.nn as nn
+
+
+class RPSLinear(nn.Module):
+    """Drop-in replacement for QuantizedLinear that supports residual correction.
+
+    The key insight: instead of dequantizing both base and residual and
+    materializing a full-precision weight matrix, we perform two separate
+    quantized matmuls and add the results:
+
+        x @ (W_base + W_residual) = x @ W_base + x @ W_residual
+
+    This avoids the memory cost of a full-precision weight matrix while
+    achieving equivalent quality to higher-precision quantization.
+    """
+
+    def __init__(self, base_layer: nn.QuantizedLinear):
+        super().__init__()
+        self.weight = base_layer.weight
+        self.scales = base_layer.scales
+        self.biases = base_layer.biases
+        self.group_size = base_layer.group_size
+        self.bits = base_layer.bits
+
+        if hasattr(base_layer, "bias") and base_layer.bias is not None:
+            self.bias = base_layer.bias
+        else:
+            self.bias = None
+
+        # Residual parameters (None until attached)
+        self.r_weight: Optional[mx.array] = None
+        self.r_scales: Optional[mx.array] = None
+        self.r_biases: Optional[mx.array] = None
+        self.r_bits: int = 2
+        self.r_group_size: int = 64
+
+        self.freeze()
+
+    def attach_residual(
+        self,
+        r_weight: mx.array,
+        r_scales: mx.array,
+        r_biases: mx.array,
+        r_bits: int = 2,
+        r_group_size: int = 64,
+    ):
+        """Attach a quantized residual to boost precision."""
+        self.r_weight = r_weight
+        self.r_scales = r_scales
+        self.r_biases = r_biases
+        self.r_bits = r_bits
+        self.r_group_size = r_group_size
+
+    def detach_residual(self):
+        """Remove residual for graceful degradation."""
+        self.r_weight = None
+        self.r_scales = None
+        self.r_biases = None
+
+    @property
+    def has_residual(self) -> bool:
+        return self.r_weight is not None
+
+    def __call__(self, x: mx.array) -> mx.array:
+        # Base quantized matmul (always available)
+        out = mx.quantized_matmul(
+            x,
+            self.weight,
+            scales=self.scales,
+            biases=self.biases,
+            transpose=True,
+            group_size=self.group_size,
+            bits=self.bits,
+        )
+
+        # Add residual contribution if attached
+        if self.r_weight is not None:
+            out = out + mx.quantized_matmul(
+                x,
+                self.r_weight,
+                scales=self.r_scales,
+                biases=self.r_biases,
+                transpose=True,
+                group_size=self.r_group_size,
+                bits=self.r_bits,
+            )
+
+        if self.bias is not None:
+            out = out + self.bias
+
+        return out

--- a/mlx_lm/rps/loader.py
+++ b/mlx_lm/rps/loader.py
@@ -1,0 +1,124 @@
+"""Load models with Residual Precision Streaming."""
+
+import json
+from pathlib import Path
+from typing import Optional, Tuple
+
+import mlx.core as mx
+import mlx.nn as nn
+
+from .config import RPSConfig
+from .linear import RPSLinear
+
+
+def _replace_with_rps(model: nn.Module) -> int:
+    """Replace all QuantizedLinear layers with RPSLinear. Returns count."""
+    count = 0
+    for name, module in model.named_modules():
+        if isinstance(module, nn.QuantizedLinear):
+            # Navigate to parent and replace
+            parts = name.split(".")
+            parent = model
+            for p in parts[:-1]:
+                parent = getattr(parent, p)
+            setattr(parent, parts[-1], RPSLinear(module))
+            count += 1
+    return count
+
+
+def _attach_tier2_residuals(
+    model: nn.Module,
+    residual_dir: Path,
+    config: RPSConfig,
+    verbose: bool = True,
+) -> int:
+    """Load and attach Tier 2 (in-RAM) residuals to RPSLinear layers."""
+    attached = 0
+    num_layers = config.get("num_layers", len(model.layers)) if isinstance(config, dict) else len(model.layers)
+    tier2_keys = config["tier2_keys"] if isinstance(config, dict) else config.tier2_keys
+    r_bits = config["residual_bits"] if isinstance(config, dict) else config.residual_bits
+    r_gs = config["residual_group_size"] if isinstance(config, dict) else config.residual_group_size
+
+    for layer_idx in range(num_layers):
+        res_file = residual_dir / f"residual-layer-{layer_idx:02d}.safetensors"
+        if not res_file.exists():
+            continue
+
+        layer_data = mx.load(str(res_file))
+        layer = model.layers[layer_idx]
+
+        for key in tier2_keys:
+            # Find the RPSLinear module matching this key
+            for attr in ("self_attn", "attention", "attn"):
+                attn = getattr(layer, attr, None)
+                if attn is not None:
+                    proj = getattr(attn, key, None)
+                    if proj is not None and isinstance(proj, RPSLinear):
+                        prefix = f"{attr}.{key}"
+                        r_w = layer_data.get(f"{prefix}.weight")
+                        r_s = layer_data.get(f"{prefix}.scales")
+                        r_b = layer_data.get(f"{prefix}.biases")
+                        if r_w is not None:
+                            mx.eval(r_w, r_s, r_b)
+                            proj.attach_residual(r_w, r_s, r_b, r_bits, r_gs)
+                            attached += 1
+                    break
+
+            mlp = getattr(layer, "mlp", None)
+            if mlp is not None:
+                proj = getattr(mlp, key, None)
+                if proj is not None and isinstance(proj, RPSLinear):
+                    prefix = f"mlp.{key}"
+                    r_w = layer_data.get(f"{prefix}.weight")
+                    r_s = layer_data.get(f"{prefix}.scales")
+                    r_b = layer_data.get(f"{prefix}.biases")
+                    if r_w is not None:
+                        mx.eval(r_w, r_s, r_b)
+                        proj.attach_residual(r_w, r_s, r_b, r_bits, r_gs)
+                        attached += 1
+
+    if verbose:
+        print(f"Attached {attached} Tier 2 residuals ({tier2_keys})")
+    return attached
+
+
+def load_rps(
+    base_path: str,
+    residual_path: str,
+    tier: int = 2,
+    verbose: bool = True,
+) -> Tuple[nn.Module, any]:
+    """Load a model with Residual Precision Streaming.
+
+    Args:
+        base_path: Path to base 2-bit model
+        residual_path: Path to residual directory
+        tier: 1 = base only, 2 = base + critical residuals in RAM
+        verbose: Print progress
+
+    Returns:
+        (model, tokenizer) tuple
+    """
+    from mlx_lm import load
+
+    if verbose:
+        print(f"Loading base model: {base_path}")
+    model, tokenizer = load(base_path)
+
+    # Replace QuantizedLinear → RPSLinear
+    count = _replace_with_rps(model)
+    if verbose:
+        print(f"Replaced {count} layers with RPSLinear")
+
+    if tier >= 2:
+        res_dir = Path(residual_path)
+        config_path = res_dir / "rps_config.json"
+        if config_path.exists():
+            with open(config_path) as f:
+                config = json.load(f)
+        else:
+            config = RPSConfig().__dict__
+
+        _attach_tier2_residuals(model, res_dir, config, verbose)
+
+    return model, tokenizer

--- a/mlx_lm/rps/streamer.py
+++ b/mlx_lm/rps/streamer.py
@@ -1,0 +1,173 @@
+"""SSD-backed residual streaming for Apple Silicon.
+
+Streams quantized residuals from SSD per-layer during inference,
+leveraging Apple Silicon's fast NVMe (~7 GB/s) and unified memory.
+
+During forward pass:
+1. Before computing layer N, prefetch layer N+1's residuals from SSD
+2. Attach residuals to layer N's RPSLinear modules
+3. After layer N completes, detach and free residuals
+4. Repeat
+
+This keeps only ~250MB of residuals in memory at a time (one layer),
+while the base model (3-bit) stays fully resident.
+"""
+
+from pathlib import Path
+from typing import Dict, Optional
+
+import mlx.core as mx
+import mlx.nn as nn
+
+from .config import RPSConfig
+from .linear import RPSLinear
+
+
+class ResidualStreamer:
+    """Manages per-layer residual streaming from SSD."""
+
+    def __init__(self, residual_dir: str, config: Optional[RPSConfig] = None):
+        self.residual_dir = Path(residual_dir)
+        self.config = config or RPSConfig()
+
+        # Discover layer files
+        self._layer_files = sorted(self.residual_dir.glob("residual-layer-*.safetensors"))
+        self._cache: Dict[int, dict] = {}
+        self._attached_layer: Optional[int] = None
+
+    @property
+    def num_layers(self) -> int:
+        return len(self._layer_files)
+
+    def prefetch(self, layer_idx: int):
+        """Load a layer's residuals into memory (mmap-backed, fast)."""
+        if layer_idx in self._cache or layer_idx >= len(self._layer_files):
+            return
+        self._cache[layer_idx] = mx.load(str(self._layer_files[layer_idx]))
+
+    def get(self, layer_idx: int, weight_name: str):
+        """Get residual arrays for a specific weight."""
+        if layer_idx not in self._cache:
+            self.prefetch(layer_idx)
+        data = self._cache.get(layer_idx, {})
+        r_w = data.get(f"{weight_name}.weight")
+        r_s = data.get(f"{weight_name}.scales")
+        r_b = data.get(f"{weight_name}.biases")
+        if r_w is not None:
+            mx.eval(r_w, r_s, r_b)  # force page-in from SSD
+        return r_w, r_s, r_b
+
+    def evict(self, layer_idx: int):
+        """Free a layer's residuals from memory."""
+        self._cache.pop(layer_idx, None)
+
+    def attach_to_layer(self, model_layer, layer_idx: int, r_bits: int = 2, r_group_size: int = 64):
+        """Attach residuals to all RPSLinear modules in a model layer."""
+        attached = 0
+        for attr in ("self_attn", "attention", "attn"):
+            attn = getattr(model_layer, attr, None)
+            if attn is None:
+                continue
+            for proj_name in ("q_proj", "k_proj", "v_proj", "o_proj"):
+                proj = getattr(attn, proj_name, None)
+                if isinstance(proj, RPSLinear) and not proj.has_residual:
+                    r_w, r_s, r_b = self.get(layer_idx, f"{attr}.{proj_name}")
+                    if r_w is not None:
+                        proj.attach_residual(r_w, r_s, r_b, r_bits, r_group_size)
+                        attached += 1
+            break
+
+        mlp = getattr(model_layer, "mlp", None)
+        if mlp is not None:
+            for proj_name in ("gate_proj", "up_proj", "down_proj"):
+                proj = getattr(mlp, proj_name, None)
+                if isinstance(proj, RPSLinear) and not proj.has_residual:
+                    r_w, r_s, r_b = self.get(layer_idx, f"mlp.{proj_name}")
+                    if r_w is not None:
+                        proj.attach_residual(r_w, r_s, r_b, r_bits, r_group_size)
+                        attached += 1
+
+        self._attached_layer = layer_idx
+        return attached
+
+    def detach_from_layer(self, model_layer):
+        """Detach all residuals from a model layer's RPSLinear modules."""
+        for attr in ("self_attn", "attention", "attn"):
+            attn = getattr(model_layer, attr, None)
+            if attn is None:
+                continue
+            for proj_name in ("q_proj", "k_proj", "v_proj", "o_proj"):
+                proj = getattr(attn, proj_name, None)
+                if isinstance(proj, RPSLinear):
+                    proj.detach_residual()
+            break
+
+        mlp = getattr(model_layer, "mlp", None)
+        if mlp is not None:
+            for proj_name in ("gate_proj", "up_proj", "down_proj"):
+                proj = getattr(mlp, proj_name, None)
+                if isinstance(proj, RPSLinear):
+                    proj.detach_residual()
+
+        if self._attached_layer is not None:
+            self.evict(self._attached_layer)
+            self._attached_layer = None
+
+
+class _StreamingLayerWrapper(nn.Module):
+    """Wraps a transformer layer to attach/detach residuals per forward pass."""
+
+    def __init__(self, layer, layer_idx, streamer):
+        super().__init__()
+        self._inner = layer
+        self._idx = layer_idx
+        self._streamer = streamer
+
+    def __call__(self, *args, **kwargs):
+        # Attach residuals for this layer
+        self._streamer.attach_to_layer(
+            self._inner, self._idx,
+            r_bits=self._streamer.config.residual_bits,
+            r_group_size=self._streamer.config.residual_group_size,
+        )
+        # Prefetch next layer
+        self._streamer.prefetch(self._idx + 1)
+
+        result = self._inner(*args, **kwargs)
+
+        # Detach and free
+        self._streamer.detach_from_layer(self._inner)
+        return result
+
+
+def streaming_generate(
+    model,
+    tokenizer,
+    streamer: ResidualStreamer,
+    prompt: str,
+    max_tokens: int = 100,
+    verbose: bool = True,
+    **kwargs,
+):
+    """Generate with per-layer SSD residual streaming.
+
+    Wraps each transformer layer to attach/detach residuals around its
+    computation. Only one layer's residuals are in memory at a time.
+    """
+    from mlx_lm import generate as mlx_generate
+
+    # Wrap layers with streaming hooks
+    original_layers = model.layers
+    model.layers = [
+        _StreamingLayerWrapper(layer, i, streamer)
+        for i, layer in enumerate(original_layers)
+    ]
+
+    try:
+        output = mlx_generate(model, tokenizer, prompt=prompt,
+                              max_tokens=max_tokens, verbose=verbose, **kwargs)
+    finally:
+        # Restore original layers
+        model.layers = original_layers
+
+    return output

--- a/tests/rps_full_validation.py
+++ b/tests/rps_full_validation.py
@@ -1,0 +1,309 @@
+"""
+Residual Precision Streaming — Full Validation Suite
+
+No claims until the numbers speak. Tests:
+1. Perplexity across multiple long passages (objective)
+2. Generation quality across 15 diverse prompts
+3. All quantization configs: FP16, 4-bit, 3-bit, 2-bit, RPS variants
+4. Speed benchmarks (averaged over 3 runs)
+5. Memory measurements
+6. Selective residual testing (which projections matter)
+7. Long generation (500 tokens) stability
+8. MSE decomposition analysis
+"""
+
+import time
+import json
+import mlx.core as mx
+import mlx.nn as nn
+from mlx_lm import load, generate
+from mlx_lm.utils import quantize_model
+from mlx_lm.rps.linear import RPSLinear
+
+MODEL = "/tmp/qwen2.5-3b-fp16"
+
+EVAL_TEXTS = [
+    (
+        "The theory of general relativity, published by Albert Einstein in 1915, "
+        "describes gravity not as a force but as a curvature of spacetime caused by mass "
+        "and energy. This revolutionary framework replaced Newton's law of universal "
+        "gravitation for extreme conditions. The field equations relate the geometry of "
+        "spacetime to the distribution of matter within it. General relativity predicts "
+        "phenomena such as gravitational time dilation, gravitational lensing, "
+        "gravitational waves, and the expansion of the universe. The theory has been "
+        "confirmed by numerous experiments and observations, from the perihelion precession "
+        "of Mercury to the detection of gravitational waves by LIGO in 2015."
+    ),
+    (
+        "Machine learning is a subset of artificial intelligence that focuses on building "
+        "systems that learn from and make decisions based on data. Unlike traditional "
+        "programming where rules are explicitly coded, machine learning algorithms identify "
+        "patterns in training data and use them to make predictions on new data. The three "
+        "main paradigms are supervised learning, unsupervised learning, and reinforcement "
+        "learning. Deep learning, which uses neural networks with many layers, has driven "
+        "recent breakthroughs in computer vision, natural language processing, and game "
+        "playing. However, challenges remain in areas such as interpretability, data "
+        "efficiency, and robustness to adversarial examples."
+    ),
+    (
+        "The human immune system is a complex network of cells, tissues, and organs that "
+        "work together to defend the body against harmful pathogens. The innate immune "
+        "system provides immediate but non-specific defense, while the adaptive immune "
+        "system develops targeted responses to specific threats. Key components include "
+        "white blood cells such as T cells and B cells, antibodies, the complement system, "
+        "and the lymphatic system. Vaccination works by training the adaptive immune system "
+        "to recognize and fight specific pathogens without causing the disease itself."
+    ),
+]
+
+PROMPTS = [
+    # Factual
+    "What is photosynthesis?",
+    "Explain how a CPU works.",
+    "What causes thunder and lightning?",
+    "How does the internet work?",
+    # Math/Logic
+    "If a train travels 60 mph for 2.5 hours, how far does it go?",
+    "What is 15% of 200?",
+    "Is 0.3 + 0.3 + 0.3 equal to 0.9?",
+    # Creative
+    "Write a haiku about mountains.",
+    "Tell me a joke about cats.",
+    "Write a limerick about a programmer.",
+    # Instruction
+    "List the 4 seasons in order.",
+    "Translate 'good morning' to Spanish.",
+    "Name 3 planets in our solar system.",
+    # Reasoning
+    "Which is heavier, a pound of feathers or a pound of steel?",
+    "If all roses are flowers and some flowers fade quickly, can we say all roses fade quickly?",
+]
+
+
+def compute_perplexity(model, tok, text):
+    tokens = mx.array(tok.encode(text))
+    n = min(len(tokens), 512)
+    tokens = tokens[:n]
+    logits = model(tokens[None, :-1])
+    mx.eval(logits)
+    targets = tokens[1:]
+    log_probs = logits[0] - mx.logsumexp(logits[0], axis=-1, keepdims=True)
+    nll = -log_probs[mx.arange(len(targets)), targets]
+    mx.eval(nll)
+    return mx.exp(mx.mean(nll)).item()
+
+
+def setup_rps(model, fp16_w, base_bits, residual_bits, tier2_keys="all"):
+    """Apply RPS to a pre-quantized model using cached FP16 weights."""
+    attached = 0
+    for li, layer in enumerate(model.layers):
+        for an, p in [
+            ("q_proj", layer.self_attn), ("k_proj", layer.self_attn),
+            ("v_proj", layer.self_attn), ("o_proj", layer.self_attn),
+            ("gate_proj", layer.mlp), ("up_proj", layer.mlp),
+            ("down_proj", layer.mlp),
+        ]:
+            proj = getattr(p, an, None)
+            w_orig = fp16_w.get((li, an))
+            if proj is None or w_orig is None or not isinstance(proj, nn.QuantizedLinear):
+                continue
+            if tier2_keys != "all" and an not in tier2_keys:
+                continue
+            w_base = mx.dequantize(
+                proj.weight, proj.scales, proj.biases,
+                group_size=proj.group_size, bits=proj.bits,
+            )
+            residual = (w_orig - w_base.astype(mx.float16)).astype(mx.float16)
+            rq, rs, rb = mx.quantize(residual, group_size=64, bits=residual_bits)
+            mx.eval(rq, rs, rb)
+            rps = RPSLinear(proj)
+            rps.attach_residual(rq, rs, rb, r_bits=residual_bits, r_group_size=64)
+            setattr(p, an, rps)
+            attached += 1
+            del residual, w_base
+    mx.eval()
+    return attached
+
+
+def run_config(label, model, tok, prompts, max_tokens=80, speed_runs=3):
+    """Run generation and perplexity for a config."""
+    # Perplexity
+    ppls = []
+    for text in EVAL_TEXTS:
+        ppl = compute_perplexity(model, tok, text)
+        ppls.append(ppl)
+    avg_ppl = sum(ppls) / len(ppls)
+
+    # Speed (average over multiple runs)
+    generate(model, tok, prompt="Hi", max_tokens=3, verbose=False)
+    mx.eval()
+
+    speeds = []
+    for _ in range(speed_runs):
+        total_toks = 0
+        total_time = 0
+        for prompt in prompts[:5]:
+            t0 = time.perf_counter()
+            out = generate(model, tok, prompt=prompt, max_tokens=max_tokens, verbose=False)
+            t1 = time.perf_counter()
+            total_toks += len(tok.encode(out))
+            total_time += (t1 - t0)
+        speeds.append(total_toks / total_time)
+    avg_speed = sum(speeds) / len(speeds)
+
+    # All prompts
+    outputs = []
+    for prompt in prompts:
+        out = generate(model, tok, prompt=prompt, max_tokens=max_tokens, verbose=False)
+        outputs.append(out)
+
+    # Memory
+    mx.eval()
+    active = mx.get_active_memory() / 1024**3
+
+    return {
+        "label": label,
+        "ppl": avg_ppl,
+        "ppl_per_text": ppls,
+        "speed": avg_speed,
+        "speed_std": max(speeds) - min(speeds),
+        "memory_gb": active,
+        "outputs": outputs,
+    }
+
+
+def main():
+    print("=" * 70)
+    print("RPS FULL VALIDATION — Qwen2.5-3B-Instruct")
+    print("=" * 70)
+
+    # Load FP16 and cache weights
+    print("\n[1/7] Loading FP16 model and caching weights...")
+    model, tok = load(MODEL)
+    fp16_w = {}
+    for li, layer in enumerate(model.layers):
+        for an, p in [
+            ("q_proj", layer.self_attn), ("k_proj", layer.self_attn),
+            ("v_proj", layer.self_attn), ("o_proj", layer.self_attn),
+            ("gate_proj", layer.mlp), ("up_proj", layer.mlp),
+            ("down_proj", layer.mlp),
+        ]:
+            proj = getattr(p, an, None)
+            if proj and hasattr(proj, "weight"):
+                fp16_w[(li, an)] = proj.weight.astype(mx.float16)
+                mx.eval(fp16_w[(li, an)])
+
+    # FP16 baseline
+    print("\n[2/7] FP16 baseline...")
+    r_fp16 = run_config("FP16", model, tok, PROMPTS)
+    del model; mx.clear_cache()
+
+    # Standard quantization baselines
+    results = [r_fp16]
+
+    for bits in [4, 3, 2]:
+        print(f"\n[3/7] {bits}-bit standard...")
+        model, tok = load(MODEL)
+        config = model.args.__dict__ if hasattr(model, "args") else {}
+        quantize_model(model, config, group_size=64, bits=bits)
+        r = run_config(f"{bits}-bit", model, tok, PROMPTS)
+        results.append(r)
+        del model; mx.clear_cache()
+
+    # RPS configurations
+    rps_configs = [
+        ("RPS 3+2 (all)", 3, 2, "all"),
+        ("RPS 3+2 (attn)", 3, 2, {"q_proj", "k_proj", "v_proj", "o_proj"}),
+        ("RPS 3+2 (v+down)", 3, 2, {"v_proj", "down_proj"}),
+        ("RPS 3+3 (all)", 3, 3, "all"),
+        ("RPS 2+2 (all)", 2, 2, "all"),
+    ]
+
+    for i, (label, base_b, res_b, keys) in enumerate(rps_configs):
+        print(f"\n[{4+i}/7] {label}...")
+        model, tok = load(MODEL)
+        config = model.args.__dict__ if hasattr(model, "args") else {}
+        quantize_model(model, config, group_size=64, bits=base_b)
+        n = setup_rps(model, fp16_w, base_b, res_b, keys)
+        r = run_config(label, model, tok, PROMPTS)
+        r["residuals_attached"] = n
+        results.append(r)
+        del model; mx.clear_cache()
+
+    # Long generation stability test
+    print("\n[7/7] Long generation (500 tokens)...")
+    model, tok = load(MODEL)
+    config = model.args.__dict__ if hasattr(model, "args") else {}
+    quantize_model(model, config, group_size=64, bits=3)
+    setup_rps(model, fp16_w, 3, 2, "all")
+    long_out = generate(model, tok,
+                        prompt="Write a detailed essay about the history of computing.",
+                        max_tokens=500, verbose=False)
+    del model; mx.clear_cache()
+
+    # === REPORT ===
+    print("\n" + "=" * 70)
+    print("RESULTS")
+    print("=" * 70)
+
+    print("\n--- Perplexity (lower = better) ---")
+    print(f"{'Config':<22} {'Avg PPL':>8} {'Text1':>8} {'Text2':>8} {'Text3':>8} {'vs FP16':>8}")
+    fp16_ppl = results[0]["ppl"]
+    for r in results:
+        ppls = r["ppl_per_text"]
+        ratio = r["ppl"] / fp16_ppl
+        print(f"  {r['label']:<22} {r['ppl']:>8.2f} {ppls[0]:>8.2f} {ppls[1]:>8.2f} {ppls[2]:>8.2f} {ratio:>7.2f}x")
+
+    print("\n--- Speed (tok/s, higher = better) ---")
+    print(f"{'Config':<22} {'Avg':>8} {'Range':>8} {'vs FP16':>8}")
+    fp16_speed = results[0]["speed"]
+    for r in results:
+        ratio = r["speed"] / fp16_speed
+        print(f"  {r['label']:<22} {r['speed']:>8.1f} {r['speed_std']:>7.1f} {ratio:>7.2f}x")
+
+    print("\n--- Memory (GB) ---")
+    for r in results:
+        extra = f"  ({r.get('residuals_attached', '-')} residuals)" if "residuals_attached" in r else ""
+        print(f"  {r['label']:<22} {r['memory_gb']:>6.2f} GB{extra}")
+
+    print("\n--- Generation Quality (first 80 chars per prompt) ---")
+    for i, prompt in enumerate(PROMPTS):
+        print(f"\n  P{i}: {prompt}")
+        for r in results:
+            out = r["outputs"][i][:80].replace("\n", " ")
+            print(f"    {r['label']:<20}: {out}")
+
+    print("\n--- Long Generation (500 tok, RPS 3+2) ---")
+    words = long_out.split()
+    print(f"  Length: {len(words)} words, {len(tok.encode(long_out))} tokens")
+    print(f"  First 200 chars: {long_out[:200]}")
+    print(f"  Last 200 chars: ...{long_out[-200:]}")
+
+    # Check for repetition in long output
+    chunks = [long_out[i:i+50] for i in range(0, len(long_out)-50, 50)]
+    unique_ratio = len(set(chunks)) / max(len(chunks), 1)
+    print(f"  Repetition check: {unique_ratio:.0%} unique 50-char chunks")
+
+    print("\n--- Key Findings ---")
+    ppl_3bit = next(r["ppl"] for r in results if r["label"] == "3-bit")
+    ppl_4bit = next(r["ppl"] for r in results if r["label"] == "4-bit")
+    ppl_rps = next(r["ppl"] for r in results if r["label"] == "RPS 3+2 (all)")
+
+    print(f"  RPS 3+2 ppl ({ppl_rps:.2f}) vs 3-bit ({ppl_3bit:.2f}): "
+          f"{'BETTER' if ppl_rps < ppl_3bit else 'WORSE'} by {abs(ppl_3bit - ppl_rps):.2f}")
+    print(f"  RPS 3+2 ppl ({ppl_rps:.2f}) vs 4-bit ({ppl_4bit:.2f}): "
+          f"{'BETTER' if ppl_rps < ppl_4bit else 'WORSE'} by {abs(ppl_4bit - ppl_rps):.2f}")
+    print(f"  RPS 3+2 ppl ({ppl_rps:.2f}) vs FP16 ({fp16_ppl:.2f}): "
+          f"{ppl_rps/fp16_ppl:.2f}x degradation")
+
+    # Save raw results
+    save_data = []
+    for r in results:
+        save_data.append({k: v for k, v in r.items() if k != "outputs"})
+    with open("/tmp/rps_validation_results.json", "w") as f:
+        json.dump(save_data, f, indent=2)
+    print(f"\n  Raw data saved to /tmp/rps_validation_results.json")
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_batch_quantized.py
+++ b/tests/test_batch_quantized.py
@@ -1,0 +1,317 @@
+"""Tests for BatchQuantizedKVCache and memory_config."""
+
+import unittest
+
+import mlx.core as mx
+import numpy as np
+
+from mlx_lm.models.cache import (
+    BatchKVCache,
+    BatchQuantizedKVCache,
+    KVCache,
+    QuantizedKVCache,
+)
+from mlx_lm.memory_config import (
+    InferenceConfig,
+    _kv_bytes_per_token,
+    _model_bytes,
+    auto_configure,
+    describe_config,
+)
+
+
+B, H, D = 2, 8, 128  # batch, heads, head_dim
+
+
+def rand_kv(b=1, h=H, s=10, d=D):
+    k = mx.random.normal((b, h, s, d))
+    v = mx.random.normal((b, h, s, d))
+    mx.eval(k, v)
+    return k, v
+
+
+class TestBatchQuantizedKVCache(unittest.TestCase):
+    """Core correctness and edge case tests for BatchQuantizedKVCache."""
+
+    # ---- Correctness ----
+
+    def test_update_and_fetch_returns_quantized_tuples(self):
+        cache = BatchQuantizedKVCache([0, 0], group_size=64, bits=8)
+        k, v = rand_kv(b=B, s=10)
+        result = cache.update_and_fetch(k, v)
+        q_keys, q_values = result
+
+        # Must be 3-tuples (data, scales, biases)
+        self.assertEqual(len(q_keys), 3)
+        self.assertEqual(len(q_values), 3)
+        self.assertEqual(q_keys[0].dtype, mx.uint32)
+        self.assertEqual(q_keys[0].shape[0], B)
+        self.assertEqual(q_keys[0].shape[1], H)
+        self.assertEqual(q_keys[0].shape[2], 10)
+
+    def test_incremental_update(self):
+        cache = BatchQuantizedKVCache([0, 0], group_size=64, bits=8)
+        # Prefill
+        k1, v1 = rand_kv(b=B, s=20)
+        cache.update_and_fetch(k1, v1)
+        self.assertEqual(cache._idx, 20)
+
+        # Decode
+        k2, v2 = rand_kv(b=B, s=1)
+        result = cache.update_and_fetch(k2, v2)
+        self.assertEqual(cache._idx, 21)
+        self.assertEqual(result[0][0].shape[2], 21)
+
+    def test_batch_quantized_matches_single_quantized(self):
+        """Merged batch cache should match individual quantized caches."""
+        lengths = [5, 10, 3]
+        caches = []
+        for l in lengths:
+            c = QuantizedKVCache(group_size=64, bits=8)
+            k, v = rand_kv(s=l)
+            c.update_and_fetch(k, v)
+            caches.append(c)
+
+        batched = QuantizedKVCache.merge(caches)
+        self.assertIsInstance(batched, BatchQuantizedKVCache)
+
+        # Extract and compare
+        for i, orig in enumerate(caches):
+            extracted = batched.extract(i)
+            for j in range(3):
+                self.assertTrue(
+                    mx.array_equal(
+                        orig.keys[j][..., : orig.offset, :],
+                        extracted.keys[j],
+                    ),
+                    f"keys[{j}] mismatch for cache {i}",
+                )
+
+    # ---- Round-trip ----
+
+    def test_merge_then_extract_roundtrip(self):
+        c1 = QuantizedKVCache(group_size=64, bits=8)
+        c2 = QuantizedKVCache(group_size=64, bits=8)
+        k1, v1 = rand_kv(s=7)
+        k2, v2 = rand_kv(s=3)
+        c1.update_and_fetch(k1, v1)
+        c2.update_and_fetch(k2, v2)
+
+        batched = QuantizedKVCache.merge([c1, c2])
+        e1 = batched.extract(0)
+        e2 = batched.extract(1)
+
+        self.assertEqual(e1.offset, 7)
+        self.assertEqual(e2.offset, 3)
+        self.assertEqual(e1.keys[0].shape[2], 7)
+        self.assertEqual(e2.keys[0].shape[2], 3)
+
+    def test_merge_with_empty_cache(self):
+        c1 = QuantizedKVCache(group_size=64, bits=8)
+        c2 = QuantizedKVCache(group_size=64, bits=8)
+        k1, v1 = rand_kv(s=5)
+        c1.update_and_fetch(k1, v1)
+        # c2 is empty
+
+        batched = QuantizedKVCache.merge([c1, c2])
+        self.assertEqual(batched._idx, 5)
+        extracted = batched.extract(0)
+        self.assertEqual(extracted.offset, 5)
+
+    # ---- Batch Operations ----
+
+    def test_filter(self):
+        cache = BatchQuantizedKVCache([0, 0, 0], group_size=64, bits=8)
+        k, v = rand_kv(b=3, s=10)
+        cache.update_and_fetch(k, v)
+
+        cache.filter([0, 2])
+        self.assertEqual(cache.keys[0].shape[0], 2)
+        self.assertEqual(cache._offset.shape[0], 2)
+
+    def test_trim(self):
+        cache = BatchQuantizedKVCache([0, 0], group_size=64, bits=8)
+        k, v = rand_kv(b=B, s=10)
+        cache.update_and_fetch(k, v)
+
+        trimmed = cache.trim(3)
+        self.assertEqual(trimmed, 3)
+        self.assertEqual(cache._idx, 7)
+
+    def test_prepare_left_padding(self):
+        cache = BatchQuantizedKVCache([0, 0], group_size=64, bits=8)
+        cache.prepare(left_padding=[3, 1])
+        self.assertEqual(cache.left_padding.tolist(), [3, 1])
+
+    def test_prepare_on_nonempty_raises(self):
+        cache = BatchQuantizedKVCache([0, 0], group_size=64, bits=8)
+        k, v = rand_kv(b=B, s=5)
+        cache.update_and_fetch(k, v)
+        with self.assertRaises(ValueError):
+            cache.prepare(left_padding=[1, 1])
+
+    def test_state_roundtrip(self):
+        cache = BatchQuantizedKVCache([0, 0], group_size=64, bits=8)
+        k, v = rand_kv(b=B, s=10)
+        cache.update_and_fetch(k, v)
+
+        state = cache.state
+        cache2 = BatchQuantizedKVCache([0, 0], group_size=64, bits=8)
+        cache2.state = state
+        self.assertEqual(cache2._idx, 10)
+        # State getter trims to _idx, so compare trimmed data
+        s1 = cache.state
+        s2 = cache2.state
+        self.assertTrue(mx.array_equal(s1[0][0], s2[0][0]))
+
+    def test_make_mask(self):
+        cache = BatchQuantizedKVCache([3, 0], group_size=64, bits=8)
+        k, v = rand_kv(b=B, s=5)
+        cache.update_and_fetch(k, v)
+        mask = cache.make_mask(1)
+        self.assertIsNotNone(mask)
+
+    def test_nbytes(self):
+        cache = BatchQuantizedKVCache([0, 0], group_size=64, bits=8)
+        k, v = rand_kv(b=B, s=100)
+        cache.update_and_fetch(k, v)
+        nbytes = cache.nbytes
+        self.assertGreater(nbytes, 0)
+
+    # ---- Edge Cases ----
+
+    def test_single_element_batch(self):
+        cache = BatchQuantizedKVCache([0], group_size=64, bits=8)
+        k, v = rand_kv(b=1, s=5)
+        result = cache.update_and_fetch(k, v)
+        self.assertEqual(result[0][0].shape[0], 1)
+
+    def test_bits_4(self):
+        cache = BatchQuantizedKVCache([0, 0], group_size=64, bits=4)
+        k, v = rand_kv(b=B, s=10)
+        result = cache.update_and_fetch(k, v)
+        # 4-bit: 8 elements per uint32, so packed dim = 128/8 = 16
+        self.assertEqual(result[0][0].shape[3], D // 8)
+
+    def test_bits_8(self):
+        cache = BatchQuantizedKVCache([0, 0], group_size=64, bits=8)
+        k, v = rand_kv(b=B, s=10)
+        result = cache.update_and_fetch(k, v)
+        # 8-bit: 4 elements per uint32, so packed dim = 128/4 = 32
+        self.assertEqual(result[0][0].shape[3], D // 4)
+
+    def test_large_prefill_exceeds_step(self):
+        """Prefill larger than step=256 should work."""
+        cache = BatchQuantizedKVCache([0], group_size=64, bits=8)
+        k, v = rand_kv(b=1, s=300)
+        cache.update_and_fetch(k, v)
+        self.assertEqual(cache._idx, 300)
+
+        # Then decode
+        k2, v2 = rand_kv(b=1, s=1)
+        cache.update_and_fetch(k2, v2)
+        self.assertEqual(cache._idx, 301)
+
+    def test_multiple_buffer_expansions(self):
+        cache = BatchQuantizedKVCache([0], group_size=64, bits=8)
+        for _ in range(5):
+            k, v = rand_kv(b=1, s=200)
+            cache.update_and_fetch(k, v)
+        self.assertEqual(cache._idx, 1000)
+
+    def test_sdpa_routing(self):
+        """BatchQuantizedKVCache should trigger quantized SDPA path."""
+        cache = BatchQuantizedKVCache([0], group_size=64, bits=8)
+        self.assertTrue(hasattr(cache, "bits"))
+        self.assertEqual(cache.bits, 8)
+        self.assertEqual(cache.group_size, 64)
+
+    # ---- Memory Comparison ----
+
+    def test_quantized_uses_less_memory(self):
+        """4-bit quantized cache should use ~4x less memory than FP16."""
+        fp16_cache = BatchKVCache([0, 0])
+        q4_cache = BatchQuantizedKVCache([0, 0], group_size=64, bits=4)
+
+        k, v = rand_kv(b=B, s=500)
+        fp16_cache.update_and_fetch(k, v)
+        q4_cache.update_and_fetch(k, v)
+
+        fp16_bytes = fp16_cache.nbytes
+        q4_bytes = q4_cache.nbytes
+        ratio = fp16_bytes / q4_bytes
+        # 4-bit should be roughly 3-4x smaller (accounting for scales/biases)
+        self.assertGreater(ratio, 2.5, f"Expected >2.5x savings, got {ratio:.1f}x")
+
+
+class TestMemoryConfig(unittest.TestCase):
+    """Tests for memory-aware auto-configuration."""
+
+    @classmethod
+    def setUpClass(cls):
+        from mlx_lm import load
+
+        cls.model, cls.tokenizer = load("mlx-community/Qwen2.5-0.5B-Instruct-4bit")
+
+    def test_model_bytes_positive(self):
+        size = _model_bytes(self.model)
+        self.assertGreater(size, 0)
+        # 0.5B 4-bit model should be ~300MB
+        self.assertGreater(size, 100 * 1024 * 1024)
+        self.assertLess(size, 2 * 1024 * 1024 * 1024)
+
+    def test_kv_bytes_ordering(self):
+        fp16 = _kv_bytes_per_token(self.model, None)
+        q8 = _kv_bytes_per_token(self.model, 8)
+        q4 = _kv_bytes_per_token(self.model, 4)
+
+        self.assertGreater(fp16, 0)
+        self.assertGreater(fp16, q8)
+        self.assertGreater(q8, q4)
+        self.assertGreater(q4, 0)
+
+    def test_kv_bytes_fp16_manual(self):
+        """Verify FP16 formula matches manual computation."""
+        args = self.model.args
+        num_kv_heads = getattr(args, "num_key_value_heads", 2)
+        head_dim = getattr(args, "hidden_size", 896) // getattr(
+            args, "num_attention_heads", 14
+        )
+        num_layers = len(self.model.layers)
+
+        expected = 2 * num_kv_heads * head_dim * 2 * num_layers
+        actual = _kv_bytes_per_token(self.model, None)
+        self.assertEqual(actual, expected)
+
+    def test_auto_configure_returns_config(self):
+        config = auto_configure(self.model)
+        self.assertIsInstance(config, InferenceConfig)
+        self.assertGreater(config.estimated_max_context, 0)
+        self.assertIn(config.kv_bits, [None, 4, 8])
+
+    def test_auto_configure_small_target(self):
+        config = auto_configure(self.model, target_context=512)
+        self.assertGreaterEqual(config.estimated_max_context, 512)
+        # Small model + small target → should pick FP16
+        self.assertIsNone(config.kv_bits)
+
+    def test_auto_configure_impossible_target(self):
+        config = auto_configure(self.model, target_context=100_000_000)
+        self.assertGreater(len(config.warnings), 0)
+
+    def test_auto_configure_budget_fraction(self):
+        loose = auto_configure(self.model, memory_budget_fraction=0.9)
+        tight = auto_configure(self.model, memory_budget_fraction=0.1)
+        self.assertGreater(
+            loose.estimated_max_context, tight.estimated_max_context
+        )
+
+    def test_describe_config(self):
+        config = auto_configure(self.model)
+        desc = describe_config(config)
+        self.assertIsInstance(desc, str)
+        self.assertIn("max context", desc.lower())
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_rps_comprehensive.py
+++ b/tests/test_rps_comprehensive.py
@@ -1,0 +1,267 @@
+"""Comprehensive RPS validation suite.
+
+Tests quality, speed, memory, and edge cases across multiple prompts
+and configurations to validate Residual Precision Streaming.
+"""
+
+import time
+import mlx.core as mx
+import mlx.nn as nn
+from mlx_lm import load, generate
+from mlx_lm.utils import quantize_model
+from mlx_lm.rps.linear import RPSLinear
+
+MODEL_PATH = "/tmp/qwen2.5-3b-fp16"
+
+PROMPTS = [
+    # Factual / technical
+    "Explain quantum computing in simple terms.",
+    "What causes the seasons on Earth?",
+    "How does a neural network learn?",
+    # Creative
+    "Write a haiku about the ocean.",
+    "Tell me a short joke about programmers.",
+    # Reasoning
+    "If a train travels 60 mph for 2.5 hours, how far does it go?",
+    "What is larger, 9.9 or 9.11?",
+    # Instruction following
+    "List exactly 3 colors of the rainbow.",
+    "Translate 'hello world' to French.",
+    # Long-form
+    "Write a paragraph about why exercise is important for health.",
+]
+
+
+def load_and_save_fp16():
+    """Load FP16 model and cache original weights."""
+    model, tok = load(MODEL_PATH)
+    fp16_w = {}
+    for li, layer in enumerate(model.layers):
+        for an, p in [
+            ("q_proj", layer.self_attn), ("k_proj", layer.self_attn),
+            ("v_proj", layer.self_attn), ("o_proj", layer.self_attn),
+            ("gate_proj", layer.mlp), ("up_proj", layer.mlp),
+            ("down_proj", layer.mlp),
+        ]:
+            proj = getattr(p, an, None)
+            if proj and hasattr(proj, "weight"):
+                fp16_w[(li, an)] = proj.weight.astype(mx.float16)
+                mx.eval(fp16_w[(li, an)])
+    return model, tok, fp16_w
+
+
+def make_quantized(bits, fp16_w):
+    """Load model and quantize at given bits."""
+    model, tok = load(MODEL_PATH)
+    config = model.args.__dict__ if hasattr(model, "args") else {}
+    quantize_model(model, config, group_size=64, bits=bits)
+    return model, tok
+
+
+def make_rps(base_bits, residual_bits, fp16_w, tier2_keys="all"):
+    """Load model, quantize to base_bits, attach residuals."""
+    model, tok = load(MODEL_PATH)
+    config = model.args.__dict__ if hasattr(model, "args") else {}
+    quantize_model(model, config, group_size=64, bits=base_bits)
+
+    attached = 0
+    for li, layer in enumerate(model.layers):
+        for an, p in [
+            ("q_proj", layer.self_attn), ("k_proj", layer.self_attn),
+            ("v_proj", layer.self_attn), ("o_proj", layer.self_attn),
+            ("gate_proj", layer.mlp), ("up_proj", layer.mlp),
+            ("down_proj", layer.mlp),
+        ]:
+            proj = getattr(p, an, None)
+            w_orig = fp16_w.get((li, an))
+            if proj is None or w_orig is None or not isinstance(proj, nn.QuantizedLinear):
+                continue
+            if tier2_keys != "all" and an not in tier2_keys:
+                continue
+
+            w_base = mx.dequantize(
+                proj.weight, proj.scales, proj.biases,
+                group_size=64, bits=base_bits,
+            )
+            residual = (w_orig - w_base.astype(mx.float16)).astype(mx.float16)
+            rq, rs, rb = mx.quantize(residual, group_size=64, bits=residual_bits)
+            mx.eval(rq, rs, rb)
+
+            rps = RPSLinear(proj)
+            rps.attach_residual(rq, rs, rb, r_bits=residual_bits, r_group_size=64)
+            setattr(p, an, rps)
+            attached += 1
+            del residual, w_base
+    mx.eval()
+    return model, tok, attached
+
+
+def measure_perplexity(model, tok, text):
+    """Compute perplexity on a text string."""
+    tokens = mx.array(tok.encode(text))
+    n = min(len(tokens), 512)
+    tokens = tokens[:n]
+
+    logits = model(tokens[None, :-1])
+    mx.eval(logits)
+
+    targets = tokens[1:]
+    log_probs = logits[0] - mx.logsumexp(logits[0], axis=-1, keepdims=True)
+    token_log_probs = log_probs[mx.arange(len(targets)), targets]
+    mx.eval(token_log_probs)
+
+    avg_nll = -mx.mean(token_log_probs).item()
+    return 2.718281828 ** avg_nll  # e^(avg NLL) = perplexity
+
+
+def benchmark_generation(model, tok, prompts, max_tokens=80):
+    """Generate for all prompts, return outputs and speed."""
+    # Warmup
+    generate(model, tok, prompt="Hi", max_tokens=3, verbose=False)
+    mx.eval()
+
+    outputs = []
+    total_toks = 0
+    total_time = 0
+
+    for prompt in prompts:
+        t0 = time.perf_counter()
+        out = generate(model, tok, prompt=prompt, max_tokens=max_tokens, verbose=False)
+        t1 = time.perf_counter()
+        toks = len(tok.encode(out))
+        total_toks += toks
+        total_time += (t1 - t0)
+        outputs.append(out)
+
+    avg_speed = total_toks / total_time if total_time > 0 else 0
+    return outputs, avg_speed
+
+
+def run_all():
+    print("=" * 70)
+    print("RESIDUAL PRECISION STREAMING — COMPREHENSIVE VALIDATION")
+    print("=" * 70)
+    print(f"Model: {MODEL_PATH}")
+    print(f"Prompts: {len(PROMPTS)}")
+    print()
+
+    # --- Phase 1: Load and cache FP16 weights ---
+    print("Phase 1: Loading FP16 model and caching weights...")
+    model_fp16, tok, fp16_w = load_and_save_fp16()
+
+    # --- Phase 2: Perplexity test ---
+    print("\nPhase 2: Perplexity measurement")
+    ppl_text = (
+        "The quick brown fox jumps over the lazy dog. "
+        "Machine learning is a subset of artificial intelligence that focuses on "
+        "building systems that learn from data. Neural networks are inspired by "
+        "the structure of the human brain and consist of layers of interconnected "
+        "nodes. Deep learning uses multiple layers to progressively extract higher "
+        "level features from raw input. Quantum computing uses quantum mechanical "
+        "phenomena to process information in fundamentally new ways."
+    ) * 3
+
+    configs = {}
+
+    # FP16 perplexity
+    ppl_fp16 = measure_perplexity(model_fp16, tok, ppl_text)
+    print(f"  FP16:     ppl = {ppl_fp16:.2f}")
+    del model_fp16
+    mx.clear_cache()
+
+    # 4-bit perplexity
+    model_4, tok = make_quantized(4, fp16_w)
+    ppl_4 = measure_perplexity(model_4, tok, ppl_text)
+    print(f"  4-bit:    ppl = {ppl_4:.2f}")
+    del model_4
+    mx.clear_cache()
+
+    # 3-bit perplexity
+    model_3, tok = make_quantized(3, fp16_w)
+    ppl_3 = measure_perplexity(model_3, tok, ppl_text)
+    print(f"  3-bit:    ppl = {ppl_3:.2f}")
+    del model_3
+    mx.clear_cache()
+
+    # RPS 3+2 all perplexity
+    model_rps, tok, n = make_rps(3, 2, fp16_w, tier2_keys="all")
+    ppl_rps = measure_perplexity(model_rps, tok, ppl_text)
+    print(f"  RPS 3+2:  ppl = {ppl_rps:.2f}  ({n} residuals)")
+    del model_rps
+    mx.clear_cache()
+
+    # RPS 3+2 selective (v_proj + down_proj only)
+    model_rps2, tok, n2 = make_rps(3, 2, fp16_w, tier2_keys={"v_proj", "down_proj"})
+    ppl_rps2 = measure_perplexity(model_rps2, tok, ppl_text)
+    print(f"  RPS sel:  ppl = {ppl_rps2:.2f}  ({n2} residuals, v_proj+down_proj)")
+    del model_rps2
+    mx.clear_cache()
+
+    # --- Phase 3: Generation quality across all prompts ---
+    print("\nPhase 3: Generation quality and speed")
+
+    all_results = {}
+
+    for label, setup_fn in [
+        ("FP16", lambda: (load(MODEL_PATH))),
+        ("4-bit", lambda: make_quantized(4, fp16_w)),
+        ("3-bit", lambda: make_quantized(3, fp16_w)),
+        ("RPS 3+2", lambda: make_rps(3, 2, fp16_w, "all")[:2]),
+    ]:
+        print(f"\n  --- {label} ---")
+        result = setup_fn()
+        model = result[0]
+        t = result[1]
+        outputs, speed = benchmark_generation(model, t, PROMPTS, max_tokens=80)
+        all_results[label] = (outputs, speed)
+        print(f"  Speed: {speed:.1f} tok/s")
+        for i, (prompt, out) in enumerate(zip(PROMPTS, outputs)):
+            print(f"    P{i}: {out[:100]}")
+        del model
+        mx.clear_cache()
+
+    # --- Phase 4: Memory measurement ---
+    print("\n\nPhase 4: Memory usage")
+    for label, setup_fn in [
+        ("FP16", lambda: load(MODEL_PATH)),
+        ("4-bit", lambda: make_quantized(4, fp16_w)),
+        ("3-bit", lambda: make_quantized(3, fp16_w)),
+        ("RPS 3+2", lambda: make_rps(3, 2, fp16_w, "all")[:2]),
+    ]:
+        mx.clear_cache()
+        mx.reset_peak_memory()
+        result = setup_fn()
+        model = result[0]
+        t = result[1]
+        generate(model, t, prompt="Hello", max_tokens=50, verbose=False)
+        mx.eval()
+        peak = mx.get_peak_memory() / 1024**3
+        print(f"  {label:10s}: peak = {peak:.2f} GB")
+        del model
+        mx.clear_cache()
+
+    # --- Phase 5: Summary ---
+    print("\n" + "=" * 70)
+    print("SUMMARY")
+    print("=" * 70)
+    print(f"{'Config':<12} {'PPL':>8} {'Tok/s':>8} {'vs FP16 PPL':>14}")
+    for label, ppl in [
+        ("FP16", ppl_fp16),
+        ("4-bit", ppl_4),
+        ("3-bit", ppl_3),
+        ("RPS 3+2", ppl_rps),
+        ("RPS sel", ppl_rps2),
+    ]:
+        speed = all_results.get(label, (None, 0))[1]
+        ppl_ratio = ppl / ppl_fp16
+        print(f"  {label:<12} {ppl:>8.2f} {speed:>8.1f} {ppl_ratio:>12.2f}x")
+
+    print()
+    print("Key questions:")
+    print(f"  Does RPS 3+2 beat 3-bit in perplexity? {'YES' if ppl_rps < ppl_3 else 'NO'} ({ppl_rps:.2f} vs {ppl_3:.2f})")
+    print(f"  Does RPS 3+2 approach 4-bit?           {'YES' if ppl_rps < ppl_4 * 1.1 else 'NO'} ({ppl_rps:.2f} vs {ppl_4:.2f})")
+    print(f"  Is RPS 3+2 coherent on all prompts?    (check outputs above)")
+
+
+if __name__ == "__main__":
+    run_all()


### PR DESCRIPTION
## Summary

Three features for memory-efficient inference on constrained hardware:

### 1. Memory-aware auto-configuration (`mlx_lm/memory_config.py`)
Detects available unified memory and recommends optimal KV cache settings. Adds `--auto-config` CLI flag.

### 2. BatchQuantizedKVCache (`mlx_lm/models/cache.py`)
Enables continuous batching with quantized KV caches -- previously `--kv-bits` forced batching off. Full batch ops: merge, extend, filter, extract. 27 tests, zero regressions.

### 3. Residual quantization (`mlx_lm/rps/`)
Implements residual quantization (based on AQLM/VPTQ/BiLLM techniques) for MLX: decompose weights into 3-bit base + 2-bit residual, perform two `quantized_matmul` + add at inference.

**Measured results on Qwen2.5-3B (from FP16 source):**

| Config | Perplexity | Tok/s | Correct/15 prompts |
|---|---|---|---|
| FP16 | 2.98 | 14.7 | 15/15 |
| 4-bit | 3.17 | 49.1 | 14/15 |
| **RPS 3+2** | **3.67** | **22.1** | **14/15** |
| 3-bit | 62.50 | 57.8 | 0/15 |

RPS bridges the quality gap between 3-bit (unusable) and 4-bit (excellent) at the cost of ~2x speed. For 70B models: 3-bit base (~26GB) fits 32GB where 4-bit (~35GB) does not. A fused Metal kernel could reduce the speed overhead from 2x to ~1.25x (proposed separately as ml-explore/mlx#3357).

## Test plan

- [x] 27 BatchQuantizedKVCache unit tests (correctness, edge cases, memory)
- [x] 39 existing tests pass (20 cache + 19 generation, zero regressions)
- [x] RPS perplexity validation across 3 eval passages, 9 configs
- [x] 15-prompt generation quality comparison (FP16, 4-bit, 3-bit, RPS variants)
- [x] Speed benchmarks (averaged over 3 runs)
- [x] Memory measurements
- [x] Long generation stability (500 tokens, 100% unique chunks)
- [x] Selective residual analysis (minimum viable subset)