### PR TITLE
perf: reduce peak memory during model quantization

### DIFF
--- a/mlx_lm/utils.py
+++ b/mlx_lm/utils.py
@@ -769,6 +769,16 @@ def save_model(
         )
 
 
+def _eval_quantized_per_layer(model: nn.Module):
+    """Materialize quantized weights layer by layer to reduce peak memory."""
+    inner = getattr(model, "model", model)
+    layers = getattr(inner, "layers", None)
+    if layers is not None:
+        for layer in layers:
+            mx.eval(layer.parameters())
+    mx.eval(model.parameters())
+
+
 def quantize_model(
     model: nn.Module,
     config: dict,
@@ -839,6 +849,10 @@ def quantize_model(
         mode=mode,
         class_predicate=wrapped_predicate,
     )
+
+    # Materialize quantized weights per layer to bound peak memory
+    _eval_quantized_per_layer(model)
+
     # support hf model tree #957
     quantized_config["quantization_config"] = quantized_config["quantization"]
 


### PR DESCRIPTION
Fixes #1121

## Summary

Reduce peak memory during `quantize_model()` by materializing quantized weights layer by layer instead of accumulating all intermediates in the lazy computation graph.

Tested on 3 models / 3 architectures. Output is bit-identical. Peak reduced 22-37%.

## The problem

`nn.quantize()` lazily transforms all layers' weights via `to_quantized()`. No evaluation happens inside `nn.quantize` — everything stays in the lazy graph. When the quantized parameters are subsequently materialized (during `save()` or `compute_bits_per_weight()`), the intermediate arrays from all layers must exist simultaneously.

For a model with `L` layers:

- **Current peak** = `model_quantized + L * quantization_overhead`

## The fix

Add a per-layer materialization step after `nn.quantize()`:

```python
def _eval_quantized_per_layer(model):
    inner = getattr(model, "model", model)
    layers = getattr(inner, "layers", None)
    if layers is not None:
        for layer in layers:
            mx.eval(layer.parameters())
    mx.eval(model.parameters())
```

This bounds the overhead to one layer at a time:

- **New peak** = `model_quantized + 1 * quantization_overhead`

For architectures without `model.layers` (e.g., GPT-2), the function falls back to `mx.eval(model.parameters())` — same behavior as before, no regression.

## Results

Each model tested in a fresh process for clean peak measurement. Output verified bit-identical (same prompt, same seed, character-by-character comparison).

| Model | Arch | Final size | Peak before | Peak after | Reduction |
|---|---|---|---|---|---|
| Qwen3-0.6B | Qwen | 0.34 GB | 0.99 GB | 0.65 GB | **-35%** |
| TinyLlama-1.1B | Llama | 0.62 GB | 1.40 GB | 0.88 GB | **-37%** |
| Mistral-7B | Mistral | 4.07 GB | 5.91 GB | 4.60 GB | **-22%** |

The smaller reduction on Mistral-7B (-22% vs -35%) is because `compute_bits_per_weight()`, called after per-layer eval, triggers evaluation of remaining non-layer arrays (embeddings, norms) in one batch. The per-layer pass still eliminates the majority of the overhead.

This applies to every `mlx_lm.convert -q` invocation — the most common quantization path.

## Test plan

- [x] Full test suite passes (175/175)
- [x] `pre-commit` clean
- [x] Output bit-identical on 3 models / 3 architectures
- [x] Peak memory reduced on all tested models
- [x] Graceful fallback for architectures without `model.layers`