### PR TITLE
fix: SafeRotatingKVCache merge crash + Gemma 4 tool parser

### DIFF
--- a/mlx_lm/models/gemma4_text.py
+++ b/mlx_lm/models/gemma4_text.py
@@ -11,6 +11,25 @@ from .base import BaseModelArgs, create_attention_mask, scaled_dot_product_atten
 from .cache import KVCache, RotatingKVCache, _BaseCache
 
 
+class _SafeRotatingKVCache(RotatingKVCache):
+    """RotatingKVCache that trims on first insertion.
+
+    Workaround for upstream bug: RotatingKVCache._update_concat doesn't trim
+    on first insertion, so prompts longer than max_size cause shape mismatches
+    in merge(). This subclass trims _temporal_order output to max_size.
+
+    Safe because _temporal_order is only called by merge() and subsequent
+    _update_concat calls — not by the initial update_and_fetch return, so
+    single-prompt attention still sees the full prompt.
+    """
+
+    def _temporal_order(self, v):
+        result = super()._temporal_order(v)
+        if result.shape[2] > self.max_size:
+            return result[..., -self.max_size :, :]
+        return result
+
+
 class _OffsetCache(_BaseCache):
     """Lightweight cache for KV-shared layers that only tracks offset."""
 
@@ -483,7 +502,9 @@ class Gemma4TextModel(nn.Module):
                 config.vocab_size_per_layer_input,
                 config.num_hidden_layers * config.hidden_size_per_layer_input,
             )
-            self.embed_tokens_per_layer_scale = config.hidden_size_per_layer_input**0.5
+            self.embed_tokens_per_layer_scale = (
+                config.hidden_size_per_layer_input**0.5
+            )
             self.per_layer_input_scale = 2.0**-0.5
             self.per_layer_model_projection = ScaledLinear(
                 config.hidden_size,
@@ -670,7 +691,7 @@ class Model(nn.Module):
                 caches.append(KVCache())
             else:
                 caches.append(
-                    RotatingKVCache(
+                    _SafeRotatingKVCache(
                         max_size=self.args.sliding_window,
                         keep=0,
                     )

--- a/mlx_lm/tokenizer_utils.py
+++ b/mlx_lm/tokenizer_utils.py
@@ -475,6 +475,8 @@ def _infer_tool_parser(chat_template):
         return "minimax_m2"
     elif "<start_function_call>" in chat_template:
         return "function_gemma"
+    elif "<|tool_call>" in chat_template and "<tool_call|>" in chat_template:
+        return "function_gemma4"
     elif "<longcat_tool_call>" in chat_template:
         return "longcat"
     elif "<arg_key>" in chat_template:

--- a/mlx_lm/tool_parsers/function_gemma4.py
+++ b/mlx_lm/tool_parsers/function_gemma4.py
@@ -1,0 +1,51 @@
+# Copyright © 2025 Apple Inc.
+
+"""Gemma 4 tool call parser.
+
+Gemma 4 uses <|tool_call>...<tool_call|> delimiters with JSON content.
+String values use <|"|> as escaped quotes instead of standard \".
+
+Example:
+  <|tool_call>{"name": "get_weather", "arguments": {"city": <|"|>London<|"|>}}<tool_call|>
+
+Distinct from Gemma 3's <start_function_call>call:func{key:value} format.
+"""
+
+import json
+from typing import Any, Optional
+
+import regex as re
+
+_tool_call_regex = re.compile(r"<\|tool_call\>(.*?)<tool_call\|>", re.DOTALL)
+
+
+def _unescape_quotes(s: str) -> str:
+    """Replace Gemma 4's <|"|> escape sequences with standard quotes."""
+    return s.replace('<|"|>', '"')
+
+
+def parse_tool_call(text: str, _: Optional[Any] = None):
+    match = _tool_call_regex.findall(text)
+    if not match:
+        raise ValueError("No tool call found.")
+
+    raw = _unescape_quotes(match[0].strip())
+    try:
+        parsed = json.loads(raw)
+    except json.JSONDecodeError:
+        raise ValueError(f"Failed to parse tool call JSON: {raw}")
+
+    name = parsed.get("name", "")
+    arguments = parsed.get("arguments", {})
+
+    if isinstance(arguments, str):
+        try:
+            arguments = json.loads(arguments)
+        except json.JSONDecodeError:
+            pass
+
+    return dict(name=name, arguments=arguments)
+
+
+tool_call_start = "<|tool_call>"
+tool_call_end = "<tool_call|>"

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -137,6 +137,38 @@ class TestModels(unittest.TestCase):
         self.assertEqual(cache.offset, 22)
         self.assertTrue(mx.allclose(x, k[..., -2:, :]))
 
+    def test_safe_rotating_kv_cache_merge(self):
+        """_SafeRotatingKVCache fixes merge crash when prompt > max_size.
+
+        RotatingKVCache._update_concat doesn't trim on first insertion,
+        so merge() allocates based on size() (capped at max_size) but
+        _temporal_order returns the full untrimmed array → shape mismatch.
+        _SafeRotatingKVCache trims _temporal_order to fix this.
+        """
+        from mlx_lm.models.gemma4_text import _SafeRotatingKVCache
+
+        max_size = 64
+        prompt_len = 100  # > max_size
+        h, d = 4, 32
+
+        cache = _SafeRotatingKVCache(max_size=max_size, keep=0)
+        k = mx.random.uniform(shape=(1, h, prompt_len, d))
+        v = mx.random.uniform(shape=(1, h, prompt_len, d))
+        cache.update_and_fetch(k, v)
+
+        # size() caps at max_size, but without the fix _temporal_order
+        # would return (1, h, prompt_len, d) → merge crash
+        self.assertEqual(cache.size(), max_size)
+
+        # This would raise ValueError with plain RotatingKVCache
+        _SafeRotatingKVCache.merge([cache])
+
+        # Verify generation after oversized prompt still works
+        k2 = mx.random.uniform(shape=(1, h, 1, d))
+        v2 = mx.random.uniform(shape=(1, h, 1, d))
+        k_out, v_out = cache.update_and_fetch(k2, v2)
+        self.assertEqual(k_out.shape[2], max_size)
+
     def test_causal_mask_padding(self):
         right_padding = mx.array([2, 1, 0])
         mask = create_causal_mask(3, right_padding=right_padding)


### PR DESCRIPTION
## Summary

Two independent fixes for the Gemma 4 branch:

### SafeRotatingKVCache — batch server crash fix

`RotatingKVCache._update_concat` doesn't trim on first insertion. When a prompt exceeds `max_size` (e.g. 1259 tokens vs 1024 `sliding_window`), `merge()` allocates based on `size()` (capped at `max_size`) but `_temporal_order()` returns the full untrimmed array → shape mismatch:

```
size() = min(1259, 1024) = 1024  →  merge allocates (B, H, 1024, D)
_temporal_order() returns (1, 16, 1259, 256)  →  doesn't fit
ValueError: Shapes (1,16,1259,256) and (1,16,1024,256) cannot be broadcast.
```

`_SafeRotatingKVCache` trims `_temporal_order` output to `max_size`. This is safe because `_temporal_order` is only called by `merge()` and subsequent `_update_concat` calls — not by the initial `update_and_fetch` return, so single-prompt attention still sees the full prompt for correct computation.

Reproduction:
```python
from mlx_lm.models.cache import RotatingKVCache
import mlx.core as mx

cache = RotatingKVCache(max_size=1024, keep=0)
cache.update_and_fetch(mx.zeros((1, 16, 1259, 256)), mx.zeros((1, 16, 1259, 256)))
RotatingKVCache.merge([cache])  # ValueError
```

Note: This is an upstream `cache.py` bug affecting any model using `RotatingKVCache` with prompts longer than `max_size` in the server's batch path. The subclass is a model-level workaround until the core fix lands. Related: #1097.

### Gemma 4 tool call parser

New `function_gemma4` parser for the `<|tool_call>...<tool_call|>` format with `<|"|>` quote escaping (distinct from Gemma 3's `<start_function_call>` format). Auto-detected via `_infer_tool_parser` — checks for both delimiters to avoid false matches.

### Files changed
- `mlx_lm/models/gemma4_text.py` — `_SafeRotatingKVCache` subclass, used in `make_cache()`
- `mlx_lm/tool_parsers/function_gemma4.py` — new tool call parser
- `mlx_lm/tokenizer_utils.py` — Gemma 4 auto-detection
- `tests/test_models.py` — merge crash reproduction + fix verification

## Test plan
- [x] `test_safe_rotating_kv_cache_merge` — proves the crash and the fix
- [x] `test_gemma4_text` — existing E2B test still passes
- [x] Full test suite: 69 passed, 1 skipped, 0 failures
- [x] `pre-commit` (black + isort) passes