### PR TITLE
Standardize config attribute to self.args in inner model classes

### DIFF
--- a/mlx_lm/models/deepseek.py
+++ b/mlx_lm/models/deepseek.py
@@ -200,6 +200,7 @@ class DeepseekDecoderLayer(nn.Module):
 class DeepseekModel(nn.Module):
     def __init__(self, config: ModelArgs):
         super().__init__()
+        self.args = config
         self.config = config
         self.embed_tokens = nn.Embedding(config.vocab_size, config.hidden_size)
         self.layers = [

--- a/mlx_lm/models/gemma3n.py
+++ b/mlx_lm/models/gemma3n.py
@@ -379,6 +379,7 @@ def logit_softcap(softcap, x):
 class LanguageModel(nn.Module):
     def __init__(self, config: TextConfig):
         super().__init__()
+        self.args = config
         self.config = config
         self.hidden_size = config.hidden_size
         self.hidden_size_per_layer_input = config.hidden_size_per_layer_input
@@ -418,12 +419,12 @@ class LanguageModel(nn.Module):
 
         self.altup_projections = [
             nn.Linear(config.hidden_size, config.hidden_size, bias=False)
-            for _ in range(1, self.config.altup_num_inputs)
+            for _ in range(1, self.args.altup_num_inputs)
         ]
 
         self.altup_unembed_projections = [
             nn.Linear(config.hidden_size, config.hidden_size, bias=False)
-            for _ in range(1, self.config.altup_num_inputs)
+            for _ in range(1, self.args.altup_num_inputs)
         ]
 
         self.norm = nn.RMSNorm(
@@ -444,7 +445,7 @@ class LanguageModel(nn.Module):
         )
 
         self.layer_idx_to_cache_idx = []
-        for i, layer_type in enumerate(self.config.layer_types):
+        for i, layer_type in enumerate(self.args.layer_types):
             if i < self.first_kv_shared_layer_idx:
                 self.layer_idx_to_cache_idx.append(i)
             else:
@@ -494,7 +495,7 @@ class LanguageModel(nn.Module):
         for i, layer in enumerate(self.layers):
             per_layer_input = per_layer_inputs[:, :, i, :]
 
-            is_global = self.config.layer_types[i] == "full_attention"
+            is_global = self.args.layer_types[i] == "full_attention"
 
             if is_global:
                 mask = global_mask
@@ -545,20 +546,20 @@ class LanguageModel(nn.Module):
         )
         per_layer_projection = per_layer_projection.reshape(
             *inputs_embeds.shape[:-1],
-            self.config.num_hidden_layers,
-            self.config.hidden_size_per_layer_input,
+            self.args.num_hidden_layers,
+            self.args.hidden_size_per_layer_input,
         )
         per_layer_projection = self.per_layer_projection_norm(per_layer_projection)
         return (per_layer_projection + per_layer_inputs) * (2.0**-0.5)
 
     def make_cache(self):
         caches = []
-        for layer_type in self.config.layer_types[: self.first_kv_shared_layer_idx]:
+        for layer_type in self.args.layer_types[: self.first_kv_shared_layer_idx]:
             if layer_type == "full_attention":
                 caches.append(KVCache())
             elif layer_type == "sliding_attention":
                 caches.append(
-                    RotatingKVCache(max_size=self.config.sliding_window, keep=0)
+                    RotatingKVCache(max_size=self.args.sliding_window, keep=0)
                 )
             else:
                 raise NotImplementedError(f"Unknown layer type: {layer_type}")

--- a/mlx_lm/models/gemma4_text.py
+++ b/mlx_lm/models/gemma4_text.py
@@ -418,7 +418,8 @@ class ScaledLinear(nn.Module):
 class Gemma4TextModel(nn.Module):
     def __init__(self, config: ModelArgs):
         super().__init__()
-        self.config = config
+        self.args = config
+        self.config = config  # backward compat
         self.vocab_size = config.vocab_size
         self.window_size = config.sliding_window
         self.sliding_window_pattern = config.sliding_window_pattern
@@ -502,7 +503,7 @@ class Gemma4TextModel(nn.Module):
         return mx.unflatten(
             result,
             -1,
-            (self.config.num_hidden_layers, self.hidden_size_per_layer_input),
+            (self.args.num_hidden_layers, self.hidden_size_per_layer_input),
         )
 
     def _project_per_layer_inputs(
@@ -514,7 +515,7 @@ class Gemma4TextModel(nn.Module):
         per_layer_projection = mx.unflatten(
             per_layer_projection,
             -1,
-            (self.config.num_hidden_layers, self.hidden_size_per_layer_input),
+            (self.args.num_hidden_layers, self.hidden_size_per_layer_input),
         )
         per_layer_projection = self.per_layer_projection_norm(per_layer_projection)
 

--- a/mlx_lm/models/plamo.py
+++ b/mlx_lm/models/plamo.py
@@ -164,6 +164,7 @@ class PlamoDecoder(nn.Module):
 class PlamoModel(nn.Module):
     def __init__(self, config: ModelArgs):
         super().__init__()
+        self.args = config
         self.config = config
         self.vocab_size = config.vocab_size
 

--- a/mlx_lm/models/plamo2.py
+++ b/mlx_lm/models/plamo2.py
@@ -412,6 +412,7 @@ class PlamoModel(nn.Module):
     def __init__(self, config: ModelArgs):
         super().__init__()
 
+        self.args = config
         self.config = config
         self.vocab_size = config.vocab_size
 

--- a/mlx_lm/models/recurrent_gemma.py
+++ b/mlx_lm/models/recurrent_gemma.py
@@ -364,6 +364,7 @@ class Griffin(nn.Module):
     def __init__(self, config):
         super().__init__()
 
+        self.args = config
         self.config = config
         self.embed_tokens = nn.Embedding(
             config.vocab_size,

--- a/mlx_lm/models/youtu_llm.py
+++ b/mlx_lm/models/youtu_llm.py
@@ -182,6 +182,7 @@ class YoutuLLMDecoderLayer(nn.Module):
 class YoutuLLMModel(nn.Module):
     def __init__(self, config: ModelArgs):
         super().__init__()
+        self.args = config
         self.config = config
         self.vocab_size = config.vocab_size
         self.num_hidden_layers = config.num_hidden_layers


### PR DESCRIPTION
## Summary

Standardize `self.config` → `self.args` in inner model classes to match the convention used by ~103 other model implementations. Adds `self.config` as a backward-compatible alias so existing code is not broken.

## Problem

Inner model classes accessed via `model.model` or `model.language_model.model` use inconsistent attribute names for `ModelArgs`:

| Attribute | Count | Examples |
|-----------|-------|---------|
| `self.args` | ~103 files | llama, mistral, qwen, phi3, ... |
| `self.config` | ~15 files | gemma4_text, gemma3n, deepseek, ... |

This causes `AttributeError` when downstream code accesses `inner.args.hidden_size` on affected models, while the same pattern works on the majority of models.

## Changes

In 7 inner model classes:

1. Added `self.args = config` as the canonical attribute (matching the established convention)
2. Kept `self.config = config` as a backward-compatible alias (same object reference)

Both `inner.args` and `inner.config` now work on all models.

**Files changed:**
- `gemma4_text.py` — `Gemma4TextModel`
- `gemma3n.py` — `LanguageModel`
- `deepseek.py` — `DeepseekModel`
- `plamo.py` — `PlamoModel`
- `plamo2.py` — `PlamoModel`
- `youtu_llm.py` — `YoutuLLMModel`
- `recurrent_gemma.py` — `Griffin`

Helper classes (Router, Experts, MLP, Attention, DecoderLayer) and outer `Model` classes are **not** changed.

## Backward Compatibility

**Fully backward compatible.** Both attributes point to the same `ModelArgs` object:

```python
inner = model.language_model.model  # Gemma4TextModel
inner.args.hidden_size    # ✅ works (new)
inner.config.hidden_size  # ✅ still works (preserved)
inner.args is inner.config  # True — same object
```

Fixes #1107