### PR TITLE
Fix output corruption in speculative decoding

### DIFF
--- a/mlx_lm/generate.py
+++ b/mlx_lm/generate.py
@@ -525,6 +525,12 @@ def speculative_generate_step(
         model_cache = prompt_cache[: len(model.layers)]
         draft_cache = prompt_cache[len(model.layers) :]
 
+    if not cache.can_trim_prompt_cache(model_cache):
+        types = {type(c).__name__ for c in model_cache if not c.is_trimmable()}
+        raise ValueError(
+            f"Speculative decoding requires a trimmable prompt cache " f"(got {types})."
+        )
+
     sampler = sampler or (lambda x: mx.argmax(x, axis=-1))
 
     quantize_cache_fn = functools.partial(
@@ -570,11 +576,12 @@ def speculative_generate_step(
                 return _process_and_sample(None, logits.squeeze(0))
 
     def _prefill(model, cache, y):
-        while y.size > prefill_step_size:
-            model(y[:prefill_step_size][None], cache=cache)
+        while y.size > 1:
+            n_to_process = min(prefill_step_size, y.size - 1)
+            model(y[:n_to_process][None], cache=cache)
             quantize_cache_fn(cache)
             mx.eval([c.state for c in cache])
-            y = y[prefill_step_size:]
+            y = y[n_to_process:]
             mx.clear_cache()
         return y
 


### PR DESCRIPTION
This fixes two issues with speculative decoding that silently produce wrong output. I ran into these issues when experimenting with ngram lookup decoding, but it was previously reported in #846.

1. Refuse speculative decoding when the target model's cache can't be rewound. `speculative_generate_step` relies on `trim_prompt_cache` to roll back rejected drafts from the target cache. This is a noop for non-trimmable caches (e.g. `ArraysCache`), so rejected drafts remain in the recurrent state and corrupt subsequent predictions. Instead raise an error if the target cache is non-trimmable.

2. Ensure the decoding path processes tokens the same way as the generation path. `_prefill` processed the whole prompt remainder in one batched call, while `generate_step` leaves 1 token for the first `_step`. The different kernel dispatch can flip argmax at the first generated position on tie-like logits. `_prefill` now leaves 1 token for the first `_step`, matching `generate_step`.

