### PR TITLE
Add logits processor support to batch_generate

### DIFF
--- a/mlx_lm/generate.py
+++ b/mlx_lm/generate.py
@@ -1336,7 +1336,7 @@ class GenerationBatch:
             for e in range(len(self.uids)):
                 sample_logits = logits[e : e + 1]
                 for processor in self.logits_processors[e]:
-                    sample_logits = processor(self.tokens[e], sample_logits)
+                    sample_logits = processor(self._token_context[e], sample_logits)
                 processed_logits.append(sample_logits)
             logits = mx.concatenate(processed_logits, axis=0)
 
@@ -1876,7 +1876,12 @@ def batch_generate(
     max_tokens: Union[int, List[int]] = 128,
     verbose: bool = False,
     return_prompt_caches: bool = False,
-    logits_processors: Optional[List[Callable[[mx.array, mx.array], mx.array]]] = None,
+    logits_processors: Optional[
+        Union[
+            List[Callable[[mx.array, mx.array], mx.array]],
+            List[List[Callable[[mx.array, mx.array], mx.array]]],
+        ]
+    ] = None,
     **kwargs,
 ) -> BatchResponse:
     """
@@ -1895,8 +1900,11 @@ def batch_generate(
           can be per prompt if a list is provided.
        return_prompt_caches (bool): Return the prompt caches in the batch
           responses. Default: ``False``.
-       logits_processors (List[Callable[[mx.array, mx.array], mx.array]], optional):
-          A list of functions that take tokens and logits and return the processed logits. Default: ``None``.
+       logits_processors
+          Either a shared list of processors applied to every prompt or a
+          per-prompt list of processor lists. Each processor takes the token
+          history and current logits and returns the processed logits.
+          Default: ``None``.
        kwargs: The remaining options get passed to :obj:`BatchGenerator`.
           See :obj:`BatchGenerator` for more details.
     """
@@ -1914,7 +1922,15 @@ def batch_generate(
     if isinstance(max_tokens, int):
         max_tokens = [max_tokens] * len(prompts)
 
-    uids = gen.insert(prompts, max_tokens, caches=prompt_caches)
+    if logits_processors and all(callable(processor) for processor in logits_processors):
+        logits_processors = [logits_processors] * len(prompts)
+
+    uids = gen.insert(
+        prompts,
+        max_tokens,
+        caches=prompt_caches,
+        logits_processors=logits_processors,
+    )
     results = {uid: [] for uid in uids}
     prompt_caches = {}
     with gen.stats() as stats:

--- a/tests/test_generate.py
+++ b/tests/test_generate.py
@@ -402,6 +402,35 @@ class TestGenerate(unittest.TestCase):
         self.assertEqual(responses[uid1].logprobs[1].item(), 0.0)
         self.assertEqual(responses[uid2].logprobs[2].item(), 0.0)
 
+    def test_batch_generate_helper_with_shared_logits_processors(self):
+        """Test that batch_generate forwards shared logits processors."""
+        prompts = [self.tokenizer.encode("hello"), self.tokenizer.encode("world")]
+        outputs = batch_generate(
+            self.model,
+            self.tokenizer,
+            prompts,
+            max_tokens=1,
+            logits_processors=make_logits_processors({0: 2000.0}),
+        )
+
+        self.assertEqual(outputs.texts, ["!", "!"])
+
+    def test_batch_generate_helper_with_per_prompt_logits_processors(self):
+        """Test that batch_generate supports distinct processor chains per prompt."""
+        prompts = [self.tokenizer.encode("hello"), self.tokenizer.encode("world")]
+        outputs = batch_generate(
+            self.model,
+            self.tokenizer,
+            prompts,
+            max_tokens=1,
+            logits_processors=[
+                make_logits_processors({0: 2000.0}),
+                make_logits_processors({1: 2000.0}),
+            ],
+        )
+
+        self.assertEqual(outputs.texts, ["!", '"'])
+
     def test_batch_generate_with_samplers(self):
         """Test that batch_generate with logits_processors produces correct results."""
         batch_gen = BatchGenerator(


### PR DESCRIPTION
## Summary

This PR wires `logits_processors` through the top-level `batch_generate(...)` helper.
This allows constrained decoding for batched generation through the `batch_generate(...)` API.

In practice, that means higher-level integrations can batch multiple prompts while still applying logits processors for:
- structured generation
- regex-constrained generation
- JSON/schema-constrained generation
- custom per-sequence decoding rules etc


## Details
`BatchGenerator` already supported per-sequence logits processors, but `batch_generate(...)` accepted a `logits_processors` argument without passing it into `BatchGenerator.insert(...)`. This appears to have been an oversight.

As a result, constrained decoding worked through the lower-level batch API but not through the public helper.

This change makes `batch_generate(...)` support:
- a shared processor chain applied to every prompt in the batch
- distinct processor chains per prompt
- validation of the per-prompt form through the existing batch machinery


## Changes
- forward `logits_processors` from `batch_generate(...)` into `BatchGenerator.insert(...)`
- accept both:
  - `List[Callable[...]]` for one shared chain
  - `List[List[Callable[...]]]` for per-prompt chains
- add regression tests covering helper-level batch logits processor usage

Expected behavior:
- if a flat `List[Callable[...]]` is passed, it is treated as one shared processor chain and expanded across the full batch
- if a nested `List[List[Callable[...]]]` is passed, its length must match the batch size
- if the nested per-prompt list length does not match the batch size, the existing batch validation raises a `ValueError`



## Why
This is needed so higher-level integrations can use constrained decoding through the public batch helper instead of dropping down to `BatchGenerator` directly.
One downstream integration this enables is `outlines`, which currently supports structured generation in batch mode for backends like `transformers`, but not for `mlx-lm` through this helper path.


## Tests
Ran:
```bash
uv run python -m unittest tests.test_generate.TestGenerate
```
Result:
- all 24 tests passed

Also added new regression test for:
- shared logits processors in `batch_generate(...)`
- per-prompt logits processors in `batch_generate(...)`
These tests were added to the existing `tests/test_generate.py` suite, so they run as part of the normal `TestGenerate` test class.


### Clarification about this line

```                  
-  sample_logits = processor(self.tokens[e], sample_logits)
+. sample_logits = processor(self._token_context[e], sample_logits)
````

self.tokens[e] lags the current decoding step, while self._token_context[e] reflects the up-to-date per-sequence context seen by the model. Batch logits processors need the latter for correct stateful constrained decoding.

Stateful constrained decoders need the up-to-date per-sequence context for the current step, so this now uses self._token_context[e] instead.


---
Once this PR is merged, I plan to open a corresponding `outlines` PR to enable batch constrained decoding through its `mlx-lm` integration.
