### PR TITLE
fix: unconditionally pop prefix entries in LRUPromptCache.insert_cache

### DIFF
--- a/mlx_lm/models/cache.py
+++ b/mlx_lm/models/cache.py
@@ -1682,13 +1682,20 @@ class LRUPromptCache:
             self._lru.remove(model, tokens)
         self._lru.push(model, tokens, cache_type)
 
-        # If it is a trimmable cache remove all prefixes cause they just take
-        # space
-        if can_trim_prompt_cache(prompt_cache):
-            for prefix_len, entry in self._trie.pop_prefixes(model, tokens):
-                self._n_bytes -= entry.nbytes
-                self._n_bytes_by_type[entry.cache_type] -= entry.nbytes
-                self._lru.remove(model, tokens[:prefix_len])
+        # Remove all strict-prefix entries for this key. Any stored entry
+        # whose key is a strict prefix of ``tokens`` has been superseded:
+        # fetch_nearest_cache always prefers the longest (deepest-in-trie)
+        # match, so shorter entries are unreachable dead weight.
+        #
+        # This was previously gated on ``can_trim_prompt_cache(prompt_cache)``
+        # which is False for models with sliding-window attention
+        # (RotatingKVCache). That caused every turn's cache entry to
+        # accumulate without eviction, leaking memory until Metal OOM on
+        # long multi-turn conversations with Gemma 4, Mistral, etc.
+        for prefix_len, entry in self._trie.pop_prefixes(model, tokens):
+            self._n_bytes -= entry.nbytes
+            self._n_bytes_by_type[entry.cache_type] -= entry.nbytes
+            self._lru.remove(model, tokens[:prefix_len])
 
         # Ensure we match the constraints
         if len(self._lru) > self.max_size:


### PR DESCRIPTION
Removes the `can_trim_prompt_cache()` gate on `pop_prefixes()` in `insert_cache()`. For models with sliding-window attention (Gemma 4, Mistral, Mixtral), `is_trimmable()` returns False after ~512 tokens, so prefix entries were never evicted. Multi-turn conversations accumulated 1 dead-weight trie entry per turn (~2-5 GB each), causing Metal OOM at ~40-45 GB on Apple Silicon. The gate is unnecessary because `pop_prefixes` only removes strict-prefix entries that are logically superseded by the longer newly-inserted key — `fetch_nearest_cache` always prefers the longest match.