### PR TITLE
fix: honor --prompt-cache-bytes in sequential serve mode

### DIFF
--- a/mlx_lm/server.py
+++ b/mlx_lm/server.py
@@ -1727,7 +1727,14 @@ def run(
     handler_class=APIHandler,
 ):
     group = mx.distributed.init()
-    prompt_cache = LRUPromptCache(model_provider.cli_args.prompt_cache_size)
+    # Pass --prompt-cache-bytes to the LRU so it enforces the byte limit
+    # in _serve_single (sequential) mode as well as in the batched path.
+    _pc_kwargs = {}
+    if getattr(model_provider.cli_args, "prompt_cache_bytes", None) is not None:
+        _pc_kwargs["max_bytes"] = model_provider.cli_args.prompt_cache_bytes
+    prompt_cache = LRUPromptCache(
+        model_provider.cli_args.prompt_cache_size, **_pc_kwargs
+    )
     response_generator = ResponseGenerator(model_provider, prompt_cache)
     if group.rank() == 0:
         _run_http_server(host, port, response_generator)


### PR DESCRIPTION
`--prompt-cache-bytes` was silently ignored in `_serve_single` (sequential) mode because `LRUPromptCache` was constructed with only `max_size`, leaving `max_bytes` at the default `2**63`. The flag was only enforced in the batched path via `trim_to()`. This allowed unbounded cache growth on Apple Silicon until Metal OOM. Fix: pass `prompt_cache_bytes` as `max_bytes` to the `LRUPromptCache` constructor.