### PR TITLE
feat(tuner): support loading PEFT/Unsloth LoRA adapters in load_adapters()

### DIFF
--- a/mlx_lm/LORA.md
+++ b/mlx_lm/LORA.md
@@ -173,6 +173,58 @@ mlx_lm.fuse \
 This will save the GGUF model in `fused_model/ggml-model-f16.gguf`. You
 can specify the file name with `--gguf-path`.
 
+## Loading PEFT / Unsloth Adapters
+
+If you have trained a LoRA adapter using [PEFT](https://github.com/huggingface/peft)
+or [Unsloth](https://github.com/unslothai/unsloth) on a CUDA GPU, you can load it
+directly on Apple Silicon without any manual conversion.
+
+Detection is automatic: if `adapter_config.json` contains a `"peft_type"` key,
+mlx-lm treats the directory as a PEFT adapter.
+
+### Supported formats
+
+| Field | PEFT (auto-detected) | mlx-lm native |
+|---|---|---|
+| Config file | `adapter_config.json` with `"peft_type"` | `adapter_config.json` with `"fine_tune_type"` |
+| Weight file | `adapter_model.safetensors` | `adapters.safetensors` |
+| Supported type | `"LORA"` | `"lora"`, `"dora"`, `"full"` |
+
+### Usage
+
+No change to your existing commands — use the PEFT adapter directory directly:
+
+```shell
+mlx_lm.generate \
+    --model <path_to_base_model> \
+    --adapter-path <path_to_peft_adapter_dir> \
+    --prompt "<your_prompt>"
+```
+
+Or in Python:
+
+```python
+from mlx_lm import load, generate
+
+model, tokenizer = load(
+    "<path_to_base_model>",
+    adapter_path="<path_to_peft_adapter_dir>",
+)
+response = generate(model, tokenizer, prompt="Hello!", max_tokens=100)
+```
+
+### Scale conversion
+
+PEFT's `lora_alpha` and `r` are automatically converted to mlx-lm's `scale`
+parameter as `scale = lora_alpha / r`, which matches PEFT's own effective scaling
+of the LoRA update.
+
+### Limitations
+
+- Only `peft_type: "LORA"` is supported. `"DORA"`, `"ADALORA"`, and `"IA3"` are
+  not yet supported via this path.
+- The `mlx_lm.fuse` command works with PEFT adapters loaded this way.
+
 ## Data
 
 The LoRA command expects you to provide a dataset with `--data`. The MLX

--- a/mlx_lm/tuner/lora.py
+++ b/mlx_lm/tuner/lora.py
@@ -49,8 +49,11 @@ class LoRALinear(nn.Module):
         output_dims, input_dims = weight.shape
         fused_linear = nn.Linear(input_dims, output_dims, bias=bias)
 
-        delta = ((self.scale * self.lora_b.T) @ self.lora_a.T).astype(weight.dtype)
-        fused_linear.weight = weight + delta
+        # Compute the LoRA delta in float32 to avoid precision loss when the
+        # base weight dtype is bfloat16. The merged weight is then cast back to
+        # the original dtype.
+        delta = (self.scale * self.lora_b.T) @ self.lora_a.T
+        fused_linear.weight = (weight.astype(mx.float32) + delta).astype(weight.dtype)
         if bias:
             fused_linear.bias = linear.bias
 
@@ -233,9 +236,8 @@ class LoRAEmbedding(nn.Module):
         num_embeddings, dims = weight.shape
         fused_embedding = nn.Embedding(num_embeddings, dims)
 
-        lora_a = self.scale * self.lora_a
-        lora_b = self.lora_b
-        fused_embedding.weight = weight + (lora_a @ lora_b).astype(weight.dtype)
+        delta = (self.scale * self.lora_a) @ self.lora_b
+        fused_embedding.weight = (weight.astype(mx.float32) + delta).astype(weight.dtype)
 
         if is_quantized and not dequantize:
             fused_embedding = nn.QuantizedEmbedding.from_embedding(

--- a/mlx_lm/tuner/utils.py
+++ b/mlx_lm/tuner/utils.py
@@ -1,5 +1,6 @@
 # Copyright © 2024 Apple Inc.
 import json
+import re
 import types
 from pathlib import Path
 from typing import Dict
@@ -110,31 +111,159 @@ def linear_to_lora_layers(
         model.update_modules(tree_unflatten(lora_modules))
 
 
+_LAYER_RE = re.compile(r"\.layers\.(\d+)\.")
+
+
+def _is_peft_config(raw_config: dict) -> bool:
+    """Return True if the config dict is in PEFT/Hugging Face format."""
+    return "peft_type" in raw_config
+
+
+def _convert_peft_config(
+    peft_config: dict, adapter_path: Path
+) -> types.SimpleNamespace:
+    """
+    Convert a PEFT adapter_config dict into an MLX-compatible config namespace.
+
+    Args:
+        peft_config: Raw dict loaded from PEFT's adapter_config.json.
+        adapter_path: Path to the adapter directory (used to inspect weight keys).
+
+    Returns:
+        types.SimpleNamespace with fields: fine_tune_type, num_layers, lora_parameters.
+
+    Raises:
+        ValueError: If peft_type is not "LORA", or required fields are missing.
+        FileNotFoundError: If adapter_model.safetensors is not present.
+    """
+    peft_type = peft_config.get("peft_type", "").upper()
+    if peft_type != "LORA":
+        raise ValueError(
+            f"Only PEFT peft_type='LORA' is supported, got '{peft_type}'. "
+            "DoRA and AdaLoRA are not currently supported via this path."
+        )
+
+    weight_file = adapter_path / "adapter_model.safetensors"
+    if not weight_file.exists():
+        raise FileNotFoundError(
+            f"Expected PEFT weight file not found: {weight_file}"
+        )
+
+    raw_weights = mx.load(str(weight_file))
+    layer_indices = [
+        int(m.group(1))
+        for key in raw_weights.keys()
+        if (m := _LAYER_RE.search(key))
+    ]
+    if not layer_indices:
+        raise ValueError(
+            "Could not determine num_layers: no layer index found in weight keys. "
+            f"Sample keys: {list(raw_weights.keys())[:5]}"
+        )
+    num_layers = max(layer_indices) + 1
+
+    r = peft_config.get("r")
+    if r is None:
+        raise ValueError("PEFT config missing required field 'r' (rank).")
+    lora_alpha = peft_config.get("lora_alpha", r)
+    dropout = peft_config.get("lora_dropout", 0.0)
+
+    return types.SimpleNamespace(
+        fine_tune_type="lora",
+        num_layers=num_layers,
+        lora_parameters={"rank": r, "scale": lora_alpha / r, "dropout": dropout},
+    )
+
+
+def _remap_peft_weights(weights: dict) -> dict:
+    """
+    Remap PEFT weight keys and shapes to MLX LoRA conventions.
+
+    PEFT stores lora_A as (rank, in_features) and lora_B as (out_features, rank).
+    MLX expects lora_a as (in_features, rank) and lora_b as (rank, out_features).
+    Both matrices require transposing.
+
+    Args:
+        weights: Dict mapping PEFT weight key strings to mx.array values.
+
+    Returns:
+        Dict mapping MLX weight key strings to correctly-shaped mx.array values.
+        Keys that are not recognizable LoRA adapter weights are silently dropped.
+    """
+    remapped = {}
+    for key, value in weights.items():
+        if not key.startswith("base_model.model."):
+            continue
+        stripped = key[len("base_model.model."):]
+
+        if stripped.endswith(".lora_A.weight"):
+            mlx_key = stripped[: -len(".lora_A.weight")] + ".lora_a"
+            remapped[mlx_key] = mx.transpose(value)  # (rank, in) → (in, rank)
+        elif stripped.endswith(".lora_B.weight"):
+            mlx_key = stripped[: -len(".lora_B.weight")] + ".lora_b"
+            remapped[mlx_key] = mx.transpose(value)  # (out, rank) → (rank, out)
+        # Other keys (base model weights, scaling vectors, etc.) are silently skipped.
+
+    return remapped
+
+
 def load_adapters(model: nn.Module, adapter_path: str) -> nn.Module:
     """
-    Load any fine-tuned adapters / layers.
+    Load fine-tuned adapters / layers, supporting both mlx-lm native format
+    and PEFT/Unsloth LoRA adapter format.
+
+    For native mlx-lm adapters, the adapter directory must contain:
+        - adapter_config.json  (with fine_tune_type, num_layers, lora_parameters)
+        - adapters.safetensors
+
+    For PEFT/Unsloth adapters, the adapter directory must contain:
+        - adapter_config.json  (with peft_type, r, lora_alpha, ...)
+        - adapter_model.safetensors
 
     Args:
         model (nn.Module): The neural network model.
-        adapter_path (str): Path to the adapter configuration file.
+        adapter_path (str): Path to the adapter directory.
 
     Returns:
-        nn.Module: The updated model with LoRA layers applied.
+        nn.Module: The updated model with LoRA layers applied and weights loaded.
     """
     adapter_path = Path(adapter_path)
     if not adapter_path.exists():
         raise FileNotFoundError(f"The adapter path does not exist: {adapter_path}")
+
     with open(adapter_path / "adapter_config.json", "r") as fid:
-        config = types.SimpleNamespace(**json.load(fid))
-    fine_tune_type = getattr(config, "fine_tune_type", "lora")
-    if fine_tune_type != "full":
+        raw_config = json.load(fid)
+
+    if _is_peft_config(raw_config):
+        # --- PEFT / Unsloth path ---
+        config = _convert_peft_config(raw_config, adapter_path)
         linear_to_lora_layers(
             model,
             config.num_layers,
             config.lora_parameters,
-            use_dora=(fine_tune_type == "dora"),
+            use_dora=False,
         )
-    model.load_weights(str(adapter_path / "adapters.safetensors"), strict=False)
+        raw_weights = mx.load(str(adapter_path / "adapter_model.safetensors"))
+        remapped = _remap_peft_weights(raw_weights)
+        if not remapped:
+            raise ValueError(
+                "No LoRA weights found after remapping PEFT adapter. "
+                "Ensure adapter_model.safetensors contains lora_A/lora_B weights."
+            )
+        model.load_weights(list(remapped.items()), strict=False)
+    else:
+        # --- Native mlx-lm path (unchanged) ---
+        config = types.SimpleNamespace(**raw_config)
+        fine_tune_type = getattr(config, "fine_tune_type", "lora")
+        if fine_tune_type != "full":
+            linear_to_lora_layers(
+                model,
+                config.num_layers,
+                config.lora_parameters,
+                use_dora=(fine_tune_type == "dora"),
+            )
+        model.load_weights(str(adapter_path / "adapters.safetensors"), strict=False)
+
     return model
 
 

--- a/tests/test_tuner_utils.py
+++ b/tests/test_tuner_utils.py
@@ -1,14 +1,24 @@
 # Copyright © 2024 Apple Inc.
 
+import json
 import sys
+import tempfile
 import unittest
 from io import StringIO
-from unittest.mock import MagicMock
+from pathlib import Path
+from unittest.mock import MagicMock, patch
 
+import mlx.core as mx
 import mlx.nn as nn
 
 from mlx_lm.tuner.lora import LoRALinear
-from mlx_lm.tuner.utils import print_trainable_parameters
+from mlx_lm.tuner.utils import (
+    _convert_peft_config,
+    _is_peft_config,
+    _remap_peft_weights,
+    load_adapters,
+    print_trainable_parameters,
+)
 
 
 class TestTunerUtils(unittest.TestCase):
@@ -80,6 +90,204 @@ class TestTunerUtils(unittest.TestCase):
         expected_output = "Trainable parameters: 50.000% (3.000M/6.000M)\n"
         print_trainable_parameters(model)
         self.assertEqual(self.capturedOutput.getvalue(), expected_output)
+
+
+def _make_peft_config(r=8, lora_alpha=16, dropout=0.05):
+    return {
+        "peft_type": "LORA",
+        "r": r,
+        "lora_alpha": lora_alpha,
+        "lora_dropout": dropout,
+        "target_modules": ["q_proj", "v_proj"],
+        "bias": "none",
+    }
+
+
+def _make_mlx_config():
+    return {
+        "fine_tune_type": "lora",
+        "num_layers": 4,
+        "lora_parameters": {"rank": 8, "scale": 20.0, "dropout": 0.0},
+    }
+
+
+def _make_peft_weights(num_layers=2, rank=8, in_dim=64, out_dim=64):
+    weights = {}
+    for i in range(num_layers):
+        prefix = f"base_model.model.model.layers.{i}.self_attn.q_proj"
+        weights[f"{prefix}.lora_A.weight"] = mx.zeros((rank, in_dim))
+        weights[f"{prefix}.lora_B.weight"] = mx.zeros((out_dim, rank))
+    return weights
+
+
+class TestIsPeftConfig(unittest.TestCase):
+    def test_returns_true_for_peft_config(self):
+        self.assertTrue(_is_peft_config(_make_peft_config()))
+
+    def test_returns_false_for_mlx_config(self):
+        self.assertFalse(_is_peft_config(_make_mlx_config()))
+
+    def test_returns_false_for_empty_dict(self):
+        self.assertFalse(_is_peft_config({}))
+
+    def test_case_sensitive(self):
+        self.assertFalse(_is_peft_config({"PEFT_TYPE": "LORA"}))
+
+
+class TestConvertPeftConfig(unittest.TestCase):
+    @patch("mlx_lm.tuner.utils.mx.load")
+    def test_basic_conversion(self, mock_load):
+        mock_load.return_value = _make_peft_weights(num_layers=3, rank=8)
+        with patch.object(Path, "exists", return_value=True):
+            config = _convert_peft_config(_make_peft_config(r=8, lora_alpha=16), Path("/fake"))
+        self.assertEqual(config.fine_tune_type, "lora")
+        self.assertEqual(config.num_layers, 3)
+        self.assertEqual(config.lora_parameters["rank"], 8)
+        self.assertAlmostEqual(config.lora_parameters["scale"], 2.0)
+        self.assertAlmostEqual(config.lora_parameters["dropout"], 0.05)
+
+    @patch("mlx_lm.tuner.utils.mx.load")
+    def test_scale_equals_one_when_alpha_equals_rank(self, mock_load):
+        mock_load.return_value = _make_peft_weights(num_layers=2)
+        with patch.object(Path, "exists", return_value=True):
+            config = _convert_peft_config(_make_peft_config(r=16, lora_alpha=16), Path("/fake"))
+        self.assertAlmostEqual(config.lora_parameters["scale"], 1.0)
+
+    @patch("mlx_lm.tuner.utils.mx.load")
+    def test_missing_lora_alpha_defaults_to_rank(self, mock_load):
+        cfg = _make_peft_config(r=8)
+        del cfg["lora_alpha"]
+        mock_load.return_value = _make_peft_weights(num_layers=2)
+        with patch.object(Path, "exists", return_value=True):
+            config = _convert_peft_config(cfg, Path("/fake"))
+        self.assertAlmostEqual(config.lora_parameters["scale"], 1.0)
+
+    @patch("mlx_lm.tuner.utils.mx.load")
+    def test_num_layers_from_max_index(self, mock_load):
+        weights = {}
+        for idx in [0, 2, 5]:
+            weights[f"base_model.model.model.layers.{idx}.self_attn.q_proj.lora_A.weight"] = mx.zeros((8, 64))
+            weights[f"base_model.model.model.layers.{idx}.self_attn.q_proj.lora_B.weight"] = mx.zeros((64, 8))
+        mock_load.return_value = weights
+        with patch.object(Path, "exists", return_value=True):
+            config = _convert_peft_config(_make_peft_config(r=8), Path("/fake"))
+        self.assertEqual(config.num_layers, 6)  # max(0,2,5) + 1
+
+    def test_raises_for_unsupported_peft_type(self):
+        cfg = _make_peft_config()
+        cfg["peft_type"] = "ADALORA"
+        with self.assertRaises(ValueError):
+            _convert_peft_config(cfg, Path("/fake"))
+
+    @patch("mlx_lm.tuner.utils.mx.load")
+    def test_raises_for_missing_rank(self, mock_load):
+        mock_load.return_value = _make_peft_weights(num_layers=2)
+        cfg = _make_peft_config()
+        del cfg["r"]
+        with patch.object(Path, "exists", return_value=True):
+            with self.assertRaises(ValueError):
+                _convert_peft_config(cfg, Path("/fake"))
+
+    def test_raises_when_weight_file_missing(self):
+        with patch.object(Path, "exists", return_value=False):
+            with self.assertRaises(FileNotFoundError):
+                _convert_peft_config(_make_peft_config(), Path("/fake"))
+
+    @patch("mlx_lm.tuner.utils.mx.load")
+    def test_raises_when_no_layer_indices(self, mock_load):
+        mock_load.return_value = {"base_model.model.lm_head.lora_A.weight": mx.zeros((8, 64))}
+        with patch.object(Path, "exists", return_value=True):
+            with self.assertRaises(ValueError):
+                _convert_peft_config(_make_peft_config(), Path("/fake"))
+
+
+class TestRemapPeftWeights(unittest.TestCase):
+    def test_lora_a_key_and_shape(self):
+        weights = {"base_model.model.model.layers.0.self_attn.q_proj.lora_A.weight": mx.zeros((8, 64))}
+        result = _remap_peft_weights(weights)
+        self.assertIn("model.layers.0.self_attn.q_proj.lora_a", result)
+        self.assertEqual(result["model.layers.0.self_attn.q_proj.lora_a"].shape, (64, 8))
+
+    def test_lora_b_key_and_shape(self):
+        weights = {"base_model.model.model.layers.0.self_attn.q_proj.lora_B.weight": mx.zeros((64, 8))}
+        result = _remap_peft_weights(weights)
+        self.assertIn("model.layers.0.self_attn.q_proj.lora_b", result)
+        self.assertEqual(result["model.layers.0.self_attn.q_proj.lora_b"].shape, (8, 64))
+
+    def test_non_peft_prefix_dropped(self):
+        weights = {"model.embed_tokens.weight": mx.zeros((100, 64))}
+        self.assertEqual(_remap_peft_weights(weights), {})
+
+    def test_base_model_weight_without_lora_suffix_dropped(self):
+        weights = {"base_model.model.model.embed_tokens.weight": mx.zeros((100, 64))}
+        self.assertEqual(_remap_peft_weights(weights), {})
+
+    def test_multiple_layers(self):
+        result = _remap_peft_weights(_make_peft_weights(num_layers=4))
+        self.assertEqual(len(result), 8)  # 4 layers × 2 keys
+
+    def test_values_are_transposed(self):
+        a = mx.array([[1.0, 2.0], [3.0, 4.0], [5.0, 6.0]])  # (3, 2)
+        weights = {"base_model.model.model.layers.0.self_attn.q_proj.lora_A.weight": a}
+        result = _remap_peft_weights(weights)
+        expected = mx.transpose(a)  # (2, 3)
+        self.assertTrue(
+            mx.all(result["model.layers.0.self_attn.q_proj.lora_a"] == expected).item()
+        )
+
+    def test_empty_input(self):
+        self.assertEqual(_remap_peft_weights({}), {})
+
+
+class TestLoadAdaptersPeft(unittest.TestCase):
+    def _write_adapter_config(self, tmpdir, config_dict, weight_filename):
+        with open(Path(tmpdir) / "adapter_config.json", "w") as f:
+            json.dump(config_dict, f)
+        (Path(tmpdir) / weight_filename).touch()
+
+    @patch("mlx_lm.tuner.utils.linear_to_lora_layers")
+    @patch("mlx_lm.tuner.utils.mx.load")
+    def test_peft_path_invoked(self, mock_load, mock_lora_layers):
+        mock_load.return_value = _make_peft_weights(num_layers=2, rank=8)
+        mock_model = MagicMock()
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            self._write_adapter_config(tmpdir, _make_peft_config(r=8, lora_alpha=16), "adapter_model.safetensors")
+            load_adapters(mock_model, tmpdir)
+
+        mock_lora_layers.assert_called_once()
+        args = mock_lora_layers.call_args[0]
+        self.assertEqual(args[1], 2)  # num_layers
+
+    @patch("mlx_lm.tuner.utils.linear_to_lora_layers")
+    @patch("mlx_lm.tuner.utils.mx.load")
+    def test_peft_load_weights_called_with_list(self, mock_load, mock_lora_layers):
+        mock_load.return_value = _make_peft_weights(num_layers=2, rank=8)
+        mock_model = MagicMock()
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            self._write_adapter_config(tmpdir, _make_peft_config(), "adapter_model.safetensors")
+            load_adapters(mock_model, tmpdir)
+
+        call_arg = mock_model.load_weights.call_args[0][0]
+        self.assertIsInstance(call_arg, list)
+
+    @patch("mlx_lm.tuner.utils.linear_to_lora_layers")
+    def test_mlx_native_path_unchanged(self, mock_lora_layers):
+        mock_model = MagicMock()
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            self._write_adapter_config(tmpdir, _make_mlx_config(), "adapters.safetensors")
+            load_adapters(mock_model, tmpdir)
+
+        mock_lora_layers.assert_called_once()
+        self.assertEqual(mock_lora_layers.call_args[0][1], 4)  # num_layers from config
+        call_arg = mock_model.load_weights.call_args[0][0]
+        self.assertIsInstance(call_arg, str)  # path string, not list
+
+    def test_raises_for_missing_path(self):
+        with self.assertRaises(FileNotFoundError):
+            load_adapters(MagicMock(), "/nonexistent/path")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

Adds automatic PEFT adapter format detection and conversion to `load_adapters()`.
Users can now load adapters trained with Unsloth or Hugging Face PEFT directly,
without any manual conversion step.

Closes #1119

## Changes

- `mlx_lm/tuner/utils.py`: Added `_is_peft_config()`, `_convert_peft_config()`, `_remap_peft_weights()`, and updated `load_adapters()` to handle PEFT format
- `mlx_lm/tuner/lora.py`: `fuse()` now merges in float32 precision to avoid bfloat16 rounding loss before casting back to original dtype
- `mlx_lm/LORA.md`: Added usage documentation for PEFT/Unsloth adapters
- `tests/test_tuner_utils.py`: Added 23 new test cases (25 total, all passing)

## How It Works

When `adapter_config.json` contains `peft_type`, the loader:

1. Converts config keys (`r` → `rank`, `lora_alpha/r` → `scale`, etc.)
2. Derives `num_layers` from the maximum layer index present in the weight file
3. Remaps weight tensor names (`base_model.model.*.lora_A.weight` → `*.lora_a`)
4. Transposes `lora_A` / `lora_B` from PEFT storage shape to MLX expected shape

## Scope

`peft_type: "LORA"` only. DoRA/AdaLoRA can be follow-up work if useful.

## Testing

Tested with:
- Base model: `LiquidAI/LFM2.5-1.2B-Base`
- Adapter: `YUGOROU/TeenEmo-LFM2.5-1.2B-DPO` (Unsloth DPO adapter, rank=32, 184 weight tensors, 16 layers)
- LoRA delta numerically verified (`max|PEFT_delta.T − MLX_delta| = 0.0`)
- All 25 unit tests pass

```
python -m pytest tests/test_tuner_utils.py -v
# 25 passed
```

## Notes

- Backward compatible: existing mlx-lm format adapters are completely unaffected
- The `num_layers` derivation uses the maximum layer index present in the adapter file
- Generation behavior may differ slightly from GGUF inference due to quantization differences between backends, which is expected