### PR TITLE
[Bugfix] Fix Gemma 4 tool call regex failing on unbalanced braces in string arguments

### DIFF
--- a/mlx_lm/tool_parsers/gemma4.py
+++ b/mlx_lm/tool_parsers/gemma4.py
@@ -10,6 +10,35 @@ import regex as re
 # second capture group so nested objects like {a:{b:1}} are captured whole.
 _tool_call_regex = re.compile(r"call:(\w+)(\{(?:[^{}]|(?2))*\})", re.DOTALL)
 
+_STRING_DELIM = '<|"|>'
+
+
+def _shield_string_braces(text: str) -> str:
+    """Replace ``{`` and ``}`` inside <|"|>…<|"|> spans with placeholders
+    so the balanced-brace regex is not confused by string content."""
+    parts: list[str] = []
+    i = 0
+    n = len(text)
+    dlen = len(_STRING_DELIM)
+    while i < n:
+        if text[i : i + dlen] == _STRING_DELIM:
+            end = text.find(_STRING_DELIM, i + dlen)
+            if end == -1:
+                parts.append(text[i:])
+                break
+            inner = text[i + dlen : end].replace("{", "\x01").replace("}", "\x02")
+            parts.append(_STRING_DELIM + inner + _STRING_DELIM)
+            i = end + dlen
+        else:
+            parts.append(text[i])
+            i += 1
+    return "".join(parts)
+
+
+def _restore_braces(text: str) -> str:
+    """Restore shielded brace placeholders."""
+    return text.replace("\x01", "{").replace("\x02", "}")
+
 
 def _gemma4_args_to_json(text: str) -> str:
     """Convert Gemma 4 tool call args to valid JSON.
@@ -37,14 +66,15 @@ def _gemma4_args_to_json(text: str) -> str:
 def _parse_single(match: re.Match) -> dict:
     """Parse a single call:name{args} regex match into a tool call dict."""
     func_name = match.group(1)
-    args_str = match.group(2)
+    args_str = _restore_braces(match.group(2))
     json_str = _gemma4_args_to_json(args_str)
     arguments = json.loads(json_str)
     return dict(name=func_name, arguments=arguments)
 
 
 def parse_tool_call(text: str, _: Optional[Any] = None):
-    matches = list(_tool_call_regex.finditer(text))
+    shielded = _shield_string_braces(text)
+    matches = list(_tool_call_regex.finditer(shielded))
     if not matches:
         raise ValueError("No function provided.")
     if len(matches) == 1:

--- a/tests/test_tool_parsing.py
+++ b/tests/test_tool_parsing.py
@@ -254,6 +254,25 @@ class TestToolParsing(unittest.TestCase):
             {"settings": {"enabled": True, "name": "test"}},
         )
 
+    def test_gemma4_unbalanced_braces_in_strings(self):
+        # Unbalanced opening brace inside a string argument
+        test_case = 'call:write_file{content:<|"|>if (x) { console.log(y)<|"|>}'
+        tool_call = gemma4.parse_tool_call(test_case, None)
+        self.assertEqual(tool_call["name"], "write_file")
+        self.assertEqual(
+            tool_call["arguments"],
+            {"content": "if (x) { console.log(y)"},
+        )
+
+        # Unbalanced closing brace inside a string argument
+        test_case = 'call:write_file{content:<|"|>test } only<|"|>}'
+        tool_call = gemma4.parse_tool_call(test_case, None)
+        self.assertEqual(tool_call["name"], "write_file")
+        self.assertEqual(
+            tool_call["arguments"],
+            {"content": "test } only"},
+        )
+
     def test_kimi_k2(self):
         # Single tool call
         test_case = (


### PR DESCRIPTION
Fix `_tool_call_regex` failing to match when `<|"|>`-delimited strings contain unbalanced `{` or `}`.

**Root cause**: `[^{}]` in the regex treats braces inside `<|"|>...<|"|>` as structural. `_gemma4_args_to_json()` handles strings correctly but runs after the regex — when the regex fails, it never gets called.

**Fix**: Shield braces inside `<|"|>` spans with placeholder characters before regex matching, restore after.

Fixes #1126

### Test commands run and results

```
python -c "..." # Direct function verification (7 tests)
# Existing: nested object, mixed types, array, multiple calls — all PASS
# New: unbalanced open brace, unbalanced close brace, CSS balanced — all PASS
```

### AI Assistance Disclosure

AI assistance (Claude) was used for code analysis, identifying the root cause, and drafting this PR. All changes were reviewed and verified by a human.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-authored-by: Claude Opus 4.6 (1M context) <noreply@anthropic.com>