### PR TITLE
fix(cache): fix batch-size inconsistency crashes in ArraysCache, BatchKVCache, and BatchRotatingKVCache under concurrent generation

### DIFF
--- a/mlx_lm/models/cache.py
+++ b/mlx_lm/models/cache.py
@@ -932,12 +932,8 @@ class BatchKVCache(_BaseCache):
     def update_and_fetch(self, keys, values):
         prev = self._idx
         if self.keys is None or (prev + keys.shape[2]) > self.keys.shape[2]:
-            if self.keys is not None:
-                B, n_kv_heads, _, k_head_dim = self.keys.shape
-                v_head_dim = self.values.shape[3]
-            else:
-                B, n_kv_heads, _, k_head_dim = keys.shape
-                v_head_dim = values.shape[3]
+            B, n_kv_heads, _, k_head_dim = keys.shape
+            v_head_dim = values.shape[3]
             n_steps = (self.step + keys.shape[2] - 1) // self.step
             k_shape = (B, n_kv_heads, n_steps * self.step, k_head_dim)
             v_shape = (B, n_kv_heads, n_steps * self.step, v_head_dim)
@@ -1050,8 +1046,11 @@ class BatchKVCache(_BaseCache):
         def pad(c):
             k, v = c.keys, c.values
             if k is None:
-                k = mx.array([]).reshape(B, H, 0, D)
-                v = mx.array([]).reshape(B, H, 0, M)
+                # Use the true per-cache batch size from left_padding, not the
+                # outer-scope B which may belong to the other cache in the pair.
+                b = c.left_padding.shape[0]
+                k = mx.array([]).reshape(b, H, 0, D)
+                v = mx.array([]).reshape(b, H, 0, M)
             left = max_idx - c._idx
             right = max_size - k.shape[2] - left
             if right < 0:
@@ -1386,8 +1385,11 @@ class BatchRotatingKVCache(_BaseCache):
             left = max_idx - c._idx
             k, v = c.keys, c.values
             if k is None:
-                k = mx.array([]).reshape(B, H, 0, D)
-                v = mx.array([]).reshape(B, H, 0, M)
+                # Use the true per-cache batch size from left_padding, not the
+                # outer-scope B which may belong to the other cache in the pair.
+                b = c.left_padding.shape[0]
+                k = mx.array([]).reshape(b, H, 0, D)
+                v = mx.array([]).reshape(b, H, 0, M)
             right = max_size - k.shape[2] - left
             if right < 0:
                 k = k[..., :right, :]

--- a/mlx_lm/models/cache.py
+++ b/mlx_lm/models/cache.py
@@ -932,8 +932,12 @@ class BatchKVCache(_BaseCache):
     def update_and_fetch(self, keys, values):
         prev = self._idx
         if self.keys is None or (prev + keys.shape[2]) > self.keys.shape[2]:
-            B, n_kv_heads, _, k_head_dim = keys.shape
-            v_head_dim = values.shape[3]
+            if self.keys is not None:
+                B, n_kv_heads, _, k_head_dim = self.keys.shape
+                v_head_dim = self.values.shape[3]
+            else:
+                B, n_kv_heads, _, k_head_dim = keys.shape
+                v_head_dim = values.shape[3]
             n_steps = (self.step + keys.shape[2] - 1) // self.step
             k_shape = (B, n_kv_heads, n_steps * self.step, k_head_dim)
             v_shape = (B, n_kv_heads, n_steps * self.step, v_head_dim)

--- a/mlx_lm/models/cache.py
+++ b/mlx_lm/models/cache.py
@@ -596,10 +596,12 @@ class ArraysCache(_BaseCache):
         instance = super().__new__(cls)
         instance.left_padding = None
         instance.lengths = None
+        instance._batch_size = 1
         return instance
 
     def __init__(self, size, left_padding: Optional[List[int]] = None):
         self.cache = [None] * size
+        self._batch_size = 1
         if left_padding:
             self.left_padding = mx.array(left_padding)
 
@@ -622,26 +624,45 @@ class ArraysCache(_BaseCache):
         In-place filter to keep just the given indices in the cache.
         """
         self.cache = [c[batch_indices] if c is not None else None for c in self.cache]
+        self._batch_size = len(batch_indices)
         if self.lengths is not None:
             self.lengths = self.lengths[batch_indices]
 
     def extend(self, other):
         """
         In-place extend this cache with the other cache.
+
+        When one side has no state yet (None) and the other does, the missing
+        side is zero-initialised rather than dropped. Without this, hybrid
+        models (Mamba, RWKV7, Qwen3.5, Falcon-H1, …) crash with a shape
+        mismatch in their linear-attention / SSM state once a second sequence
+        is added to an in-flight generation batch.
         """
 
         def cat(a, b):
+            if a is None and b is None:
+                return None
             if a is None:
-                return b
+                # self had no state for these sequences; zero-init then concat
+                zeros = mx.zeros(
+                    (self._batch_size, *b.shape[1:]), dtype=b.dtype
+                )
+                return mx.concatenate([zeros, b], axis=0)
             if b is None:
-                return a
-            return mx.concatenate([a, b])
+                # other has no state yet; zero-init for the new sequences
+                zeros = mx.zeros(
+                    (other._batch_size, *a.shape[1:]), dtype=a.dtype
+                )
+                return mx.concatenate([a, zeros], axis=0)
+            return mx.concatenate([a, b], axis=0)
 
         self.cache = [cat(c, o) for c, o in zip(self.cache, other.cache)]
+        self._batch_size += other._batch_size
 
     def extract(self, idx):
         cache = ArraysCache(len(self.cache))
         cache.cache = [c[idx : idx + 1] for c in self.cache]
+        # _batch_size is already 1 from __init__
         return cache
 
     def prepare(self, lengths=None, **kwargs):
@@ -672,6 +693,7 @@ class ArraysCache(_BaseCache):
         n_state = len(caches[0].cache)
         B = len(caches)
         cache = cls(n_state)
+        cache._batch_size = B
 
         # All caches are empty so return early
         if all(c.empty() for c in caches):


### PR DESCRIPTION
This PR contains two related fixes for batch-size inconsistency bugs in the KV cache layer that crash concurrent generation (`--decode-concurrency > 1`).

---

## Fix 1 — `ArraysCache.extend()`: zero-init missing state instead of dropping it

### Problem

`ArraysCache.extend()` silently dropped state when the incoming cache slot was `None` (a fresh, never-used per-sequence cache). The inner `cat` helper returned `a` unchanged instead of padding it, leaving the batch-dimension at its old size while the actual in-flight batch had grown.

This caused an immediate crash in every hybrid model that stores linear-attention or SSM state in `ArraysCache` the moment a second concurrent request was added to an in-flight generation batch:

```
Exception in thread Thread-1 (_generate):
ValueError: [concatenate] All the input array dimensions must match exactly
  except for the concatenation axis.
  However, the provided shapes are (1,3,8192), (2,2048,8192), and the
  concatenation axis is 1.
```

### Affected models

Any model that calls `make_cache()` and returns `ArraysCache` instances, including (but not limited to):

- `qwen3_5` / `qwen3_next`
- `mamba` / `mamba2`
- `rwkv7`
- `falcon_h1`
- `nemotron_h`
- `plamo2`
- `kimi_linear`
- `bailing_moe_linear`
- `recurrent_gemma`
- `jamba`

In practice this meant `--decode-concurrency > 1` or `--prompt-concurrency > 1` was unusable for all hybrid architectures.

### Root Cause

```python
# Before — returns `a` unchanged when b is None
def cat(a, b):
    if a is None:
        return b
    if b is None:
        return a          # <-- batch dim stays at a.shape[0], not a.shape[0] + len(other)
    return mx.concatenate([a, b])
```

### Fix

Track `_batch_size` on `ArraysCache` (always `1` for a fresh per-sequence cache created by `make_cache()`). In `extend()`, use that count to zero-initialise the missing state rather than silently dropping it.

```python
def cat(a, b):
    if a is None and b is None:
        return None
    if a is None:
        zeros = mx.zeros((self._batch_size, *b.shape[1:]), dtype=b.dtype)
        return mx.concatenate([zeros, b], axis=0)
    if b is None:
        zeros = mx.zeros((other._batch_size, *a.shape[1:]), dtype=a.dtype)
        return mx.concatenate([a, zeros], axis=0)
    return mx.concatenate([a, b], axis=0)
```

`_batch_size` is kept consistent across `filter()` and `merge()` as well.

---

## Fix 2 — `BatchKVCache.update_and_fetch`: use existing batch size when expanding buffer

### Problem

When `BatchKVCache.update_and_fetch` needs to grow its pre-allocated KV buffer, it derives the batch size `B` from the **incoming** `keys` tensor. If the batch shrank between the last allocation (e.g. a sequence finished and `filter()` was called), `self.keys.shape[0] != keys.shape[0]`, and the subsequent `mx.concatenate` crashes:

```
ValueError: [concatenate] All the input array dimensions must match exactly
except for the concatenation axis.
However, the provided shapes are (4,2,47104,256), (3,2,2048,256),
and the concatenation axis is 2.
```

This reliably occurs during concurrent generation (`--decode-concurrency > 1`) once any sequence in the batch finishes and the next KV allocation boundary is hit for the remaining sequences.

### Fix

When `self.keys` already exists, derive `B`, `n_kv_heads`, and `k_head_dim` from `self.keys.shape` rather than from the incoming `keys`. The expansion buffer must match the tensor it will be appended to, not the current batch.

---

## Testing

Reproduced both crashes locally with `--decode-concurrency 4 --prompt-concurrency 4` and Qwen3.5-35B-A3B-4bit. After both fixes, 4 simultaneous requests complete without error or thread exception.
