### PR TITLE
Add pipeline parallel support for Qwen3 MoE and MiniMax models

### DIFF
--- a/mlx_lm/models/minimax.py
+++ b/mlx_lm/models/minimax.py
@@ -265,7 +265,7 @@ class MiniMaxModel(PipelineMixin, nn.Module):
         from .cache import KVCache
 
         return [
-            KVCache(self.args.head_dim, self.args.num_key_value_heads)
+            KVCache()
             for _ in self.pipeline_layers
         ]
 
@@ -391,6 +391,12 @@ class Model(nn.Module):
                 group=group,
             )
             layer.block_sparse_moe.sharding_group = group
+
+    def make_cache(self):
+        if hasattr(self.model, "make_cache"):
+            return self.model.make_cache()
+        from .cache import KVCache
+        return [KVCache() for _ in self.model.layers]
 
     @property
     def layers(self):

--- a/mlx_lm/models/minimax.py
+++ b/mlx_lm/models/minimax.py
@@ -9,6 +9,7 @@ import mlx.nn as nn
 from mlx.nn.layers.distributed import shard_inplace, shard_linear, sum_gradients
 
 from .base import BaseModelArgs, create_attention_mask, scaled_dot_product_attention
+from .pipeline import PipelineMixin
 from .switch_layers import SwitchGLU
 
 
@@ -221,9 +222,10 @@ class MiniMaxDecoderLayer(nn.Module):
         return r
 
 
-class MiniMaxModel(nn.Module):
+class MiniMaxModel(PipelineMixin, nn.Module):
     def __init__(self, args: ModelArgs):
         super().__init__()
+        self.args = args
         self.embed_tokens = nn.Embedding(args.vocab_size, args.hidden_size)
 
         self.layers = [
@@ -241,14 +243,31 @@ class MiniMaxModel(nn.Module):
         h = self.embed_tokens(inputs)
 
         if cache is None:
-            cache = [None] * len(self.layers)
+            cache = [None] * len(self.pipeline_layers)
 
         mask = create_attention_mask(h, cache[0])
 
-        for layer, c in zip(self.layers, cache):
+        if self.pipeline_rank < self.pipeline_size - 1:
+            h = mx.distributed.recv_like(h, self.pipeline_rank + 1)
+
+        for layer, c in zip(self.pipeline_layers, cache):
             h = layer(h, mask, c)
 
+        if self.pipeline_rank != 0:
+            h = mx.distributed.send(h, (self.pipeline_rank - 1) % self.pipeline_size)
+
+        if self.pipeline_size > 1:
+            h = mx.distributed.all_gather(h)[: h.shape[0]]
+
         return self.norm(h)
+
+    def make_cache(self):
+        from .cache import KVCache
+
+        return [
+            KVCache(self.args.head_dim, self.args.num_key_value_heads)
+            for _ in self.pipeline_layers
+        ]
 
 
 class Model(nn.Module):

--- a/mlx_lm/models/qwen3_moe.py
+++ b/mlx_lm/models/qwen3_moe.py
@@ -8,6 +8,7 @@ import mlx.nn as nn
 
 from .activations import swiglu
 from .base import BaseModelArgs, create_attention_mask, scaled_dot_product_attention
+from .pipeline import PipelineMixin
 from .switch_layers import SwitchGLU
 
 
@@ -171,7 +172,7 @@ class Qwen3MoeDecoderLayer(nn.Module):
         return out
 
 
-class Qwen3MoeModel(nn.Module):
+class Qwen3MoeModel(PipelineMixin, nn.Module):
     def __init__(self, args: ModelArgs):
         super().__init__()
         self.args = args
@@ -197,14 +198,36 @@ class Qwen3MoeModel(nn.Module):
             h = self.embed_tokens(inputs)
 
         if cache is None:
-            cache = [None] * len(self.layers)
+            cache = [None] * len(self.pipeline_layers)
 
-        mask = create_attention_mask(h, cache[0])
+        mask = create_attention_mask(h, cache[0], return_array=True)
 
-        for layer, c in zip(self.layers, cache):
-            h = layer(h, mask, c)
+        # In pipeline parallel, receive hidden state from the next rank
+        # (which processed earlier layers)
+        if self.pipeline_rank < self.pipeline_size - 1:
+            h = mx.distributed.recv_like(h, self.pipeline_rank + 1)
+
+        for layer, c in zip(self.pipeline_layers, cache):
+            h = layer(h, mask, cache=c)
+
+        # Send hidden state to the previous rank (which has later layers)
+        if self.pipeline_rank != 0:
+            h = mx.distributed.send(h, (self.pipeline_rank - 1) % self.pipeline_size)
+
+        # All ranks need the final output for lm_head
+        if self.pipeline_size > 1:
+            h = mx.distributed.all_gather(h)[: h.shape[0]]
 
         return self.norm(h)
+
+    def make_cache(self):
+        """Return KV cache entries only for this rank's layers."""
+        from .cache import KVCache
+
+        return [
+            KVCache(self.args.head_dim, self.args.num_key_value_heads)
+            for _ in self.pipeline_layers
+        ]
 
 
 class Model(nn.Module):

--- a/mlx_lm/models/qwen3_moe.py
+++ b/mlx_lm/models/qwen3_moe.py
@@ -225,7 +225,7 @@ class Qwen3MoeModel(PipelineMixin, nn.Module):
         from .cache import KVCache
 
         return [
-            KVCache(self.args.head_dim, self.args.num_key_value_heads)
+            KVCache()
             for _ in self.pipeline_layers
         ]
 
@@ -276,6 +276,12 @@ class Model(nn.Module):
             return True
 
         return predicate
+
+    def make_cache(self):
+        if hasattr(self.model, "make_cache"):
+            return self.model.make_cache()
+        from .cache import KVCache
+        return [KVCache() for _ in self.model.layers]
 
     @property
     def layers(self):


### PR DESCRIPTION
## Summary

Adds pipeline parallel support (PipelineMixin) to Qwen3 MoE and MiniMax model architectures.

### Changes

**`mlx_lm/models/qwen3_moe.py`**
- `Qwen3MoeModel` extends `PipelineMixin`
- Forward pass: `recv_like` → pipeline_layers → `send` → `all_gather` → `norm`
- `make_cache()` returns KV cache entries only for this rank's layers

**`mlx_lm/models/minimax.py`**
- Same pipeline support as qwen3_moe
- `make_cache()` delegation from outer Model class

### Testing

- Qwen3-235B-A22B-Instruct-2507-8bit on 2-node (80/14, 17.8 tok/s) and 3-node (70/14/10, 11.3 tok/s)
- Tested on mlx-lm 0.31.1 and 0.31.2
- Requires PR #1137 for pipeline infrastructure