### PR TITLE
[Fix] Add alias for served model

### DIFF
--- a/mlx_lm/server.py
+++ b/mlx_lm/server.py
@@ -289,9 +289,9 @@ class ModelProvider:
         self.default_model_map = {}
         if self.cli_args.model is not None:
             self.default_model_map[self.cli_args.model] = "default_model"
-            # Map the base name (short name) so API calls match properly
-            short_name = Path(self.cli_args.model).name
-            self.default_model_map[short_name] = "default_model"
+            # Map path base or alias from args as default model name
+            alias = self.cli_args.model_alias or Path(self.cli_args.model).name
+            self.default_model_map[alias] = "default_model"
             self.load(self.cli_args.model, draft_model_path="default_model")
 
     # Added in adapter_path to load dynamically
@@ -1744,6 +1744,11 @@ def main():
         "--model",
         type=str,
         help="The path to the MLX model weights, tokenizer, and config",
+    )
+    parser.add_argument(
+        "--model-alias",
+        type=str,
+        help="Optional alias of the served model.",
     )
     parser.add_argument(
         "--adapter-path",

--- a/mlx_lm/server.py
+++ b/mlx_lm/server.py
@@ -289,6 +289,9 @@ class ModelProvider:
         self.default_model_map = {}
         if self.cli_args.model is not None:
             self.default_model_map[self.cli_args.model] = "default_model"
+            # Map the base name (short name) so API calls match properly
+            short_name = Path(self.cli_args.model).name
+            self.default_model_map[short_name] = "default_model"
             self.load(self.cli_args.model, draft_model_path="default_model")
 
     # Added in adapter_path to load dynamically


### PR DESCRIPTION
## Usage

1. Starting the HTTP server
```bash
uv run python -m mlx_lm server \
--model /Users/austin/.cache/huggingface/hub/models--mlx-community--Qwen3-1.7B-8bit/snapshots/8c24f6782a91421513803ce527a27dcc560ab904/ \
--model-alias "Qwen3-1.7B-8bit"
```

2. Request:
```bash
curl http://127.0.0.1:8080/v1/chat/completions \
-H "Content-Type: application/json" \
-d '{"model": "Qwen3-1.7B-8bit", "messages": [{"role": "user", "content": "hello"}]}'
```
2. Response:
```bash
{"id": "chatcmpl-1d6719c7-ec05-4d43-9a54-4de800331e08", "system_fingerprint": "0.31.3-0.30.6-macOS-26.3.1-arm64-arm-64bit-applegpu_g14g", "object": "chat.completion", "model": "Qwen3-1.7B-8bit", "created": 1776462660, "choices": [{"index": 0, "finish_reason": "stop", "message": {"role": "assistant", "content": "\n\nHello! How are you today? I'm doing well, thanks! How can I help you today? \ud83d\ude0a", "reasoning": "\nOkay, the user said \"hello\". I need to respond appropriately. Let me start by greeting them back. Maybe \"Hello!\" to keep it friendly. Then ask how they're doing. \"How are you today?\" seems good. Next, I should offer assistance. \"I'm doing well, thanks! How can I help you today?\" That covers the basics. Keep the tone cheerful and open-ended. Make sure it's concise and not too long. Check for any possible misunderstandings, but since it's a simple greeting, it should be fine. Alright, that should work.\n"}}], "usage": {"prompt_tokens": 9, "completion_tokens": 143, "total_tokens": 152, "prompt_tokens_details": {"cached_tokens": 0}}}
```






## Issue

https://github.com/ml-explore/mlx-lm/issues/1133

It happens because the server strictly registers the exact string provided to the model argument as the default model, but your API request is naturally using just the model's directory name.

## Error Case

Because user launched the server with `/path/to/models/qwen3.5-397b-a17b-4bit`, the dictionary looks exactly like this:
`{"/path/to/models/qwen3.5-397b-a17b-4bit": "default_model"}`

When the curl request asks for `"model": "qwen3.5-397b-a17b-4bit"`, the load function checks `self.default_model_map.get("qwen3.5-397b-a17b-4bit")`. It misses, assumes it's a remote Hugging Face repository, and attempts to download it, resulting in the 404 error.

## Solution Proposed [updated]

Option 1. Check if the requested model name matches the basename of any currently loaded model path.

Option 2. Match against the `id` field in `/v1/models` responses, which already includes the full local path.
> "I'm a bit hesitant about the second option. Sending an API request to the server at startup seems counterintuitive, and checking /v1/models for the id during every chat completion would likely introduce too much overhead."

Option 3. Immediate workarounds without code changes. Passing the full path in the API request.

Option 4. Add `--model-alias` cli arg as optional served model name. Thanks to @Atomic-Germ for the nice suggestion https://github.com/ml-explore/mlx-lm/pull/1140#issuecomment-4227459372 .

## Solution

Register model file path basename or model alias (when provided) in `default_model_map`.

## Tests

<img width="1278" height="156" alt="Screenshot 2026-04-09 at 1 40 19 PM" src="https://github.com/user-attachments/assets/fbbfcf89-19a5-4623-8cf2-b496bff97dc0" />

## Question

1. Should it also check Hugging Face cache paths via `scan_cache_dir` (like the ones output by `uv run mlx_lm.manage --scan`)?

## Environment

- mlx-lm version: 0.30.7
- macOS