### PR TITLE
fix(gemma4): return [] instead of raising on empty tool-call match

### DIFF
--- a/mlx_lm/tool_parsers/gemma4.py
+++ b/mlx_lm/tool_parsers/gemma4.py
@@ -46,7 +46,12 @@ def _parse_single(match: re.Match) -> dict:
 def parse_tool_call(text: str, _: Optional[Any] = None):
     matches = list(_tool_call_regex.finditer(text))
     if not matches:
-        raise ValueError("No function provided.")
+        # No `call:name{...}` pattern in the output — this happens on every
+        # plain-text reply when the request had `tools=[...]` attached.
+        # Return an empty list instead of raising so the HTTP server path
+        # can emit a normal chat-completion response rather than a dropped
+        # stream (see #1125).
+        return []
     if len(matches) == 1:
         return _parse_single(matches[0])
     return [_parse_single(m) for m in matches]

--- a/tests/test_tool_parsing.py
+++ b/tests/test_tool_parsing.py
@@ -254,6 +254,13 @@ class TestToolParsing(unittest.TestCase):
             {"settings": {"enabled": True, "name": "test"}},
         )
 
+        # Empty match — plain-text reply with no `call:name{...}` pattern.
+        # This fires on every tool-capable request where the model answers
+        # in natural language, so it must return `[]` rather than raising
+        # (see #1125).
+        self.assertEqual(gemma4.parse_tool_call("", None), [])
+        self.assertEqual(gemma4.parse_tool_call("Sure, I will do that.", None), [])
+
     def test_kimi_k2(self):
         # Single tool call
         test_case = (


### PR DESCRIPTION
## Summary

\`mlx_lm/tool_parsers/gemma4.py::parse_tool_call\` currently raises \`ValueError(\"No function provided.\")\` whenever the \`call:name{...}\` regex finds zero matches. In practice this fires on every plain-text reply when the request had \`tools=[...]\` attached, because the server still routes model output through \`parse_tool_call\` even when the model didn't emit a tool-call marker.

The exception propagates out of \`mlx_lm.server\` / \`mlx_vlm.server\` stream handlers and drops the client connection, manifesting as opaque timeouts in downstream OpenAI-compatible clients. This is the bug reported in #1125 — same model (\`mlx-community/gemma-4-26b-a4b-it-4bit\`), same traceback (\`gemma4.py line 49\`), same \`ValueError: No function provided.\`

## Reproduction

Minimal unit-test style:

\`\`\`python
from mlx_lm.tool_parsers.gemma4 import parse_tool_call
parse_tool_call(\"Sure, I'll do that for you.\")
\`\`\`

Expected: returns \`[]\`.
Actual (on current \`main\`): raises \`ValueError: No function provided.\`

Server-level: send any chat request with \`tools=[...]\` attached and a prompt that elicits a plain-text response rather than a tool call. The stream handler dies, most OpenAI-compatible clients see it as a dropped connection and eventually hit their idle timeout.

## Fix

Return \`[]\` on empty match instead of raising.

I deliberately kept the asymmetric \"single match returns dict, multiple matches return list\" behaviour untouched so that the existing \`tests/test_tool_parsing.py::test_gemma4\` cases (which rely on \`tool_call[\"name\"]\` dict subscripting) continue to pass unchanged. Normalising the return type to always be a list would be cleaner going forward but is a separate, more invasive change; happy to do it in a follow-up PR if you'd prefer.

## Tests

Added two assertions to \`test_gemma4\` covering the empty-match path:

\`\`\`python
self.assertEqual(gemma4.parse_tool_call(\"\", None), [])
self.assertEqual(gemma4.parse_tool_call(\"Sure, I will do that.\", None), [])
\`\`\`

Verified all three existing \`test_gemma4\` cases (single-match-as-dict, multi-match-as-list, nested args) still pass with the fix applied.

## Backwards compatibility

- \`ValueError(\"No function provided.\")\` is no longer raised on empty input. The only in-tree caller I could find is \`process_tool_calls\` in \`mlx_vlm/utils.py\`, which doesn't explicitly catch that exception. Any external caller relying on the raise will need to check for an empty list instead.
- Single-match and multi-match return types are unchanged.

## Context

Discovered downstream during a migration from Ollama to \`mlx_vlm.server\` with Gemma 4 26B-A4B + TurboQuant KV compression. Every tool-capable chat request where the model answered in plain text (which is most of them in a real agent loop) crashed the stream handler. Patched locally and running in production for ~24 hours while we confirmed the fix was sound before upstreaming.

Fixes #1125