### PR TITLE
Fix empty tool_call_end breaking Mistral tool calls

### DIFF
--- a/mlx_lm/server.py
+++ b/mlx_lm/server.py
@@ -651,10 +651,11 @@ class ResponseGenerator:
             ts = tokenizer.tool_call_start_tokens
             te = tokenizer.tool_call_end_tokens
             transitions["normal"].append((ts, "tool"))
-            transitions["tool"] = [(te, "normal")]
+            transitions["tool"] = [(te, "normal")] if te else []
             transitions["tool"].extend(common_stops)
             sequences[ts] = tokenizer.tool_call_start
-            sequences[te] = tokenizer.tool_call_end
+            if te:
+                sequences[te] = tokenizer.tool_call_end
 
         sm = SequenceStateMachine(transitions, initial=initial_state)
         if len(self._state_machine_cache) > 100:

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -205,6 +205,33 @@ class TestServer(unittest.TestCase):
         self.assertIn("id", response_body)
         self.assertIn("choices", response_body)
 
+    def test_make_state_machine_empty_tool_call_end(self):
+        class FakeTokenizer:
+            has_thinking = False
+            has_tool_calling = True
+            tool_call_start = "[TOOL_CALLS]"
+            tool_call_end = ""
+            tool_call_start_tokens = (100,)
+            tool_call_end_tokens = ()
+            eos_token_ids = [2]
+
+            def convert_ids_to_tokens(self, t):
+                return f"<eos{t}>"
+
+        sm, _ = self.response_generator._make_state_machine(
+            ("fake-empty-end", None, None),
+            FakeTokenizer(),
+            stop_words=[],
+        )
+        state = sm.make_state()
+        state, _, s = sm.match(state, 100)
+        self.assertEqual(s, "tool")
+        for tok in [42, 43, 44]:
+            state, _, s = sm.match(state, tok)
+            self.assertEqual(s, "tool")
+        state, _, s = sm.match(state, 2)
+        self.assertIsNone(s)
+
     def test_handle_models(self):
         url = f"http://localhost:{self.port}/v1/models"
         response = requests.get(url)


### PR DESCRIPTION
Mistral's tool parser sets `tool_call_end = ""`, so `_tool_call_end_tokens` ends up as the empty tuple. In `_make_state_machine`, the empty tuple becomes a transition `((), "normal")` for the "tool" state. Aho-Corasick stores `__match__` at the trie root for an empty sequence, so the first token after `[TOOL_CALLS]` matches immediately and flips the state back to `normal`. The tool call body then leaks into the normal assistant response.

The fix skips the `tool -> normal` transition and the `sequences` entry when the end tokens are empty. `common_stops` are still added, so EOS terminates the segment.

Fixes #1110.
