### PR TITLE
Fix stale token data in logits processors due to lazy evaluation

### DIFF
--- a/mlx_lm/generate.py
+++ b/mlx_lm/generate.py
@@ -412,6 +412,7 @@ def generate_step(
                     if tokens is not None
                     else input_tokens
                 )
+                mx.eval(tokens)
                 for processor in logits_processors:
                     logits = processor(tokens, logits)
 
@@ -543,6 +544,7 @@ def speculative_generate_step(
 
     def _process_and_sample(tokens, logits):
         if logits_processors:
+            mx.eval(tokens)
             for processor in logits_processors:
                 logits = processor(tokens, logits)
 
@@ -1340,6 +1342,7 @@ class GenerationBatch:
                 tc.update_and_fetch(inputs[i : i + 1])
                 for i, tc in enumerate(self._token_context)
             ]
+            mx.eval(token_context)
             processed_logits = []
             for e in range(len(self.uids)):
                 sample_logits = logits[e : e + 1]

--- a/tests/test_generate.py
+++ b/tests/test_generate.py
@@ -438,6 +438,50 @@ class TestGenerate(unittest.TestCase):
         generated_token = self.tokenizer.encode(response.texts[0])[0]
         self.assertEqual(generated_token, 0)
 
+    def test_stateful_processor_sees_materialized_tokens(self):
+        """Stateful processors must see correct (materialized) token values.
+
+        Regression test: lazy mx.concat inside mx.stream caused processors
+        to see stale prompt tokens instead of the most recently generated
+        token. Stateful processors like Outlines FSM depend on tokens[-1]
+        being the actual last generated token.
+        """
+        prompt = self.tokenizer.encode("hello")
+        last_tokens_seen = []
+
+        def stateful_processor(tokens, logits):
+            # Capture the last token the processor sees on each call.
+            # After materialization fix, this must be the actual generated
+            # token, not a stale prompt token.
+            mx.eval(tokens)
+            last_tokens_seen.append(tokens[-1].item())
+            return logits
+
+        generate(
+            self.model,
+            self.tokenizer,
+            "hello",
+            max_tokens=3,
+            verbose=False,
+            logits_processors=[stateful_processor],
+        )
+
+        # First call: last token is the last prompt token (correct — no
+        # generated tokens yet). Subsequent calls: last token must differ
+        # from the prompt's last token (it's a generated token).
+        self.assertEqual(len(last_tokens_seen), len(prompt) + 3)
+        # The generated tokens (after prompt) should be actual model output,
+        # not repeated copies of the last prompt token.
+        prompt_last = prompt[-1]
+        generated_last_tokens = last_tokens_seen[len(prompt) :]
+        # At least one of the generated tokens should differ from the
+        # last prompt token (statistical near-certainty with 3 tokens).
+        self.assertTrue(
+            any(t != prompt_last for t in generated_last_tokens),
+            f"All generated tokens matched last prompt token {prompt_last}, "
+            f"suggesting stale/lazy data: {generated_last_tokens}",
+        )
+
     def test_batch_generate_with_samplers(self):
         """Test that batch_generate with logits_processors produces correct results."""
         batch_gen = BatchGenerator(


### PR DESCRIPTION
## Summary

Stateful logits processors receive stale/lazy token arrays inside `mx.stream` contexts, causing them to read prompt tokens instead of generated tokens via `tokens[-1]`.

## Problem

Token arrays passed to `logits_processors` are built via `mx.concat` inside `mx.stream` contexts. The concat is lazy — `tokens[-1]` returns the old value until `mx.eval()` is called. This breaks stateful processors like [Outlines](https://github.com/dottxt-ai/outlines) that use FSM-based constrained decoding, which depend on the actual last generated token to advance the grammar state machine.

Discovered while integrating Outlines for JSON schema constrained decoding on Apple Silicon (vllm-mlx).

## Fix

Add `mx.eval()` before processor invocation in all three generation paths:

- **Serial generate `_step`**: materialize `tokens` after `mx.concat`
- **MTP `_process_and_sample`**: materialize `tokens` (passed as `prev_tokens`)
- **`BatchGenerator._step`**: materialize `token_context` arrays

The `mx.eval()` calls only execute when `logits_processors` is non-empty, so there is no performance impact on generation without processors.

## Test plan

- Added `test_stateful_processor_sees_materialized_tokens` which captures the last token seen by the processor on each call and verifies generated tokens differ from the stale prompt token
- Existing processor tests continue to pass