### PR TITLE
Fix Gemma 4 KV-shared layers creating unused projections

### DIFF
--- a/mlx_lm/models/gemma4_text.py
+++ b/mlx_lm/models/gemma4_text.py
@@ -180,6 +180,7 @@ class Attention(nn.Module):
         self.layer_idx = layer_idx
         self.layer_type = config.layer_types[layer_idx]
         self.is_sliding = self.layer_type == "sliding_attention"
+        self.has_kv = layer_idx < config.num_hidden_layers - config.num_kv_shared_layers 
 
         self.head_dim = (
             config.global_head_dim
@@ -201,14 +202,8 @@ class Attention(nn.Module):
 
         self.scale = 1.0
 
-        # Determine if this layer shares KV from an earlier layer
-        first_kv_shared_layer_idx = (
-            config.num_hidden_layers - config.num_kv_shared_layers
-        )
-        self.is_kv_shared_layer = layer_idx >= first_kv_shared_layer_idx > 0
-
         self.q_proj = nn.Linear(dim, self.n_heads * self.head_dim, bias=False)
-        if not self.is_kv_shared_layer:
+        if self.has_kv:
             self.k_proj = nn.Linear(dim, self.n_kv_heads * self.head_dim, bias=False)
             if not self.use_k_eq_v:
                 self.v_proj = nn.Linear(
@@ -217,7 +212,7 @@ class Attention(nn.Module):
         self.o_proj = nn.Linear(self.n_heads * self.head_dim, dim, bias=False)
 
         self.q_norm = nn.RMSNorm(self.head_dim, eps=config.rms_norm_eps)
-        if not self.is_kv_shared_layer:
+        if self.has_kv:
             self.k_norm = nn.RMSNorm(self.head_dim, eps=config.rms_norm_eps)
             self.v_norm = RMSNormNoScale(self.head_dim, eps=config.rms_norm_eps)
 
@@ -248,7 +243,7 @@ class Attention(nn.Module):
 
         if shared_kv is not None:
             keys, values = shared_kv
-        elif self.is_kv_shared_layer:
+        elif not self.has_kv:
             raise ValueError(
                 f"Layer {self.layer_idx} is a KV-shared layer but received no shared_kv"
             )

--- a/mlx_lm/models/gemma4_text.py
+++ b/mlx_lm/models/gemma4_text.py
@@ -180,7 +180,7 @@ class Attention(nn.Module):
         self.layer_idx = layer_idx
         self.layer_type = config.layer_types[layer_idx]
         self.is_sliding = self.layer_type == "sliding_attention"
-        self.has_kv = layer_idx < config.num_hidden_layers - config.num_kv_shared_layers 
+        self.has_kv = layer_idx < config.num_hidden_layers - config.num_kv_shared_layers
 
         self.head_dim = (
             config.global_head_dim

--- a/mlx_lm/models/gemma4_text.py
+++ b/mlx_lm/models/gemma4_text.py
@@ -201,15 +201,25 @@ class Attention(nn.Module):
 
         self.scale = 1.0
 
+        # Determine if this layer shares KV from an earlier layer
+        first_kv_shared_layer_idx = (
+            config.num_hidden_layers - config.num_kv_shared_layers
+        )
+        self.is_kv_shared_layer = layer_idx >= first_kv_shared_layer_idx > 0
+
         self.q_proj = nn.Linear(dim, self.n_heads * self.head_dim, bias=False)
-        self.k_proj = nn.Linear(dim, self.n_kv_heads * self.head_dim, bias=False)
-        if not self.use_k_eq_v:
-            self.v_proj = nn.Linear(dim, self.n_kv_heads * self.head_dim, bias=False)
+        if not self.is_kv_shared_layer:
+            self.k_proj = nn.Linear(dim, self.n_kv_heads * self.head_dim, bias=False)
+            if not self.use_k_eq_v:
+                self.v_proj = nn.Linear(
+                    dim, self.n_kv_heads * self.head_dim, bias=False
+                )
         self.o_proj = nn.Linear(self.n_heads * self.head_dim, dim, bias=False)
 
         self.q_norm = nn.RMSNorm(self.head_dim, eps=config.rms_norm_eps)
-        self.k_norm = nn.RMSNorm(self.head_dim, eps=config.rms_norm_eps)
-        self.v_norm = RMSNormNoScale(self.head_dim, eps=config.rms_norm_eps)
+        if not self.is_kv_shared_layer:
+            self.k_norm = nn.RMSNorm(self.head_dim, eps=config.rms_norm_eps)
+            self.v_norm = RMSNormNoScale(self.head_dim, eps=config.rms_norm_eps)
 
         # RoPE (with partial rotation support)
         layer_key = "sliding_attention" if self.is_sliding else "full_attention"
@@ -238,6 +248,10 @@ class Attention(nn.Module):
 
         if shared_kv is not None:
             keys, values = shared_kv
+        elif self.is_kv_shared_layer:
+            raise ValueError(
+                f"Layer {self.layer_idx} is a KV-shared layer but received no shared_kv"
+            )
         else:
             keys = self.k_proj(x).reshape(B, L, self.n_kv_heads, self.head_dim)
             values = keys

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -1597,14 +1597,14 @@ class TestModels(unittest.TestCase):
         # Non-shared layers (0-5) should have KV projections
         for i in range(6):
             attn = model.model.layers[i].self_attn
-            self.assertFalse(attn.is_kv_shared_layer)
+            self.assertTrue(attn.has_kv)
             self.assertTrue(hasattr(attn, "k_proj"))
             self.assertTrue(hasattr(attn, "k_norm"))
 
         # Shared layers (6-9) should NOT have KV projections
         for i in range(6, 10):
             attn = model.model.layers[i].self_attn
-            self.assertTrue(attn.is_kv_shared_layer)
+            self.assertFalse(attn.has_kv)
             self.assertFalse(hasattr(attn, "k_proj"))
             self.assertFalse(hasattr(attn, "k_norm"))
             self.assertFalse(hasattr(attn, "v_proj"))
@@ -1617,7 +1617,7 @@ class TestModels(unittest.TestCase):
         for k in kv_keys:
             # All KV keys should belong to non-shared layers (0-5)
             layer_idx = int(k.split("layers.")[1].split(".")[0])
-            self.assertLess(layer_idx, 6, f"Shared layer has KV param: {k}")
+            self.assertLess(layer_idx, 6)
 
     def test_gemma4_input_embeddings_reconstruct_per_layer_inputs(self):
         from mlx_lm.models import gemma4_text

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -5,7 +5,7 @@ import unittest
 
 import mlx.core as mx
 import mlx.nn as nn
-from mlx.utils import tree_map
+from mlx.utils import tree_flatten, tree_map
 
 from mlx_lm.models import rope_utils
 from mlx_lm.models.base import create_causal_mask, scaled_dot_product_attention
@@ -1546,6 +1546,78 @@ class TestModels(unittest.TestCase):
         self.assertTrue(
             mx.allclose(logits, mx.ones((1, 1, 4), dtype=mx.float32) * 32.0)
         )
+
+    def test_gemma4_kv_shared_layers_omit_kv_projections(self):
+        """KV-shared layers must not create k_proj/v_proj/k_norm/v_norm so that
+        models saved without redundant weights (e.g. via transformers
+        save_pretrained) can be loaded with strict=True."""
+        from mlx_lm.models import gemma4_text
+
+        args = gemma4_text.ModelArgs(
+            model_type="gemma4_text",
+            hidden_size=128,
+            num_hidden_layers=10,
+            intermediate_size=256,
+            num_attention_heads=4,
+            head_dim=32,
+            global_head_dim=64,
+            rms_norm_eps=1e-6,
+            vocab_size=1000,
+            vocab_size_per_layer_input=1000,
+            num_key_value_heads=1,
+            num_kv_shared_layers=4,
+            hidden_size_per_layer_input=32,
+            sliding_window=8,
+            sliding_window_pattern=5,
+            final_logit_softcapping=30.0,
+            layer_types=[
+                "sliding_attention",
+                "sliding_attention",
+                "sliding_attention",
+                "sliding_attention",
+                "full_attention",
+                "sliding_attention",
+                "sliding_attention",
+                "sliding_attention",
+                "sliding_attention",
+                "full_attention",
+            ],
+            rope_parameters={
+                "full_attention": {
+                    "partial_rotary_factor": 0.25,
+                    "rope_theta": 1000000.0,
+                },
+                "sliding_attention": {
+                    "rope_theta": 10000.0,
+                },
+            },
+        )
+        model = gemma4_text.Model(args)
+
+        # Non-shared layers (0-5) should have KV projections
+        for i in range(6):
+            attn = model.model.layers[i].self_attn
+            self.assertFalse(attn.is_kv_shared_layer)
+            self.assertTrue(hasattr(attn, "k_proj"))
+            self.assertTrue(hasattr(attn, "k_norm"))
+
+        # Shared layers (6-9) should NOT have KV projections
+        for i in range(6, 10):
+            attn = model.model.layers[i].self_attn
+            self.assertTrue(attn.is_kv_shared_layer)
+            self.assertFalse(hasattr(attn, "k_proj"))
+            self.assertFalse(hasattr(attn, "k_norm"))
+            self.assertFalse(hasattr(attn, "v_proj"))
+
+        # Verify the model can load weights that omit shared-layer KV params
+        weights = dict(tree_flatten(model.parameters()))
+        kv_keys = [
+            k for k in weights if "k_proj" in k or "v_proj" in k or "k_norm" in k
+        ]
+        for k in kv_keys:
+            # All KV keys should belong to non-shared layers (0-5)
+            layer_idx = int(k.split("layers.")[1].split(".")[0])
+            self.assertLess(layer_idx, 6, f"Shared layer has KV param: {k}")
 
     def test_gemma4_input_embeddings_reconstruct_per_layer_inputs(self):
         from mlx_lm.models import gemma4_text


### PR DESCRIPTION
## Summary

- Gemma 4 E4B/E2B models share KV projections across later layers (`num_kv_shared_layers`). The `Attention` class was creating `k_proj`, `v_proj`, `k_norm`, and `v_norm` for **all** layers, but shared layers never use them — the forward pass routes KV from earlier layers via `shared_kv`.
- This caused `load_weights(strict=True)` to fail for any Gemma 4 model saved through transformers (`save_pretrained`), since transformers correctly omits these weights for shared layers. This affects all derivative models: fine-tunes, merges, abliterations, etc.
- Skip creating `k_proj`/`v_proj`/`k_norm`/`v_norm` for KV-shared layers, matching the transformers implementation.
- Add a defensive `ValueError` if a shared layer somehow receives no `shared_kv` at runtime.

## Test plan

- [x] All 8 existing `gemma4` tests pass
- [x] New test `test_gemma4_kv_shared_layers_omit_kv_projections` verifies shared layers don't create KV modules
- [x] Verified forward pass produces identical top-5 logits vs transformers on `OBLITERATUS/gemma-4-E4B-it-OBLITERATED`
- [x] Verified cached generation produces coherent output
- [x] Formatted with `black`

🤖 Generated with [Claude Code](https://claude.com/claude-code)