### PR TITLE
Add reasoning → tool state machine transition

### DIFF
--- a/mlx_lm/server.py
+++ b/mlx_lm/server.py
@@ -656,6 +656,12 @@ class ResponseGenerator:
             sequences[ts] = tokenizer.tool_call_start
             sequences[te] = tokenizer.tool_call_end
 
+            # Allow reasoning -> tool transitions for thinking models that
+            # emit tool calls without first closing the think block
+            # (e.g. Kimi K2.5).
+            if tokenizer.has_thinking:
+                transitions["reasoning"].append((ts, "tool"))
+
         sm = SequenceStateMachine(transitions, initial=initial_state)
         if len(self._state_machine_cache) > 100:
             self._state_machine_cache.clear()

--- a/tests/test_generate.py
+++ b/tests/test_generate.py
@@ -505,6 +505,48 @@ class TestGenerate(unittest.TestCase):
         self.assertEqual(responses[uid1].match_sequence, (1,))
         self.assertEqual(responses[uid2].match_sequence, (2,))
 
+    def test_state_machine_reasoning_to_tool_transition(self):
+        """Thinking models can transition reasoning -> tool on the tool start token."""
+        think_start = (100,)
+        think_end = (101,)
+        tool_start = (200,)
+        tool_end = (201,)
+        eos = (0,)
+
+        transitions = {
+            "normal": [
+                (think_start, "reasoning"),
+                (tool_start, "tool"),
+                (eos, None),
+            ],
+            "reasoning": [
+                (think_end, "normal"),
+                (tool_start, "tool"),
+                (eos, None),
+            ],
+            "tool": [
+                (tool_end, "normal"),
+                (eos, None),
+            ],
+        }
+
+        sm = SequenceStateMachine(transitions, initial="reasoning")
+        state = sm.make_state()
+
+        for tok in [50, 51, 52]:
+            state, _, current = sm.match(state, tok)
+            self.assertEqual(current, "reasoning")
+
+        state, _, current = sm.match(state, 200)
+        self.assertEqual(current, "tool")
+
+        for tok in [60, 61]:
+            state, _, current = sm.match(state, tok)
+            self.assertEqual(current, "tool")
+
+        state, _, current = sm.match(state, 201)
+        self.assertEqual(current, "normal")
+
     def test_batch_continued_generation(self):
         for rotating in [False, True]:
             if rotating:


### PR DESCRIPTION
## Problem

When a tokenizer has both `has_thinking` and `has_tool_calling` set, the server-side state machine in `_make_state_machine()` has no edge from `reasoning` to `tool`. If the model emits the tool-call start token while still inside a `<think>` block (i.e. without first emitting `</think>`), the tool-call markers are accumulated as reasoning text and the tool parser never runs.

This affects models like **Kimi K2.5** (`mlx-community/Kimi-K2.5`), which opens `<think>` at the start of every response and will happily emit `<|tool_calls_section_begin|>` from inside the think block.

## Fix

In `_make_state_machine()`, when both `has_thinking` and `has_tool_calling` are true, add a `(tool_call_start_tokens, "tool")` edge to the `reasoning` state. This lets the state machine transition from reasoning directly to tool on the tool start token, the same way it does from normal.

The fix reuses the `ts = tokenizer.tool_call_start_tokens` binding from the existing `has_tool_calling` block — no re-encoding needed.

## Testing

Added `test_state_machine_reasoning_to_tool_transition` in `tests/test_generate.py`. It constructs a `SequenceStateMachine` starting in `reasoning`, feeds reasoning-state tokens, then the tool start token, and asserts the machine transitions `reasoning → tool → normal` correctly.

Ran the full suite locally on Apple Silicon (Python 3.10, `pip install -e ".[test]"`, `HF_HOME=.` with the release test_data bundle):

```
Ran 191 tests in 82.768s
OK (skipped=1)
```

Pre-commit (black + isort) passes.

## Note on Kimi K2.5 specifically

This fix alone does not fully resolve Kimi K2.5 tool calling, because that model also emits the function identifier (`functions.name:idx`) **before** `<|tool_calls_section_begin|>` — so the function name is still consumed as reasoning text before the tool state begins, and the `kimi_k2` parser only sees the bare JSON arguments. A separate parser enhancement would be needed for full Kimi K2.5 support.

However, the missing `reasoning → tool` transition is a correctness gap in its own right that affects any thinking + tool-calling model where tool calls may be emitted from inside a think block. This PR closes that gap.