### PR TITLE
feat(nemotron_h): add Multi-Token Prediction (MTP) module

### DIFF
--- a/mlx_lm/benchmark.py
+++ b/mlx_lm/benchmark.py
@@ -56,6 +56,11 @@ def setup_arg_parser():
         help="Use pipelining instead of tensor parallelism",
     )
     parser.add_argument(
+        "--trust-remote-code",
+        action="store_true",
+        help="Enable trusting remote code for tokenizer",
+    )
+    parser.add_argument(
         "--quantize-activations",
         "-qa",
         action="store_true",
@@ -94,13 +99,21 @@ def main():
 
     if group.size() > 1:
         model, tokenizer, config = sharded_load(
-            model_path, pipeline_group, tensor_group, return_config=True
+            model_path,
+            pipeline_group,
+            tensor_group,
+            return_config=True,
+            tokenizer_config={
+                "trust_remote_code": True if args.trust_remote_code else None
+            },
         )
     else:
         model, tokenizer, config = load(
             model_path,
             return_config=True,
-            tokenizer_config={"trust_remote_code": True},
+            tokenizer_config={
+                "trust_remote_code": True if args.trust_remote_code else None
+            },
             model_config={"quantize_activations": args.quantize_activations},
         )
 

--- a/mlx_lm/chat.py
+++ b/mlx_lm/chat.py
@@ -105,7 +105,14 @@ def main():
     if group.size() > 1:
         if args.adapter_path:
             parser.error("Adapters not supported in distributed mode")
-        model, tokenizer = sharded_load(args.model, pipeline_group, tensor_group)
+        model, tokenizer = sharded_load(
+            args.model,
+            pipeline_group,
+            tensor_group,
+            tokenizer_config={
+                "trust_remote_code": True if args.trust_remote_code else None
+            },
+        )
     else:
         model, tokenizer = load(
             args.model,

--- a/mlx_lm/examples/sharded_generate.py
+++ b/mlx_lm/examples/sharded_generate.py
@@ -49,6 +49,11 @@ if __name__ == "__main__":
         action="store_true",
         help="Use pipelining instead of tensor parallelism",
     )
+    parser.add_argument(
+        "--trust-remote-code",
+        action="store_true",
+        help="Enable trusting remote code for tokenizer",
+    )
     args = parser.parse_args()
 
     group = mx.distributed.init()
@@ -60,7 +65,14 @@ if __name__ == "__main__":
         if rank == 0:
             print(*args, **kwargs)
 
-    model, tokenizer = sharded_load(args.model, pipeline_group, tensor_group)
+    model, tokenizer = sharded_load(
+        args.model,
+        pipeline_group,
+        tensor_group,
+        tokenizer_config={
+            "trust_remote_code": True if args.trust_remote_code else None
+        },
+    )
 
     messages = [{"role": "user", "content": args.prompt}]
     prompt = tokenizer.apply_chat_template(

--- a/mlx_lm/generate.py
+++ b/mlx_lm/generate.py
@@ -223,7 +223,7 @@ def setup_arg_parser():
 
 
 # A stream on the default device just for generation
-generation_stream = mx.new_stream(mx.default_device())
+generation_stream = mx.new_thread_local_stream(mx.default_device())
 
 
 @contextlib.contextmanager

--- a/mlx_lm/generate.py
+++ b/mlx_lm/generate.py
@@ -682,6 +682,11 @@ def stream_generate(
         GenerationResponse: An instance containing the generated text segment and
             associated metadata. See :class:`GenerationResponse` for details.
     """
+    if max_tokens < 0:
+        raise ValueError("max_tokens must be non-negative")
+    if max_tokens == 0:
+        return
+
     if not isinstance(tokenizer, TokenizerWrapper):
         tokenizer = TokenizerWrapper(tokenizer)
 
@@ -1610,17 +1615,37 @@ class BatchGenerator:
     ):
         uids = []
 
-        max_tokens = max_tokens or [self.max_tokens] * len(segments)
-        all_tokens = all_tokens or [[] for _ in segments]
-        samplers = samplers or [None] * len(segments)
-        logits_processors = logits_processors or (
-            [self.logits_processors] * len(segments)
+        count = len(segments)
+        values = {
+            "max_tokens": max_tokens,
+            "caches": caches,
+            "all_tokens": all_tokens,
+            "samplers": samplers,
+            "logits_processors": logits_processors,
+            "state_machines": state_machines,
+        }
+        for name, value in values.items():
+            if value is not None and len(value) != count:
+                raise ValueError(
+                    f"{name} must have one entry per segment: "
+                    f"expected {count}, got {len(value)}"
+                )
+
+        max_tokens = max_tokens if max_tokens is not None else [self.max_tokens] * count
+        all_tokens = all_tokens if all_tokens is not None else [[] for _ in segments]
+        samplers = samplers if samplers is not None else [None] * count
+        logits_processors = (
+            logits_processors
+            if logits_processors is not None
+            else [self.logits_processors] * count
         )
-        state_machines = state_machines or (
-            [self._default_state_machine] * len(segments)
+        state_machines = (
+            state_machines
+            if state_machines is not None
+            else [self._default_state_machine] * count
         )
 
-        caches = caches or [None] * len(segments)
+        caches = caches if caches is not None else [None] * count
         for i in range(len(segments)):
             if caches[i] is None:
                 caches[i] = self._make_new_cache()

--- a/mlx_lm/lora.py
+++ b/mlx_lm/lora.py
@@ -75,6 +75,7 @@ CONFIG_DEFAULTS = {
     "mask_prompt": False,
     "report_to": None,
     "project_name": None,
+    "trust_remote_code": False,
 }
 
 
@@ -84,6 +85,12 @@ def build_parser():
         "--model",
         type=str,
         help="The path to the local model directory or Hugging Face repo.",
+    )
+    parser.add_argument(
+        "--trust-remote-code",
+        action="store_true",
+        default=None,
+        help="Enable trusting remote code for tokenizer",
     )
 
     # Training args
@@ -326,7 +333,12 @@ def run(args, training_callback: TrainingCallback = None):
     )
 
     print("Loading pretrained model")
-    model, tokenizer = load(args.model, tokenizer_config={"trust_remote_code": True})
+    model, tokenizer = load(
+        args.model,
+        tokenizer_config={
+            "trust_remote_code": True if args.trust_remote_code else None
+        },
+    )
 
     print("Loading datasets")
     train_set, valid_set, test_set = load_dataset(args, tokenizer)

--- a/mlx_lm/models/nemotron_h.py
+++ b/mlx_lm/models/nemotron_h.py
@@ -1,6 +1,6 @@
 # Copyright © 2025 Apple Inc.
 
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from functools import partial
 from typing import Any, List, Optional, Tuple
 
@@ -56,6 +56,9 @@ class ModelArgs(BaseModelArgs):
     time_step_limit: Optional[Tuple[float, float]] = None
     time_step_min: Optional[float] = None
     time_step_max: Optional[float] = None
+    num_nextn_predict_layers: int = 0
+    mtp_hybrid_override_pattern: Optional[str] = None
+    mtp_layers_block_type: Optional[List[str]] = None
 
     # Map from layers_block_type names to single-char pattern codes
     _block_type_to_char = {"mamba": "M", "attention": "*", "moe": "E", "mlp": "-"}
@@ -71,6 +74,19 @@ class ModelArgs(BaseModelArgs):
             ]
         if self.hybrid_override_pattern is not None:
             self.num_hidden_layers = len(self.hybrid_override_pattern)
+
+        # Normalize MTP pattern
+        if self.mtp_hybrid_override_pattern is not None:
+            if isinstance(self.mtp_hybrid_override_pattern, str):
+                self._mtp_pattern = list(self.mtp_hybrid_override_pattern)
+            else:
+                self._mtp_pattern = list(self.mtp_hybrid_override_pattern)
+        elif self.mtp_layers_block_type is not None:
+            self._mtp_pattern = [
+                self._block_type_to_char[t] for t in self.mtp_layers_block_type
+            ]
+        else:
+            self._mtp_pattern = []
 
 
 class MambaRMSNormGated(nn.Module):
@@ -455,6 +471,105 @@ class NemotronHBlock(nn.Module):
         return x + hidden_states
 
 
+class NemotronHMTPBlock(nn.Module):
+    """A single block in the MTP head. Follows the same pattern as
+    NemotronHBlock but only supports attention ('*') and MoE ('E') types,
+    matching the ``mtp_hybrid_override_pattern``."""
+
+    def __init__(self, args: ModelArgs, block_type: str):
+        super().__init__()
+        self.block_type = block_type
+        self.norm = nn.RMSNorm(args.hidden_size, eps=args.layer_norm_epsilon)
+
+        if block_type == "*":
+            self.mixer = NemotronHAttention(args)
+        elif block_type == "E":
+            self.mixer = NemotronHMoE(args)
+        elif block_type == "-":
+            self.mixer = NemotronHMLP(args)
+        else:
+            raise ValueError(f"Unsupported MTP block type: {block_type}")
+
+    def __call__(
+        self,
+        x: mx.array,
+        mask: Optional[mx.array] = None,
+        cache: Optional[Any] = None,
+    ) -> mx.array:
+        h = self.norm(x)
+        if self.block_type == "*":
+            h = self.mixer(h, mask=mask, cache=cache)
+        else:
+            h = self.mixer(h)
+        return x + h
+
+
+class NemotronHMTPModule(nn.Module):
+    """Multi-Token Prediction head for Nemotron-H.
+
+    Predicts token t+2 from the backbone's pre-norm hidden state h_t and the
+    sampled token t+1, using a shared ``lm_head`` with the backbone.
+
+    Architecture (for ``mtp_hybrid_override_pattern = "*E"``):
+      1. Embed next_token via shared embedding
+      2. Dual-norm fusion: ``eh_proj(cat(enorm(embed), hnorm(hidden)))``
+      3. Attention block (``*``) with its own KVCache
+      4. MoE block (``E``) — same structure as backbone MoE
+      5. Final layernorm
+
+    Weight mapping from HF checkpoints:
+      ``mtp.layers.0.hnorm``   → ``hnorm``
+      ``mtp.layers.0.enorm``   → ``enorm``
+      ``mtp.layers.0.eh_proj`` → ``eh_proj``
+      ``mtp.layers.0.norm``    → ``layers.0.norm``
+      ``mtp.layers.0.mixer.*`` → ``layers.0.mixer.*``
+      ``mtp.layers.1.norm``    → ``layers.1.norm``
+      ``mtp.layers.1.mixer.*`` → ``layers.1.mixer.*``
+      ``mtp.layers.1.final_layernorm`` → ``final_layernorm``
+    """
+
+    def __init__(self, args: ModelArgs):
+        super().__init__()
+        self.hnorm = nn.RMSNorm(args.hidden_size, eps=args.layer_norm_epsilon)
+        self.enorm = nn.RMSNorm(args.hidden_size, eps=args.layer_norm_epsilon)
+        self.eh_proj = nn.Linear(args.hidden_size * 2, args.hidden_size, bias=False)
+        self.layers = [NemotronHMTPBlock(args, bt) for bt in args._mtp_pattern]
+        self.final_layernorm = nn.RMSNorm(args.hidden_size, eps=args.layer_norm_epsilon)
+
+    def __call__(
+        self,
+        hidden_states: mx.array,
+        next_token_ids: mx.array,
+        embed_tokens: nn.Embedding,
+        cache: Optional[Any] = None,
+    ) -> mx.array:
+        embeds = embed_tokens(next_token_ids)
+        e = self.enorm(embeds)
+        h = self.hnorm(hidden_states)
+        fused = self.eh_proj(mx.concatenate([e, h], axis=-1))
+
+        if cache is None:
+            cache = [None] * len(self.layers)
+
+        # Build attention mask from the first attention layer's cache
+        attn_cache_idx = 0
+        for i, layer in enumerate(self.layers):
+            if layer.block_type == "*":
+                attn_cache_idx = i
+                break
+        mask = create_attention_mask(fused, cache[attn_cache_idx])
+
+        cache_idx = 0
+        for layer in self.layers:
+            if layer.block_type == "*":
+                fused = layer(fused, mask=mask, cache=cache[cache_idx])
+                cache_idx += 1
+            else:
+                fused = layer(fused)
+
+        return self.final_layernorm(fused)
+
+
 class NemotronHModel(nn.Module):
     def __init__(self, args: ModelArgs):
         super().__init__()
@@ -503,7 +618,7 @@ class NemotronHModel(nn.Module):
                 mask = ssm_mask
             hidden_states = layer(hidden_states, mask=mask, cache=c)
 
-        return self.norm_f(hidden_states)
+        return hidden_states
 
 
 class Model(nn.Module):
@@ -513,14 +628,45 @@ class Model(nn.Module):
         self.backbone = NemotronHModel(args)
         self.lm_head = nn.Linear(args.hidden_size, args.vocab_size, bias=False)
         self.model_type = args.model_type
+        if args.num_nextn_predict_layers > 0 and len(args._mtp_pattern) > 0:
+            self.mtp = NemotronHMTPModule(args)
 
     def __call__(
         self,
         inputs: mx.array,
         cache: Optional[Any] = None,
+        return_hidden: bool = False,
+        n_confirmed: int = 0,
     ):
-        out = self.backbone(inputs, cache=cache)
-        return self.lm_head(out)
+        hidden = self.backbone(inputs, cache=cache)
+        out = self.lm_head(self.backbone.norm_f(hidden))
+        if return_hidden:
+            return out, hidden
+        return out
+
+    def mtp_forward(
+        self,
+        hidden_states: mx.array,
+        next_token_ids: mx.array,
+        mtp_cache: Any,
+    ) -> mx.array:
+        """Run the MTP head and apply the shared lm_head.
+
+        Args:
+            hidden_states: (B, 1, H) — backbone pre-norm hidden at last position.
+            next_token_ids: (B, 1) — sampled main token.
+            mtp_cache: list of KVCache entries for MTP attention layers.
+
+        Returns:
+            logits: (B, 1, vocab_size)
+        """
+        mtp_out = self.mtp(
+            hidden_states,
+            next_token_ids,
+            self.backbone.embeddings,
+            mtp_cache,
+        )
+        return self.lm_head(mtp_out)
 
     @property
     def layers(self):
@@ -535,13 +681,22 @@ class Model(nn.Module):
                 caches.append(KVCache())
         return caches
 
+    def make_mtp_cache(self):
+        """Return a fresh list of KVCache entries for MTP attention layers."""
+        if hasattr(self, "mtp"):
+            return [KVCache() for layer in self.mtp.layers if layer.block_type == "*"]
+        return []
+
     def sanitize(self, weights):
-        weights = {k: v for (k, v) in weights.items() if not k.startswith("mtp.")}
-        for k, v in weights.items():
+        has_mtp = self.args.num_nextn_predict_layers > 0
+        if not has_mtp:
+            weights = {k: v for (k, v) in weights.items() if not k.startswith("mtp.")}
+
+        for k, v in list(weights.items()):
             if "conv1d.weight" in k and v.shape[-1] != 1:
                 weights[k] = v.moveaxis(2, 1)
 
-        # Stack experts
+        # Stack backbone experts
         for l in range(self.args.num_hidden_layers):
             prefix = f"backbone.layers.{l}.mixer"
             for m, n in [("down_proj", "fc2"), ("up_proj", "fc1")]:
@@ -551,6 +706,72 @@ class Model(nn.Module):
                         for e in range(self.args.n_routed_experts)
                     ]
                     weights[f"{prefix}.switch_mlp.{n}.weight"] = mx.stack(to_join)
+
+        if has_mtp:
+            # Remap MTP weights from HF naming to our module structure.
+            #
+            # HF layout (num_nextn_predict_layers=1, pattern "*E"):
+            #   mtp.layers.0.hnorm        → fusion norms
+            #   mtp.layers.0.enorm
+            #   mtp.layers.0.eh_proj       → fusion projection
+            #   mtp.layers.0.norm          → attention block norm
+            #   mtp.layers.0.mixer.*       → attention block mixer
+            #   mtp.layers.1.norm          → MoE block norm
+            #   mtp.layers.1.mixer.*       → MoE block mixer
+            #   mtp.layers.1.final_layernorm → final output norm
+            #
+            # Our layout:
+            #   mtp.hnorm, mtp.enorm, mtp.eh_proj
+            #   mtp.layers.0.norm, mtp.layers.0.mixer.*  (attention)
+            #   mtp.layers.1.norm, mtp.layers.1.mixer.*  (MoE)
+            #   mtp.final_layernorm
+
+            remap = {}
+            mtp_keys = [k for k in weights if k.startswith("mtp.")]
+            for k in mtp_keys:
+                v = weights.pop(k)
+                rest = k[len("mtp.") :]
+
+                # Fusion components live on HF layer 0
+                if rest.startswith("layers.0.hnorm."):
+                    new_k = "mtp." + rest.replace("layers.0.hnorm.", "hnorm.")
+                elif rest.startswith("layers.0.enorm."):
+                    new_k = "mtp." + rest.replace("layers.0.enorm.", "enorm.")
+                elif rest.startswith("layers.0.eh_proj."):
+                    new_k = "mtp." + rest.replace("layers.0.eh_proj.", "eh_proj.")
+                # Attention block: HF layer 0 norm/mixer → our layers.0
+                elif rest.startswith("layers.0.norm."):
+                    new_k = "mtp.layers.0.norm." + rest[len("layers.0.norm.") :]
+                elif rest.startswith("layers.0.mixer."):
+                    new_k = "mtp.layers.0.mixer." + rest[len("layers.0.mixer.") :]
+                # MoE block: HF layer 1 → our layers.1
+                elif rest.startswith("layers.1.norm."):
+                    new_k = "mtp.layers.1.norm." + rest[len("layers.1.norm.") :]
+                elif rest.startswith("layers.1.final_layernorm."):
+                    new_k = (
+                        "mtp.final_layernorm."
+                        + rest[len("layers.1.final_layernorm.") :]
+                    )
+                elif rest.startswith("layers.1.mixer."):
+                    new_k = "mtp.layers.1.mixer." + rest[len("layers.1.mixer.") :]
+                else:
+                    new_k = "mtp." + rest
+
+                remap[new_k] = v
+
+            # Stack MTP MoE experts (same pattern as backbone)
+            for m, n in [("down_proj", "fc2"), ("up_proj", "fc1")]:
+                expert_key = f"mtp.layers.1.mixer.experts.0.{m}.weight"
+                if expert_key in remap:
+                    to_join = [
+                        remap.pop(f"mtp.layers.1.mixer.experts.{e}.{m}.weight")
+                        for e in range(self.args.n_routed_experts)
+                    ]
+                    remap[f"mtp.layers.1.mixer.switch_mlp.{n}.weight"] = mx.stack(
+                        to_join
+                    )
+
+            weights.update(remap)
 
         return weights
 

--- a/mlx_lm/models/nemotron_h.py
+++ b/mlx_lm/models/nemotron_h.py
@@ -88,6 +88,12 @@ class ModelArgs(BaseModelArgs):
         else:
             self._mtp_pattern = []
 
+        if self._mtp_pattern and self._mtp_pattern != ["*", "E"]:
+            raise ValueError(
+                "Nemotron-H MTP currently supports only the '*E' block pattern; "
+                f"got {''.join(self._mtp_pattern)!r}"
+            )
+
 
 class MambaRMSNormGated(nn.Module):
     def __init__(self, hidden_size: int, eps: float, group_size: int):

--- a/mlx_lm/models/olmo.py
+++ b/mlx_lm/models/olmo.py
@@ -1,6 +1,5 @@
 # Copyright © 2023-2024 Apple Inc.
 
-import sys
 from dataclasses import dataclass
 from typing import Any, Optional
 
@@ -9,12 +8,6 @@ import mlx.nn as nn
 
 from .activations import swiglu
 from .base import BaseModelArgs, create_attention_mask
-
-try:
-    import hf_olmo
-except ImportError:
-    print("To run olmo install ai2-olmo: pip install ai2-olmo")
-    sys.exit(1)
 
 
 @dataclass
@@ -90,7 +83,15 @@ class TransformerBlock(nn.Module):
 
         scores = (queries * self.scale) @ keys.transpose(0, 1, 3, 2)
         if mask is not None:
-            scores += mask
+            if isinstance(mask, str):
+                query_length, key_length = scores.shape[-2:]
+                query_indices = mx.arange(key_length - query_length, key_length)
+                key_indices = mx.arange(key_length)
+                mask = query_indices[:, None] >= key_indices[None]
+            if mask.dtype == mx.bool_:
+                scores = mx.where(mask, scores, mx.finfo(scores.dtype).min)
+            else:
+                scores += mask
         scores = mx.softmax(scores.astype(mx.float32), axis=-1).astype(scores.dtype)
         output = (scores @ values).transpose(0, 2, 1, 3).reshape(B, L, -1)
         return self.attn_out(output)

--- a/mlx_lm/models/pipeline.py
+++ b/mlx_lm/models/pipeline.py
@@ -20,11 +20,14 @@ class PipelineMixin:
         # rank=pipeline_size-1 gets the first
         self.pipeline_rank = group.rank()
         self.pipeline_size = group.size()
-        layers_per_rank = len(self.layers) // self.pipeline_size
-        extra = len(self.layers) - layers_per_rank * self.pipeline_size
-        if self.pipeline_rank < extra:
-            layers_per_rank += 1
-        self.start_idx = (self.pipeline_size - self.pipeline_rank - 1) * layers_per_rank
+        num_layers = len(self.layers)
+        layers_per_rank, extra = divmod(num_layers, self.pipeline_size)
+        # Convert the reverse pipeline rank to the corresponding forward
+        # partition, then use a prefix sum. Multiplying by a rank-local shard
+        # size creates gaps whenever the division has a remainder.
+        partition = self.pipeline_size - self.pipeline_rank - 1
+        self.start_idx = partition * layers_per_rank + min(partition, extra)
+        layers_per_rank += partition < extra
         self.end_idx = self.start_idx + layers_per_rank
         self.layers = self.layers[: self.end_idx]
         # Keep the layer numbers the same for model loading

--- a/mlx_lm/perplexity.py
+++ b/mlx_lm/perplexity.py
@@ -35,13 +35,13 @@ def load_data(
 
     perm = np.random.permutation(len(dataset)).tolist()
 
-    num_tokens = sequence_length * num_samples if num_samples > 0 else float("inf")
+    num_tokens = sequence_length * num_samples if num_samples > 0 else None
     data = []
-    i = 0
-    while len(data) < num_tokens:
-        tokens, _ = dataset.process(dataset[perm[i]])
-        i += 1
+    for index in perm:
+        tokens, _ = dataset.process(dataset[index])
         data.extend(tokens)
+        if num_tokens is not None and len(data) >= num_tokens:
+            break
 
     data = mx.array(data[: (len(data) // sequence_length) * sequence_length])
     data = data.reshape(-1, sequence_length)

--- a/mlx_lm/server.py
+++ b/mlx_lm/server.py
@@ -1,8 +1,11 @@
 # Copyright © 2023-2024 Apple Inc.
 
 import argparse
+import hmac
+import ipaddress
 import json
 import logging
+import os
 import pickle
 import platform
 import socket
@@ -320,7 +323,10 @@ class ModelProvider:
             # TODO: Generalize distributed load
             if self.is_distributed:
                 model, tokenizer = sharded_load(
-                    self.cli_args.model, self.pipeline_group, self.tensor_group
+                    self.cli_args.model,
+                    self.pipeline_group,
+                    self.tensor_group,
+                    tokenizer_config=tokenizer_config,
                 )
             else:
                 model, tokenizer = load(
@@ -332,7 +338,10 @@ class ModelProvider:
             # TODO: Generalize distributed load
             if self.is_distributed:
                 model, tokenizer = sharded_load(
-                    model_path, self.pipeline_group, self.tensor_group
+                    model_path,
+                    self.pipeline_group,
+                    self.tensor_group,
+                    tokenizer_config=tokenizer_config,
                 )
             else:
                 model, tokenizer = load(
@@ -1081,6 +1090,19 @@ class APIHandler(BaseHTTPRequestHandler):
         self.send_header("Cache-Control", "no-cache")
         self._set_cors_headers()
 
+    def _authenticate(self) -> bool:
+        api_key = getattr(self.response_generator.cli_args, "api_key", None)
+        if not api_key:
+            return True
+        authorization = self.headers.get("Authorization", "")
+        if hmac.compare_digest(authorization, f"Bearer {api_key}"):
+            return True
+        self._set_completion_headers(401)
+        self.send_header("WWW-Authenticate", "Bearer")
+        self.end_headers()
+        self.wfile.write(json.dumps({"error": "Unauthorized"}).encode())
+        return False
+
     def do_OPTIONS(self):
         self._set_completion_headers(204)
         self.end_headers()
@@ -1089,6 +1111,9 @@ class APIHandler(BaseHTTPRequestHandler):
         """
         Respond to a POST request from a client.
         """
+        if not self._authenticate():
+            return
+
         request_factories = {
             "/v1/completions": self.handle_text_completions,
             "/v1/chat/completions": self.handle_chat_completions,
@@ -1408,10 +1433,16 @@ class APIHandler(BaseHTTPRequestHandler):
                 args,
                 progress_callback=keepalive_callback,
             )
-        except Exception as e:
-            self._set_completion_headers(404)
+        except (AssertionError, ValueError) as error:
+            self._set_completion_headers(400)
             self.end_headers()
-            self.wfile.write(json.dumps({"error": str(e)}).encode())
+            self.wfile.write(json.dumps({"error": str(error)}).encode())
+            return
+        except Exception:
+            logging.exception("Generation request failed")
+            self._set_completion_headers(500)
+            self.end_headers()
+            self.wfile.write(json.dumps({"error": "Internal server error"}).encode())
             return
 
         # Prepare the headers
@@ -1608,6 +1639,9 @@ class APIHandler(BaseHTTPRequestHandler):
         """
         Respond to a GET request from a client.
         """
+        if not self._authenticate():
+            return
+
         if self.path.startswith("/v1/models"):
             self.handle_models_request()
         elif self.path == "/health":
@@ -1693,6 +1727,17 @@ def _run_http_server(
     server_class=ThreadingHTTPServer,
     handler_class=APIHandler,
 ):
+    api_key = getattr(response_generator.cli_args, "api_key", None)
+    try:
+        is_loopback = ipaddress.ip_address(host).is_loopback
+    except ValueError:
+        is_loopback = host.lower() == "localhost"
+    if not is_loopback and not api_key:
+        raise ValueError(
+            "Binding mlx_lm.server to a non-loopback host requires --api-key "
+            "or MLX_LM_API_KEY"
+        )
+
     server_address = (host, port)
     infos = socket.getaddrinfo(
         *server_address, type=socket.SOCK_STREAM, flags=socket.AI_PASSIVE
@@ -1764,6 +1809,11 @@ def main():
         type=lambda x: x.split(","),
         default="*",
         help="Allowed origins (default: *)",
+    )
+    parser.add_argument(
+        "--api-key",
+        default=os.environ.get("MLX_LM_API_KEY"),
+        help="Bearer token required for HTTP requests (or set MLX_LM_API_KEY)",
     )
     parser.add_argument(
         "--draft-model",

--- a/mlx_lm/tokenizer_utils.py
+++ b/mlx_lm/tokenizer_utils.py
@@ -69,6 +69,8 @@ class NaiveStreamingDetokenizer(StreamingDetokenizer):
     def __init__(self, tokenizer):
         self._tokenizer = tokenizer
         self._tokenizer.decode([0])
+        probe = tokenizer.encode("a ,b", add_special_tokens=False)
+        self._clean_spaces = " ," not in tokenizer.decode(probe)
         self.reset()
 
     def reset(self):
@@ -92,7 +94,7 @@ class NaiveStreamingDetokenizer(StreamingDetokenizer):
         if self._current_tokens:
             self._current_text = self._tokenizer.decode(self._current_tokens)
             if self._current_text.endswith("\ufffd") or (
-                self._tokenizer.clean_up_tokenization_spaces
+                self._clean_spaces
                 and len(self._current_text) > 0
                 and self._current_text[-1] == " "
             ):
@@ -160,11 +162,8 @@ class BPEStreamingDetokenizer(StreamingDetokenizer):
     """
 
     _byte_decoder = None
-    _space_matches = (".", "?", "!", ",", "n't", "'m", "'s", "'ve", "'re")
 
     def __init__(self, tokenizer):
-        self.clean_spaces = tokenizer.clean_up_tokenization_spaces
-
         # Extract the tokens in a list from id to text
         self.tokenmap = [None] * len(tokenizer.vocab)
         for value, tokenid in tokenizer.vocab.items():
@@ -198,8 +197,6 @@ class BPEStreamingDetokenizer(StreamingDetokenizer):
         elif current_text[0] != " ":
             return current_text
         elif not self.text:
-            return current_text[1:]
-        elif self.clean_spaces and current_text[1:].startswith(self._space_matches):
             return current_text[1:]
         return current_text
 

--- a/mlx_lm/utils.py
+++ b/mlx_lm/utils.py
@@ -266,12 +266,8 @@ def load_config(model_path: Path) -> dict:
 
     generation_config_file = model_path / "generation_config.json"
     if generation_config_file.exists():
-        generation_config = {}
-        try:
-            with open(generation_config_file, "r") as f:
-                generation_config = json.load(f)
-        except json.JSONDecodeError:
-            pass
+        with open(generation_config_file, "r") as f:
+            generation_config = json.load(f)
 
         if eos_token_id := generation_config.get("eos_token_id", False):
             config["eos_token_id"] = eos_token_id
@@ -507,6 +503,7 @@ def sharded_load(
     pipeline_group: Optional[mx.distributed.Group] = None,
     tensor_group: Optional[mx.distributed.Group] = None,
     return_config: bool = False,
+    tokenizer_config: Optional[Dict[str, Any]] = None,
 ):
     # Get model path with everything but weight safetensors
     model_path = _download(
@@ -571,7 +568,7 @@ def sharded_load(
     # Load and shard the model, and load the weights
     tokenizer = load_tokenizer(
         model_path,
-        {"trust_remote_code": True},
+        tokenizer_config or {},
         eos_token_ids=config.get("eos_token_id", None),
     )
     model, _ = load_model(model_path, lazy=True, strict=False)
@@ -589,8 +586,14 @@ def sharded_load(
         return model, tokenizer
 
 
-def pipeline_load(repo, return_config=False):
-    return sharded_load(repo, mx.distributed.init(), None, return_config)
+def pipeline_load(repo, return_config=False, tokenizer_config=None):
+    return sharded_load(
+        repo,
+        mx.distributed.init(),
+        None,
+        return_config,
+        tokenizer_config=tokenizer_config,
+    )
 
 
 def make_shards(weights: dict, max_file_size_gb: int = MAX_FILE_SIZE_GB) -> list:
@@ -670,8 +673,7 @@ def upload_to_hub(path: str, upload_repo: str):
     else:
         provenance = ""
 
-    card.text = dedent(
-        f"""
+    card.text = dedent(f"""
         # {upload_repo}
         {provenance}
         ## Use with mlx
@@ -695,8 +697,7 @@ def upload_to_hub(path: str, upload_repo: str):
 
         response = generate(model, tokenizer, prompt=prompt, verbose=True)
         ```
-        """
-    )
+        """)
     card.save(card_path)
 
     api = HfApi()

--- a/setup.py
+++ b/setup.py
@@ -31,6 +31,9 @@ setup(
         "protobuf",
         "pyyaml",
         "jinja2",
+        "huggingface-hub",
+        "regex",
+        "tqdm",
     ],
     packages=[
         "mlx_lm",
@@ -40,7 +43,7 @@ setup(
         "mlx_lm.tool_parsers",
         "mlx_lm.chat_templates",
     ],
-    python_requires=">=3.8",
+    python_requires=">=3.10",
     extras_require={
         "test": ["datasets", "lm-eval"],
         "train": ["datasets", "tqdm"],

--- a/tests/test_generate.py
+++ b/tests/test_generate.py
@@ -63,6 +63,19 @@ class TestGenerate(unittest.TestCase):
             tokens.append(response.token)
         self.assertEqual(len(tokens), 4)
 
+    def test_stream_generate_zero_max_tokens_is_empty(self):
+        self.assertEqual(
+            list(stream_generate(self.model, self.tokenizer, "hello", max_tokens=0)),
+            [],
+        )
+
+    def test_batch_insert_rejects_short_per_prompt_options(self):
+        batch_gen = BatchGenerator(self.model, max_tokens=1)
+        prompts = [[1], [2]]
+
+        with self.assertRaisesRegex(ValueError, "max_tokens.*expected 2, got 1"):
+            batch_gen.insert(prompts, max_tokens=[1])
+
     def test_generate_with_processor(self):
         init_toks = self.tokenizer.encode("hello")
 

--- a/tests/test_gguf.py
+++ b/tests/test_gguf.py
@@ -35,6 +35,9 @@ class TestConvertToGGUFWithoutMocks(unittest.TestCase):
         mock_tokenizer.get_vocab.return_value = {"<pad>": 0, "hello": 1, "world": 2}
         mock_tokenizer.all_special_tokens = ["<pad>"]
         mock_tokenizer.all_special_ids = [0]
+        mock_tokenizer.bos_token_id = None
+        mock_tokenizer.eos_token_id = None
+        mock_tokenizer.unk_token_id = None
         mock_from_pretrained.return_value = mock_tokenizer
 
         model_path = Path(self.test_dir)

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -525,7 +525,6 @@ class TestModels(unittest.TestCase):
             model, args.model_type, args.vocab_size, args.num_hidden_layers
         )
 
-    @unittest.skip("requires ai2-olmo")
     def test_olmo(self):
         from mlx_lm.models import olmo
 

--- a/tests/test_nemotron_mtp.py
+++ b/tests/test_nemotron_mtp.py
@@ -1,0 +1,42 @@
+# Copyright © 2026 Apple Inc.
+
+import pytest
+
+from mlx_lm.models.nemotron_h import ModelArgs
+
+
+def _args(pattern):
+    return ModelArgs(
+        model_type="nemotron_h",
+        vocab_size=32,
+        hidden_size=16,
+        intermediate_size=32,
+        num_hidden_layers=2,
+        max_position_embeddings=128,
+        num_attention_heads=2,
+        num_key_value_heads=2,
+        attention_bias=False,
+        mamba_num_heads=2,
+        mamba_head_dim=8,
+        mamba_proj_bias=False,
+        ssm_state_size=8,
+        conv_kernel=3,
+        n_groups=1,
+        mlp_bias=False,
+        layer_norm_epsilon=1e-5,
+        use_bias=False,
+        use_conv_bias=False,
+        hybrid_override_pattern=["*", "M"],
+        num_nextn_predict_layers=1,
+        mtp_hybrid_override_pattern=pattern,
+    )
+
+
+def test_nemotron_mtp_accepts_supported_attention_then_expert_pattern():
+    assert _args("*E")._mtp_pattern == ["*", "E"]
+
+
+@pytest.mark.parametrize("pattern", ["E*", "*", "EE", "M*"])
+def test_nemotron_mtp_rejects_unsupported_patterns(pattern):
+    with pytest.raises(ValueError, match="supports only the '\\*E' block pattern"):
+        _args(pattern)

--- a/tests/test_perplexity.py
+++ b/tests/test_perplexity.py
@@ -1,0 +1,32 @@
+# Copyright © 2026 Apple Inc.
+
+from mlx_lm import perplexity
+
+
+class _Dataset:
+    values = [[1, 2, 3], [4, 5], [6, 7, 8, 9]]
+
+    def __len__(self):
+        return len(self.values)
+
+    def __getitem__(self, index):
+        return self.values[index]
+
+    def process(self, value):
+        return value, None
+
+
+def test_load_data_all_samples_consumes_finite_dataset_once(monkeypatch):
+    monkeypatch.setattr(
+        perplexity, "load_dataset", lambda args, tokenizer: (_Dataset(), None, None)
+    )
+    monkeypatch.setattr(
+        perplexity.np.random,
+        "permutation",
+        lambda size: perplexity.np.arange(size),
+    )
+
+    data = perplexity.load_data(None, "fixture", num_samples=-1, sequence_length=4)
+
+    assert data.shape == (2, 4)
+    assert data.tolist() == [[1, 2, 3, 4], [5, 6, 7, 8]]

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -1,0 +1,34 @@
+# Copyright © 2026 Apple Inc.
+
+from mlx_lm.models.pipeline import PipelineMixin
+
+
+class _Group:
+    def __init__(self, rank, size):
+        self._rank = rank
+        self._size = size
+
+    def rank(self):
+        return self._rank
+
+    def size(self):
+        return self._size
+
+
+class _Pipeline(PipelineMixin):
+    def __init__(self, layers):
+        super().__init__()
+        self.layers = layers
+
+
+def test_pipeline_partition_covers_non_divisible_layer_count_exactly_once():
+    assigned = []
+    for rank in range(3):
+        pipeline = _Pipeline(list(range(10)))
+        pipeline.pipeline(_Group(rank, 3))
+        assigned.extend(
+            layer for layer in pipeline.pipeline_layers if layer is not None
+        )
+
+    assert sorted(assigned) == list(range(10))
+    assert len(assigned) == len(set(assigned))

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -10,7 +10,12 @@ import mlx.core as mx
 import requests
 
 from mlx_lm.models.cache import KVCache
-from mlx_lm.server import APIHandler, LRUPromptCache, ResponseGenerator
+from mlx_lm.server import (
+    APIHandler,
+    LRUPromptCache,
+    ResponseGenerator,
+    _run_http_server,
+)
 from mlx_lm.utils import load
 
 
@@ -132,6 +137,55 @@ class TestServer(unittest.TestCase):
             json.loads(requests.post(url, json=post_data).text)["choices"][0]["text"],
         )
 
+    def test_api_key_protects_model_selection_endpoints(self):
+        url = f"http://localhost:{self.port}/v1/models"
+        cli_args = self.response_generator.cli_args
+        cli_args.api_key = "test-secret"
+        try:
+            unauthorized = requests.get(url)
+            authorized = requests.get(
+                url, headers={"Authorization": "Bearer test-secret"}
+            )
+        finally:
+            cli_args.api_key = None
+
+        self.assertEqual(unauthorized.status_code, 401)
+        self.assertEqual(authorized.status_code, 200)
+
+    def test_generation_failure_is_not_reported_as_not_found(self):
+        url = f"http://localhost:{self.port}/v1/completions"
+        original_generate = self.response_generator.generate
+        self.response_generator.generate = lambda *args, **kwargs: (
+            _ for _ in ()
+        ).throw(RuntimeError("generation failed"))
+        try:
+            response = requests.post(
+                url,
+                json={"model": "default_model", "prompt": "hello"},
+            )
+        finally:
+            self.response_generator.generate = original_generate
+
+        self.assertEqual(response.status_code, 500)
+        self.assertEqual(response.json(), {"error": "Internal server error"})
+
+    def test_invalid_generation_request_is_bad_request(self):
+        url = f"http://localhost:{self.port}/v1/completions"
+        original_generate = self.response_generator.generate
+        self.response_generator.generate = lambda *args, **kwargs: (
+            _ for _ in ()
+        ).throw(ValueError("invalid generation option"))
+        try:
+            response = requests.post(
+                url,
+                json={"model": "default_model", "prompt": "hello"},
+            )
+        finally:
+            self.response_generator.generate = original_generate
+
+        self.assertEqual(response.status_code, 400)
+        self.assertEqual(response.json(), {"error": "invalid generation option"})
+
     def test_handle_chat_completions(self):
         url = f"http://localhost:{self.port}/v1/chat/completions"
         chat_post_data = {
@@ -217,6 +271,18 @@ class TestServer(unittest.TestCase):
         self.assertIn("id", model)
         self.assertEqual(model["object"], "model")
         self.assertIn("created", model)
+
+
+class TestRemoteBindingSecurity(unittest.TestCase):
+    def test_remote_binding_requires_api_key(self):
+        response_generator = type(
+            "ResponseGenerator",
+            (),
+            {"cli_args": type("Args", (), {"api_key": None})()},
+        )()
+
+        with self.assertRaisesRegex(ValueError, "non-loopback host requires"):
+            _run_http_server("0.0.0.0", 8080, response_generator)
 
 
 class TestServerWithDraftModel(unittest.TestCase):

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,6 +1,7 @@
 # Copyright © 2024 Apple Inc.
 
 import os
+import json
 import tempfile
 import unittest
 from pathlib import Path
@@ -40,6 +41,15 @@ class TestUtils(unittest.TestCase):
         p1 = model.layers[0].mlp.up_proj.weight
         p2 = model_lazy.layers[0].mlp.up_proj.weight
         self.assertTrue(mx.allclose(p1, p2))
+
+    def test_load_config_rejects_malformed_generation_config(self):
+        with tempfile.TemporaryDirectory() as directory:
+            model_path = Path(directory)
+            (model_path / "config.json").write_text("{}")
+            (model_path / "generation_config.json").write_text("{invalid")
+
+            with self.assertRaises(json.JSONDecodeError):
+                utils.load_config(model_path)
 
     def test_make_shards(self):
         from mlx_lm.models import llama


### PR DESCRIPTION
## Summary

Nemotron-3-Super-120B ships MTP prediction heads (1,040 weight keys covering attention + 512-expert MoE) in its HuggingFace checkpoint, but neither HF transformers nor mlx-lm currently use them — `sanitize()` explicitly strips `mtp.*` keys.

This PR adds native MTP support to the Nemotron-H model definition:

- **`NemotronHMTPModule`**: dual-norm embedding/hidden fusion via `eh_proj`, followed by attention + MoE layers matching `mtp_hybrid_override_pattern` (`*E` = 1 attention + 1 MoE layer)
- **`NemotronHMTPBlock`**: supports attention (`*`), MoE (`E`), and MLP (`-`) block types
- **Model interface**: `mtp_forward()`, `make_mtp_cache()`, and `return_hidden` parameter on `__call__` — the standard MTP model contract already used by Qwen3.5 models
- **Weight remapping**: `sanitize()` remaps HF `mtp.layers.0.*` → flat `mtp.*` keys and stacks 512-expert weight shards
- Removes the `mtp.*` weight stripping so MTP weights are loaded when present

## Test results

38% MTP acceptance rate on `Nemotron-3-Super-120B-A12B-5bit` with extracted FP16 MTP weights (5.5 GB from BF16 shards 49-50). Coherent generation confirmed.

## Scope

This is **model-only** — it adds the MTP architecture and weight loading to `nemotron_h.py`. The generate-level `mtp_generate_step()` integration (which calls `mtp_forward()` during decoding) is a separate concern for a follow-up PR.

The model-level interface (`mtp_forward`, `make_mtp_cache`, `return_hidden`) matches the existing Qwen3.5 MTP contract, so existing MTP generate infrastructure can use it without modification.

## MTP weight availability

The MTP weights are present in the original NVIDIA checkpoint but need to be extracted separately since they span the last 2 of 50 BF16 safetensors shards. A conversion script for extracting and stacking the MTP weights is available separately.