### PR TITLE
Fix missing tree_reduce import in models/cache.py

### DIFF
--- a/mlx_lm/models/cache.py
+++ b/mlx_lm/models/cache.py
@@ -7,7 +7,7 @@ from typing import Any, Dict, List, Optional
 
 import mlx.core as mx
 import mlx.nn as nn
-from mlx.utils import tree_flatten, tree_map, tree_unflatten
+from mlx.utils import tree_flatten, tree_map, tree_reduce, tree_unflatten
 
 from .base import create_causal_mask
 


### PR DESCRIPTION
`_BaseCache.nbytes` calls `tree_reduce`, but the module only imports `tree_flatten`, `tree_map`, `tree_unflatten` from `mlx.utils`. Reading `.nbytes` on any cache that inherits the base implementation (hit by MoE architectures like Qwen3.5 MoE) raises `NameError: name 'tree_reduce' is not defined`.

Fixes #1164.

## Diff

```diff
-from mlx.utils import tree_flatten, tree_map, tree_unflatten
+from mlx.utils import tree_flatten, tree_map, tree_reduce, tree_unflatten
```

## Repro (before the fix)

```bash
curl -sS -X POST http://127.0.0.1:8888/v1/chat/completions \
  -H "Content-Type: application/json" \
  -d '{"model":"qwen3.5-397b-a17b-mlx","stream":false,"max_tokens":20,
       "messages":[{"role":"user","content":"Say hello."}]}'
# → {"error":"Error in iterating prediction stream: NameError: name 'tree_reduce' is not defined"}
```

After the patch, the same request returns a normal completion. Verified on LM Studio 0.4.12+1 with bundled mlx-lm 0.31.3 on macOS Apple Silicon.