### PR TITLE
fix: handle NoneType check for think tokens in TokenizerWrapper

### DIFF
--- a/mlx_lm/tokenizer_utils.py
+++ b/mlx_lm/tokenizer_utils.py
@@ -397,6 +397,7 @@ class TokenizerWrapper:
 
     @property
     def think_start_id(self):
+        if not getattr(self, "_think_start_tokens", None): return None
         if len(self._think_start_tokens) > 1:
             raise ValueError("The start thinking sequence is more than 1 token")
         return self._think_start_tokens[0]
@@ -411,6 +412,7 @@ class TokenizerWrapper:
 
     @property
     def think_end_id(self):
+        if not getattr(self, "_think_end_tokens", None): return None
         if len(self._think_end_tokens) > 1:
             raise ValueError("The end thinking sequence is more than 1 token")
         return self._think_end_tokens[0]

--- a/mlx_lm/tokenizer_utils.py
+++ b/mlx_lm/tokenizer_utils.py
@@ -397,7 +397,8 @@ class TokenizerWrapper:
 
     @property
     def think_start_id(self):
-        if not getattr(self, "_think_start_tokens", None): return None
+        if self._think_start_tokens is None:
+            return None
         if len(self._think_start_tokens) > 1:
             raise ValueError("The start thinking sequence is more than 1 token")
         return self._think_start_tokens[0]
@@ -412,7 +413,8 @@ class TokenizerWrapper:
 
     @property
     def think_end_id(self):
-        if not getattr(self, "_think_end_tokens", None): return None
+        if self._think_end_tokens is None:
+            return None
         if len(self._think_end_tokens) > 1:
             raise ValueError("The end thinking sequence is more than 1 token")
         return self._think_end_tokens[0]

--- a/tests/test_tokenizers.py
+++ b/tests/test_tokenizers.py
@@ -109,5 +109,6 @@ class TestTokenizers(unittest.TestCase):
         self.assertIsNone(tokenizer.think_start_id)
         self.assertIsNone(tokenizer.think_end_id)
 
+
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_tokenizers.py
+++ b/tests/test_tokenizers.py
@@ -101,20 +101,13 @@ class TestTokenizers(unittest.TestCase):
         self.assertEqual(tokenizer.think_start, "<think>")
         self.assertEqual(tokenizer.think_end, "</think>")
 
-    def test_no_think_tokens_safe_access(self):
         tokenizer_repo = "mlx-community/Llama-3.2-1B-Instruct-4bit"
         tokenizer = load_tokenizer(tokenizer_repo)
-        
         self.assertFalse(tokenizer.has_thinking)
-        
         self.assertIsNone(tokenizer.think_start)
         self.assertIsNone(tokenizer.think_end)
-        
-        try:
-            self.assertIsNone(tokenizer.think_start_id, "think_start_id should be None")
-            self.assertIsNone(tokenizer.think_end_id, "think_end_id should be None")
-        except (TypeError, AttributeError) as e:
-            self.fail(f"Accessing think_id properties raised an exception: {e}")
+        self.assertIsNone(tokenizer.think_start_id)
+        self.assertIsNone(tokenizer.think_end_id)
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_tokenizers.py
+++ b/tests/test_tokenizers.py
@@ -101,6 +101,20 @@ class TestTokenizers(unittest.TestCase):
         self.assertEqual(tokenizer.think_start, "<think>")
         self.assertEqual(tokenizer.think_end, "</think>")
 
+    def test_no_think_tokens_safe_access(self):
+        tokenizer_repo = "mlx-community/Llama-3.2-1B-Instruct-4bit"
+        tokenizer = load_tokenizer(tokenizer_repo)
+        
+        self.assertFalse(tokenizer.has_thinking)
+        
+        self.assertIsNone(tokenizer.think_start)
+        self.assertIsNone(tokenizer.think_end)
+        
+        try:
+            self.assertIsNone(tokenizer.think_start_id, "think_start_id should be None")
+            self.assertIsNone(tokenizer.think_end_id, "think_end_id should be None")
+        except (TypeError, AttributeError) as e:
+            self.fail(f"Accessing think_id properties raised an exception: {e}")
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
#### **The Problem**
When using models that do not explicitly define thinking tokens in their configuration (for example, **Qwen2.5-Coder** or **Llama 3.2**), accessing `tokenizer.think_start_id` or `tokenizer.think_end_id` triggers a `TypeError: object of type 'NoneType' has no len()`. 

This occurs because the current implementation assumes `self._think_start_tokens` is always a list, even when it hasn't been initialized for non-thinking models. This crash is particularly disruptive for downstream tools like **Aider** or custom inference schedulers that attempt to detect thinking capabilities via these properties.

#### **The Fix**
- Implemented a **non-intrusive defensive check** using `getattr()` and `if not` logic in both `think_start_id` and `think_end_id`.
- If the thinking tokens are `None` or missing, the properties now gracefully return `None` instead of crashing.
- **Preserved original validation**: The `ValueError` for token sequences longer than 1 remains intact to ensure backward compatibility and logical consistency for models that *do* support thinking tokens.

---

### **Testing**

#### **Automated Tests**
- Added a new test case `test_no_think_tokens_safe_access` in `tests/test_tokenizers.py` which:
    - Verifies `has_thinking` is `False` for non-thinking models.
    - Verifies `think_start_id` and `think_end_id` return `None` safely.
    - Ensures no `TypeError` or `AttributeError` is raised.
- **Full Suite Result**: Ran `pytest tests` on Apple M3 Max (macOS 15, Python 3.12.8).
    - **Result**: `191 passed, 1 skipped, 2 warnings` (Warnings are unrelated SWIG/Python 3.12 deprecations).

#### **Manual Traceback Verification (Before Fix)**
```text
Traceback (most recent call last):
  File "/opt/homebrew/Cellar/omlx/1/libexec/lib/python3.11/site-packages/omlx/engine_core.py", line 175, in _engine_loop
    output = await loop.run_in_executor(
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/opt/homebrew/Cellar/python@3.11/3.11.15/Frameworks/Python.framework/Versions/3.11/lib/python3.11/concurrent/futures/thread.py", line 58, in run
    result = self.fn(*self.args, **self.kwargs)
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/opt/homebrew/Cellar/omlx/1/libexec/lib/python3.11/site-packages/omlx/scheduler.py", line 3539, in step
    scheduled, rejected = self._schedule_waiting()
                          ^^^^^^^^^^^^^^^^^^^^^^^^
  File "/opt/homebrew/Cellar/omlx/1/libexec/lib/python3.11/site-packages/omlx/scheduler.py", line 2846, in _schedule_waiting
    if self._detect_needs_think_prefix(request):
       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/opt/homebrew/Cellar/omlx/1/libexec/lib/python3.11/site-packages/omlx/scheduler.py", line 1427, in _detect_needs_think_prefix
    think_start_id = getattr(self.tokenizer, 'think_start_id', None)
                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/opt/homebrew/Cellar/omlx/1/libexec/lib/python3.11/site-packages/mlx_lm/tokenizer_utils.py", line 400, in think_start_id
    if len(self._think_start_tokens) > 1:
       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
TypeError: object of type 'NoneType' has no len()
```

---

### **Checklist**
- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.
