### PR TITLE
Fix batch dimension mismatch in ArraysCache extend()

### DIFF
--- a/mlx_lm/models/cache.py
+++ b/mlx_lm/models/cache.py
@@ -629,11 +629,22 @@ class ArraysCache(_BaseCache):
         """
         In-place extend this cache with the other cache.
         """
+        # When all of other's states are None (e.g. a freshly-merged cache
+        # for new sequences joining a batch), we still need to know its
+        # batch size to zero-pad self's populated states so the batch
+        # dimension grows correctly.
+        n_other = next(
+            (o.shape[0] for o in other.cache if o is not None),
+            getattr(other, "_n_seqs", None),
+        )
 
         def cat(a, b):
             if a is None:
                 return b
             if b is None:
+                if n_other is not None:
+                    pad = mx.zeros((n_other,) + a.shape[1:], dtype=a.dtype)
+                    return mx.concatenate([a, pad])
                 return a
             return mx.concatenate([a, b])
 
@@ -675,6 +686,7 @@ class ArraysCache(_BaseCache):
 
         # All caches are empty so return early
         if all(c.empty() for c in caches):
+            cache._n_seqs = B
             return cache
 
         for e in range(n_state):

--- a/mlx_lm/models/cache.py
+++ b/mlx_lm/models/cache.py
@@ -603,6 +603,18 @@ class ArraysCache(_BaseCache):
         if left_padding:
             self.left_padding = mx.array(left_padding)
 
+    @property
+    def batch_size(self):
+        for c in self.cache:
+            if c is not None:
+                return c.shape[0]
+        if self.left_padding is not None:
+            return self.left_padding.size
+        elif self.lengths is not None:
+            return self.lengths.size
+        else:
+            return 1
+
     def __setitem__(self, idx, value):
         self.cache[idx] = value
 
@@ -622,6 +634,8 @@ class ArraysCache(_BaseCache):
         In-place filter to keep just the given indices in the cache.
         """
         self.cache = [c[batch_indices] if c is not None else None for c in self.cache]
+        if self.left_padding is not None:
+            self.left_padding = self.left_padding[batch_indices]
         if self.lengths is not None:
             self.lengths = self.lengths[batch_indices]
 
@@ -629,26 +643,29 @@ class ArraysCache(_BaseCache):
         """
         In-place extend this cache with the other cache.
         """
-        # When all of other's states are None (e.g. a freshly-merged cache
-        # for new sequences joining a batch), we still need to know its
-        # batch size to zero-pad self's populated states so the batch
-        # dimension grows correctly.
-        n_other = next(
-            (o.shape[0] for o in other.cache if o is not None),
-            getattr(other, "_n_seqs", None),
-        )
 
         def cat(a, b):
+            shape = dtype = None
+            if a is not None:
+                shape = a.shape
+                dtype = a.dtype
+            if b is not None:
+                shape = b.shape
+                dtype = b.dtype
+
+            if shape is None:
+                return None
+
             if a is None:
-                return b
+                a = mx.zeros((self.batch_size,) + shape[1:], dtype=dtype)
             if b is None:
-                if n_other is not None:
-                    pad = mx.zeros((n_other,) + a.shape[1:], dtype=a.dtype)
-                    return mx.concatenate([a, pad])
-                return a
+                b = mx.zeros((other.batch_size,) + shape[1:], dtype=dtype)
+
             return mx.concatenate([a, b])
 
         self.cache = [cat(c, o) for c, o in zip(self.cache, other.cache)]
+        self.left_padding = cat(self.left_padding, other.left_padding)
+        self.lengths = cat(self.lengths, other.lengths)
 
     def extract(self, idx):
         cache = ArraysCache(len(self.cache))
@@ -686,7 +703,7 @@ class ArraysCache(_BaseCache):
 
         # All caches are empty so return early
         if all(c.empty() for c in caches):
-            cache._n_seqs = B
+            cache.left_padding = mx.array([0] * B)
             return cache
 
         for e in range(n_state):

--- a/tests/test_prompt_cache.py
+++ b/tests/test_prompt_cache.py
@@ -717,6 +717,48 @@ class TestPromptCache(unittest.TestCase):
         self.assertEqual(batch_full.keys.shape[0], 5)
         self.assertEqual(batch_full.offset.shape[0], 5)
 
+    def test_arrays_cache_extend_with_empty(self):
+        """ArraysCache.extend() should grow self's batch dimension by the
+        correct amount when other's states are all None (e.g. a freshly
+        merged cache for new sequences joining a batch mid-prefill).
+
+        Without the fix, ``cat(a, None)`` returned ``a`` unchanged, leaving
+        the batch dim too small for the downstream ``filter()`` call. On
+        Metal, the resulting out-of-bounds index silently wraps (index 1
+        modulo size 1 = 0), so new sequences received another sequence's
+        state instead of fresh zeros, producing garbage output.
+        """
+        # non-empty extended by empty merge-result (2 + 1 = 3)
+        c1 = ArraysCache(2)
+        c2 = ArraysCache(2)
+        c1[0] = mx.zeros((1, 4, 8))
+        c1[1] = mx.zeros((1, 4))
+        c2[0] = mx.zeros((1, 4, 8))
+        c2[1] = mx.zeros((1, 4))
+        full = ArraysCache.merge((c1, c2))
+        self.assertEqual(full[0].shape, (2, 4, 8))
+
+        empty = ArraysCache.merge((ArraysCache(2),))  # B=1, all states None
+        full.extend(empty)
+        self.assertEqual(full[0].shape, (3, 4, 8))
+        self.assertEqual(full[1].shape, (3, 4))
+        # The appended rows must be fresh zeros, not a copy of existing state.
+        self.assertTrue(mx.all(full[0][2:] == 0).item())
+
+        # empty extended by non-empty (already worked, but guard it)
+        empty2 = ArraysCache.merge((ArraysCache(2), ArraysCache(2)))
+        content = ArraysCache.merge((c1, c2))
+        empty2.extend(content)
+        self.assertEqual(empty2[0].shape, (2, 4, 8))
+        self.assertEqual(empty2[1].shape, (2, 4))
+
+        # multiple empty extensions accumulate correctly
+        stepwise = ArraysCache.merge((c1,))  # B=1
+        stepwise.extend(ArraysCache.merge((ArraysCache(2),)))  # +1 -> 2
+        stepwise.extend(ArraysCache.merge((ArraysCache(2), ArraysCache(2))))  # +2 -> 4
+        self.assertEqual(stepwise[0].shape, (4, 4, 8))
+        self.assertEqual(stepwise[1].shape, (4, 4))
+
     def test_window_mask_with_full_kv_cache(self):
         c = KVCache()
         kv = mx.zeros((1, 1, 32, 128))

--- a/tests/test_prompt_cache.py
+++ b/tests/test_prompt_cache.py
@@ -718,17 +718,7 @@ class TestPromptCache(unittest.TestCase):
         self.assertEqual(batch_full.offset.shape[0], 5)
 
     def test_arrays_cache_extend_with_empty(self):
-        """ArraysCache.extend() should grow self's batch dimension by the
-        correct amount when other's states are all None (e.g. a freshly
-        merged cache for new sequences joining a batch mid-prefill).
-
-        Without the fix, ``cat(a, None)`` returned ``a`` unchanged, leaving
-        the batch dim too small for the downstream ``filter()`` call. On
-        Metal, the resulting out-of-bounds index silently wraps (index 1
-        modulo size 1 = 0), so new sequences received another sequence's
-        state instead of fresh zeros, producing garbage output.
-        """
-        # non-empty extended by empty merge-result (2 + 1 = 3)
+        # test simple merge
         c1 = ArraysCache(2)
         c2 = ArraysCache(2)
         c1[0] = mx.zeros((1, 4, 8))
@@ -738,24 +728,25 @@ class TestPromptCache(unittest.TestCase):
         full = ArraysCache.merge((c1, c2))
         self.assertEqual(full[0].shape, (2, 4, 8))
 
-        empty = ArraysCache.merge((ArraysCache(2),))  # B=1, all states None
+        # extend with empty
+        empty = ArraysCache.merge((ArraysCache(2),))
         full.extend(empty)
         self.assertEqual(full[0].shape, (3, 4, 8))
         self.assertEqual(full[1].shape, (3, 4))
-        # The appended rows must be fresh zeros, not a copy of existing state.
-        self.assertTrue(mx.all(full[0][2:] == 0).item())
+        self.assertTrue(mx.all(full[0][2:] == 0))
 
-        # empty extended by non-empty (already worked, but guard it)
+        # making an empty cache with 2 sequences and merging it with
+        # another one with 2 sequences
         empty2 = ArraysCache.merge((ArraysCache(2), ArraysCache(2)))
         content = ArraysCache.merge((c1, c2))
         empty2.extend(content)
-        self.assertEqual(empty2[0].shape, (2, 4, 8))
-        self.assertEqual(empty2[1].shape, (2, 4))
+        self.assertEqual(empty2[0].shape, (4, 4, 8))
+        self.assertEqual(empty2[1].shape, (4, 4))
 
         # multiple empty extensions accumulate correctly
-        stepwise = ArraysCache.merge((c1,))  # B=1
-        stepwise.extend(ArraysCache.merge((ArraysCache(2),)))  # +1 -> 2
-        stepwise.extend(ArraysCache.merge((ArraysCache(2), ArraysCache(2))))  # +2 -> 4
+        stepwise = ArraysCache.merge((c1,))
+        stepwise.extend(ArraysCache(2))
+        stepwise.extend(ArraysCache.merge((ArraysCache(2), ArraysCache(2))))
         self.assertEqual(stepwise[0].shape, (4, 4, 8))
         self.assertEqual(stepwise[1].shape, (4, 4))
 


### PR DESCRIPTION
## Fix batch dimension mismatch in ArraysCache extend()

### Summary

- Fix batch-dimension mismatch in `ArraysCache.extend()` when one side's states are all `None` (a freshly merged cache for new sequences joining a batch).
- Companion fix to #1141, which addressed the same class of bug for `BatchKVCache` / `BatchRotatingKVCache`. `ArraysCache` (used by hybrid Mamba/Transformer models such as Qwen3.5) had the same issue but was not covered there.

### Problem

When `extend()` is called on an `ArraysCache` whose states are already populated (shape `[B, ...]`) with an `other` cache whose states are all `None` (fresh sequences), the `cat()` helper returned `a` unchanged:

```python
def cat(a, b):
    if a is None: return b
    if b is None: return a        # ← batch dim does not grow
    return mx.concatenate([a, b])
```

The batch dimension therefore stayed at `B` instead of growing to `B + n_new`. The subsequent `filter()` call on the undersized tensor indexes out of bounds. On Metal this does **not** raise — it wraps silently (e.g. `index 1 mod size 1 = 0`). New sequences receive another sequence's state with the correct shape, and the guards that models like Qwen3.5 have in their attention code (which compare `conv_state.shape[0]` against the expected batch size) never fire because the shape *looks* right.

The practical symptom: under concurrent serving (e.g. with `--continuous-batching --max-num-seqs 6` and ≥ 8 concurrent clients), one of the "middle wave" requests that joins an existing prompt batch mid-prefill starts receiving a neighbour's conv/SSM state and produces degenerate output such as `!!!!!!...` for its entire response. The failure is non-deterministic (depends on arrival ordering) and leaves no trace in logs.

**Reproduction scenario (server with concurrent requests):**
1. `_prompt_batch` has sequences with populated conv/SSM state from earlier prefill steps.
2. A new sequence arrives; its fresh `ArraysCache` is `merge()`d and passed to `_prompt_batch.extend()`.
3. `extend()` runs `cat(populated, None) = populated` — batch dim unchanged.
4. The older sequence finishes prefill; scheduler calls `_prompt_batch.filter([idx_of_new_seq])` (usually `[1]`) on an array whose `shape[0] == 1`.
5. Metal's out-of-bounds indexing wraps → the new sequence runs with the old sequence's state.

### Fix

Teach `ArraysCache.extend()` to derive `other`'s batch size — either from the first populated state, or from `_n_seqs` (set by `merge()` when all caches were empty at merge time) — and zero-pad `a` with that many rows when `b is None`. Mirrors the `c.offset.shape[0]` approach from #1141, adapted for `ArraysCache` which has no always-populated attribute to read B from.

```python
def extend(self, other):
    n_other = next(
        (o.shape[0] for o in other.cache if o is not None),
        getattr(other, "_n_seqs", None),
    )

    def cat(a, b):
        if a is None:
            return b
        if b is None:
            if n_other is not None:
                pad = mx.zeros((n_other,) + a.shape[1:], dtype=a.dtype)
                return mx.concatenate([a, pad])
            return a
        return mx.concatenate([a, b])

    self.cache = [cat(c, o) for c, o in zip(self.cache, other.cache)]

@classmethod
def merge(cls, caches):
    ...
    if all(c.empty() for c in caches):
        cache._n_seqs = B      # remember batch size for a later extend()
        return cache
    ...
```

Total change: +13 / −2 in `mlx_lm/models/cache.py`.

### Test plan

- [x] Existing tests pass (`python -m unittest tests.test_prompt_cache`).
- [x] New regression test `test_arrays_cache_extend_with_empty` added adjacent to `test_extend_with_empty_and_nonempty_batch_caches`, covering:
  - non-empty extended by merge-empty (the failing scenario),
  - empty extended by non-empty (already worked; guarded),
  - multiple successive empty extensions.
- [x] Verified end-to-end with `vllm-mlx serve` on Qwen3.5-27B (hybrid) and Qwen3.5-35B-A3B (MoE) at `max-num-seqs=6` and 8 concurrent clients: prior to the fix roughly 1 in 8 requests returned `!!!!!!`; after the fix, 0/32 bad responses across 4 runs.
