### PR TITLE
Include context_length in /v1/models response (#1183)

### DIFF
--- a/mlx_lm/server.py
+++ b/mlx_lm/server.py
@@ -51,6 +51,55 @@ def get_system_fingerprint():
     return f"{__version__}-{mx.__version__}-{platform.platform()}-{gpu_arch}"
 
 
+# Fields in config.json, in priority order, that carry the maximum context
+# length a model supports. Different model families use different conventions.
+_CONTEXT_LENGTH_FIELDS = (
+    "max_position_embeddings",
+    "n_positions",
+    "max_sequence_length",
+    "seq_length",
+)
+
+
+def _find_repo_config_path(repo):
+    """Return the top-level config.json path for a cached repo, if present."""
+    snapshot_path = repo.refs["main"].snapshot_path
+    for f in repo.refs["main"].files:
+        try:
+            relative_path = f.file_path.relative_to(snapshot_path)
+        except ValueError:
+            continue
+        if relative_path == Path("config.json"):
+            return f.file_path
+    return None
+
+
+def _get_context_length(config_path):
+    """
+    Read a model's ``config.json`` and return the maximum context length
+    it declares, or ``None`` if the file is missing, unreadable, or does
+    not declare a known context-length field.
+
+    Args:
+        config_path: Path to the model's ``config.json`` file, or ``None``.
+
+    Returns:
+        The declared context length as an ``int``, or ``None``.
+    """
+    if config_path is None:
+        return None
+    try:
+        with open(config_path, "r") as f:
+            config = json.load(f)
+    except (OSError, ValueError):
+        return None
+    for field in _CONTEXT_LENGTH_FIELDS:
+        value = config.get(field)
+        if type(value) is int and value > 0:
+            return value
+    return None
+
+
 class ToolCallFormatter:
     def __init__(self, tool_parser, tools, streaming=False):
         self._idx = 0
@@ -1676,6 +1725,7 @@ class APIHandler(BaseHTTPRequestHandler):
                 "id": repo.repo_id,
                 "object": "model",
                 "created": self.created,
+                "context_length": _get_context_length(_find_repo_config_path(repo)),
             }
             for repo in downloaded_models
         ]
@@ -1689,6 +1739,9 @@ class APIHandler(BaseHTTPRequestHandler):
                         "id": model_id,
                         "object": "model",
                         "created": self.created,
+                        "context_length": _get_context_length(
+                            model_path / "config.json"
+                        ),
                     }
                 )
 

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -3,9 +3,11 @@
 import http
 import io
 import json
+import tempfile
 import threading
 import types
 import unittest
+from pathlib import Path
 
 import mlx.core as mx
 import requests
@@ -16,6 +18,8 @@ from mlx_lm.server import (
     LRUPromptCache,
     Response,
     ResponseGenerator,
+    _find_repo_config_path,
+    _get_context_length,
     _process_control_tokens,
 )
 from mlx_lm.utils import load
@@ -90,6 +94,123 @@ class MockCache:
     def trim(self, n):
         assert self._is_trimmable
         return n
+
+
+class TestGetContextLength(unittest.TestCase):
+    def _write_config(self, dirpath, payload):
+        path = dirpath / "config.json"
+        with open(path, "w") as f:
+            json.dump(payload, f)
+        return path
+
+    def test_reads_max_position_embeddings(self):
+
+        with tempfile.TemporaryDirectory() as d:
+            path = self._write_config(Path(d), {"max_position_embeddings": 32768})
+            self.assertEqual(_get_context_length(path), 32768)
+
+    def test_prefers_max_position_embeddings_over_fallbacks(self):
+
+        with tempfile.TemporaryDirectory() as d:
+            path = self._write_config(
+                Path(d),
+                {
+                    "max_position_embeddings": 32768,
+                    "n_positions": 2048,
+                    "max_sequence_length": 4096,
+                },
+            )
+            self.assertEqual(_get_context_length(path), 32768)
+
+    def test_falls_back_to_n_positions(self):
+
+        with tempfile.TemporaryDirectory() as d:
+            path = self._write_config(Path(d), {"n_positions": 2048})
+            self.assertEqual(_get_context_length(path), 2048)
+
+    def test_falls_back_to_max_sequence_length(self):
+
+        with tempfile.TemporaryDirectory() as d:
+            path = self._write_config(Path(d), {"max_sequence_length": 4096})
+            self.assertEqual(_get_context_length(path), 4096)
+
+    def test_returns_none_when_field_missing(self):
+
+        with tempfile.TemporaryDirectory() as d:
+            path = self._write_config(Path(d), {"model_type": "llama"})
+            self.assertIsNone(_get_context_length(path))
+
+    def test_returns_none_for_non_positive_values(self):
+
+        with tempfile.TemporaryDirectory() as d:
+            path = self._write_config(
+                Path(d), {"max_position_embeddings": 0, "n_positions": -1}
+            )
+            self.assertIsNone(_get_context_length(path))
+
+    def test_returns_none_for_non_int_values(self):
+
+        with tempfile.TemporaryDirectory() as d:
+            # HF configs occasionally stash strings or floats here
+            path = self._write_config(Path(d), {"max_position_embeddings": "32768"})
+            self.assertIsNone(_get_context_length(path))
+
+    def test_returns_none_for_bool_values(self):
+
+        with tempfile.TemporaryDirectory() as d:
+            path = self._write_config(Path(d), {"max_position_embeddings": True})
+            self.assertIsNone(_get_context_length(path))
+
+    def test_returns_none_for_missing_file(self):
+
+        self.assertIsNone(_get_context_length(Path("/nonexistent/path/config.json")))
+
+    def test_returns_none_for_malformed_json(self):
+
+        with tempfile.TemporaryDirectory() as d:
+            path = Path(d) / "config.json"
+            path.write_text("{not valid json")
+            self.assertIsNone(_get_context_length(path))
+
+    def test_returns_none_for_none_path(self):
+        self.assertIsNone(_get_context_length(None))
+
+
+class TestFindRepoConfigPath(unittest.TestCase):
+    def test_prefers_top_level_config_json(self):
+        snapshot_path = Path("/tmp/snapshot")
+        repo = types.SimpleNamespace(
+            refs={
+                "main": types.SimpleNamespace(
+                    snapshot_path=snapshot_path,
+                    files=[
+                        types.SimpleNamespace(
+                            file_path=snapshot_path / "subdir" / "config.json"
+                        ),
+                        types.SimpleNamespace(file_path=snapshot_path / "config.json"),
+                    ],
+                )
+            }
+        )
+
+        self.assertEqual(_find_repo_config_path(repo), snapshot_path / "config.json")
+
+    def test_returns_none_when_top_level_config_missing(self):
+        snapshot_path = Path("/tmp/snapshot")
+        repo = types.SimpleNamespace(
+            refs={
+                "main": types.SimpleNamespace(
+                    snapshot_path=snapshot_path,
+                    files=[
+                        types.SimpleNamespace(
+                            file_path=snapshot_path / "subdir" / "config.json"
+                        ),
+                    ],
+                )
+            }
+        )
+
+        self.assertIsNone(_find_repo_config_path(repo))
 
 
 class TestProcessControlTokens(unittest.TestCase):
@@ -319,6 +440,12 @@ class TestServer(unittest.TestCase):
         self.assertIn("id", model)
         self.assertEqual(model["object"], "model")
         self.assertIn("created", model)
+        # context_length must be present on every entry; None is allowed
+        # when a config.json cannot be read or has no recognized field.
+        for entry in response_body["data"]:
+            self.assertIn("context_length", entry)
+            ctx = entry["context_length"]
+            self.assertTrue(ctx is None or (isinstance(ctx, int) and ctx > 0))
 
 
 class TestServerWithDraftModel(unittest.TestCase):


### PR DESCRIPTION
Closes #1183.

## What

Adds a `context_length` field to every entry returned by the `/v1/models` endpoint (and the `/v1/models/{repo_id}` single-model variant), reporting the maximum context length the model declares in its `config.json`.

Example response after this change:

```json
{
  "object": "list",
  "data": [
    {
      "id": "mlx-community/Qwen2.5-7B-Instruct-4bit",
      "object": "model",
      "created": 1745000000,
      "context_length": 32768
    }
  ]
}
```

## Why

OpenAI-compatible clients increasingly need to know a model's usable context window before constructing a request — for chunking long documents, sizing prompt caches, choosing between models, and rendering token-budget UIs. Today the endpoint exposes only `id`, `object`, and `created`, so clients have to hard-code limits or guess.

## How

- Adds `_get_context_length(config_path)` to read the first recognized max-context field from `config.json`
- Supports `max_position_embeddings`, `n_positions`, `max_sequence_length`, and `seq_length`
- Adds `_find_repo_config_path(repo)` so Hugging Face cache scans use the top-level snapshot `config.json` rather than any nested file with the same basename
- Returns `None` instead of raising if the config is missing, malformed, or has no valid positive integer context field
- Includes `context_length` in both cached-model listings and local `--model` listings

## Tests

- New unit tests for `_get_context_length` cover recognized fields, priority ordering, missing fields, malformed JSON, missing files, non-positive values, string values, bool values, and `None` input
- New unit tests for `_find_repo_config_path` cover top-level-vs-nested `config.json` selection in Hugging Face cache snapshots
- `test_handle_models` now asserts every model entry includes `context_length`, with value either `None` or a positive integer

## Verification

- `python3 -m unittest discover -s tests -p 'test_server.py' -v`
- `pre-commit run --files mlx_lm/server.py tests/test_server.py`
- `git diff --check`

## Backward compatibility

Purely additive. Existing clients that only read `id` / `object` / `created` continue to work unchanged.
