### PR TITLE
feat: add thinking budget with early-stopping prompt injection

### DIFF
--- a/mlx_lm/sample_utils.py
+++ b/mlx_lm/sample_utils.py
@@ -365,3 +365,111 @@ def make_frequency_penalty(penalty: float, context_size: int = 20):
         return logits
 
     return frequency_penalty_processor
+
+
+def make_thinking_budget_processor(
+    think_start_tokens: tuple,
+    think_end_tokens: tuple,
+    budget: int,
+    early_stop_tokens: mx.array,
+) -> Callable[[mx.array, mx.array], mx.array]:
+    """
+    Make a logits processor that enforces a thinking token budget.
+
+    Tracks the thinking state by watching for ``think_start_tokens`` /
+    ``think_end_tokens`` in the generated sequence.  When the number of
+    thinking tokens exceeds ``budget``, the processor injects
+    ``early_stop_tokens`` one token at a time by forcing each token's logit
+    to ``0.0`` and setting all other logits to ``-inf``.  After the full
+    injection sequence has been forced the processor returns to passthrough
+    mode.
+
+    Args:
+        think_start_tokens (tuple): Token IDs that mark the start of a
+            thinking block (e.g. the tokenization of ``<think>``).
+        think_end_tokens (tuple): Token IDs that mark the end of a thinking
+            block (e.g. the tokenization of ``</think>``).
+        budget (int): Maximum number of thinking tokens allowed before
+            early-stop injection begins.  Must be >= 0.
+        early_stop_tokens (mx.array): 1-D array of token IDs to inject when
+            the budget is exceeded.
+
+    Returns:
+        Callable[[mx.array, mx.array], mx.array]:
+            A stateful logits processor with signature
+            ``(tokens, logits) -> logits``.
+    """
+    if budget < 0:
+        raise ValueError(f"budget must be >= 0, got {budget}")
+
+    state = {
+        "in_thinking": False,
+        "thinking_count": 0,
+        "forcing": False,
+        "force_idx": 0,
+        "prev_len": 0,
+    }
+
+    start = list(think_start_tokens)
+    end = list(think_end_tokens)
+    stop = early_stop_tokens.tolist()
+
+    vocab_size = early_stop_tokens.shape[0] if early_stop_tokens.ndim == 1 else None
+
+    def _force_logits(logits, forced_id):
+        """Return logits with forced_id set to 0.0 and all others to -inf."""
+        indices = mx.arange(logits.shape[-1])
+        return mx.where(indices == forced_id, 0.0, float("-inf"))[None]
+
+    def _ends_with(seq, pattern):
+        """Return True if seq ends with pattern."""
+        n = len(pattern)
+        return len(seq) >= n and seq[-n:] == pattern
+
+    def thinking_budget_processor(tokens, logits):
+        token_list = tokens.tolist()
+        prev_len = state["prev_len"]
+        new_tokens = token_list[prev_len:]
+        state["prev_len"] = len(token_list)
+
+        # If currently forcing injection, continue regardless of new tokens.
+        if state["forcing"]:
+            forced_id = stop[state["force_idx"]]
+            state["force_idx"] += 1
+            if state["force_idx"] >= len(stop):
+                # Injection complete; reset to not-thinking.
+                state["forcing"] = False
+                state["force_idx"] = 0
+                state["in_thinking"] = False
+                state["thinking_count"] = 0
+            return _force_logits(logits, forced_id)
+
+        # Process each new token to update thinking state.
+        # Walk new_tokens by position to avoid index(tok) ambiguity.
+        for pos, tok in enumerate(new_tokens, start=prev_len):
+            prefix = token_list[: pos + 1]
+            if not state["in_thinking"]:
+                if _ends_with(prefix, start):
+                    state["in_thinking"] = True
+                    state["thinking_count"] = 0
+            else:
+                if _ends_with(prefix, end):
+                    state["in_thinking"] = False
+                    state["thinking_count"] = 0
+                else:
+                    state["thinking_count"] += 1
+                    if state["thinking_count"] >= budget:
+                        state["forcing"] = True
+                        state["force_idx"] = 0
+                        forced_id = stop[state["force_idx"]]
+                        state["force_idx"] += 1
+                        if state["force_idx"] >= len(stop):
+                            state["forcing"] = False
+                            state["force_idx"] = 0
+                            state["in_thinking"] = False
+                            state["thinking_count"] = 0
+                        return _force_logits(logits, forced_id)
+
+        return logits
+
+    return thinking_budget_processor

--- a/mlx_lm/sample_utils.py
+++ b/mlx_lm/sample_utils.py
@@ -81,6 +81,7 @@ def make_logits_processors(
     think_start_tokens: Optional[tuple] = None,
     think_end_tokens: Optional[tuple] = None,
     early_stop_tokens: Optional[mx.array] = None,
+    initial_thinking: bool = False,
 ):
     """
     Make logits processors for use with ``generate_step``.
@@ -139,6 +140,7 @@ def make_logits_processors(
                 think_end_tokens=think_end_tokens,
                 budget=thinking_budget,
                 early_stop_tokens=early_stop_tokens,
+                initial_thinking=initial_thinking,
             )
         )
 
@@ -411,6 +413,7 @@ def make_thinking_budget_processor(
     think_end_tokens: tuple,
     budget: int,
     early_stop_tokens: mx.array,
+    initial_thinking: bool = False,
 ) -> Callable[[mx.array, mx.array], mx.array]:
     """
     Make a logits processor that enforces a thinking token budget.
@@ -432,6 +435,10 @@ def make_thinking_budget_processor(
             early-stop injection begins.  Must be >= 0.
         early_stop_tokens (mx.array): 1-D array of token IDs to inject when
             the budget is exceeded.
+        initial_thinking (bool): If True, start in thinking state.  Use this
+            when the prompt already contains an opening ``<think>`` tag (e.g.
+            from a chat template with ``enable_thinking=True``).  Default:
+            ``False``.
 
     Returns:
         Callable[[mx.array, mx.array], mx.array]:
@@ -442,7 +449,7 @@ def make_thinking_budget_processor(
         raise ValueError(f"budget must be >= 0, got {budget}")
 
     state = {
-        "in_thinking": False,
+        "in_thinking": initial_thinking,
         "thinking_count": 0,
         "forcing": False,
         "force_idx": 0,

--- a/mlx_lm/sample_utils.py
+++ b/mlx_lm/sample_utils.py
@@ -77,6 +77,10 @@ def make_logits_processors(
     presence_context_size: Optional[int] = 20,
     frequency_penalty: Optional[float] = None,
     frequency_context_size: Optional[int] = 20,
+    thinking_budget: Optional[int] = None,
+    think_start_tokens: Optional[tuple] = None,
+    think_end_tokens: Optional[tuple] = None,
+    early_stop_tokens: Optional[mx.array] = None,
 ):
     """
     Make logits processors for use with ``generate_step``.
@@ -122,6 +126,21 @@ def make_logits_processors(
     for make_penalty, penalty, context_size in repetition_penalties:
         if penalty is not None and penalty != 0:
             logits_processors.append(make_penalty(penalty, context_size))
+
+    if (
+        thinking_budget is not None
+        and think_start_tokens is not None
+        and think_end_tokens is not None
+        and early_stop_tokens is not None
+    ):
+        logits_processors.append(
+            make_thinking_budget_processor(
+                think_start_tokens=think_start_tokens,
+                think_end_tokens=think_end_tokens,
+                budget=thinking_budget,
+                early_stop_tokens=early_stop_tokens,
+            )
+        )
 
     return logits_processors
 

--- a/mlx_lm/sample_utils.py
+++ b/mlx_lm/sample_utils.py
@@ -386,6 +386,26 @@ def make_frequency_penalty(penalty: float, context_size: int = 20):
     return frequency_penalty_processor
 
 
+_DEFAULT_EARLY_STOP_MESSAGE = (
+    "\n\nI need to provide my answer now based on my reasoning so far.\n"
+)
+
+
+def build_early_stop_tokens(
+    tokenizer,
+    think_end_tokens: tuple,
+    message: Optional[str] = None,
+) -> mx.array:
+    """Build the early-stopping injection token sequence.
+
+    Tokenizes the transition message and appends the think-end tokens.
+    """
+    if message is None:
+        message = _DEFAULT_EARLY_STOP_MESSAGE
+    msg_tokens = tokenizer.encode(message, add_special_tokens=False)
+    return mx.array(list(msg_tokens) + list(think_end_tokens))
+
+
 def make_thinking_budget_processor(
     think_start_tokens: tuple,
     think_end_tokens: tuple,

--- a/mlx_lm/server.py
+++ b/mlx_lm/server.py
@@ -193,6 +193,9 @@ class GenerationArguments:
     seed: Optional[int]
     chat_template_kwargs: Optional[Dict[str, Any]]
 
+    thinking_budget: Optional[int] = None
+    thinking_budget_message: Optional[str] = None
+
 
 @dataclass
 class CompletionRequest:
@@ -411,16 +414,29 @@ def _make_sampler(args, tokenizer):
     )
 
 
-def _make_logits_processors(args):
-    return make_logits_processors(
-        args.logits.logit_bias,
-        args.logits.repetition_penalty,
-        args.logits.repetition_context_size,
-        args.logits.presence_penalty,
-        args.logits.presence_context_size,
-        args.logits.frequency_penalty,
-        args.logits.frequency_context_size,
+def _make_logits_processors(args, tokenizer=None):
+    kwargs = dict(
+        logit_bias=args.logits.logit_bias,
+        repetition_penalty=args.logits.repetition_penalty,
+        repetition_context_size=args.logits.repetition_context_size,
+        presence_penalty=args.logits.presence_penalty,
+        presence_context_size=args.logits.presence_context_size,
+        frequency_penalty=args.logits.frequency_penalty,
+        frequency_context_size=args.logits.frequency_context_size,
     )
+    thinking_budget = getattr(args, "thinking_budget", None)
+    if thinking_budget is not None and tokenizer is not None and tokenizer.has_thinking:
+        from mlx_lm.sample_utils import build_early_stop_tokens
+
+        kwargs["thinking_budget"] = thinking_budget
+        kwargs["think_start_tokens"] = tokenizer.think_start_tokens
+        kwargs["think_end_tokens"] = tokenizer.think_end_tokens
+        kwargs["early_stop_tokens"] = build_early_stop_tokens(
+            tokenizer,
+            tokenizer.think_end_tokens,
+            getattr(args, "thinking_budget_message", None),
+        )
+    return make_logits_processors(**kwargs)
 
 
 def _format_top_logprobs(logprobs, top_n, tokenizer) -> Tuple[Dict[str, Any]]:
@@ -779,7 +795,7 @@ class ResponseGenerator:
                         caches=[cache],
                         all_tokens=[prompt[:prompt_cache_count]],
                         samplers=[_make_sampler(args, tokenizer)],
-                        logits_processors=[_make_logits_processors(args)],
+                        logits_processors=[_make_logits_processors(args, tokenizer)],
                         state_machines=[sm],
                     )
                     batch_results[uid] = {
@@ -958,7 +974,7 @@ class ResponseGenerator:
 
             # Make the sampler and logit processor
             sampler = _make_sampler(args, tokenizer)
-            logits_processors = _make_logits_processors(args)
+            logits_processors = _make_logits_processors(args, tokenizer)
 
             # Load the KV cache
             self._log_cache_stats()
@@ -1190,6 +1206,8 @@ class APIHandler(BaseHTTPRequestHandler):
         self.top_logprobs = self.body.get("top_logprobs", -1)
         self.seed = self.body.get("seed", None)
         self.chat_template_kwargs = self.body.get("chat_template_kwargs")
+        self.thinking_budget = self.body.get("thinking_budget", None)
+        self.thinking_budget_message = self.body.get("thinking_budget_message", None)
         self.validate_model_parameters()
 
         # Get stop sequences
@@ -1403,6 +1421,8 @@ class APIHandler(BaseHTTPRequestHandler):
             top_logprobs=self.top_logprobs,
             seed=self.seed,
             chat_template_kwargs=self.chat_template_kwargs,
+            thinking_budget=self.thinking_budget,
+            thinking_budget_message=self.thinking_budget_message,
         )
 
         # Keep connection allive during long prompt processing (and also log

--- a/mlx_lm/server.py
+++ b/mlx_lm/server.py
@@ -436,6 +436,14 @@ def _make_logits_processors(args, tokenizer=None):
             tokenizer.think_end_tokens,
             getattr(args, "thinking_budget_message", None),
         )
+        # Detect if the prompt already opened a thinking block (e.g. chat
+        # template with enable_thinking=True adds <think> to the prompt).
+        prompt_tokens = getattr(args, "prompt_tokens", None)
+        if prompt_tokens is not None:
+            think_start = tokenizer.rfind_think_start(prompt_tokens)
+            think_end = tokenizer.rfind_think_end(prompt_tokens)
+            if think_start > think_end:
+                kwargs["initial_thinking"] = True
     return make_logits_processors(**kwargs)
 
 

--- a/tests/test_thinking_budget.py
+++ b/tests/test_thinking_budget.py
@@ -145,5 +145,49 @@ class TestThinkingBudgetProcessor(unittest.TestCase):
         self.assertTrue(mx.array_equal(result, logits))
 
 
+class TestMakeLogitsProcessors(unittest.TestCase):
+
+    def test_thinking_budget_creates_processor(self):
+        from mlx_lm.sample_utils import make_logits_processors
+        processors = make_logits_processors(
+            thinking_budget=100,
+            think_start_tokens=(100,),
+            think_end_tokens=(101,),
+            early_stop_tokens=mx.array([50, 51, 101]),
+        )
+        self.assertEqual(len(processors), 1)
+
+    def test_thinking_budget_none_skips(self):
+        from mlx_lm.sample_utils import make_logits_processors
+        processors = make_logits_processors()
+        self.assertEqual(len(processors), 0)
+
+
+class TestEarlyStopPromptBuilder(unittest.TestCase):
+
+    def test_build_default_message(self):
+        from mlx_lm.sample_utils import build_early_stop_tokens
+
+        class MockTokenizer:
+            def encode(self, text, add_special_tokens=False):
+                return [200 + i for i in range(len(text.split()))]
+
+        result = build_early_stop_tokens(MockTokenizer(), (101,))
+        self.assertIsInstance(result, mx.array)
+        self.assertEqual(result[-1].item(), 101)
+        self.assertGreater(len(result), 1)
+
+    def test_build_custom_message(self):
+        from mlx_lm.sample_utils import build_early_stop_tokens
+
+        class MockTokenizer:
+            def encode(self, text, add_special_tokens=False):
+                return [300, 301]
+
+        result = build_early_stop_tokens(MockTokenizer(), (101,), message="Stop now.")
+        self.assertEqual(len(result), 3)  # 300, 301, 101
+        self.assertEqual(result[-1].item(), 101)
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_thinking_budget.py
+++ b/tests/test_thinking_budget.py
@@ -1,0 +1,149 @@
+# Copyright © 2023-2024 Apple Inc.
+
+import unittest
+
+import mlx.core as mx
+
+from mlx_lm.sample_utils import make_thinking_budget_processor
+
+# Token IDs used throughout all tests
+THINK_START = (1,)  # <think>
+THINK_END = (2,)  # </think>
+STOP_TOKENS = mx.array([2, 3])  # early-stop injection: </think> then \n
+VOCAB = 10
+
+
+def _logits():
+    """Uniform logits over VOCAB tokens, shape (1, VOCAB)."""
+    return mx.ones((1, VOCAB))
+
+
+class TestThinkingBudgetProcessor(unittest.TestCase):
+
+    # ------------------------------------------------------------------
+    # 1. Passthrough when not in thinking state
+    # ------------------------------------------------------------------
+    def test_passthrough_not_in_thinking(self):
+        proc = make_thinking_budget_processor(THINK_START, THINK_END, 5, STOP_TOKENS)
+        # No tokens generated yet; never entered thinking state.
+        tokens = mx.array([])
+        logits = _logits()
+        result = proc(tokens, logits)
+        self.assertTrue(mx.array_equal(result, logits))
+
+    # ------------------------------------------------------------------
+    # 2. Passthrough during thinking below budget
+    # ------------------------------------------------------------------
+    def test_passthrough_below_budget(self):
+        proc = make_thinking_budget_processor(THINK_START, THINK_END, 5, STOP_TOKENS)
+        # Enter thinking, generate 3 tokens (budget=5, so still under)
+        base = [THINK_START[0], 10, 20, 30]
+        for i, tok in enumerate(base):
+            tokens = mx.array(base[: i + 1])
+            logits = _logits()
+            result = proc(tokens, logits)
+            self.assertTrue(mx.array_equal(result, logits))
+
+    # ------------------------------------------------------------------
+    # 3. Forces first injection token when budget reached
+    # ------------------------------------------------------------------
+    def test_forces_first_token_at_budget(self):
+        proc = make_thinking_budget_processor(THINK_START, THINK_END, 3, STOP_TOKENS)
+        # Pump: <think> + 3 thinking tokens (budget=3, now exhausted)
+        seq = [THINK_START[0], 10, 20, 30]
+        for i in range(len(seq)):
+            tokens = mx.array(seq[: i + 1])
+            logits = _logits()
+            result = proc(tokens, logits)
+
+        # Last call should have forced STOP_TOKENS[0]
+        forced_id = STOP_TOKENS[0].item()
+        self.assertAlmostEqual(result[0, forced_id].item(), 0.0)
+        # Every other token should be -inf
+        for v in range(VOCAB):
+            if v != forced_id:
+                self.assertEqual(result[0, v].item(), float("-inf"))
+
+    # ------------------------------------------------------------------
+    # 4. Forces full injection sequence across calls
+    # ------------------------------------------------------------------
+    def test_forces_full_sequence(self):
+        proc = make_thinking_budget_processor(THINK_START, THINK_END, 2, STOP_TOKENS)
+        # <think> + 2 thinking tokens exhausts the budget.
+        # The call that hits the budget itself returns the first forced logit.
+        seq = [THINK_START[0], 10, 20]
+        forced_results = []
+        for i in range(len(seq)):
+            tokens = mx.array(seq[: i + 1])
+            result = proc(tokens, _logits())
+            if i == len(seq) - 1:
+                # Last pump call triggered forcing; capture its result.
+                forced_results.append(result)
+
+        # Subsequent calls with forced tokens appended should force the rest.
+        stop = STOP_TOKENS.tolist()
+        for call_idx in range(1, len(stop)):
+            tokens = mx.array(seq + stop[:call_idx])
+            result = proc(tokens, _logits())
+            forced_results.append(result)
+
+        # Each call_idx should have forced STOP_TOKENS[call_idx].
+        for call_idx, forced_id in enumerate(stop):
+            r = forced_results[call_idx]
+            self.assertAlmostEqual(r[0, forced_id].item(), 0.0)
+            for v in range(VOCAB):
+                if v != forced_id:
+                    self.assertEqual(r[0, v].item(), float("-inf"))
+
+    # ------------------------------------------------------------------
+    # 5. Returns to passthrough after injection complete
+    # ------------------------------------------------------------------
+    def test_passthrough_after_injection(self):
+        proc = make_thinking_budget_processor(THINK_START, THINK_END, 2, STOP_TOKENS)
+        seq = [THINK_START[0], 10, 20]
+        # Exhaust budget
+        for i in range(len(seq)):
+            proc(mx.array(seq[: i + 1]), _logits())
+        # Drain the injection sequence
+        injected = seq + STOP_TOKENS.tolist()
+        for i in range(len(STOP_TOKENS)):
+            proc(mx.array(injected[: len(seq) + i]), _logits())
+        # After injection, logits should pass through unmodified
+        full = mx.array(injected)
+        logits = _logits()
+        result = proc(full, logits)
+        self.assertTrue(mx.array_equal(result, logits))
+
+    # ------------------------------------------------------------------
+    # 6. No intervention without any thinking tokens
+    # ------------------------------------------------------------------
+    def test_no_intervention_without_think_start(self):
+        proc = make_thinking_budget_processor(THINK_START, THINK_END, 2, STOP_TOKENS)
+        # Generate many tokens, never entering thinking state
+        tokens = mx.array([5, 6, 7, 8, 9, 10, 11])
+        logits = _logits()
+        result = proc(tokens, logits)
+        self.assertTrue(mx.array_equal(result, logits))
+
+    # ------------------------------------------------------------------
+    # 7. Natural think_end resets count (no intervention)
+    # ------------------------------------------------------------------
+    def test_natural_end_resets_no_intervention(self):
+        proc = make_thinking_budget_processor(THINK_START, THINK_END, 10, STOP_TOKENS)
+        # Enter thinking, generate 3 tokens, then close naturally
+        seq = [THINK_START[0], 10, 20, 30, THINK_END[0]]
+        for i in range(len(seq)):
+            tokens = mx.array(seq[: i + 1])
+            logits = _logits()
+            result = proc(tokens, logits)
+            # No token should be masked
+            self.assertTrue(mx.array_equal(result, logits))
+        # After </think>, we are no longer in thinking state
+        tokens = mx.array(seq + [99])
+        logits = _logits()
+        result = proc(tokens, logits)
+        self.assertTrue(mx.array_equal(result, logits))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

Adds `thinking_budget` support using Qwen's recommended early-stopping prompt injection. When thinking tokens exceed the budget, the processor forces a transition prompt token-by-token through the model's forward pass, so the model reads the injection through full attention and transitions to content from a coherent hidden state.

- `make_thinking_budget_processor()` in `sample_utils.py` -- stateful logits processor
- `build_early_stop_tokens()` -- tokenizes transition message + think-end tokens
- `make_logits_processors()` -- wired with `thinking_budget` params
- Server accepts `thinking_budget` and `thinking_budget_message` from chat completion requests
- `initial_thinking` detects when the prompt already opened a `<think>` block

## Why this approach

The existing approaches in vLLM and llama.cpp force `</think>` via logit manipulation, but the model's hidden state never processes the transition -- it generates content from an incomplete thought state. Qwen's official recommendation for open-source inference is to inject a natural-language prompt that the model reads through attention, producing a coherent transition.

Each forced token goes through `generate_step`'s normal `_step()` call, which runs the full model forward pass and updates the KV cache. The model "reads" the injection the same way it reads any other token.

## Validated on

**Qwen3-1.7B-MLX-8bit (budget=50):**
- Thinking: model reasons about Rayleigh scattering
- Injection: "I need to provide my answer now based on my reasoning so far."
- Content: 2051 chars, coherent physics explanation with headers and sections

**Qwen3.5-2B-OptiQ-4bit (budget=50, MoE architecture):**
- Thinking: 249 chars of analysis and planning
- Content: 1908 chars, structured explanation with numbered sections

Both produce well-structured content after the injection. The `initial_thinking=True` fix handles chat templates that place `<think>` in the prompt.

## API

```python
# Direct usage
from mlx_lm.sample_utils import make_thinking_budget_processor, build_early_stop_tokens

early_stop = build_early_stop_tokens(tokenizer, tokenizer.think_end_tokens)
processor = make_thinking_budget_processor(
    think_start_tokens=tokenizer.think_start_tokens,
    think_end_tokens=tokenizer.think_end_tokens,
    budget=100,
    early_stop_tokens=early_stop,
    initial_thinking=True,
)
result = generate(model, tokenizer, prompt, logits_processors=[processor])

# Via server (chat completion request body)
{"thinking_budget": 100, "thinking_budget_message": "Summarize and answer now."}
```

## Test plan

- 11 unit tests covering passthrough, budget enforcement, full injection sequence, post-injection reset, natural end-of-thinking, and assembly function
- Integration on Qwen3 1.7B and Qwen3.5 2B
- `python -m pytest tests/test_thinking_budget.py -v`

Related: #914 (partial -- adds budget control), #1175 (MTP stale prev_tokens affects all stateful logits processors; fix suggested on #990)