### PR TITLE
fix: prevent double-shift of norm weights for converted VLM checkpoints

### DIFF
--- a/mlx_lm/models/qwen3_5.py
+++ b/mlx_lm/models/qwen3_5.py
@@ -322,6 +322,17 @@ class TextModel(nn.Module):
             ".q_norm.weight",
             ".k_norm.weight",
         )
+
+        # Check if norm weights are already shifted.  Zero-centered weights
+        # (from HuggingFace checkpoints) have mean near 0; converted MLX
+        # checkpoints have already been shifted to mean near 1.  Applying
+        # +1.0 twice corrupts every norm layer in the model.
+        if should_shift_norm_weights:
+            for k, v in weights.items():
+                if v.ndim == 1 and any(k.endswith(sfx) for sfx in norm_keys):
+                    should_shift_norm_weights = mx.abs(mx.mean(v)).item() < 0.5
+                    break
+
         for k, v in weights.items():
             if "conv1d.weight" in k and v.shape[-1] != 1:
                 weights[k] = v.moveaxis(2, 1)


### PR DESCRIPTION
## Problem

`load()` produces garbage output for VLM model checkpoints (e.g. Qwen3.6-35B-A3B-VLM-MTP-8bit) while non-VLM checkpoints of the same architecture work correctly.

## Root cause

`TextModel.sanitize()` adds +1.0 to RMS norm weights when MTP or unsanitized conv1d weights are present (converting zero-centered gamma from HuggingFace format to standard RMS norm). VLM checkpoints contain MTP weight keys, which triggers the shift. But MLX-converted checkpoints already have the shift applied during conversion. The double-shift makes norm weights ~2.0 instead of ~1.0, corrupting every norm layer in the model.

## Fix

Sample the first norm weight before applying the shift. If the mean is near 1.0, the weights are already in standard format. Only apply +1.0 when the weights are actually zero-centered (mean near 0.0).

## Validated

**Before fix:** Qwen3.6-35B-A3B-VLM-MTP-8bit produces incoherent garbage
**After fix:** Same model produces coherent output

```
Thinking: 559 chars of structured reasoning
Content: "2+2 equals 4."
```

Non-VLM models (Qwen3-1.7B, Qwen3.5-2B) continue to work correctly (norm weights are not affected because they have no MTP keys).

Refs #1197
