### PR TITLE
Add dense `qwen3_5` support for learned quantization

### DIFF
--- a/mlx_lm/LEARNED_QUANTS.md
+++ b/mlx_lm/LEARNED_QUANTS.md
@@ -40,6 +40,9 @@ Some important options, along with their default values are:
 - `--num-samples 1024`: Number of samples to use. Using more samples can lead to
   better results but takes longer.
 - `--batch-size 8`: Use a smaller batch size to reduce the memory footprint.
+- `--kl-loss-impl auto`: Select the KL loss implementation. `auto` uses the
+  Metal kernel when available and falls back to the MLX implementation when the
+  kernel cannot be used. Use `mlx` to force the fallback implementation.
 
 For a full list of options run:
 
@@ -69,9 +72,16 @@ A few options to reduce memory use for DWQ:
 
 - Distill from an 8-bit model instead of a 16-bit model. The 8-bit
   models are usually as good as 16-bit precision models.
-- Use a shorter maximum sequence length. The default is 2048. Using
+- Use a shorter maximum sequence length. For example,
   `--max-seq-length 512` reduces the memory and still gets good results.
 - Use a smaller batch size, e.g. `--batch-size 1`
+- If you use `--target-dir`, targets are saved with metadata describing the
+  model, dataset, seed, batch size, number of samples, and sequence length. DWQ
+  validates this metadata before training and fails early if the current options
+  do not match the saved targets.
+- DWQ fails fast on non-finite training or validation losses and checks
+  model parameters before saving. This avoids silently writing checkpoints
+  from runs that have already diverged.
 
 ### Dynamic Quantization
 
@@ -95,6 +105,9 @@ Some important options are:
   parameters only certain ranges are possible. For example, with the default
   parameters a BPW in the range `[4.5, 5.5]` is achievable.
 - `--sensitivities`: A path to a precomputed sensitivities file.
+- `--num-samples`: Number of samples from the calibration data. Use a small
+  value to run a shorter calibration pass.
+- `--sequence-length`: Sequence length for the calibration data.
 - `--low-bits`: The number of bits to use for the less sensitive layers.
 - `--high-bits`: The number of bits to use for the more sensitive layers.
 
@@ -139,6 +152,15 @@ Some important options, along with their default values, are:
 
 - `--mlx-path mlx_model`: The location to save the AWQ model.
 - `--bits 4`: Precision of the quantization.
+
+### Qwen3.5
+
+The learned quantization tools support dense `qwen3_5` text models, including
+hybrid linear-attention/full-attention models such as Qwen/Qwen3.5-* and
+downstream fine-tunes. AWQ uses qwen3_5-specific layer traversal for
+`linear_attn`, `self_attn`, and dense MLP blocks. Dynamic quantization computes
+sensitivities through the differentiable qwen3_5 reference path instead of the
+inference-only gated-delta Metal kernel.
 
 
 ### Evaluate

--- a/mlx_lm/quant/awq.py
+++ b/mlx_lm/quant/awq.py
@@ -140,11 +140,53 @@ deepseek_v2_awq = AWQConfig(
     ],
 )
 
+
+def _is_linear_attention_block(block):
+    return getattr(block, "is_linear", False) and "linear_attn" in block
+
+
+def _is_full_attention_block(block):
+    return not getattr(block, "is_linear", False) and "self_attn" in block
+
+
+qwen3_5_text_awq = AWQConfig(
+    embed="embed_tokens",
+    lm_head="lm_head",
+    no_clip=["q_proj", "k_proj", "in_proj_qkv"],
+    scale_configs=[
+        ScaleConfig(
+            block="self_attn",
+            prev="input_layernorm",
+            layers=["q_proj", "k_proj", "v_proj"],
+            kwargs=["mask"],
+            use_config=_is_full_attention_block,
+        ),
+        ScaleConfig(
+            block="linear_attn",
+            prev="input_layernorm",
+            layers=["in_proj_qkv", "in_proj_z", "in_proj_b", "in_proj_a"],
+            kwargs=["mask"],
+            use_config=_is_linear_attention_block,
+        ),
+        ScaleConfig(
+            prev="mlp.up_proj",
+            layers=["mlp.down_proj"],
+        ),
+        ScaleConfig(
+            block="mlp",
+            prev="post_attention_layernorm",
+            layers=["gate_proj", "up_proj"],
+        ),
+    ],
+)
+
+
 AWQ_MODEL_CONFIGS = {
     "llama": llama_awq,
     "mistral": llama_awq,
     "qwen2": llama_awq,
     "qwen3": llama_awq,
+    "qwen3_5": update(qwen3_5_text_awq, lm_key="language_model"),
     "gemma3_text": gemma3_text_awq,
     "gemma3": update(gemma3_text_awq, lm_key="language_model"),
     "deepseek_v2": deepseek_v2_awq,
@@ -415,7 +457,7 @@ def awq_quantize(
         wq = mx.quantize(w, bits=bits, group_size=group_size)
         return mx.dequantize(*wq, bits=bits, group_size=group_size)
 
-    mask = create_attention_mask(inputs)
+    attention_mask = create_attention_mask(inputs)
 
     embed_key = awq_config.embed
     model.model[embed_key] = model.model[embed_key].to_quantized(
@@ -450,17 +492,20 @@ def awq_quantize(
         return Catcher()
 
     for e, block in enumerate(tqdm(model.layers)):
+        layer_kwargs = {
+            "mask": None if getattr(block, "is_linear", False) else attention_mask
+        }
         # Capture the input features for each of the layers in the transformer block
         orig_leaves = block.leaf_modules()
         capture_leaves = tree_map(capture, orig_leaves, is_leaf=nn.Module.is_module)
         block.update_modules(capture_leaves)
-        outputs = run_layer(block, inputs, mask=mask)
+        outputs = run_layer(block, inputs, **layer_kwargs)
         block.update_modules(orig_leaves)
         del capture_leaves
 
         # Quantize the block without AWQ to obtain a reference loss
         nn.quantize(block, group_size=group_size, bits=bits)
-        outputs_q = run_layer(block, inputs, mask=mask)
+        outputs_q = run_layer(block, inputs, **layer_kwargs)
         before_loss = mse(outputs, outputs_q).sum()
         if group is not None:
             before_loss = mx.distributed.all_sum(before_loss) / group.size()
@@ -473,7 +518,7 @@ def awq_quantize(
             configs=awq_config.scale_configs,
             quantize_func=quantize_func,
             n_grid=n_grid,
-            layer_kwargs={"mask": mask},
+            layer_kwargs=layer_kwargs,
         )
 
         clip_block(
@@ -486,7 +531,7 @@ def awq_quantize(
 
         # Quantize the scaled and clipped block
         nn.quantize(block, group_size=group_size, bits=bits)
-        outputs_q = run_layer(block, inputs, mask=mask)
+        outputs_q = run_layer(block, inputs, **layer_kwargs)
         after_loss = mse(outputs, outputs_q).sum()
         if group is not None:
             after_loss = mx.distributed.all_sum(after_loss) / group.size()

--- a/mlx_lm/quant/dwq.py
+++ b/mlx_lm/quant/dwq.py
@@ -2,15 +2,18 @@
 
 import argparse
 import copy
+import json
+import math
 import time
 import types
+from datetime import datetime, timezone
 from pathlib import Path
 
 import mlx.core as mx
 import mlx.nn as nn
 import mlx.optimizers as optimizers
 import numpy as np
-from mlx.utils import tree_map
+from mlx.utils import tree_flatten, tree_map
 from tqdm import tqdm
 
 from mlx_lm.tuner.datasets import load_dataset
@@ -25,6 +28,75 @@ from mlx_lm.utils import (
     save,
 )
 
+DWQ_TARGET_TOP_K = 1024
+DWQ_TARGET_METADATA = "metadata.json"
+
+
+def build_target_metadata(args, tokenizer, num_samples):
+    return {
+        "model": args.model,
+        "data_path": args.data_path,
+        "train_split": "train",
+        "valid_split": "train[:1]",
+        "num_samples": num_samples,
+        "max_seq_length": args.max_seq_length,
+        "batch_size": args.batch_size,
+        "seed": args.seed,
+        "top_k": DWQ_TARGET_TOP_K,
+        "created_at": datetime.now(timezone.utc).isoformat(),
+    }
+
+
+def save_target_metadata(target_dir, metadata):
+    with open(target_dir / DWQ_TARGET_METADATA, "w") as fid:
+        json.dump(metadata, fid, indent=2, sort_keys=True)
+        fid.write("\n")
+
+
+def validate_target_metadata(target_dir, expected):
+    metadata_file = target_dir / DWQ_TARGET_METADATA
+    if not metadata_file.exists():
+        raise ValueError(
+            f"Target directory {target_dir} is missing {DWQ_TARGET_METADATA}. "
+            "Regenerate targets with the current mlx_lm.dwq before training."
+        )
+    with open(metadata_file, "r") as fid:
+        actual = json.load(fid)
+
+    required_matches = (
+        "model",
+        "data_path",
+        "num_samples",
+        "max_seq_length",
+        "batch_size",
+        "seed",
+        "top_k",
+    )
+    for key in required_matches:
+        if actual.get(key) != expected.get(key):
+            raise ValueError(
+                f"Target directory was generated with {key}={actual.get(key)!r} "
+                f"but current run uses {key}={expected.get(key)!r}. Regenerate "
+                "targets or pass matching DWQ options."
+            )
+    return actual
+
+
+def _assert_finite_array(value, message):
+    mx.eval(value)
+    if not mx.all(mx.isfinite(value)).item():
+        raise FloatingPointError(message)
+
+
+def assert_finite_tree(tree, context):
+    for name, value in tree_flatten(tree):
+        if isinstance(value, mx.array):
+            _assert_finite_array(value, f"{context}: non-finite value in {name}.")
+
+
+def _assert_finite_loss(loss, message):
+    _assert_finite_array(loss, message)
+
 
 def compute_dwq_targets(
     model,
@@ -34,8 +106,12 @@ def compute_dwq_targets(
     batch_size,
     max_seq_length,
     seed,
+    metadata=None,
 ):
     rank = mx.distributed.init().rank()
+    if rank == 0 and metadata is not None:
+        save_dir.mkdir(parents=True, exist_ok=True)
+        save_target_metadata(save_dir, metadata)
 
     def _compute_targets(data, path, split):
 
@@ -56,7 +132,8 @@ def compute_dwq_targets(
             logits = mx.stop_gradient(logits, stream=mx.cpu)
             mx.eval(logits)
             if rank == 0:
-                idx = mx.argpartition(logits, kth=-1024, axis=-1)[..., -1024:]
+                top_k = min(DWQ_TARGET_TOP_K, logits.shape[-1])
+                idx = mx.argpartition(logits, kth=-top_k, axis=-1)[..., -top_k:]
                 logits = mx.take_along_axis(logits, idx, axis=-1)
 
                 file = path / f"{i:010d}.safetensors"
@@ -78,6 +155,7 @@ def dwq_quantize(
     dtype: mx.Dtype = mx.bfloat16,
     gradient_checkpoint: bool = False,
     temperature: float = 2.0,
+    kl_loss_impl: str = "auto",
 ):
     group = mx.distributed.init()
     world_size = group.size()
@@ -110,8 +188,28 @@ def dwq_quantize(
         logits = model(x)
         if isinstance(targets, tuple):
             targets, ids = targets
+            if logits.shape[:2] != targets.shape[:2]:
+                raise ValueError(
+                    "DWQ target shape mismatch: model logits have token shape "
+                    f"{logits.shape[:2]} but targets have token shape "
+                    f"{targets.shape[:2]}. Regenerate target-dir with matching "
+                    "max_seq_length, batch_size, and dataset options."
+                )
+            if ids.shape != targets.shape:
+                raise ValueError(
+                    "DWQ target indices shape mismatch: indices have shape "
+                    f"{ids.shape} but targets have shape {targets.shape}."
+                )
             logits = mx.take_along_axis(logits, ids, axis=-1)
-        losses = kl_div_loss(scale * logits, scale * targets)
+        elif logits.shape[:2] != targets.shape[:2]:
+            raise ValueError(
+                "DWQ target shape mismatch: model logits have token shape "
+                f"{logits.shape[:2]} but targets have token shape "
+                f"{targets.shape[:2]}."
+            )
+        losses = kl_div_loss(
+            scale * logits, scale * targets, implementation=kl_loss_impl
+        )
         mask = mx.arange(1, 1 + targets.shape[1]) < lengths[:, 1:]
         ntoks = mask.sum()
         loss = (mask * losses).sum() / ntoks
@@ -141,11 +239,23 @@ def dwq_quantize(
             mx.eval(targets)
             loss, ntoks = loss_fn(params, batch, targets, lengths)
             mx.eval(loss, ntoks)
+            _assert_finite_loss(
+                loss,
+                "DWQ produced non-finite validation loss at "
+                f"iteration {it}, validation batch {i}. This usually indicates "
+                "incompatible targets, unstable KL loss, or invalid calibration data.",
+            )
             loss = mx.distributed.all_sum(loss, stream=mx.cpu).item() / world_size
             ntoks = mx.distributed.all_sum(ntoks, stream=mx.cpu).item()
             v_tokens += ntoks
             v_loss += loss * ntoks
         loss = v_loss / v_tokens
+        if not math.isfinite(loss):
+            raise FloatingPointError(
+                f"DWQ produced non-finite validation loss at iteration {it}. "
+                "Regenerate target-dir with matching options or try "
+                "--kl-loss-impl mlx."
+            )
         rprint(f"Validation: {it=}, {loss=:.3f}")
         return loss
 
@@ -177,7 +287,22 @@ def dwq_quantize(
         mx.eval(targets)
         loss, ntoks, params = step(batch, targets, lengths, params)
         mx.eval(loss, params)
+        _assert_finite_loss(
+            loss,
+            f"DWQ produced non-finite training loss at iteration {it}. "
+            "This usually indicates incompatible targets, unstable KL loss, "
+            "or invalid calibration data. Try regenerating target-dir with "
+            "matching options or use --kl-loss-impl mlx.",
+        )
+        assert_finite_tree(
+            params,
+            f"DWQ trainable parameters became non-finite at iteration {it}",
+        )
         loss = mx.distributed.all_sum(loss, stream=mx.cpu).item() / world_size
+        if not math.isfinite(loss):
+            raise FloatingPointError(
+                f"DWQ produced non-finite distributed training loss at iteration {it}."
+            )
         ntoks = mx.distributed.all_sum(ntoks, stream=mx.cpu).item()
         tokens += ntoks
         total_loss += loss * ntoks
@@ -206,7 +331,12 @@ def dwq_quantize(
             " Model quality will likely be degraded.\n❌❌❌"
         )
 
+    assert_finite_tree(params, "DWQ final trainable parameters are non-finite")
     model.update(tree_map(lambda x: x.astype(dtype), params))
+    assert_finite_tree(
+        model.parameters(),
+        "DWQ final saved parameters are non-finite",
+    )
 
 
 def load_data(
@@ -290,6 +420,12 @@ def main():
         help="Use gradient checkpointing to reduce memory use.",
     )
     parser.add_argument(
+        "--kl-loss-impl",
+        choices=["auto", "metal", "mlx"],
+        default="auto",
+        help="KL loss implementation for DWQ training.",
+    )
+    parser.add_argument(
         "--target-dir", type=str, default=None, help="Directory to save/load targets."
     )
     parser.add_argument(
@@ -324,10 +460,17 @@ def main():
         target_dir = None
 
     tokenizer = load_tokenizer(args.model)
+    expected_target_metadata = build_target_metadata(args, tokenizer, num_samples)
 
     train_data, valid_data = load_data(
-        tokenizer, args.data_path, args.num_samples, args.max_seq_length
+        tokenizer,
+        args.data_path,
+        num_samples,
+        args.max_seq_length,
     )
+
+    if has_targets:
+        validate_target_metadata(target_dir, expected_target_metadata)
 
     # Load the base model if we need it
     if not has_targets or args.quantized_model is None:
@@ -348,6 +491,7 @@ def main():
             batch_size=args.batch_size,
             max_seq_length=args.max_seq_length,
             seed=args.seed,
+            metadata=expected_target_metadata,
         )
         has_targets = True
 
@@ -401,6 +545,7 @@ def main():
         max_seq_length=args.max_seq_length,
         seed=args.seed,
         gradient_checkpoint=args.grad_checkpoint,
+        kl_loss_impl=args.kl_loss_impl,
     )
     save(
         args.mlx_path,

--- a/mlx_lm/quant/dynamic_quant.py
+++ b/mlx_lm/quant/dynamic_quant.py
@@ -22,6 +22,13 @@ from mlx_lm.utils import (
 )
 
 
+def _uses_qwen3_5_linear_attention(model):
+    return any(
+        getattr(layer, "is_linear", False) and "linear_attn" in layer
+        for layer in getattr(model, "layers", [])
+    )
+
+
 def eval_ppl(model, data, batch_size=8):
     all_loss = 0.0
     ntoks = 0
@@ -61,6 +68,8 @@ def estimate_sensitivities(
         l.unfreeze(keys=["weight"])
     q_model.freeze()
     q_model.update_modules(tree_unflatten(list(q_layers.items())))
+    if _uses_qwen3_5_linear_attention(q_model):
+        q_model.train()
 
     def loss_fn(batch, targets):
         return kl_div_loss(q_model(batch), targets).mean()
@@ -167,6 +176,18 @@ def main():
     parser.add_argument("--high-bits", type=int, default=5)
     parser.add_argument("--high-group-size", type=int, default=64)
     parser.add_argument(
+        "--num-samples",
+        type=int,
+        default=-1,
+        help="Number of samples from the calibration dataset, use -1 for all.",
+    )
+    parser.add_argument(
+        "--sequence-length",
+        type=int,
+        default=512,
+        help="Sequence length for the calibration data.",
+    )
+    parser.add_argument(
         "--report-ppl",
         action="store_true",
         help="Compute the perplexity of the base and quantized models.",
@@ -189,7 +210,11 @@ def main():
 
     if args.sensitivities is None:
         mx.random.seed(args.seed)
-        data = load_data(tokenizer, num_samples=-1, sequence_length=512)
+        data = load_data(
+            tokenizer,
+            num_samples=args.num_samples,
+            sequence_length=args.sequence_length,
+        )
 
         sensitivities = estimate_sensitivities(
             model,
@@ -210,7 +235,11 @@ def main():
 
     sensitivities = dict(sensitivities)
     mx.random.seed(args.seed)
-    data = load_data(tokenizer, num_samples=-1, sequence_length=512)
+    data = load_data(
+        tokenizer,
+        num_samples=args.num_samples,
+        sequence_length=args.sequence_length,
+    )
 
     if args.report_ppl:
         ppl = eval_ppl(model, data)

--- a/mlx_lm/tuner/losses.py
+++ b/mlx_lm/tuner/losses.py
@@ -374,16 +374,49 @@ def _kl_div_loss(primals, cotangent, output):
     return dq, dp
 
 
-def kl_div_loss(logits_q, logits_p):
-    if can_run_metal():
-        return _kl_div_loss(logits_q, logits_p)
-    else:
-        return nn.losses.kl_div_loss(
-            logits_q - mx.logsumexp(logits_q, axis=-1, keepdims=True),
-            logits_p - mx.logsumexp(logits_p, axis=-1, keepdims=True),
-            axis=-1,
-            reduction="none",
+def _mlx_kl_div_loss(logits_q, logits_p):
+    return nn.losses.kl_div_loss(
+        logits_q - mx.logsumexp(logits_q, axis=-1, keepdims=True),
+        logits_p - mx.logsumexp(logits_p, axis=-1, keepdims=True),
+        axis=-1,
+        reduction="none",
+    )
+
+
+_metal_kl_usable = {}
+
+
+def _can_run_metal_kl(logits):
+    if not can_run_metal() or _kl_forward_kernel is None or _kl_backward_kernel is None:
+        return False
+    key = (logits.dtype, logits.shape[-1])
+    if key not in _metal_kl_usable:
+        try:
+            test_logits = mx.zeros((1, logits.shape[-1]), dtype=logits.dtype)
+            mx.eval(_kl_div_loss(test_logits, test_logits))
+            _metal_kl_usable[key] = True
+        except ValueError:
+            _metal_kl_usable[key] = False
+    return _metal_kl_usable[key]
+
+
+def kl_div_loss(logits_q, logits_p, implementation="auto"):
+    if implementation not in ("auto", "metal", "mlx"):
+        raise ValueError(
+            "KL loss implementation must be one of 'auto', 'metal', or 'mlx'."
         )
+
+    if implementation == "mlx":
+        return _mlx_kl_div_loss(logits_q, logits_p)
+
+    if implementation == "metal":
+        if not can_run_metal():
+            raise ValueError("Metal KL loss requested but Metal is not available.")
+        return _kl_div_loss(logits_q, logits_p)
+
+    if _can_run_metal_kl(logits_q):
+        return _kl_div_loss(logits_q, logits_p)
+    return _mlx_kl_div_loss(logits_q, logits_p)
 
 
 def _make_js_forward_kernel():

--- a/tests/test_losses.py
+++ b/tests/test_losses.py
@@ -49,6 +49,32 @@ class TestLosses(unittest.TestCase):
 
         self.assertTrue(mx.allclose(vjp_q, expected))
 
+    def test_kl_div_loss_mlx_implementation(self):
+        mx.random.seed(0)
+
+        logits_q = mx.random.normal((2, 4, 128))
+        logits_p = mx.random.normal((2, 4, 128))
+
+        kl = kl_div_loss(logits_q, logits_p, implementation="mlx")
+
+        self.assertEqual(kl.shape, logits_q.shape[:-1])
+        self.assertTrue(mx.all(mx.isfinite(kl)).item())
+
+    def test_kl_div_loss_auto_large_bfloat16_vocab(self):
+        logits_q = mx.zeros((1, 248320), dtype=mx.bfloat16)
+        logits_p = mx.zeros((1, 248320), dtype=mx.bfloat16)
+
+        kl = kl_div_loss(logits_q, logits_p, implementation="auto")
+
+        self.assertEqual(kl.shape, logits_q.shape[:-1])
+        self.assertTrue(mx.all(mx.isfinite(kl)).item())
+
+    def test_kl_div_loss_rejects_unknown_implementation(self):
+        logits = mx.zeros((1, 4))
+
+        with self.assertRaisesRegex(ValueError, "auto.*metal.*mlx"):
+            kl_div_loss(logits, logits, implementation="fastest")
+
     def test_js_div_loss_vjp(self):
         self.assertTrue(can_run_metal())
         mx.random.seed(0)

--- a/tests/test_quantization.py
+++ b/tests/test_quantization.py
@@ -1,0 +1,144 @@
+# Copyright © 2026 Apple Inc.
+
+import tempfile
+import types
+import unittest
+from pathlib import Path
+
+import mlx.core as mx
+
+from mlx_lm.models import qwen3_5
+from mlx_lm.quant.awq import AWQ_MODEL_CONFIGS, awq_quantize
+from mlx_lm.quant.dwq import (
+    build_target_metadata,
+    compute_dwq_targets,
+    save_target_metadata,
+    validate_target_metadata,
+)
+from mlx_lm.quant.dynamic_quant import estimate_sensitivities
+
+
+class DummyTokenizer:
+    def __init__(self):
+        self._tokenizer = types.SimpleNamespace(init_kwargs={"name": "dummy"})
+        self.eos_token_id = 0
+
+    def encode(self, text):
+        return [min(ord(c), 127) for c in text]
+
+
+class SmallVocabTeacher:
+    def __call__(self, x):
+        return mx.zeros((*x.shape, 16), dtype=mx.float32)
+
+
+def tiny_qwen3_5_model():
+    args = qwen3_5.ModelArgs.from_dict(
+        {
+            "model_type": "qwen3_5",
+            "text_config": {
+                "model_type": "qwen3_5_text",
+                "hidden_size": 64,
+                "intermediate_size": 128,
+                "num_hidden_layers": 4,
+                "num_attention_heads": 2,
+                "num_key_value_heads": 1,
+                "head_dim": 32,
+                "vocab_size": 128,
+                "linear_num_value_heads": 2,
+                "linear_num_key_heads": 1,
+                "linear_key_head_dim": 32,
+                "linear_value_head_dim": 32,
+                "linear_conv_kernel_dim": 4,
+                "full_attention_interval": 4,
+                "tie_word_embeddings": False,
+                "max_position_embeddings": 64,
+            },
+        }
+    )
+    return qwen3_5.Model(args)
+
+
+class TestQuantization(unittest.TestCase):
+    def test_awq_supports_qwen3_5_hybrid_layers(self):
+        model = tiny_qwen3_5_model()
+        inputs = mx.array([[1, 2, 3, 4, 5, 6, 7, 8]], dtype=mx.int32)
+
+        awq_quantize(
+            model,
+            inputs,
+            AWQ_MODEL_CONFIGS["qwen3_5"],
+            group_size=32,
+            bits=4,
+            embed_group_size=32,
+            embed_bits=4,
+            n_grid=1,
+        )
+        logits = model(inputs)
+        mx.eval(logits)
+
+        self.assertEqual(logits.shape, (1, 8, 128))
+        self.assertTrue(mx.all(mx.isfinite(logits)).item())
+
+    def test_dynamic_quant_qwen3_5_sensitivity_avoids_custom_kernel_vjp(self):
+        model = tiny_qwen3_5_model()
+        model.eval()
+        data = mx.array([[1, 2, 3, 4, 5, 6, 7, 8]], dtype=mx.int32)
+
+        sensitivities = estimate_sensitivities(
+            model,
+            data,
+            low_bits=4,
+            low_group_size=32,
+            high_bits=8,
+            high_group_size=32,
+            batch_size=1,
+        )
+
+        self.assertGreater(len(sensitivities), 0)
+        self.assertTrue(any("linear_attn" in name for name, _ in sensitivities))
+
+    def test_dwq_target_metadata_validates_matching_options(self):
+        args = types.SimpleNamespace(
+            model="model-a",
+            data_path="dataset-a",
+            max_seq_length=128,
+            batch_size=1,
+            seed=123,
+        )
+        metadata = build_target_metadata(args, DummyTokenizer(), num_samples=4)
+
+        with tempfile.TemporaryDirectory() as tmp:
+            target_dir = Path(tmp)
+            save_target_metadata(target_dir, metadata)
+
+            actual = validate_target_metadata(target_dir, metadata)
+            self.assertEqual(actual["max_seq_length"], 128)
+
+            expected = dict(metadata)
+            expected["max_seq_length"] = 256
+            with self.assertRaisesRegex(ValueError, "max_seq_length=128.*256"):
+                validate_target_metadata(target_dir, expected)
+
+    def test_dwq_target_generation_caps_top_k_to_vocab_size(self):
+        data = [([1, 2, 3, 4], 0)]
+
+        with tempfile.TemporaryDirectory() as tmp:
+            target_dir = Path(tmp)
+            compute_dwq_targets(
+                SmallVocabTeacher(),
+                target_dir,
+                train_data=data,
+                valid_data=data,
+                batch_size=1,
+                max_seq_length=8,
+                seed=123,
+            )
+            targets = mx.load(target_dir / "train" / "0000000000.safetensors")
+
+        self.assertEqual(targets["logits"].shape[-1], 16)
+        self.assertEqual(targets["indices"].shape[-1], 16)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_qwen3_5_quantization_slow.py
+++ b/tests/test_qwen3_5_quantization_slow.py
@@ -1,0 +1,133 @@
+# Copyright © 2026 Apple Inc.
+
+import os
+import subprocess
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+RUN_SLOW = os.getenv("RUN_SLOW_QWEN35_QUANT_TESTS")
+MODEL = os.getenv("QWEN35_QUANT_TEST_MODEL", "Qwen/Qwen3.5-0.8B")
+
+
+@unittest.skipUnless(RUN_SLOW, "set RUN_SLOW_QWEN35_QUANT_TESTS=1 to run")
+class TestQwen35QuantizationSlow(unittest.TestCase):
+    def run_command(self, args):
+        subprocess.run(args, check=True)
+
+    def assert_generates(self, model_path):
+        self.run_command(
+            [
+                sys.executable,
+                "-m",
+                "mlx_lm",
+                "generate",
+                "--model",
+                str(model_path),
+                "--prompt",
+                "Explain what tool calling is.",
+                "--max-tokens",
+                "32",
+            ]
+        )
+
+    def test_qwen3_5_awq_dynamic_gptq_dwq_smoke(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            out = Path(tmp)
+
+            awq_path = out / "awq"
+            self.run_command(
+                [
+                    sys.executable,
+                    "-m",
+                    "mlx_lm",
+                    "awq",
+                    "--model",
+                    MODEL,
+                    "--bits",
+                    "4",
+                    "--num-samples",
+                    "4",
+                    "--n-grid",
+                    "2",
+                    "--sequence-length",
+                    "64",
+                    "--mlx-path",
+                    str(awq_path),
+                ]
+            )
+            self.assert_generates(awq_path)
+
+            dynamic_path = out / "dynamic"
+            self.run_command(
+                [
+                    sys.executable,
+                    "-m",
+                    "mlx_lm",
+                    "dynamic_quant",
+                    "--model",
+                    MODEL,
+                    "--target-bpw",
+                    "4.5",
+                    "--num-samples",
+                    "4",
+                    "--sequence-length",
+                    "64",
+                    "--mlx-path",
+                    str(dynamic_path),
+                ]
+            )
+            self.assert_generates(dynamic_path)
+
+            gptq_path = out / "gptq"
+            self.run_command(
+                [
+                    sys.executable,
+                    "-m",
+                    "mlx_lm",
+                    "gptq",
+                    "--model",
+                    MODEL,
+                    "--bits",
+                    "4",
+                    "--num-samples",
+                    "4",
+                    "--sequence-length",
+                    "64",
+                    "--mlx-path",
+                    str(gptq_path),
+                ]
+            )
+            self.assert_generates(gptq_path)
+
+            dwq_path = out / "dwq"
+            self.run_command(
+                [
+                    sys.executable,
+                    "-m",
+                    "mlx_lm",
+                    "dwq",
+                    "--model",
+                    MODEL,
+                    "--bits",
+                    "4",
+                    "--group-size",
+                    "64",
+                    "--num-samples",
+                    "4",
+                    "--max-seq-length",
+                    "64",
+                    "--batch-size",
+                    "1",
+                    "--kl-loss-impl",
+                    "mlx",
+                    "--mlx-path",
+                    str(dwq_path),
+                ]
+            )
+            self.assert_generates(dwq_path)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

This PR adds learned quantization support for dense `qwen3_5` text models and hardens DWQ failure handling.

Changes:
- Enable AWQ traversal for dense `qwen3_5` hybrid layers:
  - full attention blocks with `self_attn.{q,k,v,o}_proj`
  - linear-attention blocks with `linear_attn.in_proj_*`
  - dense MLP projections
- Avoid the qwen3_5 inference-only gated-delta CustomKernel during dynamic quantization sensitivity estimation.
- Add `dynamic_quant` calibration controls for small local runs:
  - `--num-samples`
  - `--sequence-length`
- Add DWQ KL loss implementation selection:
  - `--kl-loss-impl auto|metal|mlx`
- Add DWQ target metadata validation before training.
- Add DWQ shape and finite-value checks so NaN/Inf losses or weights fail before saving a corrupted checkpoint.
- Add unit tests and an opt-in slow qwen3_5 quantization smoke test.

This intentionally focuses on dense `qwen3_5` models. MoE support is left out of scope.

## Motivation

Plain conversion and GPTQ already work for qwen3_5 models, but other learned quantization paths had gaps:

- AWQ rejected `qwen3_5` as unsupported.
- Dynamic quantization could hit `[Primitive::vjp] Not implemented for CustomKernel` on qwen3_5 linear-attention paths.
- DWQ could fail on Apple Silicon devices where the Metal KL-loss kernel configuration is not usable, and unstable runs could continue far enough to save invalid checkpoints.

## Testing

```bash
uv run python -m unittest tests.test_losses tests.test_quantization -v
```

```bash
uv run python -m unittest discover tests -v
```

```bash
uv run pre-commit run --files \
  mlx_lm/LEARNED_QUANTS.md \
  mlx_lm/quant/awq.py \
  mlx_lm/quant/dwq.py \
  mlx_lm/quant/dynamic_quant.py \
  mlx_lm/tuner/losses.py \
  tests/test_losses.py \
  tests/test_quantization.py \
  tests/test_qwen3_5_quantization_slow.py
```

Opt-in slow smoke test on Qwen/Qwen3.5-0.8B:

```bash
RUN_SLOW_QWEN35_QUANT_TESTS=1 \
QWEN35_QUANT_TEST_MODEL=/path/to/Qwen3.5-0.8B \
uv run python -m unittest tests.test_qwen3_5_quantization_slow -v
```

Local smoke checks also verified that AWQ, dynamic quantization, and DWQ start and save loadable artifacts for the downstream finetuned model LakoMoor/QClaw-4B. GPTQ was checked to reach Hessian collection and quantization startup as an existing baseline.