### PR TITLE
fix(gemma4): drop KV-shared layer projections in sanitize

### DIFF
--- a/mlx_lm/models/gemma4_text.py
+++ b/mlx_lm/models/gemma4_text.py
@@ -608,6 +608,21 @@ class Model(nn.Module):
         return out
 
     def sanitize(self, weights):
+        import re as _re
+
+        # KV-shared layers reuse projections from an earlier layer and have no
+        # k_proj/v_proj/k_norm attributes.  The safetensors files still ship
+        # those tensors, so we drop them here to avoid a strict-load error.
+        # This is the complement of PR #1158, which stopped mlx-lm from
+        # creating unused projection slots for these layers.
+        _cfg = getattr(self, "config", None) or getattr(self, "args", None)
+        if _cfg is not None:
+            first_kv_shared = (
+                _cfg.num_hidden_layers - _cfg.num_kv_shared_layers
+            )
+        else:
+            first_kv_shared = 0
+
         sanitized = {}
         for k, v in weights.items():
             if any(
@@ -620,6 +635,10 @@ class Model(nn.Module):
                     "output_min",
                 )
             ):
+                continue
+
+            m = _re.search(r"\.layers\.(\d+)\.self_attn\.(k_proj|v_proj|k_norm)\.", k)
+            if m and int(m.group(1)) >= first_kv_shared:
                 continue
 
             if k.endswith(".experts.gate_up_proj"):


### PR DESCRIPTION
## Problem

Quantized Gemma 4 safetensors files ship `k_proj`/`v_proj`/`k_norm` weights for layers `>= num_hidden_layers - num_kv_shared_layers`, even though those layers reuse KV projections from an earlier layer and have no corresponding model attributes. Loading any quantized Gemma 4 model fails with:

```
ValueError: Received 126 parameters not in model:
model.layers.24.self_attn.k_norm.weight,
model.layers.24.self_attn.k_proj.biases,
...
model.layers.41.self_attn.v_proj.weight
```

This affects `mlx-community/gemma-4-e4b-it-4bit` (52k downloads) and other quantized variants.

## Fix

Drop those tensors in `Gemma4TextModel.sanitize()`, the complement of #1158. That PR stopped mlx-lm from *creating* unused projection slots for KV-shared layers. This PR drops the *incoming weights* for those slots that still arrive from the checkpoint. Together they make quantized Gemma 4 models load cleanly.

```python
m = _re.search(r"\.layers\.(\d+)\.self_attn\.(k_proj|v_proj|k_norm)\.", k)
if m and int(m.group(1)) >= first_kv_shared:
    continue
```

## Testing

Tested on M4 MacBook Air 24 GB with `mlx-community/gemma-4-e4b-it-4bit`. Loads cleanly and runs at 18–25 tok/s across 500–4K token prompts. Before this fix it failed immediately with the ValueError above.