### PR TITLE
feat(server): add OpenAI Responses API endpoint (/v1/responses)

### DIFF
--- a/README.md
+++ b/README.md
@@ -257,6 +257,65 @@ model, tokenizer = load(
 )
 ```
 
+### Server
+
+`mlx-lm` includes an OpenAI-compatible HTTP server:
+
+```bash
+mlx_lm.server --model mlx-community/Qwen3.6-35B-A3B-4bit --port 8080
+```
+
+The server supports the following endpoints:
+
+| Endpoint | Description |
+|----------|-------------|
+| `GET /v1/models` | List available models |
+| `POST /v1/chat/completions` | Chat Completions API |
+| `POST /v1/completions` | Text Completions API |
+| `POST /v1/responses` | **Responses API** (new) |
+
+#### Responses API
+
+The `/v1/responses` endpoint implements the [OpenAI Responses API](https://platform.openai.com/docs/api-reference/responses), enabling compatibility with clients that require this format (e.g., [Codex CLI](https://github.com/openai/codex)).
+
+Features:
+- Translates Responses API requests to the internal Chat Completions pipeline
+- Supports both streaming (SSE) and non-streaming responses
+- Handles native tool calls via the model's tool parser
+- Fallback parsing for models that emit tool calls as plain text JSON
+- Consolidates system/developer messages at the start of the conversation
+- Filters unsupported tool types (web_search, image_generation, namespace)
+
+**Example usage with Codex CLI:**
+
+```toml
+# ~/.codex/config.toml
+model_provider = "mlx-local"
+model = "mlx-community/Qwen3.6-35B-A3B-4bit"
+
+[model_providers.mlx-local]
+name = "MLX Local"
+base_url = "http://127.0.0.1:8080/v1"
+wire_api = "responses"
+```
+
+**Server options for optimal performance:**
+
+```bash
+mlx_lm.server \
+  --model mlx-community/Qwen3.6-35B-A3B-4bit \
+  --port 8080 \
+  --max-tokens 8192 \
+  --prompt-cache-size 10 \
+  --prefill-step-size 4096
+```
+
+| Option | Default | Description |
+|--------|---------|-------------|
+| `--max-tokens` | 512 | Maximum tokens to generate per response |
+| `--prompt-cache-size` | 1 | Number of KV caches to keep (increase for multiple sessions) |
+| `--prefill-step-size` | 2048 | Tokens processed per prefill step (increase for faster prompt processing) |
+
 ### Large Models
 
 > [!NOTE]

--- a/mlx_lm/server.py
+++ b/mlx_lm/server.py
@@ -1106,6 +1106,8 @@ class APIHandler(BaseHTTPRequestHandler):
             "/v1/completions": self.handle_text_completions,
             "/v1/chat/completions": self.handle_chat_completions,
             "/chat/completions": self.handle_chat_completions,
+            "/v1/responses": self.handle_responses,
+            "/responses": self.handle_responses,
         }
 
         if self.path not in request_factories:
@@ -1199,7 +1201,10 @@ class APIHandler(BaseHTTPRequestHandler):
 
         # Create the completion request
         request = request_factories[self.path]()
-        self.handle_completion(request, stop_words)
+        if self.object_type == "response":
+            self.handle_responses_completion(request, stop_words)
+        else:
+            self.handle_completion(request, stop_words)
 
     def _validate(
         self,
@@ -1575,6 +1580,572 @@ class APIHandler(BaseHTTPRequestHandler):
                 "cached_tokens": prompt_cache_count,
             }
         return response
+
+    def handle_responses(self) -> CompletionRequest:
+        """
+        Parse an OpenAI Responses API request and return a CompletionRequest.
+
+        Translates the Responses API schema to the internal chat-completion
+        representation so the existing generation pipeline can be reused.
+
+        Responses API reference:
+          https://platform.openai.com/docs/api-reference/responses
+        """
+        body = self.body
+        self.request_id = f"resp_{uuid.uuid4().hex}"
+        self.object_type = "response"
+
+        if "max_output_tokens" in body:
+            self.max_tokens = body["max_output_tokens"]
+
+        # Collect all system/developer messages first, then non-system messages.
+        # Many models require system messages only at the beginning.
+        system_parts = []
+        non_system_messages = []
+
+        instructions = body.get("instructions")
+        if instructions:
+            system_parts.append(instructions)
+
+        inp = body.get("input", "")
+        if isinstance(inp, str):
+            non_system_messages.append({"role": "user", "content": inp})
+        elif isinstance(inp, list):
+            for item in inp:
+                if isinstance(item, dict):
+                    item_type = item.get("type", "")
+                    if item_type == "message":
+                        content = item.get("content", "")
+                        if isinstance(content, list):
+                            parts = []
+                            for c in content:
+                                if isinstance(c, dict):
+                                    text = c.get("text", "")
+                                    if text:
+                                        parts.append(text)
+                                elif isinstance(c, str):
+                                    parts.append(c)
+                            content = "\n".join(parts) if parts else ""
+                        role = item.get("role", "user")
+                        if role in ("developer", "system"):
+                            system_parts.append(content)
+                            continue
+                        non_system_messages.append(
+                            {"role": role, "content": content}
+                        )
+                    elif item_type == "function_call":
+                        non_system_messages.append(
+                            {
+                                "role": "assistant",
+                                "tool_calls": [
+                                    {
+                                        "id": item.get("call_id", ""),
+                                        "type": "function",
+                                        "function": {
+                                            "name": item.get("name", ""),
+                                            "arguments": item.get(
+                                                "arguments", "{}"
+                                            ),
+                                        },
+                                    }
+                                ],
+                            }
+                        )
+                    elif item_type == "function_call_output":
+                        non_system_messages.append(
+                            {
+                                "role": "tool",
+                                "tool_call_id": item.get("call_id", ""),
+                                "content": item.get("output", ""),
+                            }
+                        )
+                    elif "role" in item:
+                        role = item.get("role", "user")
+                        if role in ("developer", "system"):
+                            system_parts.append(item.get("content", ""))
+                        else:
+                            non_system_messages.append(item)
+                else:
+                    non_system_messages.append(
+                        {"role": "user", "content": str(item)}
+                    )
+
+        # Build final messages: single system message at start + rest
+        messages = []
+        if system_parts:
+            messages.append(
+                {"role": "system", "content": "\n\n".join(system_parts)}
+            )
+        messages.extend(non_system_messages)
+
+        # Convert Responses API tools to Chat Completions format and filter
+        # unsupported types (web_search, image_generation, namespace, etc.).
+        # Responses API: {"type": "function", "name": ..., "parameters": ...}
+        # Chat Completions: {"type": "function", "function": {"name": ...}}
+        raw_tools = body.get("tools") or None
+        if raw_tools:
+            converted_tools = []
+            for tool in raw_tools:
+                tool_type = tool.get("type", "")
+                if tool_type == "function" and "function" not in tool:
+                    converted_tools.append(
+                        {
+                            "type": "function",
+                            "function": {
+                                "name": tool.get("name", ""),
+                                "description": tool.get("description", ""),
+                                "parameters": tool.get("parameters", {}),
+                                **(
+                                    {"strict": tool["strict"]}
+                                    if "strict" in tool
+                                    else {}
+                                ),
+                            },
+                        }
+                    )
+                elif tool_type == "function" and "function" in tool:
+                    converted_tools.append(tool)
+                else:
+                    logging.debug(
+                        f"Skipping unsupported tool type: {tool_type} "
+                        f"({tool.get('name', 'unnamed')})"
+                    )
+            raw_tools = converted_tools or None
+
+        return CompletionRequest(
+            "chat",
+            "",
+            messages,
+            raw_tools,
+            body.get("role_mapping"),
+        )
+
+    def handle_responses_completion(
+        self, request: CompletionRequest, stop_words: List[str]
+    ):
+        """
+        Generate and send a response in OpenAI Responses API format.
+
+        Supports both text and tool-call outputs. Streaming emits the
+        following SSE event sequence:
+
+          response.created ->
+          response.output_item.added -> response.content_part.added ->
+          response.output_text.delta (N) -> response.output_text.done ->
+          response.content_part.done -> response.output_item.done ->
+          [response.output_item.added ->
+           response.function_call_arguments.delta ->
+           response.function_call_arguments.done ->
+           response.output_item.done] (per tool call) ->
+          response.completed
+
+        Non-streaming returns the full response object in one JSON payload.
+        """
+        args = GenerationArguments(
+            model=ModelDescription(
+                model=self.requested_model,
+                draft=self.requested_draft_model,
+                adapter=self.adapter,
+            ),
+            sampling=SamplingArguments(
+                temperature=self.temperature,
+                top_p=self.top_p,
+                top_k=self.top_k,
+                min_p=self.min_p,
+                xtc_probability=self.xtc_probability,
+                xtc_threshold=self.xtc_threshold,
+            ),
+            logits=LogitsProcessorArguments(
+                logit_bias=self.logit_bias,
+                repetition_penalty=self.repetition_penalty,
+                repetition_context_size=self.repetition_context_size,
+                presence_penalty=self.presence_penalty,
+                presence_context_size=self.presence_context_size,
+                frequency_penalty=self.frequency_penalty,
+                frequency_context_size=self.frequency_context_size,
+            ),
+            stop_words=stop_words,
+            max_tokens=self.max_tokens,
+            num_draft_tokens=self.num_draft_tokens,
+            logprobs=False,
+            top_logprobs=-1,
+            seed=self.seed,
+            chat_template_kwargs=self.chat_template_kwargs,
+        )
+
+        def keepalive_callback(processed, total):
+            logging.info(f"Prompt processing progress: {processed}/{total}")
+            if self.stream:
+                self.wfile.write(
+                    f": keepalive {processed}/{total}\n\n".encode()
+                )
+                self.wfile.flush()
+
+        try:
+            ctx, response_gen = self.response_generator.generate(
+                request, args, progress_callback=keepalive_callback
+            )
+        except Exception as e:
+            logging.error(f"handle_responses_completion error: {e}")
+            self._set_completion_headers(500)
+            self.end_headers()
+            self.wfile.write(json.dumps({"error": str(e)}).encode())
+            return
+
+        # Tool call formatter (reuses the model's native tool parser)
+        tool_formatter = ToolCallFormatter(
+            ctx.tool_parser, request.tools, False
+        )
+
+        msg_id = f"msg_{uuid.uuid4().hex}"
+        full_text = ""
+        tokens = []
+        finish_reason = "stop"
+        prev_state = None
+        tool_text = ""
+        tool_calls_raw = []
+        made_tool_call = False
+
+        if self.stream:
+            self._set_stream_headers(200)
+            self.end_headers()
+            self.wfile.write(
+                self._sse_event(
+                    "response.created",
+                    {
+                        "type": "response.created",
+                        "response": {
+                            "id": self.request_id,
+                            "object": "response",
+                            "status": "in_progress",
+                            "model": self.requested_model,
+                            "output": [],
+                        },
+                    },
+                )
+            )
+            self.wfile.write(
+                self._sse_event(
+                    "response.output_item.added",
+                    {
+                        "type": "response.output_item.added",
+                        "output_index": 0,
+                        "item": {
+                            "id": msg_id,
+                            "type": "message",
+                            "role": "assistant",
+                            "content": [],
+                            "status": "in_progress",
+                        },
+                    },
+                )
+            )
+            self.wfile.write(
+                self._sse_event(
+                    "response.content_part.added",
+                    {
+                        "type": "response.content_part.added",
+                        "item_id": msg_id,
+                        "output_index": 0,
+                        "content_index": 0,
+                        "part": {"type": "output_text", "text": ""},
+                    },
+                )
+            )
+            self.wfile.flush()
+
+        try:
+            for gen in response_gen:
+                tokens.append(gen.token)
+                if gen.state == "tool":
+                    tool_text += gen.text
+                elif gen.state == "normal":
+                    if prev_state == "tool":
+                        tool_calls_raw.append(tool_text)
+                        tool_text = ""
+                        made_tool_call = True
+                    if gen.text:
+                        full_text += gen.text
+                        if self.stream:
+                            self.wfile.write(
+                                self._sse_event(
+                                    "response.output_text.delta",
+                                    {
+                                        "type": "response.output_text.delta",
+                                        "item_id": msg_id,
+                                        "output_index": 0,
+                                        "content_index": 0,
+                                        "delta": gen.text,
+                                    },
+                                )
+                            )
+                            self.wfile.flush()
+                if gen.finish_reason is not None:
+                    finish_reason = gen.finish_reason
+                prev_state = gen.state
+
+            if prev_state == "tool" and tool_text:
+                tool_calls_raw.append(tool_text)
+                made_tool_call = True
+            if finish_reason == "stop" and made_tool_call:
+                finish_reason = "tool_calls"
+        finally:
+            ctx.stop()
+
+        # Strip leaked special tokens (e.g. <|im_end|> from Qwen models)
+        import re as _re
+
+        full_text = _re.sub(r"<\|im_end\|>\s*$", "", full_text).rstrip()
+
+        # Format tool calls via the model's native tool parser
+        formatted_tool_calls = tool_formatter(tool_calls_raw)
+
+        # Fallback: if the model generated a tool call as plain text (JSON
+        # in a code block or raw JSON) instead of using native tool_call
+        # tokens, try to parse it from the generated text.
+        if not formatted_tool_calls and request.tools and full_text:
+            import re
+
+            json_pattern = re.compile(
+                r"(?:```(?:json)?\s*\n?)?\s*"
+                r'(\{\s*"name"\s*:\s*"[^"]+"\s*,\s*'
+                r'"arguments"\s*:\s*\{[^}]*\}\s*\})'
+                r"\s*(?:\n?```)?",
+                re.DOTALL,
+            )
+            match = json_pattern.search(full_text)
+            if match:
+                try:
+                    tc_data = json.loads(match.group(1))
+                    if "name" in tc_data and "arguments" in tc_data:
+                        tool_names = {
+                            t["function"]["name"]
+                            for t in (request.tools or [])
+                            if isinstance(t, dict)
+                            and t.get("type") == "function"
+                            and "function" in t
+                        }
+                        if tc_data["name"] in tool_names:
+                            args_str = tc_data["arguments"]
+                            if isinstance(args_str, dict):
+                                args_str = json.dumps(
+                                    args_str, ensure_ascii=False
+                                )
+                            formatted_tool_calls = [
+                                {
+                                    "id": f"call_{uuid.uuid4().hex}",
+                                    "type": "function",
+                                    "function": {
+                                        "name": tc_data["name"],
+                                        "arguments": args_str,
+                                    },
+                                }
+                            ]
+                            full_text = ""
+                            made_tool_call = True
+                            finish_reason = "tool_calls"
+                            logging.info(
+                                "Fallback tool call parsed: "
+                                f"{tc_data['name']}"
+                            )
+                except (json.JSONDecodeError, KeyError):
+                    pass
+
+        usage = {
+            "input_tokens": len(ctx.prompt),
+            "output_tokens": len(tokens),
+            "total_tokens": len(ctx.prompt) + len(tokens),
+        }
+        if ctx.prompt_cache_count is not None and ctx.prompt_cache_count >= 0:
+            usage["input_tokens_details"] = {
+                "cached_tokens": ctx.prompt_cache_count
+            }
+
+        # Build output items
+        output_items = []
+        output_index = 0
+
+        text_item = {
+            "id": msg_id,
+            "type": "message",
+            "role": "assistant",
+            "status": "completed",
+            "content": [
+                {
+                    "type": "output_text",
+                    "text": full_text,
+                    "annotations": [],
+                }
+            ],
+        }
+        if full_text or not formatted_tool_calls:
+            output_items.append(text_item)
+            output_index += 1
+
+        # Convert Chat Completions tool_calls to Responses API function_call
+        for tc in formatted_tool_calls:
+            func = tc.get("function", {})
+            arguments = func.get("arguments", "{}")
+            if isinstance(arguments, dict):
+                arguments = json.dumps(arguments, ensure_ascii=False)
+            fc_item = {
+                "id": f"fc_{uuid.uuid4().hex}",
+                "type": "function_call",
+                "call_id": tc.get("id", f"call_{uuid.uuid4().hex}"),
+                "name": func.get("name", ""),
+                "arguments": arguments,
+                "status": "completed",
+            }
+            output_items.append(fc_item)
+
+        if self.stream:
+            # Close text message item
+            self.wfile.write(
+                self._sse_event(
+                    "response.output_text.done",
+                    {
+                        "type": "response.output_text.done",
+                        "item_id": msg_id,
+                        "output_index": 0,
+                        "content_index": 0,
+                        "text": full_text,
+                    },
+                )
+            )
+            self.wfile.write(
+                self._sse_event(
+                    "response.content_part.done",
+                    {
+                        "type": "response.content_part.done",
+                        "item_id": msg_id,
+                        "output_index": 0,
+                        "content_index": 0,
+                        "part": {
+                            "type": "output_text",
+                            "text": full_text,
+                            "annotations": [],
+                        },
+                    },
+                )
+            )
+            self.wfile.write(
+                self._sse_event(
+                    "response.output_item.done",
+                    {
+                        "type": "response.output_item.done",
+                        "output_index": 0,
+                        "item": text_item,
+                    },
+                )
+            )
+
+            # Emit tool call items
+            for i, fc_item in enumerate(
+                item
+                for item in output_items
+                if item["type"] == "function_call"
+            ):
+                tc_idx = output_index + i
+                self.wfile.write(
+                    self._sse_event(
+                        "response.output_item.added",
+                        {
+                            "type": "response.output_item.added",
+                            "output_index": tc_idx,
+                            "item": {
+                                **fc_item,
+                                "arguments": "",
+                                "status": "in_progress",
+                            },
+                        },
+                    )
+                )
+                self.wfile.write(
+                    self._sse_event(
+                        "response.function_call_arguments.delta",
+                        {
+                            "type": (
+                                "response.function_call_arguments.delta"
+                            ),
+                            "item_id": fc_item["id"],
+                            "output_index": tc_idx,
+                            "delta": fc_item["arguments"],
+                        },
+                    )
+                )
+                self.wfile.write(
+                    self._sse_event(
+                        "response.function_call_arguments.done",
+                        {
+                            "type": (
+                                "response.function_call_arguments.done"
+                            ),
+                            "item_id": fc_item["id"],
+                            "output_index": tc_idx,
+                            "arguments": fc_item["arguments"],
+                        },
+                    )
+                )
+                self.wfile.write(
+                    self._sse_event(
+                        "response.output_item.done",
+                        {
+                            "type": "response.output_item.done",
+                            "output_index": tc_idx,
+                            "item": fc_item,
+                        },
+                    )
+                )
+
+            self.wfile.write(
+                self._sse_event(
+                    "response.completed",
+                    {
+                        "type": "response.completed",
+                        "response": {
+                            "id": self.request_id,
+                            "object": "response",
+                            "status": "completed",
+                            "model": self.requested_model,
+                            "output": output_items,
+                            "usage": usage,
+                        },
+                    },
+                )
+            )
+            self.wfile.flush()
+        else:
+            resp = {
+                "id": self.request_id,
+                "object": "response",
+                "created_at": self.created,
+                "model": self.requested_model,
+                "status": (
+                    "completed" if finish_reason != "length" else "incomplete"
+                ),
+                "output": output_items,
+                "usage": usage,
+                "error": None,
+                "incomplete_details": None,
+                "instructions": self.body.get("instructions"),
+                "metadata": {},
+                "parallel_tool_calls": True,
+                "temperature": self.temperature,
+                "tool_choice": "auto",
+                "tools": [],
+                "top_p": self.top_p,
+                "truncation": "disabled",
+            }
+            self._set_completion_headers(200)
+            resp_bytes = json.dumps(resp).encode()
+            self.send_header("Content-Length", str(len(resp_bytes)))
+            self.end_headers()
+            self.wfile.write(resp_bytes)
+            self.wfile.flush()
+
+    def _sse_event(self, event: str, data: dict) -> bytes:
+        """Format a Server-Sent Event."""
+        return f"event: {event}\ndata: {json.dumps(data)}\n\n".encode()
 
     def handle_chat_completions(self) -> CompletionRequest:
         """

--- a/mlx_lm/server.py
+++ b/mlx_lm/server.py
@@ -1584,12 +1584,8 @@ class APIHandler(BaseHTTPRequestHandler):
     def handle_responses(self) -> CompletionRequest:
         """
         Parse an OpenAI Responses API request and return a CompletionRequest.
-
         Translates the Responses API schema to the internal chat-completion
         representation so the existing generation pipeline can be reused.
-
-        Responses API reference:
-          https://platform.openai.com/docs/api-reference/responses
         """
         body = self.body
         self.request_id = f"resp_{uuid.uuid4().hex}"
@@ -1599,7 +1595,7 @@ class APIHandler(BaseHTTPRequestHandler):
             self.max_tokens = body["max_output_tokens"]
 
         # Collect all system/developer messages first, then non-system messages.
-        # Many models require system messages only at the beginning.
+        # Many models require system messages at the beginning only.
         system_parts = []
         non_system_messages = []
 
@@ -1630,35 +1626,25 @@ class APIHandler(BaseHTTPRequestHandler):
                         if role in ("developer", "system"):
                             system_parts.append(content)
                             continue
-                        non_system_messages.append(
-                            {"role": role, "content": content}
-                        )
+                        non_system_messages.append({"role": role, "content": content})
                     elif item_type == "function_call":
-                        non_system_messages.append(
-                            {
-                                "role": "assistant",
-                                "tool_calls": [
-                                    {
-                                        "id": item.get("call_id", ""),
-                                        "type": "function",
-                                        "function": {
-                                            "name": item.get("name", ""),
-                                            "arguments": item.get(
-                                                "arguments", "{}"
-                                            ),
-                                        },
-                                    }
-                                ],
-                            }
-                        )
+                        non_system_messages.append({
+                            "role": "assistant",
+                            "tool_calls": [{
+                                "id": item.get("call_id", ""),
+                                "type": "function",
+                                "function": {
+                                    "name": item.get("name", ""),
+                                    "arguments": item.get("arguments", "{}"),
+                                },
+                            }],
+                        })
                     elif item_type == "function_call_output":
-                        non_system_messages.append(
-                            {
-                                "role": "tool",
-                                "tool_call_id": item.get("call_id", ""),
-                                "content": item.get("output", ""),
-                            }
-                        )
+                        non_system_messages.append({
+                            "role": "tool",
+                            "tool_call_id": item.get("call_id", ""),
+                            "content": item.get("output", ""),
+                        })
                     elif "role" in item:
                         role = item.get("role", "user")
                         if role in ("developer", "system"):
@@ -1666,43 +1652,31 @@ class APIHandler(BaseHTTPRequestHandler):
                         else:
                             non_system_messages.append(item)
                 else:
-                    non_system_messages.append(
-                        {"role": "user", "content": str(item)}
-                    )
+                    non_system_messages.append({"role": "user", "content": str(item)})
 
         # Build final messages: single system message at start + rest
         messages = []
         if system_parts:
-            messages.append(
-                {"role": "system", "content": "\n\n".join(system_parts)}
-            )
+            messages.append({"role": "system", "content": "\n\n".join(system_parts)})
         messages.extend(non_system_messages)
 
         # Convert Responses API tools to Chat Completions format and filter
-        # unsupported types (web_search, image_generation, namespace, etc.).
-        # Responses API: {"type": "function", "name": ..., "parameters": ...}
-        # Chat Completions: {"type": "function", "function": {"name": ...}}
+        # unsupported types (web_search, image_generation, namespace, etc.)
         raw_tools = body.get("tools") or None
         if raw_tools:
             converted_tools = []
             for tool in raw_tools:
                 tool_type = tool.get("type", "")
                 if tool_type == "function" and "function" not in tool:
-                    converted_tools.append(
-                        {
-                            "type": "function",
-                            "function": {
-                                "name": tool.get("name", ""),
-                                "description": tool.get("description", ""),
-                                "parameters": tool.get("parameters", {}),
-                                **(
-                                    {"strict": tool["strict"]}
-                                    if "strict" in tool
-                                    else {}
-                                ),
-                            },
-                        }
-                    )
+                    converted_tools.append({
+                        "type": "function",
+                        "function": {
+                            "name": tool.get("name", ""),
+                            "description": tool.get("description", ""),
+                            "parameters": tool.get("parameters", {}),
+                            **({"strict": tool["strict"]} if "strict" in tool else {}),
+                        },
+                    })
                 elif tool_type == "function" and "function" in tool:
                     converted_tools.append(tool)
                 else:
@@ -1725,21 +1699,7 @@ class APIHandler(BaseHTTPRequestHandler):
     ):
         """
         Generate and send a response in OpenAI Responses API format.
-
-        Supports both text and tool-call outputs. Streaming emits the
-        following SSE event sequence:
-
-          response.created ->
-          response.output_item.added -> response.content_part.added ->
-          response.output_text.delta (N) -> response.output_text.done ->
-          response.content_part.done -> response.output_item.done ->
-          [response.output_item.added ->
-           response.function_call_arguments.delta ->
-           response.function_call_arguments.done ->
-           response.output_item.done] (per tool call) ->
-          response.completed
-
-        Non-streaming returns the full response object in one JSON payload.
+        Supports both text and tool-call outputs with streaming.
         """
         args = GenerationArguments(
             model=ModelDescription(
@@ -1776,9 +1736,7 @@ class APIHandler(BaseHTTPRequestHandler):
         def keepalive_callback(processed, total):
             logging.info(f"Prompt processing progress: {processed}/{total}")
             if self.stream:
-                self.wfile.write(
-                    f": keepalive {processed}/{total}\n\n".encode()
-                )
+                self.wfile.write(f": keepalive {processed}/{total}\n\n".encode())
                 self.wfile.flush()
 
         try:
@@ -1786,19 +1744,19 @@ class APIHandler(BaseHTTPRequestHandler):
                 request, args, progress_callback=keepalive_callback
             )
         except Exception as e:
+            import traceback
             logging.error(f"handle_responses_completion error: {e}")
+            logging.error(traceback.format_exc())
             self._set_completion_headers(500)
             self.end_headers()
             self.wfile.write(json.dumps({"error": str(e)}).encode())
             return
 
-        # Tool call formatter (reuses the model's native tool parser)
-        tool_formatter = ToolCallFormatter(
-            ctx.tool_parser, request.tools, False
-        )
+        tool_formatter = ToolCallFormatter(ctx.tool_parser, request.tools, False)
 
         msg_id = f"msg_{uuid.uuid4().hex}"
         full_text = ""
+        reasoning_text = ""
         tokens = []
         finish_reason = "stop"
         prev_state = None
@@ -1809,49 +1767,23 @@ class APIHandler(BaseHTTPRequestHandler):
         if self.stream:
             self._set_stream_headers(200)
             self.end_headers()
-            self.wfile.write(
-                self._sse_event(
-                    "response.created",
-                    {
-                        "type": "response.created",
-                        "response": {
-                            "id": self.request_id,
-                            "object": "response",
-                            "status": "in_progress",
-                            "model": self.requested_model,
-                            "output": [],
-                        },
-                    },
-                )
-            )
-            self.wfile.write(
-                self._sse_event(
-                    "response.output_item.added",
-                    {
-                        "type": "response.output_item.added",
-                        "output_index": 0,
-                        "item": {
-                            "id": msg_id,
-                            "type": "message",
-                            "role": "assistant",
-                            "content": [],
-                            "status": "in_progress",
-                        },
-                    },
-                )
-            )
-            self.wfile.write(
-                self._sse_event(
-                    "response.content_part.added",
-                    {
-                        "type": "response.content_part.added",
-                        "item_id": msg_id,
-                        "output_index": 0,
-                        "content_index": 0,
-                        "part": {"type": "output_text", "text": ""},
-                    },
-                )
-            )
+            self.wfile.write(self._sse_event("response.created", {
+                "type": "response.created",
+                "response": {
+                    "id": self.request_id, "object": "response",
+                    "status": "in_progress", "model": self.requested_model, "output": [],
+                },
+            }))
+            self.wfile.write(self._sse_event("response.output_item.added", {
+                "type": "response.output_item.added", "output_index": 0,
+                "item": {"id": msg_id, "type": "message", "role": "assistant",
+                         "content": [], "status": "in_progress"},
+            }))
+            self.wfile.write(self._sse_event("response.content_part.added", {
+                "type": "response.content_part.added", "item_id": msg_id,
+                "output_index": 0, "content_index": 0,
+                "part": {"type": "output_text", "text": ""},
+            }))
             self.wfile.flush()
 
         try:
@@ -1859,6 +1791,17 @@ class APIHandler(BaseHTTPRequestHandler):
                 tokens.append(gen.token)
                 if gen.state == "tool":
                     tool_text += gen.text
+                elif gen.state == "reasoning":
+                    if gen.text:
+                        reasoning_text += gen.text
+                        if self.stream:
+                            self.wfile.write(self._sse_event(
+                                "response.reasoning_text.delta", {
+                                    "type": "response.reasoning_text.delta",
+                                    "item_id": msg_id, "output_index": 0,
+                                    "content_index": 0, "delta": gen.text,
+                                }))
+                            self.wfile.flush()
                 elif gen.state == "normal":
                     if prev_state == "tool":
                         tool_calls_raw.append(tool_text)
@@ -1867,18 +1810,12 @@ class APIHandler(BaseHTTPRequestHandler):
                     if gen.text:
                         full_text += gen.text
                         if self.stream:
-                            self.wfile.write(
-                                self._sse_event(
-                                    "response.output_text.delta",
-                                    {
-                                        "type": "response.output_text.delta",
-                                        "item_id": msg_id,
-                                        "output_index": 0,
-                                        "content_index": 0,
-                                        "delta": gen.text,
-                                    },
-                                )
-                            )
+                            self.wfile.write(self._sse_event(
+                                "response.output_text.delta", {
+                                    "type": "response.output_text.delta",
+                                    "item_id": msg_id, "output_index": 0,
+                                    "content_index": 0, "delta": gen.text,
+                                }))
                             self.wfile.flush()
                 if gen.finish_reason is not None:
                     finish_reason = gen.finish_reason
@@ -1892,26 +1829,19 @@ class APIHandler(BaseHTTPRequestHandler):
         finally:
             ctx.stop()
 
-        # Strip leaked special tokens (e.g. <|im_end|> from Qwen models)
+        # Strip leaked special tokens
         import re as _re
+        full_text = _re.sub(r'<\|im_end\|>\s*$', '', full_text).rstrip()
 
-        full_text = _re.sub(r"<\|im_end\|>\s*$", "", full_text).rstrip()
-
-        # Format tool calls via the model's native tool parser
+        # Format tool calls via the model's tool parser
         formatted_tool_calls = tool_formatter(tool_calls_raw)
 
-        # Fallback: if the model generated a tool call as plain text (JSON
-        # in a code block or raw JSON) instead of using native tool_call
-        # tokens, try to parse it from the generated text.
+        # Fallback: parse tool calls from plain text JSON
         if not formatted_tool_calls and request.tools and full_text:
             import re
-
             json_pattern = re.compile(
-                r"(?:```(?:json)?\s*\n?)?\s*"
-                r'(\{\s*"name"\s*:\s*"[^"]+"\s*,\s*'
-                r'"arguments"\s*:\s*\{[^}]*\}\s*\})'
-                r"\s*(?:\n?```)?",
-                re.DOTALL,
+                r'(?:```(?:json)?\s*\n?)?\s*(\{\s*"name"\s*:\s*"[^"]+"\s*,\s*"arguments"\s*:\s*\{[^}]*\}\s*\})\s*(?:\n?```)?',
+                re.DOTALL
             )
             match = json_pattern.search(full_text)
             if match:
@@ -1921,35 +1851,26 @@ class APIHandler(BaseHTTPRequestHandler):
                         tool_names = {
                             t["function"]["name"]
                             for t in (request.tools or [])
-                            if isinstance(t, dict)
-                            and t.get("type") == "function"
-                            and "function" in t
+                            if isinstance(t, dict) and t.get("type") == "function" and "function" in t
                         }
                         if tc_data["name"] in tool_names:
                             args_str = tc_data["arguments"]
                             if isinstance(args_str, dict):
-                                args_str = json.dumps(
-                                    args_str, ensure_ascii=False
-                                )
-                            formatted_tool_calls = [
-                                {
-                                    "id": f"call_{uuid.uuid4().hex}",
-                                    "type": "function",
-                                    "function": {
-                                        "name": tc_data["name"],
-                                        "arguments": args_str,
-                                    },
-                                }
-                            ]
+                                args_str = json.dumps(args_str, ensure_ascii=False)
+                            formatted_tool_calls = [{
+                                "id": f"call_{uuid.uuid4().hex}",
+                                "type": "function",
+                                "function": {"name": tc_data["name"], "arguments": args_str},
+                            }]
                             full_text = ""
                             made_tool_call = True
                             finish_reason = "tool_calls"
-                            logging.info(
-                                "Fallback tool call parsed: "
-                                f"{tc_data['name']}"
-                            )
+                            logging.info(f"Fallback tool call parsed: {tc_data['name']}")
                 except (json.JSONDecodeError, KeyError):
                     pass
+
+        # Count reasoning tokens separately
+        reasoning_token_count = len(reasoning_text.split()) if reasoning_text else 0
 
         usage = {
             "input_tokens": len(ctx.prompt),
@@ -1957,184 +1878,86 @@ class APIHandler(BaseHTTPRequestHandler):
             "total_tokens": len(ctx.prompt) + len(tokens),
         }
         if ctx.prompt_cache_count is not None and ctx.prompt_cache_count >= 0:
-            usage["input_tokens_details"] = {
-                "cached_tokens": ctx.prompt_cache_count
-            }
+            usage["input_tokens_details"] = {"cached_tokens": ctx.prompt_cache_count}
+        if reasoning_token_count > 0:
+            usage["output_tokens_details"] = {"reasoning_tokens": reasoning_token_count}
 
-        # Build output items
         output_items = []
         output_index = 0
 
         text_item = {
-            "id": msg_id,
-            "type": "message",
-            "role": "assistant",
-            "status": "completed",
-            "content": [
-                {
-                    "type": "output_text",
-                    "text": full_text,
-                    "annotations": [],
-                }
-            ],
+            "id": msg_id, "type": "message", "role": "assistant", "status": "completed",
+            "content": [{"type": "output_text", "text": full_text, "annotations": []}],
         }
         if full_text or not formatted_tool_calls:
             output_items.append(text_item)
             output_index += 1
 
-        # Convert Chat Completions tool_calls to Responses API function_call
         for tc in formatted_tool_calls:
             func = tc.get("function", {})
             arguments = func.get("arguments", "{}")
             if isinstance(arguments, dict):
                 arguments = json.dumps(arguments, ensure_ascii=False)
             fc_item = {
-                "id": f"fc_{uuid.uuid4().hex}",
-                "type": "function_call",
+                "id": f"fc_{uuid.uuid4().hex}", "type": "function_call",
                 "call_id": tc.get("id", f"call_{uuid.uuid4().hex}"),
-                "name": func.get("name", ""),
-                "arguments": arguments,
-                "status": "completed",
+                "name": func.get("name", ""), "arguments": arguments, "status": "completed",
             }
             output_items.append(fc_item)
 
         if self.stream:
-            # Close text message item
-            self.wfile.write(
-                self._sse_event(
-                    "response.output_text.done",
-                    {
-                        "type": "response.output_text.done",
-                        "item_id": msg_id,
-                        "output_index": 0,
-                        "content_index": 0,
-                        "text": full_text,
-                    },
-                )
-            )
-            self.wfile.write(
-                self._sse_event(
-                    "response.content_part.done",
-                    {
-                        "type": "response.content_part.done",
-                        "item_id": msg_id,
-                        "output_index": 0,
-                        "content_index": 0,
-                        "part": {
-                            "type": "output_text",
-                            "text": full_text,
-                            "annotations": [],
-                        },
-                    },
-                )
-            )
-            self.wfile.write(
-                self._sse_event(
-                    "response.output_item.done",
-                    {
-                        "type": "response.output_item.done",
-                        "output_index": 0,
-                        "item": text_item,
-                    },
-                )
-            )
-
-            # Emit tool call items
+            self.wfile.write(self._sse_event("response.output_text.done", {
+                "type": "response.output_text.done", "item_id": msg_id,
+                "output_index": 0, "content_index": 0, "text": full_text,
+            }))
+            self.wfile.write(self._sse_event("response.content_part.done", {
+                "type": "response.content_part.done", "item_id": msg_id,
+                "output_index": 0, "content_index": 0,
+                "part": {"type": "output_text", "text": full_text, "annotations": []},
+            }))
+            self.wfile.write(self._sse_event("response.output_item.done", {
+                "type": "response.output_item.done", "output_index": 0, "item": text_item,
+            }))
             for i, fc_item in enumerate(
-                item
-                for item in output_items
-                if item["type"] == "function_call"
+                item for item in output_items if item["type"] == "function_call"
             ):
                 tc_idx = output_index + i
-                self.wfile.write(
-                    self._sse_event(
-                        "response.output_item.added",
-                        {
-                            "type": "response.output_item.added",
-                            "output_index": tc_idx,
-                            "item": {
-                                **fc_item,
-                                "arguments": "",
-                                "status": "in_progress",
-                            },
-                        },
-                    )
-                )
-                self.wfile.write(
-                    self._sse_event(
-                        "response.function_call_arguments.delta",
-                        {
-                            "type": (
-                                "response.function_call_arguments.delta"
-                            ),
-                            "item_id": fc_item["id"],
-                            "output_index": tc_idx,
-                            "delta": fc_item["arguments"],
-                        },
-                    )
-                )
-                self.wfile.write(
-                    self._sse_event(
-                        "response.function_call_arguments.done",
-                        {
-                            "type": (
-                                "response.function_call_arguments.done"
-                            ),
-                            "item_id": fc_item["id"],
-                            "output_index": tc_idx,
-                            "arguments": fc_item["arguments"],
-                        },
-                    )
-                )
-                self.wfile.write(
-                    self._sse_event(
-                        "response.output_item.done",
-                        {
-                            "type": "response.output_item.done",
-                            "output_index": tc_idx,
-                            "item": fc_item,
-                        },
-                    )
-                )
-
-            self.wfile.write(
-                self._sse_event(
-                    "response.completed",
-                    {
-                        "type": "response.completed",
-                        "response": {
-                            "id": self.request_id,
-                            "object": "response",
-                            "status": "completed",
-                            "model": self.requested_model,
-                            "output": output_items,
-                            "usage": usage,
-                        },
-                    },
-                )
-            )
+                self.wfile.write(self._sse_event("response.output_item.added", {
+                    "type": "response.output_item.added", "output_index": tc_idx,
+                    "item": {**fc_item, "arguments": "", "status": "in_progress"},
+                }))
+                self.wfile.write(self._sse_event("response.function_call_arguments.delta", {
+                    "type": "response.function_call_arguments.delta",
+                    "item_id": fc_item["id"], "output_index": tc_idx,
+                    "delta": fc_item["arguments"],
+                }))
+                self.wfile.write(self._sse_event("response.function_call_arguments.done", {
+                    "type": "response.function_call_arguments.done",
+                    "item_id": fc_item["id"], "output_index": tc_idx,
+                    "arguments": fc_item["arguments"],
+                }))
+                self.wfile.write(self._sse_event("response.output_item.done", {
+                    "type": "response.output_item.done", "output_index": tc_idx, "item": fc_item,
+                }))
+            self.wfile.write(self._sse_event("response.completed", {
+                "type": "response.completed",
+                "response": {
+                    "id": self.request_id, "object": "response", "status": "completed",
+                    "model": self.requested_model, "output": output_items, "usage": usage,
+                    "end_turn": finish_reason != "tool_calls",
+                },
+            }))
             self.wfile.flush()
         else:
             resp = {
-                "id": self.request_id,
-                "object": "response",
-                "created_at": self.created,
+                "id": self.request_id, "object": "response", "created_at": self.created,
                 "model": self.requested_model,
-                "status": (
-                    "completed" if finish_reason != "length" else "incomplete"
-                ),
-                "output": output_items,
-                "usage": usage,
-                "error": None,
-                "incomplete_details": None,
-                "instructions": self.body.get("instructions"),
-                "metadata": {},
-                "parallel_tool_calls": True,
-                "temperature": self.temperature,
-                "tool_choice": "auto",
-                "tools": [],
-                "top_p": self.top_p,
-                "truncation": "disabled",
+                "status": "completed" if finish_reason != "length" else "incomplete",
+                "output": output_items, "usage": usage, "error": None,
+                "incomplete_details": None, "instructions": self.body.get("instructions"),
+                "metadata": {}, "parallel_tool_calls": True,
+                "temperature": self.temperature, "tool_choice": "auto",
+                "tools": [], "top_p": self.top_p, "truncation": "disabled",
             }
             self._set_completion_headers(200)
             resp_bytes = json.dumps(resp).encode()
@@ -2144,7 +1967,6 @@ class APIHandler(BaseHTTPRequestHandler):
             self.wfile.flush()
 
     def _sse_event(self, event: str, data: dict) -> bytes:
-        """Format a Server-Sent Event."""
         return f"event: {event}\ndata: {json.dumps(data)}\n\n".encode()
 
     def handle_chat_completions(self) -> CompletionRequest:


### PR DESCRIPTION
## Summary

Add full support for the OpenAI Responses API endpoint (`/v1/responses`) to `mlx_lm.server`, enabling compatibility with agentic coding clients like [Codex CLI](https://github.com/openai/codex) that require this API format.

## Motivation

The OpenAI Responses API is becoming the standard for agentic coding tools. Codex CLI (v0.125+) dropped support for `wire_api = "chat"` and now requires `/v1/responses`. This prevents users from using `mlx_lm.server` as a local backend on Apple Silicon.

This PR bridges that gap by translating between the Responses API and the existing Chat Completions pipeline, requiring no changes to the generation engine.

## Changes

**Request translation (`handle_responses`):**
- Parse Responses API input format (instructions, input messages, function_call/output)
- Map `developer` role to `system` and consolidate all system messages at the start (required by models like Qwen3.5/3.6)
- Convert flat tool format (`{"type": "function", "name": ...}`) to nested Chat Completions format (`{"type": "function", "function": {"name": ...}}`)
- Filter unsupported tool types (`web_search`, `image_generation`, `namespace`)

**Response translation (`handle_responses_completion`):**
- Emit correct SSE event sequence: `response.created` → `output_text.delta` → `function_call_arguments.delta` → `response.completed`
- Support both streaming and non-streaming modes
- Handle native tool calls via the model's tool parser
- Fallback parsing for models that emit tool calls as plain text JSON (e.g., Qwen2.5)
- Strip leaked special tokens (e.g., `<|im_end|>`) from output

**Documentation:**
- Added Server section to README with endpoint table, Codex CLI configuration example, and recommended server options

## Tested with

- Qwen3.6-35B-A3B (4bit, 6bit) — native tool calling via `gemma4` parser
- Qwen2.5-Coder-7B-Instruct (4bit) — fallback JSON tool call parsing
- Gemma 4 31B — native tool calling
- Codex CLI v0.125.0 — full agentic workflow (tool calls, multi-turn, streaming)
- Both streaming and non-streaming modes
- Prompt cache verified working across multiple sessions

## Test plan

- [ ] Start server: `mlx_lm.server --model mlx-community/Qwen3.6-35B-A3B-4bit --port 8080 --max-tokens 8192`
- [ ] Test non-streaming: `curl -X POST http://localhost:8080/v1/responses -H "Content-Type: application/json" -d '{"model":"test","stream":false,"input":[{"type":"message","role":"user","content":[{"type":"input_text","text":"hello"}]}],"tools":[]}'`
- [ ] Test streaming with tools: verify SSE events match Responses API spec
- [ ] Test with Codex CLI: `codex` with `wire_api = "responses"` pointing to mlx_lm.server
- [ ] Verify existing `/v1/chat/completions` endpoint is unaffected