### PR TITLE
Skip quantizing Gemma 4 per_layer_model_projection for Swift compatibility

### DIFF
--- a/mlx_lm/models/gemma4_text.py
+++ b/mlx_lm/models/gemma4_text.py
@@ -643,6 +643,17 @@ class Model(nn.Module):
         def predicate(path, _):
             if path.endswith("router.proj"):
                 return {"group_size": 64, "bits": 8}
+            # The Swift counterpart in mlx-swift-lm models this layer with a
+            # plain `Module` wrapping a raw `MLXArray` (Gemma4Text.swift's
+            # `ScaledLinear`). It cannot dequantize a packed weight at load
+            # time, so a quantized `per_layer_model_projection` produces a
+            # shape mismatch on iOS:
+            #   Mismatched parameter ... ScaledLinear shape.
+            #   Actual [N, K/8], expected [N, K]
+            # Skip this single layer here so generated checkpoints load on
+            # both Python and Swift runtimes.
+            if path.endswith("per_layer_model_projection"):
+                return False
             return True
 
         return predicate


### PR DESCRIPTION
## Summary

Adds `per_layer_model_projection` to `Gemma4Text.quant_predicate`'s skip list so generated quantized checkpoints load on both Python (mlx-lm) and Swift (mlx-swift-lm) runtimes.

## Problem

The Swift counterpart in [mlx-swift-lm](https://github.com/ml-explore/mlx-swift-lm)'s [`Libraries/MLXLLM/Models/Gemma4Text.swift`](https://github.com/ml-explore/mlx-swift-lm/blob/main/Libraries/MLXLLM/Models/Gemma4Text.swift#L163) defines `ScaledLinear` as a plain `Module` wrapping a raw `MLXArray`:

```swift
private class ScaledLinear: Module {
    let weight: MLXArray
    let scalar: Float
    ...
}
```

This class has no quantization-aware load path. When a quantized Gemma 4 Text checkpoint is loaded by mlx-swift-lm, the loader sees the packed `(N, K/8)` uint32 shape of the quantized `per_layer_model_projection.weight` and rejects it against the `(N, K)` shape `ScaledLinear` declares:

```
Mismatched parameter model.per_layer_model_projection.weight in
Gemma4TextModel.Gemma4TextModelInner.ScaledLinear shape.
Actual [8960, 192], expected [8960, 1536]
```

(numbers above are E2B; same shape pattern applies to E4B / 26B / 31B)

This affects every existing quantized Gemma 4 Text checkpoint in `mlx-community/`, e.g.:
- `mlx-community/Gemma4-E2B-IT-Text-int4`
- `mlx-community/gemma-4-e4b-it-bf16`-derived 4/8-bit conversions
- Any user-quantized fine-tune via `mlx_lm.fuse` + `mlx_lm.convert --q-bits N`

## Fix

Add the layer to the existing skip list (one line of logic + comment):

```python
if path.endswith("per_layer_model_projection"):
    return False
```

Cost: ~25 MB on E2B (the layer stays at source dtype). Zero impact on Python runtime quality. Newly converted checkpoints become loadable from Swift without any sanitize patches.

## Repro

```bash
# Python convert produces a checkpoint that fails Swift load
mlx_lm.convert --hf-path google/gemma-4-E2B-it --mlx-path g4-e2b-4bit --q-bits 4 -q

# Try to load via mlx-swift-lm 3.31.3 -> shape mismatch
```

After this PR, the same convert produces a checkpoint that loads cleanly in both runtimes.

## Companion fix

The deeper fix — making `ScaledLinear` quantization-aware so existing checkpoints in the wild load — belongs in `mlx-swift-lm` and is tracked separately. This PR is a low-risk, one-line guard so future conversions don't keep producing broken-on-Swift checkpoints in the meantime.

## Test plan

- [ ] CI green
- [ ] `mlx_lm.convert --hf-path google/gemma-4-E2B-it --mlx-path test-out --q-bits 4 -q` produces a checkpoint where `model.per_layer_model_projection.weight` has shape `(num_hidden_layers * hidden_size_per_layer_input, hidden_size)` in source dtype (no `.scales` / `.biases`)
- [ ] `mlx_lm.generate --model test-out` still produces sensible text