### PR TITLE
Support per-expert MoE checkpoints in qwen3_5_moe.sanitize, plus FP8 dequant

### DIFF
--- a/mlx_lm/models/qwen3_5.py
+++ b/mlx_lm/models/qwen3_5.py
@@ -382,6 +382,38 @@ class Model(nn.Module):
         )
 
     def sanitize(self, weights):
+        # Dequantize FP8 weights paired with weight_scale_inv. Mirrors the
+        # inline FP8 dequant in models/{deepseek_v3,deepseek_v32,minimax,
+        # mimo_v2_flash,ministral3}.py. Triggered by checkpoints with
+        # quant_method=fp8 (e.g. Qwen/Qwen3.6-27B-FP8, Qwen3.6-35B-A3B-FP8).
+        # No-op when no weight_scale_inv keys are present.
+        def dequant(weight, scale_inv):
+            weight = mx.from_fp8(weight, dtype=mx.bfloat16)
+            bs = 128  # block size
+            m, n = weight.shape
+            pad_bottom = (-m) % bs
+            pad_side = (-n) % bs
+            weight = mx.pad(weight, ((0, pad_bottom), (0, pad_side)))
+            weight = weight.reshape(
+                ((m + pad_bottom) // bs, bs, (n + pad_side) // bs, bs)
+            )
+            weight = (weight * scale_inv[:, None, :, None]).reshape(
+                m + pad_bottom, n + pad_side
+            )
+            return weight[:m, :n].astype(mx.bfloat16)
+
+        if any("weight_scale_inv" in k for k in weights):
+            new_weights = {}
+            for k, v in weights.items():
+                if "weight_scale_inv" in k:
+                    wk = k.replace("_scale_inv", "")
+                    new_weights[wk] = dequant(weights[wk], v)
+                elif "activation_scale" in k:
+                    continue
+                elif k not in new_weights:
+                    new_weights[k] = v
+            weights = new_weights
+
         sanitized = {}
         for key, value in weights.items():
             if key.startswith("vision_tower") or key.startswith("model.visual"):

--- a/mlx_lm/models/qwen3_5_moe.py
+++ b/mlx_lm/models/qwen3_5_moe.py
@@ -2,6 +2,8 @@
 
 from dataclasses import dataclass
 
+import mlx.core as mx
+
 from .base import BaseModelArgs
 from .qwen3_5 import Model as Qwen3_5Model
 
@@ -21,6 +23,38 @@ class ModelArgs(BaseModelArgs):
 class Model(Qwen3_5Model):
 
     def sanitize(self, weights):
+        # Dequantize FP8 weights paired with weight_scale_inv. Mirrors the
+        # inline FP8 dequant in models/{deepseek_v3,deepseek_v32,minimax,
+        # mimo_v2_flash,ministral3}.py. Triggered by checkpoints with
+        # quant_method=fp8 (e.g. Qwen/Qwen3.6-35B-A3B-FP8). No-op when no
+        # weight_scale_inv keys are present.
+        def dequant(weight, scale_inv):
+            weight = mx.from_fp8(weight, dtype=mx.bfloat16)
+            bs = 128  # block size
+            m, n = weight.shape
+            pad_bottom = (-m) % bs
+            pad_side = (-n) % bs
+            weight = mx.pad(weight, ((0, pad_bottom), (0, pad_side)))
+            weight = weight.reshape(
+                ((m + pad_bottom) // bs, bs, (n + pad_side) // bs, bs)
+            )
+            weight = (weight * scale_inv[:, None, :, None]).reshape(
+                m + pad_bottom, n + pad_side
+            )
+            return weight[:m, :n].astype(mx.bfloat16)
+
+        if any("weight_scale_inv" in k for k in weights):
+            dequanted = {}
+            for k, v in weights.items():
+                if "weight_scale_inv" in k:
+                    wk = k.replace("_scale_inv", "")
+                    dequanted[wk] = dequant(weights[wk], v)
+                elif "activation_scale" in k:
+                    continue
+                elif k not in dequanted:
+                    dequanted[k] = v
+            weights = dequanted
+
         new_weights = {}
         for key, value in weights.items():
             if key.startswith("vision_tower") or key.startswith("model.visual"):
@@ -48,5 +82,44 @@ class Model(Qwen3_5Model):
                 new_weights[f"{prefix}.switch_mlp.down_proj.weight"] = new_weights.pop(
                     f"{prefix}.experts.down_proj"
                 )
+            elif f"{prefix}.experts.0.gate_proj.weight" in new_weights:
+                # Per-expert layout (Qwen/Qwen3.6-35B-A3B-FP8): one tensor per
+                # expert per projection. The bf16 master Qwen/Qwen3.6-35B-A3B
+                # is already pre-stacked and falls through the combined-format
+                # branch above unchanged. Collect all matching keys for this
+                # layer, validate the index range is contiguous from 0, then
+                # stack along axis 0 into the same shape the combined-format
+                # branch produces.
+                experts_prefix = f"{prefix}.experts."
+                gate_suffix = ".gate_proj.weight"
+                indices = set()
+                for key in new_weights:
+                    if key.startswith(experts_prefix) and key.endswith(gate_suffix):
+                        tail = key[len(experts_prefix) : -len(gate_suffix)]
+                        if tail.isdigit():
+                            indices.add(int(tail))
+                expected = set(range(len(indices)))
+                if indices != expected:
+                    missing = sorted(expected - indices)
+                    extra = sorted(indices - expected)
+                    raise ValueError(
+                        f"Per-expert MoE weights at {prefix}.experts have "
+                        f"non-contiguous indices: missing={missing}, "
+                        f"unexpected={extra}."
+                    )
+                gates, ups, downs = [], [], []
+                for e in range(len(indices)):
+                    gates.append(
+                        new_weights.pop(f"{prefix}.experts.{e}.gate_proj.weight")
+                    )
+                    ups.append(
+                        new_weights.pop(f"{prefix}.experts.{e}.up_proj.weight")
+                    )
+                    downs.append(
+                        new_weights.pop(f"{prefix}.experts.{e}.down_proj.weight")
+                    )
+                new_weights[f"{prefix}.switch_mlp.gate_proj.weight"] = mx.stack(gates)
+                new_weights[f"{prefix}.switch_mlp.up_proj.weight"] = mx.stack(ups)
+                new_weights[f"{prefix}.switch_mlp.down_proj.weight"] = mx.stack(downs)
 
         return self.language_model.sanitize(new_weights)

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -649,6 +649,322 @@ class TestModels(unittest.TestCase):
                 mx.array_equal(loaded[mlx_norm_key], converted[mlx_norm_key])
             )
 
+    def test_qwen3_5_moe_per_expert_weights_stack_to_switch_mlp(self):
+        # Qwen/Qwen3.6-35B-A3B-FP8 ships expert MLPs as one tensor per expert
+        # per projection rather than as a single combined
+        # ``experts.gate_up_proj`` / ``experts.down_proj`` tensor (the bf16
+        # master Qwen/Qwen3.6-35B-A3B is already pre-stacked). The sanitize
+        # step must stack the per-expert tensors into the combined
+        # ``switch_mlp.*`` form that ``Qwen3_5MoeSparseMlp.load_weights``
+        # expects.
+        from mlx_lm.models import qwen3_5_moe
+
+        text_config = {
+            "model_type": "qwen3_5_moe_text",
+            "hidden_size": 4,
+            "intermediate_size": 8,
+            "num_hidden_layers": 1,
+            "num_attention_heads": 1,
+            "num_key_value_heads": 1,
+            "rms_norm_eps": 1e-5,
+            "vocab_size": 16,
+            "linear_num_value_heads": 1,
+            "linear_num_key_heads": 1,
+            "linear_key_head_dim": 4,
+            "linear_value_head_dim": 4,
+            "linear_conv_kernel_dim": 1,
+            "full_attention_interval": 1,
+            "tie_word_embeddings": False,
+            "max_position_embeddings": 16,
+            "num_experts": 2,
+            "num_experts_per_tok": 1,
+            "moe_intermediate_size": 6,
+            "shared_expert_intermediate_size": 6,
+        }
+        args = qwen3_5_moe.ModelArgs.from_dict(
+            {"model_type": "qwen3_5_moe", "text_config": text_config}
+        )
+        model = qwen3_5_moe.Model(args)
+
+        prefix = "model.language_model.layers.0.mlp.experts"
+        per_expert = {
+            f"{prefix}.0.gate_proj.weight": mx.full((6, 4), 1.0),
+            f"{prefix}.0.up_proj.weight": mx.full((6, 4), 2.0),
+            f"{prefix}.0.down_proj.weight": mx.full((4, 6), 3.0),
+            f"{prefix}.1.gate_proj.weight": mx.full((6, 4), 4.0),
+            f"{prefix}.1.up_proj.weight": mx.full((6, 4), 5.0),
+            f"{prefix}.1.down_proj.weight": mx.full((4, 6), 6.0),
+        }
+        sanitized = model.sanitize(dict(per_expert))
+
+        out_prefix = "language_model.model.layers.0.mlp.switch_mlp"
+        gate_key = f"{out_prefix}.gate_proj.weight"
+        up_key = f"{out_prefix}.up_proj.weight"
+        down_key = f"{out_prefix}.down_proj.weight"
+
+        self.assertIn(gate_key, sanitized)
+        self.assertIn(up_key, sanitized)
+        self.assertIn(down_key, sanitized)
+        self.assertEqual(sanitized[gate_key].shape, (2, 6, 4))
+        self.assertEqual(sanitized[up_key].shape, (2, 6, 4))
+        self.assertEqual(sanitized[down_key].shape, (2, 4, 6))
+        # Per-expert keys must not leak through.
+        self.assertFalse(any(".experts.0." in k for k in sanitized))
+        self.assertFalse(any(".experts.1." in k for k in sanitized))
+        # Stacking preserves per-expert content along axis 0.
+        self.assertTrue(mx.array_equal(sanitized[gate_key][0], per_expert[f"{prefix}.0.gate_proj.weight"]))
+        self.assertTrue(mx.array_equal(sanitized[gate_key][1], per_expert[f"{prefix}.1.gate_proj.weight"]))
+        self.assertTrue(mx.array_equal(sanitized[down_key][1], per_expert[f"{prefix}.1.down_proj.weight"]))
+
+    def test_qwen3_5_moe_per_expert_gap_raises(self):
+        # Defensive: if a per-expert checkpoint has non-contiguous expert indices
+        # (e.g. ships 0, 1, 3 but not 2), sanitize must fail loudly rather than
+        # silently dropping expert 3 — which would replicate the strict-load
+        # failure this branch is meant to fix.
+        from mlx_lm.models import qwen3_5_moe
+
+        text_config = {
+            "model_type": "qwen3_5_moe_text",
+            "hidden_size": 4,
+            "intermediate_size": 8,
+            "num_hidden_layers": 1,
+            "num_attention_heads": 1,
+            "num_key_value_heads": 1,
+            "rms_norm_eps": 1e-5,
+            "vocab_size": 16,
+            "linear_num_value_heads": 1,
+            "linear_num_key_heads": 1,
+            "linear_key_head_dim": 4,
+            "linear_value_head_dim": 4,
+            "linear_conv_kernel_dim": 1,
+            "full_attention_interval": 1,
+            "tie_word_embeddings": False,
+            "max_position_embeddings": 16,
+            "num_experts": 3,
+            "num_experts_per_tok": 1,
+            "moe_intermediate_size": 6,
+            "shared_expert_intermediate_size": 6,
+        }
+        args = qwen3_5_moe.ModelArgs.from_dict(
+            {"model_type": "qwen3_5_moe", "text_config": text_config}
+        )
+        model = qwen3_5_moe.Model(args)
+
+        prefix = "model.language_model.layers.0.mlp.experts"
+        # Index 2 deliberately missing.
+        gapped = {
+            f"{prefix}.0.gate_proj.weight": mx.zeros((6, 4)),
+            f"{prefix}.0.up_proj.weight": mx.zeros((6, 4)),
+            f"{prefix}.0.down_proj.weight": mx.zeros((4, 6)),
+            f"{prefix}.1.gate_proj.weight": mx.zeros((6, 4)),
+            f"{prefix}.1.up_proj.weight": mx.zeros((6, 4)),
+            f"{prefix}.1.down_proj.weight": mx.zeros((4, 6)),
+            f"{prefix}.3.gate_proj.weight": mx.zeros((6, 4)),
+            f"{prefix}.3.up_proj.weight": mx.zeros((6, 4)),
+            f"{prefix}.3.down_proj.weight": mx.zeros((4, 6)),
+        }
+        with self.assertRaisesRegex(ValueError, "non-contiguous"):
+            model.sanitize(dict(gapped))
+
+    def test_qwen3_5_moe_combined_format_still_splits_to_switch_mlp(self):
+        # Regression guard: pre-stacked checkpoints (e.g. mlx-community Qwen3.5
+        # / 3.6 redistributions) ship ``experts.gate_up_proj`` /
+        # ``experts.down_proj`` as combined tensors. Sanitize must still split
+        # them into ``switch_mlp.{gate,up,down}_proj.weight`` via the original
+        # branch, untouched by the new per-expert path.
+        from mlx_lm.models import qwen3_5_moe
+
+        text_config = {
+            "model_type": "qwen3_5_moe_text",
+            "hidden_size": 4,
+            "intermediate_size": 8,
+            "num_hidden_layers": 1,
+            "num_attention_heads": 1,
+            "num_key_value_heads": 1,
+            "rms_norm_eps": 1e-5,
+            "vocab_size": 16,
+            "linear_num_value_heads": 1,
+            "linear_num_key_heads": 1,
+            "linear_key_head_dim": 4,
+            "linear_value_head_dim": 4,
+            "linear_conv_kernel_dim": 1,
+            "full_attention_interval": 1,
+            "tie_word_embeddings": False,
+            "max_position_embeddings": 16,
+            "num_experts": 2,
+            "num_experts_per_tok": 1,
+            "moe_intermediate_size": 6,
+            "shared_expert_intermediate_size": 6,
+        }
+        args = qwen3_5_moe.ModelArgs.from_dict(
+            {"model_type": "qwen3_5_moe", "text_config": text_config}
+        )
+        model = qwen3_5_moe.Model(args)
+
+        # Pre-stacked: gate_up has shape (num_experts, 2*intermediate, hidden);
+        # down has shape (num_experts, hidden, intermediate).
+        gate_up = mx.arange(2 * 12 * 4, dtype=mx.float32).reshape(2, 12, 4)
+        down = mx.arange(2 * 4 * 6, dtype=mx.float32).reshape(2, 4, 6)
+        sanitized = model.sanitize(
+            {
+                "model.language_model.layers.0.mlp.experts.gate_up_proj": gate_up,
+                "model.language_model.layers.0.mlp.experts.down_proj": down,
+            }
+        )
+
+        out_prefix = "language_model.model.layers.0.mlp.switch_mlp"
+        self.assertEqual(sanitized[f"{out_prefix}.gate_proj.weight"].shape, (2, 6, 4))
+        self.assertEqual(sanitized[f"{out_prefix}.up_proj.weight"].shape, (2, 6, 4))
+        self.assertEqual(sanitized[f"{out_prefix}.down_proj.weight"].shape, (2, 4, 6))
+        self.assertTrue(
+            mx.array_equal(sanitized[f"{out_prefix}.gate_proj.weight"], gate_up[:, :6, :])
+        )
+        self.assertTrue(
+            mx.array_equal(sanitized[f"{out_prefix}.up_proj.weight"], gate_up[:, 6:, :])
+        )
+        self.assertTrue(mx.array_equal(sanitized[f"{out_prefix}.down_proj.weight"], down))
+        # Combined keys must not leak through after split.
+        self.assertNotIn("language_model.model.layers.0.mlp.experts.gate_up_proj", sanitized)
+        self.assertNotIn("language_model.model.layers.0.mlp.experts.down_proj", sanitized)
+
+    def test_qwen3_5_fp8_weight_scale_inv_dequantizes_in_sanitize(self):
+        # Qwen-org FP8 checkpoints (Qwen/Qwen3.6-{27B,35B-A3B}-FP8) ship FP8
+        # weights paired with bf16 weight_scale_inv tensors plus optional
+        # activation_scale tensors. Sanitize must dequantize FP8 -> bf16 using
+        # the 128x128 block-scale layout (same scheme as DeepSeek-V3 / V3.2 /
+        # MiniMax / MiMo V2 Flash / Ministral 3) and silently drop the
+        # activation_scale tensors. Mirrors the inline dequant pattern in
+        # those five sibling files.
+        if not hasattr(mx, "from_fp8") or not hasattr(mx, "to_fp8"):
+            self.skipTest("mx.from_fp8 / mx.to_fp8 not available in this mlx version")
+
+        from mlx_lm.models import qwen3_5
+
+        text_config = {
+            "model_type": "qwen3_5",
+            "hidden_size": 4,
+            "intermediate_size": 8,
+            "num_hidden_layers": 1,
+            "num_attention_heads": 1,
+            "num_key_value_heads": 1,
+            "rms_norm_eps": 1e-5,
+            "vocab_size": 16,
+            "linear_num_value_heads": 1,
+            "linear_num_key_heads": 1,
+            "linear_key_head_dim": 4,
+            "linear_value_head_dim": 4,
+            "linear_conv_kernel_dim": 1,
+            "full_attention_interval": 1,
+            "tie_word_embeddings": False,
+            "max_position_embeddings": 16,
+        }
+        args = qwen3_5.ModelArgs.from_dict(
+            {"model_type": "qwen3_5", "text_config": text_config}
+        )
+        model = qwen3_5.Model(args)
+
+        # Construct an FP8 weight + bf16 scale_inv pair. Use a single 128x128
+        # block so the scale_inv shape is (1, 1) and the broadcast is trivial.
+        weight_key = "model.language_model.layers.0.linear_attn.in_proj_a.weight"
+        scale_key = weight_key + "_scale_inv"
+        activation_key = weight_key.replace(".weight", ".activation_scale")
+        # Round-trip through mx.to_fp8 produces a uint8-encoded FP8 (E4M3) array
+        # in the format `mx.from_fp8` expects to consume back.
+        weight_fp8 = mx.to_fp8(
+            mx.array([[1.0, -2.0], [0.5, 4.0]], dtype=mx.bfloat16)
+        )
+        scale_inv = mx.array([[2.0]], dtype=mx.bfloat16)
+        # Expected: from_fp8(weight) * scale_inv. Use the same dequant primitive
+        # the patched sanitize uses so the comparison is bit-identical.
+        expected = (mx.from_fp8(weight_fp8, dtype=mx.bfloat16) * 2.0).astype(
+            mx.float32
+        )
+        sanitized = model.sanitize(
+            {
+                weight_key: weight_fp8,
+                scale_key: scale_inv,
+                activation_key: mx.ones((1,), dtype=mx.bfloat16),
+            }
+        )
+
+        # weight_scale_inv and activation_scale must not leak through.
+        self.assertFalse(any("weight_scale_inv" in k for k in sanitized))
+        self.assertFalse(any("activation_scale" in k for k in sanitized))
+        # The dequanted weight should equal FP8 cast to bf16 multiplied by 2.0
+        # (the single block scale).
+        out_key = weight_key.replace("model.language_model", "language_model.model")
+        self.assertIn(out_key, sanitized)
+        np.testing.assert_allclose(
+            np.array(sanitized[out_key].astype(mx.float32)),
+            np.array(expected),
+        )
+
+    def test_qwen3_5_moe_fp8_weight_scale_inv_dequantizes_in_sanitize(self):
+        # Same FP8 dequant + activation_scale drop, exercised through the MoE
+        # sanitize entry (Qwen/Qwen3.6-35B-A3B-FP8 path).
+        if not hasattr(mx, "from_fp8") or not hasattr(mx, "to_fp8"):
+            self.skipTest("mx.from_fp8 / mx.to_fp8 not available in this mlx version")
+
+        from mlx_lm.models import qwen3_5_moe
+
+        text_config = {
+            "model_type": "qwen3_5_moe_text",
+            "hidden_size": 4,
+            "intermediate_size": 8,
+            "num_hidden_layers": 1,
+            "num_attention_heads": 1,
+            "num_key_value_heads": 1,
+            "rms_norm_eps": 1e-5,
+            "vocab_size": 16,
+            "linear_num_value_heads": 1,
+            "linear_num_key_heads": 1,
+            "linear_key_head_dim": 4,
+            "linear_value_head_dim": 4,
+            "linear_conv_kernel_dim": 1,
+            "full_attention_interval": 1,
+            "tie_word_embeddings": False,
+            "max_position_embeddings": 16,
+            "num_experts": 2,
+            "num_experts_per_tok": 1,
+            "moe_intermediate_size": 6,
+            "shared_expert_intermediate_size": 6,
+        }
+        args = qwen3_5_moe.ModelArgs.from_dict(
+            {"model_type": "qwen3_5_moe", "text_config": text_config}
+        )
+        model = qwen3_5_moe.Model(args)
+
+        weight_key = "model.language_model.layers.0.self_attn.q_proj.weight"
+        scale_key = weight_key + "_scale_inv"
+        activation_key = weight_key.replace(".weight", ".activation_scale")
+        # Round-trip through mx.to_fp8 produces a uint8-encoded FP8 (E4M3) array
+        # in the format `mx.from_fp8` expects to consume back.
+        weight_fp8 = mx.to_fp8(
+            mx.array([[1.0, -2.0], [0.5, 4.0]], dtype=mx.bfloat16)
+        )
+        scale_inv = mx.array([[2.0]], dtype=mx.bfloat16)
+        # Expected: from_fp8(weight) * scale_inv. Use the same dequant primitive
+        # the patched sanitize uses so the comparison is bit-identical.
+        expected = (mx.from_fp8(weight_fp8, dtype=mx.bfloat16) * 2.0).astype(
+            mx.float32
+        )
+        sanitized = model.sanitize(
+            {
+                weight_key: weight_fp8,
+                scale_key: scale_inv,
+                activation_key: mx.ones((1,), dtype=mx.bfloat16),
+            }
+        )
+
+        self.assertFalse(any("weight_scale_inv" in k for k in sanitized))
+        self.assertFalse(any("activation_scale" in k for k in sanitized))
+        out_key = weight_key.replace("model.language_model", "language_model.model")
+        self.assertIn(out_key, sanitized)
+        np.testing.assert_allclose(
+            np.array(sanitized[out_key].astype(mx.float32)),
+            np.array(expected),
+        )
+
     def test_gemma4_convert_then_load_keeps_language_model_prefix(self):
         from mlx_lm.models import gemma4
 


### PR DESCRIPTION
## Summary

Qwen-org's canonical FP8 release `Qwen/Qwen3.6-35B-A3B-FP8` fails strict `load_weights` on mlx-lm `main` with `Received 61690 parameters not in model`. This PR fixes both root causes and verifies the model loads end-to-end on vanilla mlx-lm with no external compat layer.

## What's broken on main

The 61,690-key failure has two independent contributors:

| Category | Count | Cause |
|---|---|---|
| Per-expert weight tensors (`...experts.{E}.{gate,up,down}_proj.weight`) | 30,720 | `qwen3_5_moe.Model.sanitize` only handles the combined-format layout (`experts.gate_up_proj` / `experts.down_proj`) produced by `mlx_lm.convert`. |
| Per-expert FP8 scale tensors (`...weight_scale_inv`) | 30,720 | No `weight_scale_inv` dequant exists in `qwen3_5{,_moe}.py`, even though five sibling files (`deepseek_v3.py`, `deepseek_v32.py`, `minimax.py`, `mimo_v2_flash.py`, `ministral3.py`) handle the same `quant_method="fp8"` block layout inline. |
| Non-expert FP8 scale tensors (attention, lm_head, etc.) | 250 | Same as above. |

The bf16 master `Qwen/Qwen3.6-35B-A3B` is already pre-stacked and has no FP8 scales; it loads on `main` unchanged. Only the FP8 release exhibits both bugs.

## Fixes

**FP8 `weight_scale_inv` dequant + `activation_scale` drop** in `qwen3_5.Model.sanitize` and `qwen3_5_moe.Model.sanitize`. Mirrors the inline pattern from `deepseek_v3.py::sanitize::dequant`: 128×128 block, `mx.from_fp8(..., dtype=mx.bfloat16)` followed by per-block scale broadcast and pad/unpad. No-op when no `weight_scale_inv` keys are present.

**Per-expert MoE stacking branch** in `qwen3_5_moe.Model.sanitize`, using a (scan → validate → walk) structure:

1. **Scan** the weights dict for per-layer experts prefixes and their expert-index sets.
2. **Validate** each prefix's index set is a contiguous `{0, 1, …, N-1}` (raises `ValueError` otherwise).
3. **Walk** per-expert tensors in order, `mx.stack` along axis 0, and emit the combined `switch_mlp.{gate,up,down}_proj.weight` form downstream `load_weights` expects.

Pre-stacked checkpoints take the original `if gate_up_key in new_weights:` branch unchanged.

**Defensive contiguity check** raises `ValueError` on non-contiguous expert indices (e.g. `{0, 1, 3}` skipping 2) so a malformed checkpoint fails loud rather than silently dropping experts.

## Tests

Five unit tests in `tests/test_models.py`:

- `test_qwen3_5_fp8_weight_scale_inv_dequantizes_in_sanitize` — FP8 dequant via dense `Model.sanitize`, `activation_scale` drop verified.
- `test_qwen3_5_moe_fp8_weight_scale_inv_dequantizes_in_sanitize` — same, via MoE `Model.sanitize`.
- `test_qwen3_5_moe_per_expert_weights_stack_to_switch_mlp` — positive: per-expert input produces correctly stacked `switch_mlp.*` output.
- `test_qwen3_5_moe_per_expert_gap_raises` — defensive: `{0, 1, 3}` raises `ValueError` with `"non-contiguous"` in the message.
- `test_qwen3_5_moe_combined_format_still_splits_to_switch_mlp` — regression guard for the original combined-format branch.

All five pass.

## End-to-end verification

Loaded `Qwen/Qwen3.6-35B-A3B-FP8` via vanilla `mlx_lm.load(...)` on Apple Silicon Metal (M3 Max / 128 GB), no downstream compat layer:

- **Before**: `ValueError: Received 61690 parameters not in model`
- **After**: load succeeds; dequanted weight tensor at `language_model.model.layers.0.linear_attn.in_proj_qkv.weight` has shape `(8192, 2048)`, dtype `bfloat16`, all finite, nonzero, norm `62.25` — values consistent with a real attention-projection weight matrix.

Pre-stacked checkpoints (mlx-community redistributions, `Qwen/Qwen3.6-35B-A3B` bf16 master, unsloth MLX variants) load unchanged via the combined-format branch, both shims dormant — confirms backward compatibility.

## Affected / not affected

| Source | Layout | Loads on `main` today | Loads with this PR |
|---|---|---|---|
| `Qwen/Qwen3.6-35B-A3B-FP8` | per-expert + FP8 (E4M3, 128×128 block) | ❌ 61,690 unrecognized keys | ✅ |
| `Qwen/Qwen3.6-35B-A3B` (bf16 master) | combined-format, pre-stacked | ✅ | ✅ unchanged |
| `mlx-community/Qwen3.6-35B-A3B-{bf16,4bit,8bit,mxfp8,nvfp4,…}` | post-sanitize MLX-native (`switch_mlp.*`) | ✅ | ✅ unchanged |
| `unsloth/Qwen3.6-35B-A3B-{UD-MLX-4bit,MLX-8bit,UD-MLX-3bit}` | post-sanitize MLX-native | ✅ | ✅ unchanged |

## Note on the inline FP8 dequant duplication

The FP8 dequant code added here is a near-byte-identical copy of the same block in `models/{deepseek_v3,deepseek_v32,minimax,mimo_v2_flash,ministral3}.py`. A future PR could extract a shared `models/_fp8.py` helper and consolidate across all six FP8-handling model files; happy to do that as a follow-up if preferred, but kept this PR scoped to "make `Qwen/Qwen3.6-35B-A3B-FP8` load" for review tractability.
