### PR TITLE
generate.py: fix per-slot samplers/logits_processors bookkeeping in filter and extend

### DIFF
--- a/mlx_lm/generate.py
+++ b/mlx_lm/generate.py
@@ -1473,8 +1473,12 @@ class GenerationBatch:
         self.tokens = [self.tokens[idx] for idx in keep]
         if any(self.samplers):
             self.samplers = [self.samplers[idx] for idx in keep]
+        else:
+            self.samplers = [None] * len(keep)
         if any(self.logits_processors):
             self.logits_processors = [self.logits_processors[idx] for idx in keep]
+        else:
+            self.logits_processors = [[]] * len(keep)
         self.max_tokens = [self.max_tokens[idx] for idx in keep]
         self.stop_matchers = [self.stop_matchers[idx] for idx in keep]
 

--- a/mlx_lm/generate.py
+++ b/mlx_lm/generate.py
@@ -1147,12 +1147,12 @@ class PromptProcessingBatch:
         if not any(self.samplers):
             self.samplers = [None] * len(self.uids)
         if not any(self.logits_processors):
-            self.logits_processors = [None] * len(self.uids)
+            self.logits_processors = [[]] * len(self.uids)
         samplers = batch.samplers if any(batch.samplers) else [None] * len(batch.uids)
         logits_processors = (
             batch.logits_processors
             if any(batch.logits_processors)
-            else [None] * len(batch.uids)
+            else [[]] * len(batch.uids)
         )
 
         self.uids.extend(batch.uids)

--- a/tests/test_generate.py
+++ b/tests/test_generate.py
@@ -8,7 +8,9 @@ import mlx.core as mx
 
 from mlx_lm.generate import (
     BatchGenerator,
+    GenerationBatch,
     GenerationResponse,
+    PromptProcessingBatch,
     StopSequenceMatcher,
     batch_generate,
     generate,
@@ -401,6 +403,60 @@ class TestGenerate(unittest.TestCase):
         self.assertEqual(responses[uid0].logprobs[0].item(), 0.0)
         self.assertEqual(responses[uid1].logprobs[1].item(), 0.0)
         self.assertEqual(responses[uid2].logprobs[2].item(), 0.0)
+
+    def test_prompt_processing_batch_extend_mixes_logits_processors(self):
+        """Test PromptProcessingBatch.extend produces a per-slot list with no None entries when merging an unconfigured batch with a processor-equipped batch."""
+        fallback = lambda x: mx.argmax(x, axis=-1)
+        a = PromptProcessingBatch.empty(self.model, fallback)
+        a.uids = [0]
+        a.tokens = [[]]
+        a.samplers = []
+        a.logits_processors = []
+        a.max_tokens = [1]
+        a.stop_matchers = [StopSequenceMatcher()]
+        a.prompt_cache = []
+
+        procs = make_logits_processors({0: 2000.0})
+        b = PromptProcessingBatch.empty(self.model, fallback)
+        b.uids = [1]
+        b.tokens = [[]]
+        b.samplers = []
+        b.logits_processors = [procs]
+        b.max_tokens = [1]
+        b.stop_matchers = [StopSequenceMatcher()]
+        b.prompt_cache = []
+
+        a.extend(b)
+
+        self.assertEqual(len(a.logits_processors), 2)
+        for entry in a.logits_processors:
+            self.assertIsInstance(entry, list)
+
+    def test_generation_batch_filter_resets_empty_per_slot_lists(self):
+        """GenerationBatch.filter must trim samplers/logits_processors even
+        when every slot is empty (any() is False) — otherwise the lists keep
+        stale length, and a subsequent extend() appends new sequences' entries
+        at shifted indices, silently bypassing their processors for one step."""
+        fallback = lambda x: mx.argmax(x, axis=-1)
+        batch = GenerationBatch.empty(self.model, fallback)
+        matcher = StopSequenceMatcher()
+        batch.uids = [0, 1]
+        batch.prompt_cache = []
+        batch.tokens = [[], []]
+        batch.samplers = [None, None]
+        batch.logits_processors = [[], []]
+        batch.max_tokens = [1, 1]
+        batch.stop_matchers = [matcher, matcher]
+        batch._next_tokens = mx.array([0, 0], dtype=mx.uint32)
+        batch._next_logprobs = [None, None]
+        batch._token_context = [[], []]
+        batch._num_tokens = [0, 0]
+        batch._matcher_states = [matcher.make_state(), matcher.make_state()]
+
+        batch.filter([1])
+
+        self.assertEqual(len(batch.samplers), 1)
+        self.assertEqual(len(batch.logits_processors), 1)
 
     def test_batch_generate_processor_tokens_match_prompt_on_first_step(self):
         prompt = self.tokenizer.encode("hello")


### PR DESCRIPTION
## Summary

`GenerationBatch.filter` (around line 1392 of `mlx_lm/generate.py`)
uses `if any(self.samplers)` and `if any(self.logits_processors)` to
guard whether it trims those per-sequence lists. When every current
slot is `None` / `[]` (the common shape for any in-flight request
that does not attach a custom sampler or logits processor),
`any(...)` is `False` and the trim is skipped. The lists keep stale
length while `self.uids` is correctly trimmed.

When new sequences subsequently arrive via `extend`, their entries
are appended to the over-long list. `_step`'s per-sequence loop
(`for e in range(len(self.uids)): for processor in self.logits_processors[e]:`)
then reads stale-index slots — silently bypassing the new sequence's
processor for exactly one generation step before the next `filter`
corrects the length.

The structurally-symmetric `PromptProcessingBatch.filter` (around
line 1117) already handles this case with explicit `else` branches
that reset to `[None] * len(keep)` / `[[]] * len(keep)`. This PR
mirrors those branches onto `GenerationBatch.filter`.

## Impact (downstream)

Discovered while running schema-constrained generation
(`response_format=json_schema` with `strict: true`) in a
production-shape FastAPI server. After any tool-bearing chat
completion (which carries no `logits_processors`), the very next
request's `xgrammar`-based grammar processor was silently bypassed —
the model returned plain unconstrained text instead of schema-valid
output. The bug is silent (no exception, no log, no error code) and
affects exactly one request before self-recovering, which made it
ordering-dependent and hard to spot.

## Diff

```diff
--- a/mlx_lm/generate.py
+++ b/mlx_lm/generate.py
@@ -1391,8 +1391,12 @@ class GenerationBatch:
         self.tokens = [self.tokens[idx] for idx in keep]
         if any(self.samplers):
             self.samplers = [self.samplers[idx] for idx in keep]
+        else:
+            self.samplers = [None] * len(keep)
         if any(self.logits_processors):
             self.logits_processors = [self.logits_processors[idx] for idx in keep]
+        else:
+            self.logits_processors = [[]] * len(keep)
         self.max_tokens = [self.max_tokens[idx] for idx in keep]
         self.state_machines = [self.state_machines[idx] for idx in keep]
```

The `[[]]` (logits_processors) and `[None]` (samplers) defaults are
copied verbatim from `PromptProcessingBatch.filter` so the two
methods stay symmetric.

## Standalone reproducer (no model required)

```python
"""Standalone reproducer for the GenerationBatch.filter stale-length bug.

Uses object.__new__(GenerationBatch) to bypass the model-requiring
__init__ — runs in milliseconds, no model load, no GPU.

Run:
    python upstream_repro.py

Exit code 0 = bug present (current upstream main).
Exit code 1 = bug fixed.
"""
from __future__ import annotations
from mlx_lm.generate import GenerationBatch


def make_bare_batch() -> GenerationBatch:
    b = object.__new__(GenerationBatch)
    b.model = None
    b.uids = []
    b.prompt_cache = []
    b.tokens = []
    b.samplers = []
    b.fallback_sampler = None
    b.logits_processors = []
    b.state_machines = []
    b.max_tokens = []
    b._next_tokens = None
    b._next_logprobs = []
    b._token_context = []
    b._num_tokens = []
    b._matcher_states = []
    return b


def populate_no_processor_request(b: GenerationBatch, uid: int) -> None:
    """A 'tool-style' request: no logits processors, no custom sampler.
    This is the common shape for any request that does not ask for
    grammar / penalty / thinking-budget logits modification."""
    b.uids.append(uid)
    b.prompt_cache.append(None)
    b.tokens.append([1, 2, 3])
    b.samplers.append(None)
    b.logits_processors.append([])
    b.state_machines.append(None)
    b.max_tokens.append(16)
    b._token_context.append(None)
    b._num_tokens.append(0)
    b._matcher_states.append(None)
    b._next_logprobs.append(None)


def main() -> int:
    b = make_bare_batch()
    populate_no_processor_request(b, uid=42)

    assert len(b.uids) == 1
    assert b.logits_processors == [[]]
    assert b.samplers == [None]

    # Simulate the request finishing — keep=[] means drop everything.
    b.filter(keep=[])

    print(f"after filter(keep=[]):")
    print(f"  uids               = {b.uids} (len={len(b.uids)})")
    print(f"  logits_processors  = {b.logits_processors} (len={len(b.logits_processors)})")
    print(f"  samplers           = {b.samplers} (len={len(b.samplers)})")

    bug = (
        len(b.logits_processors) != len(b.uids)
        or len(b.samplers) != len(b.uids)
    )
    if bug:
        print("\nBUG REPRODUCED — list length(s) do NOT match len(uids).")
        return 0
    print("\nFIX VERIFIED — all per-sequence lists have len == len(uids).")
    return 1


if __name__ == "__main__":
    raise SystemExit(main())
```

**Verified output (against `mlx-lm 0.31.3` and `main` at the time of
this PR):**

```
after filter(keep=[]):
  uids               = [] (len=0)
  logits_processors  = [[]] (len=1)
  samplers           = [None] (len=1)

BUG REPRODUCED — list length(s) do NOT match len(uids).
```

**With the diff applied:**

```
after filter(keep=[]):
  uids               = [] (len=0)
  logits_processors  = [] (len=0)
  samplers           = [] (len=0)

FIX VERIFIED — all per-sequence lists have len == len(uids).
```

## Suggested unit test

```python
def test_generation_batch_filter_clears_logits_processors_when_all_empty():
    """GenerationBatch.filter must keep self.logits_processors length
    in lockstep with self.uids even when every per-sequence slot is
    empty. Regression: prior versions guarded the trim with
    `if any(self.logits_processors)` and skipped on all-`[]`, leaving
    a stale-length list that would later mis-index `_step`."""
    from mlx_lm.generate import GenerationBatch

    b = object.__new__(GenerationBatch)
    b.uids = [42]
    b.prompt_cache = []
    b.tokens = [[1, 2, 3]]
    b.samplers = [None]
    b.fallback_sampler = None
    b.logits_processors = [[]]
    b.state_machines = [None]
    b.max_tokens = [16]
    b._next_tokens = None
    b._next_logprobs = [None]
    b._token_context = [None]
    b._num_tokens = [0]
    b._matcher_states = [None]

    b.filter(keep=[])

    assert len(b.uids) == 0
    assert len(b.logits_processors) == 0
    assert len(b.samplers) == 0
```

## Related (different bugs)

- #1175 (open) `mtp_generate_step: logits processors see stale
  prev_tokens on draft calls` — different mechanism (token history not
  updated in the MTP path), distinct from the list-length bug fixed
  here.
- #1156 (closed) `Stateful logits processors see stale tokens due to
  lazy evaluation in stream context` — also a processor-staleness
  story, but in a different code path (lazy eval ordering in streaming
  generation).

The `filter`-list-length bug fixed here appears unreported.


---

## Update 2026-06-10 — now also carries the `PromptProcessingBatch.extend` fix from #1230

@nastya236 closed #1230 as a duplicate of this PR. The two changes are
companions in the same file but fix **different code paths** — `filter`
(this PR's original scope) and `extend` (#1230's scope) — so this PR
now includes both, making the single-merge view correct:

- **Commit 1 (`filter`, original):** else branches so the per-slot
  `samplers` / `logits_processors` lists stay in lockstep with `uids`
  after trimming. Failure mode: *silent* — the next request's logits
  processor is bypassed for one step (unconstrained output under
  `response_format=json_schema`).
- **Commit 2 (`extend`, from #1230, credit @BLuchterhand):**
  `[[]] * N` instead of `[None] * N` for absent per-slot
  `logits_processors`. Merging an unconfigured batch with a
  processor-equipped batch otherwise produces `[None, ..., [fn], ...]`,
  and `_step` crashes with `TypeError: 'NoneType' object is not
  iterable`. Failure mode: *fatal* for any heterogeneous batched
  workload (hit in production at batch_size=8, mixed plain +
  grammar-constrained requests).

Both use the same asymmetric sentinel pair, matching the existing
`PromptProcessingBatch.filter`: `None` for `samplers[e]`
(type `Optional[Callable]`, consumed via `or self.fallback_sampler`)
and `[]` for `logits_processors[e]` (type `List[Callable]`, consumed
by iteration).

Commit 2 carries over #1230's regression test
(`test_prompt_processing_batch_extend_mixes_logits_processors`),
verified red on the unpatched tree and green with the fix; the full
`-k batch` suite in `tests/test_generate.py` passes (17/17).
