### PR TITLE
fix(generate): avoid None entries in merged logits_processors

### DIFF
--- a/mlx_lm/generate.py
+++ b/mlx_lm/generate.py
@@ -1063,12 +1063,12 @@ class PromptProcessingBatch:
         if not any(self.samplers):
             self.samplers = [None] * len(self.uids)
         if not any(self.logits_processors):
-            self.logits_processors = [None] * len(self.uids)
+            self.logits_processors = [[]] * len(self.uids)
         samplers = batch.samplers if any(batch.samplers) else [None] * len(batch.uids)
         logits_processors = (
             batch.logits_processors
             if any(batch.logits_processors)
-            else [None] * len(batch.uids)
+            else [[]] * len(batch.uids)
         )
 
         self.uids.extend(batch.uids)

--- a/tests/test_generate.py
+++ b/tests/test_generate.py
@@ -9,6 +9,7 @@ import mlx.core as mx
 from mlx_lm.generate import (
     BatchGenerator,
     GenerationResponse,
+    PromptProcessingBatch,
     SequenceStateMachine,
     batch_generate,
     generate,
@@ -401,6 +402,34 @@ class TestGenerate(unittest.TestCase):
         self.assertEqual(responses[uid0].logprobs[0].item(), 0.0)
         self.assertEqual(responses[uid1].logprobs[1].item(), 0.0)
         self.assertEqual(responses[uid2].logprobs[2].item(), 0.0)
+
+    def test_prompt_processing_batch_extend_mixes_logits_processors(self):
+        """Test PromptProcessingBatch.extend produces a per-slot list with no None entries when merging an unconfigured batch with a processor-equipped batch."""
+        fallback = lambda x: mx.argmax(x, axis=-1)
+        a = PromptProcessingBatch.empty(self.model, fallback)
+        a.uids = [0]
+        a.tokens = [[]]
+        a.samplers = []
+        a.logits_processors = []
+        a.max_tokens = [1]
+        a.state_machines = [SequenceStateMachine()]
+        a.prompt_cache = []
+
+        procs = make_logits_processors({0: 2000.0})
+        b = PromptProcessingBatch.empty(self.model, fallback)
+        b.uids = [1]
+        b.tokens = [[]]
+        b.samplers = []
+        b.logits_processors = [procs]
+        b.max_tokens = [1]
+        b.state_machines = [SequenceStateMachine()]
+        b.prompt_cache = []
+
+        a.extend(b)
+
+        self.assertEqual(len(a.logits_processors), 2)
+        for entry in a.logits_processors:
+            self.assertIsInstance(entry, list)
 
     def test_batch_generate_processor_tokens_match_prompt_on_first_step(self):
         prompt = self.tokenizer.encode("hello")


### PR DESCRIPTION
## Bug

`PromptProcessingBatch.extend` filled missing per-slot `logits_processors` with `[None] * N`. Merging an unconfigured batch with a processor-equipped batch produced a list shaped `[None, ..., [fn], ...]`. `GenerationBatch._step` (line 1346) iterates `self.logits_processors[e]` under the `any()` guard at line 1337, which raises `TypeError: 'NoneType' object is not iterable` on the `None` slots.

## Reproduce

```python
a = PromptProcessingBatch.empty(model, fallback)
a.uids = [0]; a.logits_processors = []
b = PromptProcessingBatch.empty(model, fallback)
b.uids = [1]; b.logits_processors = [make_logits_processors({0: 2000.0})]
a.extend(b)
# a.logits_processors == [None, [<fn>]]   ← later crashes _step
```

## Fix

```diff
-            self.logits_processors = [None] * len(self.uids)
+            self.logits_processors = [[]] * len(self.uids)
...
-            else [None] * len(batch.uids)
+            else [[]] * len(batch.uids)
```

Per-slot type is `List[Callable]`, so the absent-value sentinel should be `[]`, not `None`. Matches the existing `[[]] * len(keep)` at line 1120 (`PromptProcessingBatch.filter`).

## Test

`test_prompt_processing_batch_extend_mixes_logits_processors` in `tests/test_generate.py`. Asserts no `None` entries remain in the merged list. Fails on `main` (`AssertionError: None is not an instance of <class 'list'>`), passes with the fix.

## Related

#1225 fixes the symmetric stale-length bug in `GenerationBatch.filter`. This is situated in a different code path so both can land independently.

## Traceback (production hit)

```
File "mlx_lm/generate.py", line 1346, in _step
    for processor in self.logits_processors[e]:
TypeError: 'NoneType' object is not iterable
```
