### PR TITLE
fix: Metal resource-limit errors from batched cache metadata

### DIFF
--- a/mlx_lm/generate.py
+++ b/mlx_lm/generate.py
@@ -1366,7 +1366,13 @@ class GenerationBatch:
         # asynchronously
         self._next_tokens = sampled
         self._next_logprobs = list(logprobs)
-        mx.async_eval(self._next_tokens, self._next_logprobs, token_context)
+
+        mx.async_eval(
+            self._next_tokens,
+            self._next_logprobs,
+            token_context,
+            cache.prompt_cache_eval_targets(self.prompt_cache),
+        )
 
         # Eval the current tokens and current logprobs. After that also add
         # them to self.tokens so that it always represents the tokens contained

--- a/mlx_lm/models/cache.py
+++ b/mlx_lm/models/cache.py
@@ -111,12 +111,13 @@ def trim_prompt_cache(cache: List[Any], num_tokens: int) -> List[Any]:
     return [c.trim(num_tokens) for c in cache][0]
 
 
-_CACHE_EVAL_TARGETS = ("offset", "left_padding", "lengths", "_lengths")
+# BatchRotatingKVCache mutates this during right-padded prefill.
+_CACHE_EVAL_ATTRS = ("offset", "left_padding", "lengths", "_lengths")
 
 
 def _cache_eval_targets(c: Any) -> List[mx.array]:
     targets = []
-    for attr in _CACHE_EVAL_TARGETS:
+    for attr in _CACHE_EVAL_ATTRS:
         val = getattr(c, attr, None)
         if isinstance(val, mx.array):
             targets.append(val)

--- a/mlx_lm/models/cache.py
+++ b/mlx_lm/models/cache.py
@@ -111,6 +111,30 @@ def trim_prompt_cache(cache: List[Any], num_tokens: int) -> List[Any]:
     return [c.trim(num_tokens) for c in cache][0]
 
 
+_CACHE_EVAL_TARGETS = ("offset", "left_padding", "lengths", "_lengths")
+
+
+def _cache_eval_targets(c: Any) -> List[mx.array]:
+    targets = []
+    for attr in _CACHE_EVAL_TARGETS:
+        val = getattr(c, attr, None)
+        if isinstance(val, mx.array):
+            targets.append(val)
+    for sub_cache in getattr(c, "caches", ()):
+        targets.extend(_cache_eval_targets(sub_cache))
+    return targets
+
+
+def prompt_cache_eval_targets(prompt_cache: List[Any]) -> List[mx.array]:
+    """
+    Return lightweight cache metadata arrays that should be periodically eval'd.
+    """
+    targets = []
+    for c in prompt_cache:
+        targets.extend(_cache_eval_targets(c))
+    return targets
+
+
 def create_attention_mask(
     N: int, offset: int, return_array: bool, window_size: Optional[int]
 ):

--- a/tests/test_prompt_cache.py
+++ b/tests/test_prompt_cache.py
@@ -20,6 +20,7 @@ from mlx_lm.models.cache import (
     RotatingKVCache,
     load_prompt_cache,
     make_prompt_cache,
+    prompt_cache_eval_targets,
     save_prompt_cache,
     trim_prompt_cache,
 )
@@ -529,6 +530,24 @@ class TestPromptCache(unittest.TestCase):
         self.assertEqual(cache_a.values.shape[0], 5)
         self.assertEqual(cache_a.offset.tolist(), [6, 7, 6, 1, 4])
         self.assertEqual(cache_a.left_padding.tolist(), [2, 1, 2, 7, 4])
+
+    def test_prompt_cache_eval_targets(self):
+        batch_cache = BatchKVCache(left_padding=[1, 0])
+        rotating_cache = BatchRotatingKVCache(max_size=4, left_padding=[2, 0])
+        arrays_cache = ArraysCache(size=1, left_padding=[3, 0])
+        arrays_cache.prepare(lengths=[5, 4])
+
+        targets = prompt_cache_eval_targets(
+            [CacheList(batch_cache, CacheList(rotating_cache, arrays_cache))]
+        )
+
+        self.assertEqual(len(targets), 6)
+        self.assertIs(targets[0], batch_cache.offset)
+        self.assertIs(targets[1], batch_cache.left_padding)
+        self.assertIs(targets[2], rotating_cache.offset)
+        self.assertIs(targets[3], rotating_cache.left_padding)
+        self.assertIs(targets[4], arrays_cache.left_padding)
+        self.assertIs(targets[5], arrays_cache.lengths)
 
     def test_batch_rotating_kv_cache(self):
         cache = BatchRotatingKVCache(max_size=4, left_padding=[2, 0])


### PR DESCRIPTION
This PR fixes a lazy graph accumulation issue in long-running batched generation. Small cache metadata arrays such as `offset`, `left_padding`, and sequence lengths can be updated token-by-token without being materialized often enough. That eventually surfaces as a `[metal::malloc] Resource limit (...) exceeded`, even though the full KV cache tensors aren't growing unexpectedly.

This is similar to #960, which fixed one path for `BatchRotatingKVCache`. I took a slightly broader approach at the generation scheduling boundary: explicitly evaluate lightweight cache metadata each decode step, regardless of the specific cache shape being used.

## Details

- Adds cache-owned helper, `prompt_cache_eval_targets()`
- Collects lightweight metadata fields: `offset`, `left_padding`, `lengths`, and `_lengths`
- Handles nested `CacheList` structures
- Keeps the generation hot path simple
- Avoids evaluating full KV cache tensors
- Adds a test for recursive metadata target discovery

## Context

I originally encountered this through `mlx-vlm`, but the issue is in `mlx-lm` batched generation/cache path. 