### PR TITLE
Add fallback for invalid json values in qwen3_coder tool

### DIFF
--- a/mlx_lm/tool_parsers/qwen3_coder.py
+++ b/mlx_lm/tool_parsers/qwen3_coder.py
@@ -74,9 +74,15 @@ def _convert_param_value(param_value: str, param_name: str, param_config: dict) 
             try:
                 return json.loads(param_value)
             except json.JSONDecodeError:
-                return ast.literal_eval(param_value)
+                try:
+                    return ast.literal_eval(param_value)
+                except (ValueError, SyntaxError):
+                    return param_value
 
-        return ast.literal_eval(param_value)
+        try:
+            return ast.literal_eval(param_value)
+        except (ValueError, SyntaxError):
+            return param_value
 
 
 def _parse_xml_function_call(function_call_str: str, tools: Optional[Any]):

--- a/mlx_lm/tool_parsers/qwen3_coder.py
+++ b/mlx_lm/tool_parsers/qwen3_coder.py
@@ -72,7 +72,7 @@ def _convert_param_value(param_value: str, param_name: str, param_config: dict) 
             or param_type.startswith("list")
         ):
             try:
-                return json.loads(param_value)
+                return json.loads(param_value, strict=False)
             except json.JSONDecodeError:
                 pass
 

--- a/mlx_lm/tool_parsers/qwen3_coder.py
+++ b/mlx_lm/tool_parsers/qwen3_coder.py
@@ -74,10 +74,7 @@ def _convert_param_value(param_value: str, param_name: str, param_config: dict) 
             try:
                 return json.loads(param_value)
             except json.JSONDecodeError:
-                try:
-                    return ast.literal_eval(param_value)
-                except (ValueError, SyntaxError):
-                    return param_value
+                pass
 
         try:
             return ast.literal_eval(param_value)

--- a/tests/test_tool_parsing.py
+++ b/tests/test_tool_parsing.py
@@ -330,5 +330,70 @@ class TestToolParsing(unittest.TestCase):
         self.assertEqual(expected, tool_calls)
 
 
+    def test_qwen3_coder_iso_date(self):
+        """Qwen3 coder parser should not crash on ISO 8601 dates."""
+        tools = [
+            {
+                "type": "function",
+                "function": {
+                    "name": "schedule",
+                    "description": "Schedule a task",
+                    "parameters": {
+                        "type": "object",
+                        "required": ["name", "deadline"],
+                        "properties": {
+                            "name": {"type": "string"},
+                            "deadline": {"type": "string"},
+                        },
+                    },
+                },
+            }
+        ]
+        test_case = (
+            "<function=schedule>\n"
+            "<parameter=name>\n"
+            "deploy\n"
+            "</parameter>\n"
+            "<parameter=deadline>\n"
+            "2025-06-15T10:30:00Z\n"
+            "</parameter>\n"
+            "</function>"
+        )
+        tool_calls = qwen3_coder.parse_tool_call(test_case, tools)
+        # parse_tool_call returns dict, not list
+        self.assertEqual(tool_calls["name"], "schedule")
+        self.assertEqual(tool_calls["arguments"]["name"], "deploy")
+        self.assertEqual(tool_calls["arguments"]["deadline"], "2025-06-15T10:30:00Z")
+
+    def test_qwen3_coder_partial_number(self):
+        """Qwen3 coder parser should handle partial number-like strings."""
+        tools = [
+            {
+                "type": "function",
+                "function": {
+                    "name": "log",
+                    "description": "Log a message",
+                    "parameters": {
+                        "type": "object",
+                        "required": ["msg"],
+                        "properties": {
+                            "msg": {"type": "string"},
+                        },
+                    },
+                },
+            }
+        ]
+        test_case = (
+            "<function=log>\n"
+            "<parameter=msg>\n"
+            "version 3.10.5-beta\n"
+            "</parameter>\n"
+            "</function>"
+        )
+        tool_calls = qwen3_coder.parse_tool_call(test_case, tools)
+        # parse_tool_call returns dict, not list
+        self.assertEqual(tool_calls["arguments"]["msg"], "version 3.10.5-beta")
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_tool_parsing.py
+++ b/tests/test_tool_parsing.py
@@ -329,7 +329,6 @@ class TestToolParsing(unittest.TestCase):
         tool_calls = minimax_m2.parse_tool_call(test_case, None)
         self.assertEqual(expected, tool_calls)
 
-
     def test_qwen3_coder_iso_date(self):
         """Qwen3 coder parser should not crash on ISO 8601 dates."""
         tools = [


### PR DESCRIPTION
Fixes #1236

`_convert_param_value` calls `ast.literal_eval()` on parameter values that
don't match a known type. This crashes on strings like ISO 8601 timestamps
(`"2025-06-15T10:30:00Z"`) and partial numbers (`"3.10.5-beta"`) because
`ast.literal_eval` raises `ValueError`/`SyntaxError` on them.

Wrap both call sites in try/except, falling back to the raw string value.

Added two tests:
- `test_qwen3_coder_iso_date`: ISO 8601 timestamp passed as string param
- `test_qwen3_coder_partial_number`: version-like string passed as string param