### PR TITLE
Fix Gemma 4 sanitize() not stripping KV projections for shared layers

### DIFF
--- a/mlx_lm/models/gemma4_text.py
+++ b/mlx_lm/models/gemma4_text.py
@@ -609,6 +609,7 @@ class Model(nn.Module):
 
     def sanitize(self, weights):
         sanitized = {}
+        first_kv_shared = self.args.num_hidden_layers - self.args.num_kv_shared_layers
         for k, v in weights.items():
             if any(
                 s in k
@@ -621,6 +622,15 @@ class Model(nn.Module):
                 )
             ):
                 continue
+
+            # KV-shared layers reuse K/V from earlier layers — drop their projections
+            if any(s in k for s in (".self_attn.k_proj", ".self_attn.v_proj", ".self_attn.k_norm")):
+                try:
+                    layer_idx = int(k.split("layers.")[1].split(".")[0])
+                    if layer_idx >= first_kv_shared:
+                        continue
+                except (IndexError, ValueError):
+                    pass
 
             if k.endswith(".experts.gate_up_proj"):
                 base = k.removesuffix(".gate_up_proj")

--- a/mlx_lm/models/gemma4_text.py
+++ b/mlx_lm/models/gemma4_text.py
@@ -624,7 +624,10 @@ class Model(nn.Module):
                 continue
 
             # KV-shared layers reuse K/V from earlier layers — drop their projections
-            if any(s in k for s in (".self_attn.k_proj", ".self_attn.v_proj", ".self_attn.k_norm")):
+            if any(
+                s in k
+                for s in (".self_attn.k_proj", ".self_attn.v_proj", ".self_attn.k_norm")
+            ):
                 try:
                     layer_idx = int(k.split("layers.")[1].split(".")[0])
                     if layer_idx >= first_kv_shared:


### PR DESCRIPTION
## Problem

Loading any quantized Gemma 4 model (e.g. `mlx-community/gemma-4-e4b-it-4bit`) fails with:

```
ValueError: Received 126 parameters not in model:
language_model.model.layers.24.self_attn.k_proj.weight,
language_model.model.layers.24.self_attn.k_proj.scales,
language_model.model.layers.24.self_attn.v_proj.weight,
...
```

## Root Cause

KV-shared layers (indices >= `num_hidden_layers - num_kv_shared_layers`) reuse K/V tensors from an earlier layer and have no `k_proj`, `v_proj`, or `k_norm` attributes. The quantized safetensors files still contain weight keys for those projections in the shared layers, so `load_weights(strict=True)` rejects them.

The `sanitize()` method already filters out other unused keys (e.g. `rotary_emb`, quant min/max) but was missing this case.

## Fix

Compute `first_kv_shared` from `self.args` in `sanitize()` and skip `k_proj`, `v_proj`, and `k_norm` weight keys for any layer at or beyond that index.

## Testing

Verified with `mlx-community/gemma-4-e4b-it-4bit` on M4 Pro (24 GB) with mlx 0.31.3:

```
Prompt: 27 tokens, 42.676 tokens-per-sec
Generation: 40 tokens, 70.122 tokens-per-sec
Peak memory: 4.339 GB
```

Model loads and generates correctly after the patch.