### PR TITLE
add: lfm2/2.5 tool parser

### DIFF
--- a/mlx_lm/tokenizer_utils.py
+++ b/mlx_lm/tokenizer_utils.py
@@ -559,6 +559,10 @@ def _infer_tool_parser(chat_template):
         return "longcat"
     elif "<arg_key>" in chat_template:
         return "glm47"
+    elif "List of tools:" in chat_template and (
+        "<|tool_list_start|>" in chat_template or "<|im_start|>" in chat_template
+    ):
+        return "lfm2"
     elif "<|tool_list_start|>" in chat_template:
         return "pythonic"
     elif (

--- a/mlx_lm/tool_parsers/lfm2.py
+++ b/mlx_lm/tool_parsers/lfm2.py
@@ -1,0 +1,104 @@
+# Copyright © 2026 Apple Inc.
+
+"""
+Tool parser for LiquidAI LFM2 / LFM2.5 models.
+
+The model emits pythonic tool calls wrapped in special tokens, e.g.:
+
+    <|tool_call_start|>[get_weather(location="Paris")]<|tool_call_end|>
+
+By the time `parse_tool_call` is invoked, the surrounding sentinel tokens
+have already been stripped by the server's state machine, so this parser
+sees only the inner ``[func(args), ...]`` payload.
+
+Function names may be dotted (``grocery.orderIngredients``) and argument
+values may contain nested lists / dicts, so we parse with ``ast`` rather
+than regex. JSON-style ``true`` / ``false`` / ``null`` are tolerated as a
+fallback for models that occasionally emit JSON literals.
+"""
+
+import ast
+from typing import Any
+
+import regex as re
+
+tool_call_start = "<|tool_call_start|>"
+tool_call_end = "<|tool_call_end|>"
+
+_TOOL_CALL_REGEX = re.compile(r"\s*\[.*\]\s*$", re.DOTALL)
+
+_JSON_LITERALS = [
+    (re.compile(r"\btrue\b"), "True"),
+    (re.compile(r"\bfalse\b"), "False"),
+    (re.compile(r"\bnull\b"), "None"),
+]
+
+
+def _func_name(node: ast.AST) -> str:
+    """Resolve a Name/Attribute chain into a dotted string."""
+    if isinstance(node, ast.Name):
+        return node.id
+    if isinstance(node, ast.Attribute):
+        return f"{_func_name(node.value)}.{node.attr}"
+    raise ValueError(f"Unsupported function name node: {type(node).__name__}")
+
+
+def _literal_eval(value_node: ast.AST, source: str) -> Any:
+    try:
+        return ast.literal_eval(value_node)
+    except (ValueError, SyntaxError):
+        # Fallback: model emitted JSON literals (true/false/null) inside an
+        # otherwise pythonic structure. Re-render the node and substitute.
+        rendered = ast.unparse(value_node)
+        for pattern, replacement in _JSON_LITERALS:
+            rendered = pattern.sub(replacement, rendered)
+        return ast.literal_eval(rendered)
+
+
+def _parse_call(node: ast.AST, source: str) -> dict:
+    if not isinstance(node, ast.Call):
+        raise ValueError(f"Expected a function call, got {type(node).__name__}")
+    if node.args:
+        raise ValueError("LFM2 tool calls only accept keyword arguments")
+    name = _func_name(node.func)
+    arguments = {}
+    for kw in node.keywords:
+        if kw.arg is None:
+            raise ValueError("`**kwargs`-style arguments are not supported")
+        arguments[kw.arg] = _literal_eval(kw.value, source)
+    return {"name": name, "arguments": arguments}
+
+
+def _parse(source: str) -> ast.AST:
+    try:
+        return ast.parse(source, mode="eval")
+    except SyntaxError:
+        # Retry with JSON literals normalised. We do this on the raw source
+        # only as a fallback because a blanket replacement could otherwise
+        # corrupt strings containing the words true/false/null.
+        normalised = source
+        for pattern, replacement in _JSON_LITERALS:
+            normalised = pattern.sub(replacement, normalised)
+        return ast.parse(normalised, mode="eval")
+
+
+def parse_tool_call(text: str, tools: Any | None = None):
+    text = text.strip()
+    if not text:
+        raise ValueError("Empty tool call text")
+    if not _TOOL_CALL_REGEX.match(text):
+        raise ValueError(
+            f"LFM2 tool call must be a list expression like `[fn(...)]`, got: {text!r}"
+        )
+
+    tree = _parse(text)
+    body = tree.body
+    if not isinstance(body, ast.List) or not body.elts:
+        raise ValueError("Tool output must be a non-empty list of function calls")
+    if not all(isinstance(elt, ast.Call) for elt in body.elts):
+        raise ValueError("Every element of the tool list must be a function call")
+
+    calls = [_parse_call(elt, text) for elt in body.elts]
+    if len(calls) == 1:
+        return calls[0]
+    return calls

--- a/tests/test_tool_parsing.py
+++ b/tests/test_tool_parsing.py
@@ -7,6 +7,7 @@ from mlx_lm.tool_parsers import (
     glm47,
     json_tools,
     kimi_k2,
+    lfm2,
     longcat,
     minimax_m2,
     mistral,
@@ -52,6 +53,10 @@ class TestToolParsing(unittest.TestCase):
             (
                 "[multiply(a=12234585, b=48838483920)]",
                 pythonic,
+            ),
+            (
+                "[multiply(a=12234585, b=48838483920)]",
+                lfm2,
             ),
             (
                 'multiply[ARGS]{"a": 12234585, "b": 48838483920}',
@@ -122,6 +127,10 @@ class TestToolParsing(unittest.TestCase):
             (
                 '[get_current_temperature(location="London")]',
                 pythonic,
+            ),
+            (
+                '[get_current_temperature(location="London")]',
+                lfm2,
             ),
             (
                 'get_current_temperature[ARGS]{"location": "London"}',
@@ -312,6 +321,76 @@ class TestToolParsing(unittest.TestCase):
             },
         ]
         self.assertEqual(tool_calls, expected)
+
+    def test_lfm2(self):
+        # Basic single call (LFM2.5 server failure: basic_tool_call)
+        tool_call = lfm2.parse_tool_call('[get_current_time(location="Paris")]', None)
+        self.assertEqual(
+            tool_call,
+            {"name": "get_current_time", "arguments": {"location": "Paris"}},
+        )
+
+        # multi_tool_choice failure
+        tool_call = lfm2.parse_tool_call(
+            '[get_current_temperature(location="Tokyo")]', None
+        )
+        self.assertEqual(
+            tool_call,
+            {"name": "get_current_temperature", "arguments": {"location": "Tokyo"}},
+        )
+
+        # Dotted function name + nested list-of-dicts argument
+        # (complex_tool_call failure).
+        text = (
+            "[grocery.orderIngredients("
+            "ingredientList=["
+            '{"name": "noodles", "amount": 500, "unit": "grams"}, '
+            '{"name": "ground beef", "amount": 300, "unit": "grams"}, '
+            '{"name": "za\'atar", "amount": 1, "unit": "gram"}'
+            "], "
+            'deliveryAddress="845 Willow Lane, Springfield, IL 62704, United States"'
+            ")]"
+        )
+        tool_call = lfm2.parse_tool_call(text, None)
+        self.assertEqual(tool_call["name"], "grocery.orderIngredients")
+        self.assertEqual(
+            tool_call["arguments"]["deliveryAddress"],
+            "845 Willow Lane, Springfield, IL 62704, United States",
+        )
+        self.assertEqual(len(tool_call["arguments"]["ingredientList"]), 3)
+        self.assertEqual(
+            tool_call["arguments"]["ingredientList"][0],
+            {"name": "noodles", "amount": 500, "unit": "grams"},
+        )
+        self.assertEqual(tool_call["arguments"]["ingredientList"][2]["name"], "za'atar")
+
+        # Multiple calls in one block returns a list
+        tool_calls = lfm2.parse_tool_call(
+            '[get_current_time(location="Paris"), '
+            'get_current_temperature(location="Paris")]',
+            None,
+        )
+        self.assertIsInstance(tool_calls, list)
+        self.assertEqual(len(tool_calls), 2)
+        self.assertEqual(tool_calls[0]["name"], "get_current_time")
+        self.assertEqual(tool_calls[1]["name"], "get_current_temperature")
+
+        # JSON-style booleans / null tolerated as fallback
+        tool_call = lfm2.parse_tool_call(
+            "[configure(enabled=true, retries=null, verbose=false)]", None
+        )
+        self.assertEqual(
+            tool_call["arguments"],
+            {"enabled": True, "retries": None, "verbose": False},
+        )
+
+        # Hyphenated names are not valid Python identifiers — must raise.
+        with self.assertRaises(ValueError):
+            lfm2.parse_tool_call('[manim-video(mode="plan")]', None)
+
+        # Non-list payloads are rejected.
+        with self.assertRaises(ValueError):
+            lfm2.parse_tool_call('get_current_time(location="Paris")', None)
 
     def test_minimax_m2(self):
         test_case = (


### PR DESCRIPTION
## Issue
  LFM2 / LFM2.5 models emit tool calls as
  `<|tool_call_start|>[fn(args)]<|tool_call_end|>`, but no parser was registered for this
  format, so tool calls leaked into `message.content` instead of `tool_calls`.

  The existing `pythonic` parser also couldn't have handled real outputs: its regex
  rejects dotted names like `grocery.orderIngredients` and breaks on nested list/dict
  args.

  ## Changes
  - New `mlx_lm/tool_parsers/lfm2.py` — parses the payload with `ast` so dotted names,
  nested args, and multi-call lists all work.
  - `_infer_tool_parser` routes chat templates containing `"List of tools:"` to the new
  parser (matches both LFM2 and LFM2.5).

  ## Testing
  - [x] Added LFM-specific tool calling tests
  - [x] Tested on internal test suite for tool calling
  - [x] Tested locally against `mlx_lm.server`: single call, multi-tool selection, nested
  args, declined call, streaming, multi-turn round-trip, parallel calls