### PR TITLE
Drop redundant lm_head AWQ quant triple in load_model

### DIFF
--- a/mlx_lm/utils.py
+++ b/mlx_lm/utils.py
@@ -80,6 +80,165 @@ def _unpack_awq_weights(qweight: mx.array) -> mx.array:
     return unpacked.reshape(out_features, in_features)
 
 
+_AWQ_LM_HEAD_QUANT_SUFFIXES = ("qweight", "qzeros", "scales")
+
+
+def _module_at_path(model: nn.Module, path: str) -> Optional[nn.Module]:
+    """Walk ``model`` along the dot-separated ``path``; return None on
+    any missing attribute."""
+    if not path:
+        return model
+    sub: Optional[nn.Module] = model
+    for part in path.split("."):
+        sub = getattr(sub, part, None)
+        if sub is None:
+            return None
+    return sub
+
+
+def _owner_aliases(owner: str):
+    """Yield owner paths to consult for an ``lm_head`` at ``owner``,
+    most-specific first.
+
+    Sanitizers commonly re-namespace text weights under an extra
+    ``model.`` segment (gpt2/gpt_neox at top level; gemma4 inside the
+    text wrapper). The tying decision still belongs to the outer
+    submodel, so a missing signal at the more-specific path falls
+    back to the outer one rather than being treated as "unknown".
+    """
+    yield owner
+    if owner.endswith(".model"):
+        yield owner[: -len(".model")]
+    elif owner == "model":
+        yield ""
+
+
+def _config_for_owner(owner: str, config: Dict[str, Any]) -> Dict[str, Any]:
+    """Return the config fragment that governs construction of the
+    submodel at ``owner``. Multimodal text submodels (anything under
+    ``language_model``) are governed by ``config["text_config"]``;
+    everything else by top-level ``config``."""
+    if owner.startswith("language_model"):
+        return config.get("text_config", {})
+    return config
+
+
+def _tie_value_from_module(module: nn.Module) -> Optional[bool]:
+    """Return the submodel's ``args.tie_word_embeddings`` when the
+    ``ModelArgs`` declares it — the bool value whether explicitly set
+    to ``True`` or ``False``; return ``None`` when the field is absent
+    so the caller can fall back to another lookup. Using ``is True``
+    defensively coerces any non-True value (e.g., a ``None`` or non-
+    bool default) to ``False`` so an unset field never passes as an
+    authoritative tied signal."""
+    args = getattr(module, "args", None) or getattr(module, "config", None)
+    if args is not None and hasattr(args, "tie_word_embeddings"):
+        return getattr(args, "tie_word_embeddings") is True
+    return None
+
+
+def _is_authoritatively_tied_at(
+    outer_prefix: str,
+    model: nn.Module,
+    config: Dict[str, Any],
+) -> bool:
+    """For weights at ``outer_prefix`` (e.g., ``""`` for top-level,
+    ``"language_model."`` for multimodal text submodels), return True
+    iff the governing submodel is authoritatively tied.
+
+    Asks two model-level questions instead of branching on each known
+    sanitizer prefix:
+
+    1. Walk ``outer_prefix`` (and one level of sanitizer-renamed
+       fallback via :func:`_owner_aliases`) to find the governing
+       submodel. ``language_model.model`` falls back to
+       ``language_model`` (gemma4-style nested wrapper); ``model``
+       falls back to ``""`` (gpt2/gpt_neox transparent wrapper). The
+       extra ``model.`` segment is a sanitize-level renaming, not a
+       new tying boundary.
+    2. At each level, consult the config fragment that drove the
+       submodel's constructor (top-level for ``""``/``model``,
+       ``config["text_config"]`` for ``language_model``/
+       ``language_model.model``); fall back to the submodel's
+       ``ModelArgs.tie_word_embeddings`` only when config is silent,
+       and only when the field is literally ``True``.
+
+    Returns False (preserve the triple) when no level yields an
+    authoritative signal — strict load failing loudly is preferable
+    to silently dropping a real quantized output head.
+    """
+    owner = outer_prefix.removesuffix(".")
+    for candidate_owner in _owner_aliases(owner):
+        cfg = _config_for_owner(candidate_owner, config)
+        if isinstance(cfg, dict) and "tie_word_embeddings" in cfg:
+            return cfg["tie_word_embeddings"] is True
+        module = _module_at_path(model, candidate_owner)
+        if module is not None:
+            tied = _tie_value_from_module(module)
+            if tied is not None:
+                return tied
+    return False
+
+
+def _maybe_drop_redundant_lm_head_awq_triple(
+    weights: Dict[str, mx.array],
+    model: nn.Module,
+    config: Dict[str, Any],
+) -> Dict[str, mx.array]:
+    """Drop ``*lm_head.{qweight,qzeros,scales}`` keys that the
+    constructed model has no parameter target for, when an explicit
+    tied-embedding signal authorises the drop.
+
+    AutoAWQ checkpoints may quantize ``lm_head`` even on tied-embedding
+    models, where ``lm_head`` aliases ``embed_tokens`` and is not a
+    real parameter. The redundant quant triple would round-trip through
+    ``_transform_awq_weights`` into ``lm_head.{weight,scales,biases}``
+    and fail ``model.load_weights(..., strict=True)`` with "Received
+    parameters not in model".
+
+    Each candidate triple's outer prefix (``""`` for top-level,
+    ``"language_model."`` for VL text submodels) selects which config
+    fragment and submodel govern its tying decision. Drop only when
+    that local signal is authoritative:
+
+    * The relevant ``tie_word_embeddings`` (top-level for ``""``,
+      ``text_config.tie_word_embeddings`` for ``"language_model."``)
+      is explicitly ``True``.
+    * The signal is absent in config but the relevant submodel's
+      ``ModelArgs`` declares ``tie_word_embeddings`` (Qwen2/Llama
+      pattern): the constructor honoured the args, so the missing
+      target is authoritative even when the config omits the field.
+
+    Otherwise preserve the triple. Architectures whose ``sanitize``
+    decides tying from weight content (gemma3_text, recurrent_gemma)
+    leave a missing ``lm_head.weight`` target that is ambiguous between
+    a tied checkpoint with a redundant triple and an untied checkpoint
+    with a real quantized output head; without a config signal we
+    cannot distinguish, and silently dropping the latter would produce
+    wrong logits — strict load failing loudly is preferable.
+    """
+    valid_lm_head_prefixes = set()
+    for path, _ in tree_flatten(model.parameters()):
+        if path == "lm_head.weight" or path.endswith(".lm_head.weight"):
+            valid_lm_head_prefixes.add(path[: -len("weight")])
+
+    keys_to_drop = []
+    for key in weights:
+        for suffix in _AWQ_LM_HEAD_QUANT_SUFFIXES:
+            target = f"lm_head.{suffix}"
+            if key == target or key.endswith(f".{target}"):
+                prefix = key[: -len(suffix)]
+                if prefix not in valid_lm_head_prefixes:
+                    outer_prefix = prefix[: -len("lm_head.")]
+                    if _is_authoritatively_tied_at(outer_prefix, model, config):
+                        keys_to_drop.append(key)
+                break
+
+    if not keys_to_drop:
+        return weights
+    return {k: v for k, v in weights.items() if k not in keys_to_drop}
+
+
 def _transform_awq_weights(
     weights: Dict[str, mx.array],
     quantization_config: Dict[str, Any],
@@ -383,6 +542,11 @@ def load_model(
             config["quantization_config"] = quantization
             _quantize(quantization)
         elif quant_method in ("awq", "gptq"):
+            # AutoAWQ ckpts may include a redundant lm_head quant triple
+            # (e.g., on tied-embedding models, or under multimodal
+            # sanitize prefixes); drop any whose .weight target is not
+            # present on the constructed model before transforming.
+            weights = _maybe_drop_redundant_lm_head_awq_triple(weights, model, config)
             # Transform AutoAWQ/GPTQ packed weights to MLX format
             weights, quantization = _transform_awq_weights(weights, quantization_config)
             config["quantization"] = quantization

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -183,6 +183,389 @@ class TestUtils(unittest.TestCase):
             mx.eval(logits)
             self.assertEqual(logits.shape, (1, 3, args.vocab_size))
 
+    def _awq_lm_head_triple(self, prefix=""):
+        return {
+            f"{prefix}lm_head.qweight": mx.zeros((4, 1), dtype=mx.int32),
+            f"{prefix}lm_head.qzeros": mx.zeros((1, 1), dtype=mx.int32),
+            f"{prefix}lm_head.scales": mx.zeros((1, 8), dtype=mx.float16),
+        }
+
+    def _qwen2_args(self, **overrides):
+        from mlx_lm.models import qwen2
+
+        base = dict(
+            model_type="qwen2",
+            hidden_size=8,
+            num_hidden_layers=1,
+            intermediate_size=16,
+            num_attention_heads=2,
+            num_key_value_heads=1,
+            rms_norm_eps=1e-6,
+            vocab_size=8,
+        )
+        base.update(overrides)
+        return qwen2.ModelArgs.from_dict(base)
+
+    def _gemma3_text_model(self):
+        from mlx_lm.models import gemma3_text
+
+        return gemma3_text.Model(
+            gemma3_text.ModelArgs(
+                model_type="gemma3_text",
+                hidden_size=8,
+                num_hidden_layers=1,
+                intermediate_size=16,
+                num_attention_heads=2,
+                num_key_value_heads=1,
+                head_dim=4,
+                rms_norm_eps=1e-6,
+                vocab_size=8,
+            )
+        )
+
+    def _recurrent_gemma_model(self):
+        from mlx_lm.models import recurrent_gemma
+
+        return recurrent_gemma.Model(
+            recurrent_gemma.ModelArgs(
+                model_type="recurrent_gemma",
+                attention_bias=False,
+                conv1d_width=4,
+                hidden_size=8,
+                intermediate_size=16,
+                logits_soft_cap=30.0,
+                num_attention_heads=2,
+                num_hidden_layers=1,
+                num_key_value_heads=1,
+                rms_norm_eps=1e-6,
+                rope_theta=10000.0,
+                attention_window_size=8,
+                vocab_size=8,
+                block_types=["attention"],
+            )
+        )
+
+    def _qwen2_vl_model(self, *, tie_word_embeddings):
+        from mlx_lm.models import qwen2_vl
+
+        return qwen2_vl.Model(
+            qwen2_vl.ModelArgs(
+                model_type="qwen2_vl",
+                text_config=dict(
+                    model_type="qwen2",
+                    hidden_size=8,
+                    num_hidden_layers=1,
+                    intermediate_size=16,
+                    num_attention_heads=2,
+                    num_key_value_heads=1,
+                    rms_norm_eps=1e-6,
+                    vocab_size=8,
+                    tie_word_embeddings=tie_word_embeddings,
+                ),
+            )
+        )
+
+    def test_awq_drops_tied_lm_head_triple(self):
+        from mlx_lm.models import qwen2
+
+        model = qwen2.Model(self._qwen2_args(tie_word_embeddings=True))
+        weights = {
+            **self._awq_lm_head_triple(),
+            "model.embed_tokens.weight": mx.zeros((8, 8), dtype=mx.float16),
+        }
+        out = utils._maybe_drop_redundant_lm_head_awq_triple(weights, model, {})
+        for k in self._awq_lm_head_triple():
+            self.assertNotIn(k, out)
+        self.assertIn("model.embed_tokens.weight", out)
+
+    def test_awq_preserves_untied_lm_head_triple(self):
+        from mlx_lm.models import qwen2
+
+        model = qwen2.Model(self._qwen2_args(tie_word_embeddings=False))
+        weights = self._awq_lm_head_triple()
+        out = utils._maybe_drop_redundant_lm_head_awq_triple(weights, model, {})
+        for k in weights:
+            self.assertIn(k, out)
+
+    def test_awq_drops_when_tied_field_defaulted_in_modelargs(self):
+        # Qwen2/Llama ModelArgs default `tie_word_embeddings=True`. A
+        # checkpoint config that omits the field still produces a tied
+        # model after `from_dict`. Because Qwen2 ModelArgs declares the
+        # field, the missing parameter target is authoritative even
+        # when the raw config is silent.
+        from mlx_lm.models import qwen2
+
+        args = qwen2.ModelArgs.from_dict(
+            dict(
+                model_type="qwen2",
+                hidden_size=8,
+                num_hidden_layers=1,
+                intermediate_size=16,
+                num_attention_heads=2,
+                num_key_value_heads=1,
+                rms_norm_eps=1e-6,
+                vocab_size=8,
+            )
+        )
+        self.assertTrue(args.tie_word_embeddings)
+        model = qwen2.Model(args)
+        out = utils._maybe_drop_redundant_lm_head_awq_triple(
+            self._awq_lm_head_triple(), model, {}
+        )
+        for k in self._awq_lm_head_triple():
+            self.assertNotIn(k, out)
+
+    def test_awq_drops_prefixed_lm_head_triple_for_tied_vl(self):
+        # Qwen2-VL sanitize prefixes text weights with `language_model.`
+        # before AWQ processing runs. The triple lands at
+        # `language_model.lm_head.{qweight,qzeros,scales}` which an
+        # exact-key filter would miss.
+        model = self._qwen2_vl_model(tie_word_embeddings=True)
+        weights = self._awq_lm_head_triple(prefix="language_model.")
+        out = utils._maybe_drop_redundant_lm_head_awq_triple(weights, model, {})
+        for k in weights:
+            self.assertNotIn(k, out)
+
+    def test_awq_preserves_prefixed_lm_head_triple_for_untied_vl(self):
+        model = self._qwen2_vl_model(tie_word_embeddings=False)
+        weights = self._awq_lm_head_triple(prefix="language_model.")
+        out = utils._maybe_drop_redundant_lm_head_awq_triple(weights, model, {})
+        for k in weights:
+            self.assertIn(k, out)
+
+    def test_awq_drops_prefixed_when_text_config_overrides_top_level(self):
+        # Multimodal config can have wrapper-level
+        # `tie_word_embeddings: false` while `text_config` declares the
+        # text submodel tied. Qwen2-VL builds its language model from
+        # `args.text_config`, so the language submodel is tied per
+        # text_config; the wrapper-level flag does not govern it.
+        # `language_model.lm_head.qweight` must be dropped.
+        model = self._qwen2_vl_model(tie_word_embeddings=True)
+        weights = self._awq_lm_head_triple(prefix="language_model.")
+        config = {
+            "tie_word_embeddings": False,
+            "text_config": {"tie_word_embeddings": True},
+        }
+        out = utils._maybe_drop_redundant_lm_head_awq_triple(weights, model, config)
+        for k in weights:
+            self.assertNotIn(k, out)
+
+    def test_awq_drops_for_gemma3_with_explicit_tied_config(self):
+        # gemma3_text and recurrent_gemma decide tying by inspecting
+        # weight content rather than a config field; sanitize pops
+        # `lm_head` when `lm_head.weight` is absent. For a tied
+        # checkpoint with a redundant AWQ triple, an explicit
+        # `tie_word_embeddings: true` in config gates the drop.
+        model = self._gemma3_text_model()
+        weights = model.sanitize(self._awq_lm_head_triple())
+        out = utils._maybe_drop_redundant_lm_head_awq_triple(
+            weights, model, {"tie_word_embeddings": True}
+        )
+        for k in self._awq_lm_head_triple():
+            self.assertNotIn(k, out)
+        self.assertTrue(model.tie_word_embeddings)
+        self.assertNotIn("lm_head", model)
+
+    def test_awq_preserves_for_gemma3_with_silent_config(self):
+        # Without an explicit tied signal AND with `ModelArgs` lacking
+        # the `tie_word_embeddings` field, the missing parameter target
+        # is ambiguous between a tied checkpoint with a redundant
+        # triple and an untied checkpoint with a real quantized output
+        # head. Silently dropping the latter would produce wrong logits;
+        # preserving lets strict load fail loudly.
+        model = self._gemma3_text_model()
+        weights = model.sanitize(self._awq_lm_head_triple())
+        out = utils._maybe_drop_redundant_lm_head_awq_triple(weights, model, {})
+        for k in self._awq_lm_head_triple():
+            self.assertIn(k, out)
+
+    def test_awq_preserves_for_gemma3_with_explicit_untied_config(self):
+        # Authoritative untied: never drop, even when the model has no
+        # parameter target (sanitize already mishandled it). Strict
+        # load will fail loudly afterward, surfacing the gemma3_text
+        # sanitize limitation rather than silently using tied
+        # embeddings.
+        model = self._gemma3_text_model()
+        weights = model.sanitize(self._awq_lm_head_triple())
+        out = utils._maybe_drop_redundant_lm_head_awq_triple(
+            weights, model, {"tie_word_embeddings": False}
+        )
+        for k in self._awq_lm_head_triple():
+            self.assertIn(k, out)
+
+    def test_awq_drops_for_recurrent_gemma_with_explicit_tied_config(self):
+        model = self._recurrent_gemma_model()
+        weights = model.sanitize(self._awq_lm_head_triple())
+        out = utils._maybe_drop_redundant_lm_head_awq_triple(
+            weights, model, {"tie_word_embeddings": True}
+        )
+        for k in self._awq_lm_head_triple():
+            self.assertNotIn(k, out)
+        self.assertNotIn("lm_head", model)
+
+    def test_awq_preserves_for_recurrent_gemma_with_silent_config(self):
+        model = self._recurrent_gemma_model()
+        weights = model.sanitize(self._awq_lm_head_triple())
+        out = utils._maybe_drop_redundant_lm_head_awq_triple(weights, model, {})
+        for k in self._awq_lm_head_triple():
+            self.assertIn(k, out)
+
+    def _gpt2_model(self):
+        from mlx_lm.models import gpt2
+
+        return gpt2.Model(
+            gpt2.ModelArgs(
+                model_type="gpt2",
+                n_ctx=8,
+                n_embd=8,
+                n_head=2,
+                n_layer=1,
+                n_positions=8,
+                layer_norm_epsilon=1e-5,
+                vocab_size=8,
+            )
+        )
+
+    def test_awq_drops_model_prefixed_for_gpt2_with_explicit_tied_config(self):
+        # gpt2 (and gpt_neox) sanitize prefixes every key with `model.`
+        # so a top-level `lm_head.qweight` becomes
+        # `model.lm_head.qweight`. The constructed wrapper has no
+        # `model.lm_head` target (the head is tied to `model.wte`),
+        # and the governing tying signal lives at top-level config —
+        # the `model.` prefix is just a sanitize-level renaming, not
+        # a multimodal submodel boundary. With explicit
+        # `tie_word_embeddings: true`, drop the prefixed triple.
+        model = self._gpt2_model()
+        weights = model.sanitize(self._awq_lm_head_triple())
+        # Sanity: gpt2 sanitize re-namespaced under `model.`.
+        self.assertIn("model.lm_head.qweight", weights)
+        out = utils._maybe_drop_redundant_lm_head_awq_triple(
+            weights, model, {"tie_word_embeddings": True}
+        )
+        for k in self._awq_lm_head_triple(prefix="model."):
+            self.assertNotIn(k, out)
+
+    def test_awq_preserves_model_prefixed_for_gpt2_with_silent_config(self):
+        # gpt2 ModelArgs has no `tie_word_embeddings` field, so a
+        # silent config leaves the redundant triple ambiguous; preserve
+        # and let strict load fail loudly rather than silently produce
+        # wrong logits.
+        model = self._gpt2_model()
+        weights = model.sanitize(self._awq_lm_head_triple())
+        out = utils._maybe_drop_redundant_lm_head_awq_triple(weights, model, {})
+        for k in self._awq_lm_head_triple(prefix="model."):
+            self.assertIn(k, out)
+
+    def _gemma4_config(self, *, tie_word_embeddings):
+        return {
+            "model_type": "gemma4",
+            "vocab_size": 8,
+            "text_config": {
+                "model_type": "gemma4_text",
+                "hidden_size": 8,
+                "num_hidden_layers": 1,
+                "intermediate_size": 16,
+                "num_attention_heads": 2,
+                "num_key_value_heads": 1,
+                "num_global_key_value_heads": 1,
+                "head_dim": 4,
+                "global_head_dim": 4,
+                "sliding_window": 8,
+                "sliding_window_pattern": 1,
+                "layer_types": ["full_attention"],
+                "hidden_size_per_layer_input": 8,
+                "vocab_size_per_layer_input": 8,
+                "num_kv_shared_layers": 0,
+                "tie_word_embeddings": tie_word_embeddings,
+            },
+        }
+
+    def test_awq_drops_language_model_model_prefixed_for_tied_gemma4(self):
+        # gemma4.sanitize re-namespaces `model.language_model.X` to
+        # `language_model.model.X` (a sanitize-level renaming inside
+        # the text wrapper, not a separate tying boundary). The
+        # tying decision still belongs to the text submodel, governed
+        # by `config["text_config"]["tie_word_embeddings"]`.
+        from mlx_lm.models import gemma4
+
+        config = self._gemma4_config(tie_word_embeddings=True)
+        model = gemma4.Model(gemma4.ModelArgs.from_dict(config))
+        weights = model.sanitize(
+            self._awq_lm_head_triple(prefix="model.language_model.")
+        )
+        # Sanity: gemma4 sanitize moved keys under `language_model.model.`.
+        self.assertIn("language_model.model.lm_head.qweight", weights)
+        out = utils._maybe_drop_redundant_lm_head_awq_triple(weights, model, config)
+        for k in self._awq_lm_head_triple(prefix="language_model.model."):
+            self.assertNotIn(k, out)
+
+    def test_awq_preserves_language_model_model_prefixed_for_untied_gemma4(self):
+        # Mirror: with text_config explicitly untied, `language_model.
+        # model.lm_head.{qweight,qzeros,scales}` must NOT be dropped —
+        # the sanitize prefix is irrelevant to the tying decision, and
+        # silently dropping a real quantized output head would produce
+        # wrong logits.
+        from mlx_lm.models import gemma4
+
+        config = self._gemma4_config(tie_word_embeddings=False)
+        model = gemma4.Model(gemma4.ModelArgs.from_dict(config))
+        weights = model.sanitize(
+            self._awq_lm_head_triple(prefix="model.language_model.")
+        )
+        self.assertIn("language_model.model.lm_head.qweight", weights)
+        out = utils._maybe_drop_redundant_lm_head_awq_triple(weights, model, config)
+        for k in self._awq_lm_head_triple(prefix="language_model.model."):
+            self.assertIn(k, out)
+
+    def test_awq_preserves_for_qwen3_5_with_silent_default_untied(self):
+        # qwen3_5 TextModelArgs defaults `tie_word_embeddings=False`,
+        # i.e. defaulted-untied. The AWQ ckpt with a real quantized
+        # output head ships at `model.language_model.lm_head.*`
+        # (HF flat layout); qwen3_5 sanitize re-namespaces to
+        # `language_model.model.lm_head.*`. With silent config and a
+        # field that exists but holds False, the helper must use the
+        # actual value (not just the field's existence) to decide:
+        # preserve the triple and let strict load fail loudly rather
+        # than silently dropping a real output head.
+        from mlx_lm.models import qwen3_5
+
+        config = {
+            "model_type": "qwen3_5",
+            "text_config": {
+                "model_type": "qwen3_5_text",
+                "hidden_size": 8,
+                "intermediate_size": 16,
+                "num_hidden_layers": 1,
+                "num_attention_heads": 2,
+                "num_key_value_heads": 1,
+                "rms_norm_eps": 1e-6,
+                "vocab_size": 8,
+                "linear_num_value_heads": 2,
+                "linear_num_key_heads": 2,
+                "linear_key_head_dim": 4,
+                "linear_value_head_dim": 4,
+                "linear_conv_kernel_dim": 4,
+                "head_dim": 4,
+                "full_attention_interval": 4,
+                "rope_parameters": {
+                    "type": "default",
+                    "rope_theta": 10000,
+                    "partial_rotary_factor": 0.25,
+                },
+            },
+        }
+        model = qwen3_5.Model(qwen3_5.ModelArgs.from_dict(config))
+        # Sanity: TextModel default-untied, lm_head module exists at
+        # `language_model.lm_head` (NOT `language_model.model.lm_head`).
+        self.assertFalse(model.language_model.args.tie_word_embeddings)
+        weights = model.sanitize(
+            self._awq_lm_head_triple(prefix="model.language_model.")
+        )
+        self.assertIn("language_model.model.lm_head.qweight", weights)
+        out = utils._maybe_drop_redundant_lm_head_awq_triple(weights, model, {})
+        for k in self._awq_lm_head_triple(prefix="language_model.model."):
+            self.assertIn(k, out)
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Problem

`load_model` feeds AWQ/GPTQ checkpoints' `*lm_head.{qweight,qzeros,scales}` keys directly into `_transform_awq_weights`, which produces `*lm_head.{weight,scales,biases}`. When the source model is tied (lm_head is not a real parameter), AutoAWQ may still ship a redundant quant triple, and `model.load_weights(strict=True)` then rejects with `Received parameters not in model`.

The same failure surfaces under sanitizer prefix patterns:

* Top-level `lm_head.qweight` becomes `language_model.lm_head.qweight` (Qwen2-VL/Qwen3-VL prefix every key under `language_model.`).
* `lm_head.qweight` becomes `model.lm_head.qweight` (gpt2/gpt_neox re-namespace every key under `model.`).
* `model.language_model.lm_head.qweight` becomes `language_model.model.lm_head.qweight` (gemma4/qwen3_5 nested text wrapper).

## Fix

Add `_maybe_drop_redundant_lm_head_awq_triple` and call it in `load_model` between `model.sanitize` and the AWQ/GPTQ transform. Walk the constructed model's parameter tree to find prefixes at which an `*lm_head.weight` parameter target exists, and for any input `*lm_head.{qweight,qzeros,scales}` whose `.weight` target is absent, decide drop vs preserve via two model-level questions:

1. Walk the candidate's outer prefix (with one level of sanitizer-renamed fallback via `_owner_aliases`: `language_model.model` → `language_model`, `model` → `""`) to find the governing submodel. The extra `model.` segment is a sanitize-level renaming, not a new tying boundary.
2. At each level, consult the config fragment that drove the submodel's constructor (top-level `config` for `""`/`model`, `config["text_config"]` for `language_model*`); fall back to the submodel's `ModelArgs.tie_word_embeddings` only when config is silent. The field's actual bool value is honoured (so `qwen3_5.TextModelArgs.tie_word_embeddings = False` defaulted-untied is not treated as authoritative tied just because the field exists).

Drop only on an authoritative tied signal; otherwise preserve and let strict load fail loudly. Architectures whose `sanitize` decides tying from weight content (gemma3_text, recurrent_gemma) or whose `ModelArgs` lacks the field (gpt2, gpt_neox) leave a missing target that is ambiguous between a tied checkpoint with a redundant triple and an untied checkpoint with a real quantized output head; without a config signal we cannot disambiguate, and silently dropping the latter would produce wrong logits.

This is architecture-agnostic and avoids touching every model's `sanitize` (29 currently). No publicly distributed Qwen/Llama/Mistral AWQ release on HF currently quantizes `lm_head`; this is defense-in-depth for third-party AWQ producers, and matches the failure mode that surfaced when integrating AutoAWQ checkpoints in vllm-metal.

## Tests

16 unit tests in `tests/test_utils.py` covering:

* Tied/untied Qwen2 with explicit and defaulted `tie_word_embeddings`.
* Tied/untied Qwen2-VL with `language_model.`-prefixed keys; wrapper-level `tie_word_embeddings: false` + `text_config.tie_word_embeddings: true` resolves correctly to drop.
* gpt2 with `model.`-prefixed keys: explicit-tied drops, silent config preserves (loud fail).
* Tied/untied gemma4 with `language_model.model.`-prefixed keys.
* Default-untied qwen3_5 (`TextModelArgs.tie_word_embeddings = False` default) with silent config: preserves, does not silently drop a real quantized output head.
* gemma3_text and recurrent_gemma across explicit-tied / silent / explicit-untied configs.

`python -m unittest discover -s tests -p "test_utils.py"` → 22 passed.