### PR TITLE
Fix mlx_lm.server --adapter-path silently ignored at startup

### DIFF
--- a/mlx_lm/server.py
+++ b/mlx_lm/server.py
@@ -385,8 +385,8 @@ class ModelProvider:
             self.load("default_model", None, "default_model")
 
     def load(self, model_path, adapter_path=None, draft_model_path=None):
-        model_path = self._model_map.get(model_path, model_path)
         adapter_path = self._adapter_map.get(model_path, adapter_path)
+        model_path = self._model_map.get(model_path, model_path)
         draft_model_path = self._draft_model_map.get(draft_model_path, draft_model_path)
 
         model_key = (model_path, adapter_path, draft_model_path)


### PR DESCRIPTION
Fixes #1248.

`ModelProvider.load("default_model", ...)` overwrites `model_path` with the resolved real path before looking up `_adapter_map`. Since `_adapter_map` is keyed by the alias `"default_model"`, the lookup misses and the CLI-provided `--adapter-path` silently falls back to `None`.

Fix: resolve `adapter_path` using the alias key before reassigning `model_path`.

## Repro

Before fix — bogus adapter path is silently dropped:

```bash
mlx_lm.server --model mlx-community/Qwen2.5-0.5B-Instruct-4bit --adapter-path /tmp/does-not-exist
# Server starts cleanly.
```

After fix — same command raises `FileNotFoundError: The adapter path does not exist: /tmp/does-not-exist`, matching the behavior of the per-request HTTP API.