### PR TITLE
Fix BatchRotatingKVCache rotated flag deserializing to True

### DIFF
--- a/mlx_lm/models/cache.py
+++ b/mlx_lm/models/cache.py
@@ -1312,7 +1312,7 @@ class BatchRotatingKVCache(_BaseCache):
             int,
             v[:3],
         )
-        self.rotated = bool(v[3])
+        self.rotated = v[3] == "True"
 
     def is_trimmable(self):
         return self._offset < self.max_size

--- a/tests/test_prompt_cache.py
+++ b/tests/test_prompt_cache.py
@@ -98,6 +98,35 @@ class TestPromptCache(unittest.TestCase):
             self.assertTrue(mx.array_equal(k, lk))
             self.assertTrue(mx.array_equal(v, lv))
 
+    def test_save_load_batch_rotating_cache(self):
+        cache_file = os.path.join(self.test_dir, "prompt_cache.safetensors")
+
+        # rotated=False round-trip (regression: bool("False") was True)
+        cache = [BatchRotatingKVCache(max_size=10, left_padding=[0])]
+        cache[0].update_and_fetch(
+            mx.random.uniform(shape=(1, 4, 3, 4)),
+            mx.random.uniform(shape=(1, 4, 3, 4)),
+        )
+        self.assertFalse(cache[0].rotated)
+
+        save_prompt_cache(cache_file, cache)
+        loaded = load_prompt_cache(cache_file)
+        self.assertEqual(cache[0].rotated, loaded[0].rotated)
+        self.assertEqual(cache[0].max_size, loaded[0].max_size)
+
+        # rotated=True round-trip — fill past max_size to trigger rotation
+        cache = [BatchRotatingKVCache(max_size=4, left_padding=[0])]
+        for _ in range(6):
+            cache[0].update_and_fetch(
+                mx.random.uniform(shape=(1, 4, 1, 4)),
+                mx.random.uniform(shape=(1, 4, 1, 4)),
+            )
+        self.assertTrue(cache[0].rotated)
+
+        save_prompt_cache(cache_file, cache)
+        loaded = load_prompt_cache(cache_file)
+        self.assertEqual(cache[0].rotated, loaded[0].rotated)
+
     def test_save_load_mixed_cache(self):
         cache_file = os.path.join(self.test_dir, "prompt_cache.safetensors")
 


### PR DESCRIPTION
Fixes #1250.

`meta_state` round-trips `self.rotated` through `str()` on save and `bool()` on load, but `bool("False") is True` (any non-empty string is truthy). A cache saved with `rotated=False` reloads as `rotated=True`, silently corrupting the rotation mask in subsequent `make_mask` calls.

Fix: parse the bool by string comparison.

```python
- self.rotated = bool(v[3])
+ self.rotated = v[3] == "True"
```

Added a regression test (`test_save_load_batch_rotating_cache`) that round-trips both `rotated=False` and `rotated=True`. Verified the test fails on `main` and passes with the fix.