### PR TITLE
Fix prompt cache reuse for hybrid models (Qwen3.5, Qwen3.6, Qwen3-Next)

### DIFF
--- a/mlx_lm/models/cache.py
+++ b/mlx_lm/models/cache.py
@@ -723,6 +723,25 @@ class ArraysCache(_BaseCache):
     def empty(self):
         return self.cache[0] is None
 
+    def is_trimmable(self):
+        return True
+
+    def trim(self, n):
+        """Trim the cache by n tokens.
+
+        ArraysCache holds compressed recurrent state that cannot be partially
+        rolled back. When trimming is required, the cache is fully reset so
+        the recurrent layers recompute from scratch. KVCache layers in the
+        same hybrid model still benefit from their own trim.
+
+        For exact-match reuse (n=0), this method is not called and the full
+        recurrent state is preserved — the common server case.
+        """
+        if n <= 0:
+            return 0
+        self.cache = [None] * len(self.cache)
+        return n
+
     @property
     def nbytes(self):
         return sum(c.nbytes for c in self.cache if c is not None)

--- a/tests/test_prompt_cache.py
+++ b/tests/test_prompt_cache.py
@@ -216,22 +216,27 @@ class TestPromptCache(unittest.TestCase):
         num_trimmed = trim_prompt_cache(cache, 4)
         self.assertEqual(num_trimmed, 3)
 
-        # Can't trim arrays cache
+        # Trimming arrays cache resets recurrent state
         cache = [ArraysCache(size=2) for _ in range(2)]
         for c in cache:
             c[0] = mx.zeros((5, 5))
             c[1] = mx.zeros((5, 5))
         num_trimmed = trim_prompt_cache(cache, 7)
-        self.assertEqual(num_trimmed, 0)
+        self.assertEqual(num_trimmed, 7)
+        for c in cache:
+            self.assertTrue(c.empty())
 
-        # All cache's have to be trimmable
+        # Hybrid cache (ArraysCache + KVCache) is trimmable
         cache = [ArraysCache(size=2), KVCache()]
         cache[0][0] = mx.zeros((5, 5))
         cache[0][1] = mx.zeros((5, 5))
         x = mx.random.uniform(shape=(1, 8, 10, 4))
         cache[1].update_and_fetch(x, x)
         num_trimmed = trim_prompt_cache(cache, 1)
-        self.assertEqual(num_trimmed, 0)
+        self.assertEqual(num_trimmed, 1)
+        # ArraysCache resets, KVCache trims normally
+        self.assertTrue(cache[0].empty())
+        self.assertEqual(cache[1].offset, 9)
 
         cache = [RotatingKVCache(max_size=6) for _ in range(2)]
         for c in cache:


### PR DESCRIPTION
## Problem

`ArraysCache` (used by DeltaNet/GDN recurrent layers) inherits
`is_trimmable() → False` from `_BaseCache` and has no `trim()` method.
Hybrid models (Qwen3.5, Qwen3.6, Qwen3-Next) mix `ArraysCache` + `KVCache`,
so `can_trim_prompt_cache()` returns `False` for the entire cache, blocking:

- Server prefix reuse via `fetch_nearest_cache()`
- LRU prefix deduplication in `insert_cache()`
- Speculative decoding (raises `ValueError` at `generate.py:529`)

## Fix

Add `is_trimmable()` and `trim(n)` to `ArraysCache`. Since recurrent state
cannot be partially rolled back, `trim(n)` resets the cache — recurrent
layers recompute while KVCache layers still benefit from their own trim.
For exact-match reuse (`n=0`), `trim()` is never called and the full state
is preserved.

## Test results (Qwen3.5-4B-4bit, M4 Mac mini 16GB, mlx_lm.server)

| Request | TTFT | Cached tokens |
|---------|------|---------------|
| Cold (571 tokens) | 2030ms | 0/571 |
| Exact match | 314ms | 570/571 |
| Prefix reuse | 397ms | 424/431 |
| Extended prompt | 461ms | 564/577 |

Prefix reuse and extended prompt returned 0 cached tokens before this fix.

Fixes #1162. Also adds the missing `trim()` method for ArraysCache (#1081).