### PR TITLE
Fix LFM2.5 tool parser inference

### DIFF
--- a/mlx_lm/server.py
+++ b/mlx_lm/server.py
@@ -1354,6 +1354,8 @@ class APIHandler(BaseHTTPRequestHandler):
             choice[key_name] = {"role": "assistant"}
             if text:
                 choice[key_name]["content"] = text
+            elif tool_calls and not self.stream:
+                choice[key_name]["content"] = None
             if reasoning_text:
                 choice[key_name]["reasoning"] = reasoning_text
             if tool_calls:

--- a/mlx_lm/tokenizer_utils.py
+++ b/mlx_lm/tokenizer_utils.py
@@ -545,11 +545,11 @@ def _is_bpe_decoder(decoder):
     return isinstance(decoder, dict) and decoder.get("type", None) == "ByteLevel"
 
 
-def _infer_tool_parser(chat_template):
-    """Attempt to auto-infer a tool parser from the chat template."""
+def _infer_tool_parser_from_chat_template(chat_template):
     if not isinstance(chat_template, str):
         return None
-    elif "<minimax:tool_call>" in chat_template:
+
+    if "<minimax:tool_call>" in chat_template:
         return "minimax_m2"
     elif "<|tool_call>" in chat_template and "<tool_call|>" in chat_template:
         return "gemma4"
@@ -572,7 +572,26 @@ def _infer_tool_parser(chat_template):
         return "mistral"
     elif "<tool_call>" in chat_template and "tool_call.name" in chat_template:
         return "json_tools"
+
     return None
+
+
+def _infer_tool_parser_from_tokenizer(tokenizer):
+    if tokenizer is None:
+        return None
+
+    vocab = tokenizer.get_vocab()
+    if "<|tool_call_start|>" in vocab and "<|tool_call_end|>" in vocab:
+        return "pythonic"
+
+    return None
+
+
+def _infer_tool_parser(chat_template=None, tokenizer=None):
+    """Attempt to auto-infer a tool parser from tokenizer metadata."""
+    return _infer_tool_parser_from_chat_template(
+        chat_template
+    ) or _infer_tool_parser_from_tokenizer(tokenizer)
 
 
 def load(
@@ -622,9 +641,9 @@ def load(
             f"mlx_lm.chat_templates.{chat_template_type}"
         ).apply_chat_template
 
-    tool_parser_type = tokenizer_config.get(
-        "tool_parser_type", _infer_tool_parser(tokenizer.chat_template)
-    )
+    tool_parser_type = tokenizer_config.get("tool_parser_type")
+    if tool_parser_type is None:
+        tool_parser_type = _infer_tool_parser(tokenizer.chat_template, tokenizer)
 
     if tool_parser_type is not None:
         tool_module = importlib.import_module(f"mlx_lm.tool_parsers.{tool_parser_type}")

--- a/mlx_lm/tool_parsers/pythonic.py
+++ b/mlx_lm/tool_parsers/pythonic.py
@@ -1,9 +1,11 @@
 # Copyright © 2026 Apple Inc.
 
 import ast
-from typing import Any, Dict, List
+from typing import Any
 
 import regex as re
+
+from . import json_tools
 
 """
 Tool parser for Pythonic function call formats.
@@ -13,11 +15,69 @@ Parses assistant responses containing tool calls in formats like:
 """
 
 
-_tool_call_regex = re.compile(r"\[(\w+)\((.*?)\)\]", re.DOTALL)
+_tool_call_regex = re.compile(r"\[([\w.]+)\((.*?)\)\]", re.DOTALL)
 _tool_args_regex = re.compile(r'(\w+)=(?:"([^"]*)"|([^,]+))(?:,\s*|$)', re.DOTALL)
 
 
+def _function_name(func):
+    if isinstance(func, ast.Name):
+        return func.id
+    if isinstance(func, ast.Attribute):
+        parent = _function_name(func.value)
+        return f"{parent}.{func.attr}" if parent else func.attr
+    return None
+
+
+def _parse_json_tool_call(text):
+    text = text.strip()
+    if text.startswith("<tool_call>") and text.endswith("</tool_call>"):
+        text = text[len("<tool_call>") : -len("</tool_call>")].strip()
+
+    if not text.startswith("{"):
+        return None
+
+    parsed = json_tools.parse_tool_call(text)
+    if not isinstance(parsed, dict) or "name" not in parsed or "arguments" not in parsed:
+        return None
+    return parsed
+
+
+def _parse_pythonic_tool_call(text):
+    start = text.find("[")
+    end = text.rfind("]")
+    if start == -1 or end == -1 or end <= start:
+        return None
+
+    parsed = ast.parse(text[start : end + 1], mode="eval").body
+    if not isinstance(parsed, ast.List) or not parsed.elts:
+        return None
+
+    call = parsed.elts[0]
+    if not isinstance(call, ast.Call):
+        return None
+
+    func_name = _function_name(call.func)
+    if func_name is None:
+        return None
+
+    arguments = {}
+    for keyword in call.keywords:
+        if keyword.arg is None:
+            continue
+        arguments[keyword.arg] = ast.literal_eval(keyword.value)
+
+    return dict(name=func_name, arguments=arguments)
+
+
 def parse_tool_call(text: str, tools: Any | None = None):
+    for parser in (_parse_json_tool_call, _parse_pythonic_tool_call):
+        try:
+            parsed = parser(text)
+        except (SyntaxError, ValueError):
+            parsed = None
+        if parsed is not None:
+            return parsed
+
     match = _tool_call_regex.search(text)
     if not match:
         raise ValueError("No function provided.")

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -16,8 +16,10 @@ from mlx_lm.server import (
     LRUPromptCache,
     Response,
     ResponseGenerator,
+    ToolCallFormatter,
     _process_control_tokens,
 )
+from mlx_lm.tool_parsers import pythonic
 from mlx_lm.utils import load
 
 
@@ -155,6 +157,71 @@ class TestProcessControlTokens(unittest.TestCase):
             [t.state for t in out],
             ["tool", "tool", "tool", "normal", "normal"],
         )
+
+
+class TestToolCallFormatter(unittest.TestCase):
+    def test_formats_nested_array_json_tool_call(self):
+        formatter = ToolCallFormatter(pythonic.parse_tool_call, tools=None)
+        raw_tool_call = (
+            "<tool_call>"
+            '{"name": "grocery.orderIngredients", "arguments": {'
+            '"ingredientList": ['
+            '{"name": "noodles", "amount": 500, "unit": "g"}, '
+            '{"name": "ground beef", "amount": 300, "unit": "g"}], '
+            '"deliveryAddress": "845 Willow Lane, Springfield, IL 62704"}}'
+            "</tool_call>"
+        )
+
+        tool_calls = formatter([raw_tool_call])
+
+        self.assertEqual(len(tool_calls), 1)
+        self.assertEqual(tool_calls[0]["type"], "function")
+        self.assertEqual(
+            tool_calls[0]["function"]["name"], "grocery.orderIngredients"
+        )
+        arguments = json.loads(tool_calls[0]["function"]["arguments"])
+        self.assertEqual(
+            arguments,
+            {
+                "ingredientList": [
+                    {"name": "noodles", "amount": 500, "unit": "g"},
+                    {"name": "ground beef", "amount": 300, "unit": "g"},
+                ],
+                "deliveryAddress": "845 Willow Lane, Springfield, IL 62704",
+            },
+        )
+
+    def test_tool_only_chat_response_has_null_content(self):
+        handler = types.SimpleNamespace(
+            request_id="chatcmpl-test",
+            system_fingerprint="test",
+            object_type="chat.completion",
+            requested_model="chat_model",
+            created=0,
+            stream=False,
+        )
+        response = APIHandler.generate_response(
+            handler,
+            text="",
+            finish_reason="tool_calls",
+            prompt_token_count=1,
+            completion_token_count=1,
+            prompt_cache_count=0,
+            tool_calls=[
+                {
+                    "id": "123",
+                    "type": "function",
+                    "function": {
+                        "name": "grocery.orderIngredients",
+                        "arguments": '{"ingredientList": [], "deliveryAddress": "x"}',
+                    },
+                }
+            ],
+        )
+
+        message = response["choices"][0]["message"]
+        self.assertIsNone(message["content"])
+        self.assertEqual(message["tool_calls"][0]["function"]["name"], "grocery.orderIngredients")
 
 
 class TestServer(unittest.TestCase):

--- a/tests/test_tokenizers.py
+++ b/tests/test_tokenizers.py
@@ -5,6 +5,7 @@ from pathlib import Path
 
 from huggingface_hub import snapshot_download
 
+from mlx_lm.tool_parsers import pythonic
 from mlx_lm.tokenizer_utils import (
     BPEStreamingDetokenizer,
     NaiveStreamingDetokenizer,
@@ -93,6 +94,13 @@ class TestTokenizers(unittest.TestCase):
         tokenizer_repo = "mlx-community/Llama-3.2-1B-Instruct-4bit"
         tokenizer = load_tokenizer(tokenizer_repo)
         self.assertFalse(tokenizer.has_tool_calling)
+
+        tokenizer_repo = "LiquidAI/LFM2.5-1.2B-Instruct-MLX-8bit"
+        tokenizer = load_tokenizer(tokenizer_repo)
+        self.assertTrue(tokenizer.has_tool_calling)
+        self.assertEqual(tokenizer.tool_call_start, "<|tool_call_start|>")
+        self.assertEqual(tokenizer.tool_call_end, "<|tool_call_end|>")
+        self.assertEqual(tokenizer.tool_parser, pythonic.parse_tool_call)
 
     def test_thinking(self):
         tokenizer_repo = "mlx-community/Qwen3-4B-4bit"

--- a/tests/test_tool_parsing.py
+++ b/tests/test_tool_parsing.py
@@ -197,6 +197,40 @@ class TestToolParsing(unittest.TestCase):
         self.assertEqual(tool_call["arguments"]["filters"], {"category": "books"})
         self.assertEqual(tool_call["arguments"]["tags"], ["fiction", "new"])
 
+    def test_pythonic_nested_array_tool_call(self):
+        expected = {
+            "name": "grocery.orderIngredients",
+            "arguments": {
+                "ingredientList": [
+                    {"name": "noodles", "amount": 500, "unit": "g"},
+                    {"name": "ground beef", "amount": 300, "unit": "g"},
+                ],
+                "deliveryAddress": "845 Willow Lane, Springfield, IL 62704",
+            },
+        }
+
+        test_cases = [
+            (
+                "[grocery.orderIngredients("
+                'ingredientList=[{"name": "noodles", "amount": 500, "unit": "g"}, '
+                '{"name": "ground beef", "amount": 300, "unit": "g"}], '
+                'deliveryAddress="845 Willow Lane, Springfield, IL 62704")]'
+            ),
+            (
+                "<tool_call>"
+                '{"name": "grocery.orderIngredients", "arguments": {'
+                '"ingredientList": ['
+                '{"name": "noodles", "amount": 500, "unit": "g"}, '
+                '{"name": "ground beef", "amount": 300, "unit": "g"}], '
+                '"deliveryAddress": "845 Willow Lane, Springfield, IL 62704"}}'
+                "</tool_call>"
+            ),
+        ]
+
+        for test_case in test_cases:
+            with self.subTest(test_case=test_case):
+                self.assertEqual(pythonic.parse_tool_call(test_case, None), expected)
+
     def test_gemma4(self):
         # Nested object
         test_case = 'call:configure{settings:{enabled:true,name:<|"|>test<|"|>}}'


### PR DESCRIPTION
LFM2.5 tokenizers expose `<|tool_call_start|>` and `<|tool_call_end|>` tokens, but do not provide chat-template metadata that lets mlx-lm infer a tool parser. As a result, server responses can emit raw tool-call markup in `message.content` instead of OpenAI-compatible `tool_calls`.

This adds tokenizer-vocab based parser inference for that marker pair and maps it to the existing pythonic tool parser.

Tests:
- `uv run --with-editable . --with unittest-xml-reporting python -m unittest tests.test_tool_parsing tests.test_tokenizers.TestTokenizers.test_tool_calling`

You can try it yourself with:

```sh
uv tool install "git+https://github.com/blairhudson/mlx-lm.git@fix/lfm25-tool-parser-inference"
mlx_lm.server --model LiquidAI/LFM2.5-1.2B-Instruct-MLX-8bit
```