### PR TITLE
Add Granite tool parser

### DIFF
--- a/ACKNOWLEDGMENTS.md
+++ b/ACKNOWLEDGMENTS.md
@@ -31,3 +31,4 @@ Added support for the following other features:
 MoonshotAI's `Kimi K2.5`, Upstage's `Solar Open`, LG AI Research's `K-Exaone MoE`, 
 Meituan's `LongCat Flash Lite` Helped add support for the following model architectures: 
 Z.ai & THUKEG's `GLM5 (GLM MoE DSA)`
+- Jonathan Springer: Added architecture-specific tool parser for IBM Granite models

--- a/mlx_lm/tool_parsers/granite.py
+++ b/mlx_lm/tool_parsers/granite.py
@@ -1,0 +1,14 @@
+import json
+
+tool_call_start = "<tool_call>"
+
+tool_call_end = "</tool_call>"
+
+
+def parse_tool_call(text, tools=None):
+    text = text.strip()
+    tool_call, end = json.JSONDecoder().raw_decode(text)
+    trailing = text[end:].strip()
+    if trailing and set(trailing) != {"}"}:
+        raise json.JSONDecodeError("Unexpected trailing data", text, end)
+    return tool_call

--- a/tests/test_tool_parsing.py
+++ b/tests/test_tool_parsing.py
@@ -1,9 +1,11 @@
+import json
 import unittest
 
 from mlx_lm.tool_parsers import (
     function_gemma,
     gemma4,
     glm47,
+    granite,
     json_tools,
     kimi_k2,
     longcat,
@@ -208,6 +210,25 @@ class TestToolParsing(unittest.TestCase):
         tool_call = qwen3_coder.parse_tool_call(test_case, tools)
         self.assertEqual(tool_call["arguments"]["filters"], {"category": "books"})
         self.assertEqual(tool_call["arguments"]["tags"], ["fiction", "new"])
+
+    def test_granite(self):
+        test_cases = [
+            '{"name": "get_current_weather", "arguments": {"city": "Boston"}}',
+            '{"name": "get_current_weather", "arguments": {"city": "Boston"}}}',
+            '{"name": "get_current_weather", "arguments": {"city": "Boston"}}}}}}',
+            '{"name": "get_current_weather", "arguments": {"location": {"city": "Boston"}}}}',
+        ]
+
+        for test_case in test_cases:
+            with self.subTest(test_case=test_case):
+                tool_call = granite.parse_tool_call(test_case, None)
+                self.assertEqual(tool_call["name"], "get_current_weather")
+                self.assertIn("city", str(tool_call["arguments"]))
+
+        with self.assertRaises(json.JSONDecodeError):
+            granite.parse_tool_call(
+                '{"name": "get_current_weather", "arguments": {}} trailing junk', None
+            )
 
     def test_gemma4(self):
         # Nested object

--- a/tests/test_tool_parsing.py
+++ b/tests/test_tool_parsing.py
@@ -1,3 +1,4 @@
+import json
 import unittest
 from pathlib import Path
 
@@ -5,6 +6,7 @@ from mlx_lm.tool_parsers import (
     function_gemma,
     gemma4,
     glm47,
+    granite,
     json_tools,
     kimi_k2,
     longcat,
@@ -196,6 +198,25 @@ class TestToolParsing(unittest.TestCase):
         tool_call = qwen3_coder.parse_tool_call(test_case, tools)
         self.assertEqual(tool_call["arguments"]["filters"], {"category": "books"})
         self.assertEqual(tool_call["arguments"]["tags"], ["fiction", "new"])
+
+    def test_granite(self):
+        test_cases = [
+            '{"name": "get_current_weather", "arguments": {"city": "Boston"}}',
+            '{"name": "get_current_weather", "arguments": {"city": "Boston"}}}',
+            '{"name": "get_current_weather", "arguments": {"city": "Boston"}}}}}}',
+            '{"name": "get_current_weather", "arguments": {"location": {"city": "Boston"}}}}',
+        ]
+
+        for test_case in test_cases:
+            with self.subTest(test_case=test_case):
+                tool_call = granite.parse_tool_call(test_case, None)
+                self.assertEqual(tool_call["name"], "get_current_weather")
+                self.assertIn("city", str(tool_call["arguments"]))
+
+        with self.assertRaises(json.JSONDecodeError):
+            granite.parse_tool_call(
+                '{"name": "get_current_weather", "arguments": {}} trailing junk', None
+            )
 
     def test_gemma4(self):
         # Nested object


### PR DESCRIPTION
## Summary
- Add a Granite-specific tool parser for `<tool_call>` JSON payloads that tolerates extra trailing braces.
- Keep the generic JSON tool parser strict while allowing Granite models to opt in via `tool_parser_type: granite`.
- Add parser tests covering valid JSON, repeated trailing braces, nested arguments, and invalid trailing junk.

## Tests
- `PYTHONPATH=. uv run pytest tests/test_tool_parsing.py`