### PR TITLE
Add Olmo3 tool parser

### DIFF
--- a/mlx_lm/tokenizer_utils.py
+++ b/mlx_lm/tokenizer_utils.py
@@ -561,6 +561,8 @@ def _infer_tool_parser(chat_template):
         return "glm47"
     elif "<|tool_list_start|>" in chat_template:
         return "pythonic"
+    elif "<function_calls>" in chat_template:
+        return "olmo3"
     elif (
         "<tool_call>\\n<function=" in chat_template
         or "<tool_call>\n<function=" in chat_template

--- a/mlx_lm/tool_parsers/olmo3.py
+++ b/mlx_lm/tool_parsers/olmo3.py
@@ -1,0 +1,55 @@
+# Copyright © 2026 Apple Inc.
+
+import ast
+from typing import Any
+
+import regex as re
+
+"""
+Tool parser for Olmo 3 function call format.
+
+Parses assistant responses containing tool calls in formats like:
+<function_calls>
+function_name(arg1="value1", arg2=2)
+</function_calls>
+
+Multiple tool calls are newline-separated within the tags. Argument values
+are JSON literals (null, true, false) instead of Python literals.
+"""
+
+
+_tool_call_regex = re.compile(r"^\s*(\w+)\((.*)\)\s*$", re.MULTILINE)
+_tool_args_regex = re.compile(r'(\w+)=(?:"([^"]*)"|([^,]+))(?:,\s*|$)', re.DOTALL)
+
+_JSON_LITERALS = {"null": None, "true": True, "false": False}
+
+
+def _coerce(value: str):
+    value = value.strip()
+    if value in _JSON_LITERALS:
+        return _JSON_LITERALS[value]
+    try:
+        return ast.literal_eval(value)
+    except (ValueError, SyntaxError):
+        return value
+
+
+def parse_tool_call(text: str, tools: Any | None = None):
+    calls = []
+    for match in _tool_call_regex.finditer(text):
+        func_name = match.group(1)
+        args_str = match.group(2)
+        arguments = {}
+        if args_str:
+            for key, quoted, raw in _tool_args_regex.findall(args_str):
+                arguments[key.strip()] = quoted if quoted else _coerce(raw)
+        calls.append({"name": func_name, "arguments": arguments})
+
+    if not calls:
+        raise ValueError("No function provided.")
+
+    return calls if len(calls) > 1 else calls[0]
+
+
+tool_call_start = "<function_calls>"
+tool_call_end = "</function_calls>"

--- a/tests/test_tool_parsing.py
+++ b/tests/test_tool_parsing.py
@@ -10,6 +10,7 @@ from mlx_lm.tool_parsers import (
     longcat,
     minimax_m2,
     mistral,
+    olmo3,
     pythonic,
     qwen3_coder,
 )
@@ -52,6 +53,10 @@ class TestToolParsing(unittest.TestCase):
             (
                 "[multiply(a=12234585, b=48838483920)]",
                 pythonic,
+            ),
+            (
+                "multiply(a=12234585, b=48838483920)",
+                olmo3,
             ),
             (
                 'multiply[ARGS]{"a": 12234585, "b": 48838483920}',
@@ -122,6 +127,10 @@ class TestToolParsing(unittest.TestCase):
             (
                 '[get_current_temperature(location="London")]',
                 pythonic,
+            ),
+            (
+                'get_current_temperature(location="London")',
+                olmo3,
             ),
             (
                 'get_current_temperature[ARGS]{"location": "London"}',
@@ -312,6 +321,30 @@ class TestToolParsing(unittest.TestCase):
             },
         ]
         self.assertEqual(tool_calls, expected)
+
+    def test_olmo3(self):
+        # Multiple tool calls
+        test_case = (
+            'search(query="weather")\n'
+            'read_file(path="/tmp/test.txt")'
+        )
+        tool_calls = olmo3.parse_tool_call(test_case, None)
+        self.assertIsInstance(tool_calls, list)
+        self.assertEqual(len(tool_calls), 2)
+        self.assertEqual(tool_calls[0], {"name": "search", "arguments": {"query": "weather"}})
+        self.assertEqual(
+            tool_calls[1],
+            {"name": "read_file", "arguments": {"path": "/tmp/test.txt"}},
+        )
+
+        # JSON literals are accepted (true/false/null instead of Python literals)
+        test_case = 'configure(enabled=true, name="x", missing=null)'
+        tool_call = olmo3.parse_tool_call(test_case, None)
+        self.assertEqual(tool_call["name"], "configure")
+        self.assertEqual(
+            tool_call["arguments"],
+            {"enabled": True, "name": "x", "missing": None},
+        )
 
     def test_minimax_m2(self):
         test_case = (


### PR DESCRIPTION
  ## Summary
  - Adds a tool-call parser for Olmo 3 models (e.g.
    `mlx-community/Olmo-3-7B-Instruct-4bit`), which emit calls as
    `<function_calls>name(arg=value, ...)</function_calls>` with newline-separated
    multiple calls and JSON literals (`null` / `true` / `false`) for argument values.
  - Wires auto-detection: `_infer_tool_parser` selects `"olmo3"` when the chat
    template contains `<function_calls>`

  ## Implementation notes
  - `mlx_lm/tool_parsers/olmo3.py` mirrors `pythonic.py`. Differences:
    - No surrounding `[ ]` brackets on each call.
    - Per-line matching (`re.MULTILINE`, no `DOTALL`) so multiple calls on
      separate lines are parsed independently and returned as a list.
    - `_coerce` translates `null` / `true` / `false` before falling back to
      `ast.literal_eval`, since Olmo 3 emits JSON literals rather than Python ones.

  ## Test plan
  - [x] `python -m pytest tests/test_tool_parsing.py -v` — all 6 tests / 24 subtests pass.
  - [x] `load(Path(".../Olmo-3-7B-Instruct-4bit"))` returns a wrapper with
    `tool_call_start == "<function_calls>"`, `tool_call_end == "</function_calls>"`,
    and a non-None `tool_parser`