### PR TITLE
Support max_kv_size configuration in HTTP server

### DIFF
--- a/mlx_lm/server.py
+++ b/mlx_lm/server.py
@@ -823,6 +823,7 @@ class ResponseGenerator:
                         completion_batch_size=self.cli_args.decode_concurrency,
                         prefill_batch_size=self.cli_args.prompt_concurrency,
                         prefill_step_size=self.cli_args.prefill_step_size,
+                        max_kv_size=self.cli_args.max_kv_size,
                         stream=generation_stream,
                     )
                     unprocessed_requests.append((rqueue, request, args))
@@ -968,9 +969,13 @@ class ResponseGenerator:
             ctx.prompt_cache_count = len(prompt) - len(rest)
             cache_key = prompt[:]
             if cache is None:
-                cache = make_prompt_cache(self.model_provider.model)
+                cache = make_prompt_cache(
+                    self.model_provider.model, max_kv_size=self.cli_args.max_kv_size
+                )
                 if self.model_provider.draft_model is not None:
-                    cache += make_prompt_cache(self.model_provider.draft_model)
+                    cache += make_prompt_cache(
+                        self.model_provider.draft_model, max_kv_size=self.cli_args.max_kv_size
+                    )
 
             # Process the prompt and generate tokens
             for gen in stream_generate(
@@ -1878,6 +1883,11 @@ def main():
         "--prompt-cache-bytes",
         type=_parse_size,
         help="Maximum size in bytes of the KV caches",
+    )
+    parser.add_argument(
+        "--max-kv-size",
+        type=int,
+        help="Maximum size of the KV cache",
     )
     parser.add_argument(
         "--pipeline",

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -54,6 +54,7 @@ class DummyModelProvider:
                 "prompt_cache_size": 10,
                 "prompt_cache_bytes": 1 << 63,
                 "prompt_cache_total_bytes": None,
+                "max_kv_size": None,
                 "allowed_origins": ["*"],
             },
         )


### PR DESCRIPTION
Adds `--max-kv-size` as a server startup argument, bringing it to feature parity 
with `mlx_lm.generate()`.

Closes #615

## Changes
- Added `--max-kv-size` CLI argument to `mlx_lm.server`
- Passed `max_kv_size` to `make_prompt_cache()` for both primary and draft models in `_serve_single`
- Passed `max_kv_size` into `BatchGenerator` for the batched request path
- Updated test mock to include the new `max_kv_size` default

## Usage
```bash
python -m mlx_lm.server --model <model> --max-kv-size 4096
```