### PR TITLE
feat: add --idle-timeout to unload model after inactivity

### DIFF
--- a/mlx_lm/SERVER.md
+++ b/mlx_lm/SERVER.md
@@ -30,6 +30,20 @@ To see a full list of options run:
 mlx_lm.server --help
 ```
 
+### Idle Model Unloading
+
+By default, the server keeps model weights in memory indefinitely. To
+automatically unload the model after a period of inactivity, use
+`--idle-timeout`:
+
+```shell
+mlx_lm.server --model <path> --idle-timeout 300
+```
+
+This unloads model weights after 300 seconds (5 minutes) without requests,
+freeing GPU memory. The model reloads transparently on the next request.
+Set to `0` to disable (default).
+
 You can make a request to the model by running:
 
 ```shell

--- a/mlx_lm/server.py
+++ b/mlx_lm/server.py
@@ -1,6 +1,7 @@
 # Copyright © 2023-2024 Apple Inc.
 
 import argparse
+import gc
 import json
 import logging
 import pickle
@@ -298,6 +299,7 @@ class ModelProvider:
         self.tokenizer = None
         self.draft_model = None
         self.is_batchable = False
+        self._last_request_time = time.time()
 
         group = mx.distributed.init()
         self.pipeline_group = group if group.size() > 1 and cli_args.pipeline else None
@@ -384,15 +386,38 @@ class ModelProvider:
         if self._model_map["default_model"] is not None:
             self.load("default_model", None, "default_model")
 
+    def unload(self):
+        """Unload model weights to free memory. Preserves model_key for reload."""
+        if self.model is None:
+            return
+        mem_before = mx.metal.get_active_memory() if mx.metal.is_available() else 0
+        logging.info(f"Unloading model: {self.model_key}")
+        self.model = None
+        self.tokenizer = None
+        self.draft_model = None
+        # model_key is intentionally preserved so load() can reload on next request
+        if mx.metal.is_available():
+            mx.metal.clear_cache()
+        gc.collect()
+        mem_after = mx.metal.get_active_memory() if mx.metal.is_available() else 0
+        freed_gb = max(0.0, (mem_before - mem_after) / 1e9)
+        logging.info(
+            f"Model unloaded - freed {freed_gb:.2f} GB "
+            f"(active memory: {mem_before / 1e9:.2f} GB -> {mem_after / 1e9:.2f} GB)"
+        )
+
     def load(self, model_path, adapter_path=None, draft_model_path=None):
         model_path = self._model_map.get(model_path, model_path)
         adapter_path = self._adapter_map.get(model_path, adapter_path)
         draft_model_path = self._draft_model_map.get(draft_model_path, draft_model_path)
 
         model_key = (model_path, adapter_path, draft_model_path)
-        if self.model_key != model_key:
+        if self.model_key != model_key or self.model is None:
+            if self.model is None and self.model_key == model_key:
+                logging.info(f"Reloading model after idle unload: {model_key}")
             self._load(*model_key)
 
+        self._last_request_time = time.time()
         return self.model, self.tokenizer
 
 
@@ -443,6 +468,7 @@ class ResponseGenerator:
         self.prompt_cache = prompt_cache
         self.requests = Queue()
         self._state_machine_cache = {}
+        self._idle_timeout = getattr(model_provider.cli_args, "idle_timeout", 0)
 
         self._time_budget = TimeBudget()
         self._is_distributed = mx.distributed.init().size() > 1
@@ -918,6 +944,19 @@ class ResponseGenerator:
                         # It may have already been removed during
                         # generation
                         batch_results.pop(uid, None)
+
+            # No request and no active batch - check for idle unload
+            elif (
+                self._idle_timeout > 0
+                and self.model_provider.model is not None
+                and not self.model_provider.is_distributed
+                and not unprocessed_requests
+                and time.time() - self.model_provider._last_request_time
+                > self._idle_timeout
+            ):
+                self.model_provider.unload()
+                self.prompt_cache.trim_to(n_sequences=0)
+                self._state_machine_cache.clear()
 
     def _serve_single(self, request):
         rqueue, request, args = request
@@ -1884,7 +1923,15 @@ def main():
         action="store_true",
         help="Use pipelining instead of tensor parallelism",
     )
+    parser.add_argument(
+        "--idle-timeout",
+        type=int,
+        default=0,
+        help="Unload model after N seconds without requests. 0 = never unload (default)",
+    )
     args = parser.parse_args()
+    if args.idle_timeout < 0:
+        parser.error("--idle-timeout must be >= 0")
     if mx.metal.is_available():
         wired_limit = mx.device_info()["max_recommended_working_set_size"]
         mx.set_wired_limit(wired_limit)

--- a/tests/test_idle_unload.py
+++ b/tests/test_idle_unload.py
@@ -1,0 +1,217 @@
+# Copyright 2024 Apple Inc.
+
+import argparse
+import time
+import unittest
+from unittest.mock import MagicMock, patch
+
+import mlx.core as mx
+import mlx.nn as nn
+
+
+def _make_cli_args(**overrides):
+    """Create a minimal cli_args namespace for ModelProvider."""
+    defaults = {
+        "model": "/tmp/fake-model-path",
+        "adapter_path": None,
+        "draft_model": None,
+        "host": "127.0.0.1",
+        "port": 8080,
+        "allowed_origins": "*",
+        "num_draft_tokens": 3,
+        "trust_remote_code": False,
+        "chat_template": "",
+        "use_default_chat_template": False,
+        "temp": 0.0,
+        "top_p": 1.0,
+        "top_k": 0,
+        "min_p": 0.0,
+        "max_tokens": 512,
+        "chat_template_args": {},
+        "decode_concurrency": 32,
+        "prompt_concurrency": 8,
+        "prefill_step_size": 2048,
+        "prompt_cache_size": 10,
+        "prompt_cache_bytes": None,
+        "pipeline": False,
+        "idle_timeout": 0,
+        "log_level": "INFO",
+    }
+    defaults.update(overrides)
+    return argparse.Namespace(**defaults)
+
+
+def _make_fake_model():
+    """Create a minimal mock to act as a fake model."""
+    model = MagicMock(spec=nn.Module)
+    return model
+
+
+def _make_fake_tokenizer():
+    """Create a minimal tokenizer mock."""
+    tokenizer = MagicMock()
+    tokenizer.chat_template = None
+    tokenizer.default_chat_template = ""
+    tokenizer.vocab_size = 32000
+    return tokenizer
+
+
+# Mock distributed init to avoid MPI crash
+_mock_group = MagicMock()
+_mock_group.size.return_value = 1
+_mock_group.rank.return_value = 0
+
+
+def _make_provider(**kwargs):
+    """Create a ModelProvider with distributed mocked out."""
+    with patch("mlx.core.distributed.init", return_value=_mock_group):
+        from mlx_lm.server import ModelProvider
+
+        args = _make_cli_args(**kwargs)
+        provider = ModelProvider(args)
+    return provider
+
+
+def _make_loaded_provider(**kwargs):
+    """Create a ModelProvider with a fake model pre-loaded."""
+    provider = _make_provider(**kwargs)
+    provider.model = _make_fake_model()
+    provider.tokenizer = _make_fake_tokenizer()
+    provider.model_key = ("/tmp/fake-model-path", None, None)
+    provider._last_request_time = time.time()
+    return provider
+
+
+class TestModelProviderUnload(unittest.TestCase):
+    """Tests for ModelProvider.unload() and reload-after-unload."""
+
+    def test_unload_clears_model_state(self):
+        """After unload(), model, tokenizer, and draft_model should be None."""
+        provider = _make_loaded_provider()
+
+        self.assertIsNotNone(provider.model)
+        self.assertIsNotNone(provider.tokenizer)
+
+        provider.unload()
+
+        self.assertIsNone(provider.model)
+        self.assertIsNone(provider.tokenizer)
+        self.assertIsNone(provider.draft_model)
+
+    def test_unload_preserves_model_key(self):
+        """model_key should be preserved after unload for reload purposes."""
+        provider = _make_loaded_provider()
+        original_key = provider.model_key
+
+        provider.unload()
+
+        self.assertEqual(provider.model_key, original_key)
+
+    def test_unload_noop_when_no_model(self):
+        """Calling unload() when no model is loaded should be a no-op."""
+        provider = _make_loaded_provider()
+        provider.unload()
+
+        # Second unload should not raise
+        provider.unload()
+        self.assertIsNone(provider.model)
+
+    def test_reload_after_unload_triggers_load(self):
+        """load() after unload() should trigger _load() since model is None."""
+        provider = _make_loaded_provider()
+
+        # Unload
+        provider.unload()
+        self.assertIsNone(provider.model)
+
+        # load() should detect model is None and call _load()
+        with patch.object(provider, "_load") as mock_internal_load:
+            provider.load("/tmp/fake-model-path", None, None)
+            mock_internal_load.assert_called_once_with(
+                "/tmp/fake-model-path", None, None
+            )
+
+    def test_last_request_time_updates_on_load(self):
+        """_last_request_time should update each time load() is called."""
+        provider = _make_loaded_provider()
+        provider._last_request_time = time.time() - 100  # Set in past
+
+        old_time = provider._last_request_time
+
+        # load() with same model_key and model not None - skips _load but
+        # still updates timestamp
+        provider.load("/tmp/fake-model-path", None, None)
+
+        self.assertGreater(provider._last_request_time, old_time)
+
+    def test_last_request_time_initialized(self):
+        """_last_request_time should be set at construction."""
+        provider = _make_provider()
+
+        self.assertIsInstance(provider._last_request_time, float)
+        self.assertGreater(provider._last_request_time, 0)
+
+    def test_idle_timeout_stored_in_cli_args(self):
+        """idle_timeout arg should be accessible via cli_args."""
+        provider = _make_provider(idle_timeout=300)
+
+        self.assertEqual(provider.cli_args.idle_timeout, 300)
+
+    def test_unload_calls_metal_clear_cache(self):
+        """unload() should call mx.metal.clear_cache() when Metal is available."""
+        provider = _make_loaded_provider()
+
+        with patch("mlx.core.metal.is_available", return_value=True):
+            with patch("mlx.core.metal.clear_cache") as mock_clear:
+                with patch("mlx.core.metal.get_active_memory", return_value=1000):
+                    provider.unload()
+                    mock_clear.assert_called_once()
+
+
+class TestIdleTimeoutCondition(unittest.TestCase):
+    """Tests for the idle timeout check logic."""
+
+    def test_idle_condition_true_when_timeout_exceeded(self):
+        """Idle condition should be true when last request was long ago."""
+        provider = _make_loaded_provider(idle_timeout=5)
+        provider._last_request_time = time.time() - 10  # 10 seconds ago
+
+        idle_timeout = provider.cli_args.idle_timeout
+        elapsed = time.time() - provider._last_request_time
+
+        self.assertTrue(
+            idle_timeout > 0
+            and provider.model is not None
+            and not provider.is_distributed
+            and elapsed > idle_timeout
+        )
+
+    def test_idle_condition_false_when_within_timeout(self):
+        """Idle condition should be false when request was recent."""
+        provider = _make_loaded_provider(idle_timeout=300)
+        provider._last_request_time = time.time()  # Just now
+
+        idle_timeout = provider.cli_args.idle_timeout
+        elapsed = time.time() - provider._last_request_time
+
+        self.assertFalse(elapsed > idle_timeout)
+
+    def test_idle_condition_false_when_timeout_disabled(self):
+        """Idle condition should be false when idle_timeout is 0."""
+        provider = _make_loaded_provider(idle_timeout=0)
+        provider._last_request_time = time.time() - 9999
+
+        idle_timeout = provider.cli_args.idle_timeout
+        self.assertFalse(idle_timeout > 0)
+
+    def test_idle_condition_false_when_model_already_unloaded(self):
+        """Idle condition should be false when model is already None."""
+        provider = _make_loaded_provider(idle_timeout=5)
+        provider._last_request_time = time.time() - 10
+        provider.model = None  # Already unloaded
+
+        self.assertFalse(provider.model is not None)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -27,6 +27,8 @@ class DummyModelProvider:
         self.model, self.tokenizer = load(HF_MODEL_PATH)
         self.model_key = (HF_MODEL_PATH, None)
         self.is_batchable = True
+        self.is_distributed = False
+        self._last_request_time = 0.0
 
         # Add draft model support
         self.draft_model = None
@@ -55,6 +57,7 @@ class DummyModelProvider:
                 "prompt_cache_bytes": 1 << 63,
                 "prompt_cache_total_bytes": None,
                 "allowed_origins": ["*"],
+                "idle_timeout": 0,
             },
         )
 


### PR DESCRIPTION
## Summary

Adds `--idle-timeout <seconds>` to `mlx_lm.server` that automatically unloads model weights from memory after N seconds without requests. The model reloads transparently on the next request.

Similar to Ollama's idle unload (Ollama defaults to 5min). A 27B model drops from ~14.5 GB to near-zero at idle. `--idle-timeout 0` (the default) preserves current behavior where the model stays loaded indefinitely. Suggested value when enabled: `--idle-timeout 300`.

Closes #1235

## Design

`ModelProvider.unload()` clears model/tokenizer/draft_model, calls `mx.metal.clear_cache()` and `gc.collect()`. The `model_key` is preserved after unload so `load()` knows what to reload. The `load()` condition was changed from `model_key != key` to `model_key != key or self.model is None` to handle reload-after-unload.

The idle check runs in the generation thread (same thread that accesses model state) so there are no concurrency concerns. It is guarded by: timeout > 0, model loaded, not distributed, no pending requests, no active batch.

## Usage

```bash
mlx_lm.server --model mlx-community/Mistral-7B-Instruct-v0.3-4bit --idle-timeout 300
```

## Test plan

- [x] Unit tests for:
    - [x] `unload()` clears state and preserves model_key
    - [x] reload-after-unload triggers `_load()`
    - [x] `_last_request_time` tracking
    - [x] idle condition logic (timeout exceeded, within timeout, disabled, model already unloaded)
- [x] `DummyModelProvider` updated with new fields
- [x] Pre-commit (black + isort) passes
- [x] Existing server tests unaffected
