### PR TITLE
Add timings to server responses

### DIFF
--- a/mlx_lm/SERVER.md
+++ b/mlx_lm/SERVER.md
@@ -140,6 +140,22 @@ curl localhost:8080/v1/chat/completions \
     - `completion_tokens`: The number of tokens generated.
     - `total_tokens`: The total number of tokens, i.e. the sum of the above two fields.
 
+- `timings`: A dictionary with server-observed generation-service
+  measurements. Excludes network I/O, response serialization, and
+  client-side wait. Includes overhead inside the generation service
+  (queue hops, batch-tick scheduling), so values are approximate:
+    - `prompt_n`: The number of prompt tokens actually processed (excludes
+      cached tokens).
+    - `predicted_n`: The number of tokens generated.
+    - `prompt_per_second`: `prompt_n` divided by the server-observed time
+      until the first generated token is produced.
+    - `predicted_per_second`: `predicted_n` divided by the server-observed
+      time between the first and last generated tokens. Returns `0` when
+      fewer than two tokens are generated.
+
+  For streaming requests, `timings` is included in the final usage chunk
+  when `stream_options.include_usage` is set.
+
 ### List Models
 
 Use the `v1/models` endpoint to list available models:

--- a/mlx_lm/SERVER.md
+++ b/mlx_lm/SERVER.md
@@ -140,21 +140,22 @@ curl localhost:8080/v1/chat/completions \
     - `completion_tokens`: The number of tokens generated.
     - `total_tokens`: The total number of tokens, i.e. the sum of the above two fields.
 
-- `timings`: A dictionary with server-observed generation-service
-  measurements. Excludes network I/O, response serialization, and
-  client-side wait. Includes overhead inside the generation service
-  (queue hops, batch-tick scheduling), so values are approximate:
-    - `prompt_n`: The number of prompt tokens actually processed (excludes
-      cached tokens).
-    - `predicted_n`: The number of tokens generated.
-    - `prompt_per_second`: `prompt_n` divided by the server-observed time
-      until the first generated token is produced.
-    - `predicted_per_second`: `predicted_n` divided by the server-observed
-      time between the first and last generated tokens. Returns `0` when
-      fewer than two tokens are generated.
+- `timings`: Server-side timing measurements, following the shape used by
+  llama.cpp and several open-source clients. Times are measured around
+  the generation service only (no network or serialization) and include
+  some internal scheduling overhead, so treat them as approximate.
+    - `prompt_n`: Prompt tokens processed (excludes cached tokens).
+    - `prompt_ms`: Time to first generated token, in milliseconds.
+    - `prompt_per_second`: `prompt_n / (prompt_ms / 1000)`, or `0` if
+      `prompt_ms` is `0`.
+    - `predicted_n`: Tokens generated.
+    - `predicted_ms`: Time from first to last generated token, in
+      milliseconds. `0` when fewer than two tokens are generated.
+    - `predicted_per_second`: `predicted_n / (predicted_ms / 1000)`, or
+      `0` if `predicted_ms` is `0`.
 
-  For streaming requests, `timings` is included in the final usage chunk
-  when `stream_options.include_usage` is set.
+  For streaming requests, `timings` rides on the final usage chunk and
+  requires `stream_options.include_usage`.
 
 ### List Models
 

--- a/mlx_lm/server.py
+++ b/mlx_lm/server.py
@@ -1540,8 +1540,9 @@ class APIHandler(BaseHTTPRequestHandler):
 
             timings = None
             if include_usage:
-                prompt_n = len(ctx.prompt) - max(ctx.prompt_cache_count, 0)
-                timings = _make_timings(ctx, prompt_n, len(tokens), max(ctx.prompt_cache_count, 0))
+                cache_n = max(ctx.prompt_cache_count, 0)
+                prompt_n = len(ctx.prompt) - cache_n
+                timings = _make_timings(ctx, prompt_n, len(tokens), cache_n)
 
             if prev_state == "tool" and tool_text:
                 tool_calls.append(tool_text)

--- a/mlx_lm/server.py
+++ b/mlx_lm/server.py
@@ -440,7 +440,7 @@ def _format_top_logprobs(logprobs, top_n, tokenizer) -> Tuple[Dict[str, Any]]:
     )
 
 
-def _make_timings(ctx, prompt_n: int, predicted_n: int) -> Dict[str, Any]:
+def _make_timings(ctx, prompt_n: int, predicted_n: int, cache_n: int) -> Dict[str, Any]:
     def rate(n, start, end):
         if start is None or end is None or end <= start:
             return 0
@@ -453,6 +453,7 @@ def _make_timings(ctx, prompt_n: int, predicted_n: int) -> Dict[str, Any]:
         ),
         "prompt_n": prompt_n,
         "predicted_n": predicted_n,
+        "cache_n": cache_n,
     }
 
 
@@ -1538,7 +1539,7 @@ class APIHandler(BaseHTTPRequestHandler):
             timings = None
             if include_usage:
                 prompt_n = len(ctx.prompt) - max(ctx.prompt_cache_count, 0)
-                timings = _make_timings(ctx, prompt_n, len(tokens))
+                timings = _make_timings(ctx, prompt_n, len(tokens), max(ctx.prompt_cache_count, 0))
 
             if prev_state == "tool" and tool_text:
                 tool_calls.append(tool_text)

--- a/mlx_lm/server.py
+++ b/mlx_lm/server.py
@@ -215,6 +215,9 @@ class GenerationContext:
 
     prompt: List[int]
     prompt_cache_count: int = -1
+    prompt_start_at: Optional[float] = None
+    prompt_end_at: Optional[float] = None
+    decode_end_at: Optional[float] = None
 
     _should_stop: bool = False
 
@@ -435,6 +438,22 @@ def _format_top_logprobs(logprobs, top_n, tokenizer) -> Tuple[Dict[str, Any]]:
         {"id": i, "token": s, "logprob": g}
         for i, s, g in zip(top_indices, txts, top_probs)
     )
+
+
+def _make_timings(ctx, prompt_n: int, predicted_n: int) -> Dict[str, Any]:
+    def rate(n, start, end):
+        if start is None or end is None or end <= start:
+            return 0
+        return n / (end - start)
+
+    return {
+        "prompt_per_second": rate(prompt_n, ctx.prompt_start_at, ctx.prompt_end_at),
+        "predicted_per_second": rate(
+            predicted_n, ctx.prompt_end_at, ctx.decode_end_at
+        ),
+        "prompt_n": prompt_n,
+        "predicted_n": predicted_n,
+    }
 
 
 class ResponseGenerator:
@@ -850,15 +869,20 @@ class ResponseGenerator:
 
                 uids_to_remove = []
                 for _ in self._time_budget:
+                    tic = time.perf_counter()
                     prompt_responses, gen_responses = batch_generator.next()
+                    toc = time.perf_counter()
                     if not prompt_responses and not gen_responses:
                         break
 
                     # Progress report for prompt processing
                     for r in prompt_responses:
                         result = batch_results[r.uid]
+                        ctx = result["ctx"]
+                        if ctx.prompt_start_at is None:
+                            ctx.prompt_start_at = tic
                         result["rqueue"].put(r.progress)
-                        if result["ctx"]._should_stop:
+                        if ctx._should_stop:
                             uids_to_remove.append(r.uid)
 
                     # Save the caches at end of segments
@@ -881,6 +905,9 @@ class ResponseGenerator:
 
                     for r in gen_responses:
                         result = batch_results[r.uid]
+                        ctx = result["ctx"]
+                        if ctx.prompt_end_at is None:
+                            ctx.prompt_end_at = toc
                         result["detokenizer"].add_token(r.token)
                         result["rqueue"].put(
                             Response(
@@ -899,6 +926,7 @@ class ResponseGenerator:
                         )
 
                         if r.finish_reason is not None:
+                            ctx.decode_end_at = toc
                             result["rqueue"].put(None)
                             self.prompt_cache.insert_cache(
                                 current_model_key,
@@ -908,7 +936,7 @@ class ResponseGenerator:
                             )
                             del batch_results[r.uid]
 
-                        if result["ctx"]._should_stop:
+                        if ctx._should_stop:
                             uids_to_remove.append(r.uid)
 
                 uids_to_remove = self._share_object(uids_to_remove)
@@ -973,6 +1001,7 @@ class ResponseGenerator:
                     cache += make_prompt_cache(self.model_provider.draft_model)
 
             # Process the prompt and generate tokens
+            ctx.prompt_start_at = time.perf_counter()
             for gen in stream_generate(
                 model=model,
                 tokenizer=tokenizer,
@@ -986,6 +1015,8 @@ class ResponseGenerator:
                 prompt_progress_callback=progress,
                 prefill_step_size=self.cli_args.prefill_step_size,
             ):
+                if ctx.prompt_end_at is None:
+                    ctx.prompt_end_at = time.perf_counter()
                 finish_reason = gen.finish_reason
                 sm_state, match_sequence, current_state = sm.match(sm_state, gen.token)
                 if match_sequence is not None and current_state is None:
@@ -1013,6 +1044,7 @@ class ResponseGenerator:
                 if finish_reason is not None:
                     break
 
+            ctx.decode_end_at = time.perf_counter()
             rqueue.put(None)
 
             # Save the KV cache again
@@ -1268,6 +1300,7 @@ class APIHandler(BaseHTTPRequestHandler):
         tokens: Optional[List[int]] = None,
         tool_calls: Optional[List[str]] = None,
         reasoning_text: Optional[str] = None,
+        timings: Optional[Dict[str, Any]] = None,
     ) -> dict:
         """
         Generate a single response packet based on response type (stream or
@@ -1345,6 +1378,8 @@ class APIHandler(BaseHTTPRequestHandler):
                 response["usage"]["prompt_tokens_details"] = {
                     "cached_tokens": prompt_cache_count,
                 }
+            if timings is not None:
+                response["timings"] = timings
 
         choice = response["choices"][0]
 
@@ -1450,6 +1485,9 @@ class APIHandler(BaseHTTPRequestHandler):
         tokens = []
         token_logprobs = []
         top_tokens = []
+        include_usage = (not self.stream) or bool(
+            self.stream_options and self.stream_options.get("include_usage")
+        )
 
         try:
             for gen in response:
@@ -1497,6 +1535,11 @@ class APIHandler(BaseHTTPRequestHandler):
 
                 prev_state = gen.state
 
+            timings = None
+            if include_usage:
+                prompt_n = len(ctx.prompt) - max(ctx.prompt_cache_count, 0)
+                timings = _make_timings(ctx, prompt_n, len(tokens))
+
             if prev_state == "tool" and tool_text:
                 tool_calls.append(tool_text)
                 made_tool_call = True
@@ -1513,14 +1556,12 @@ class APIHandler(BaseHTTPRequestHandler):
                 )
                 self.wfile.write(f"data: {json.dumps(resp)}\n\n".encode())
                 self.wfile.flush()
-                if (
-                    self.stream_options is not None
-                    and self.stream_options["include_usage"]
-                ):
+                if include_usage:
                     resp = self.completion_usage_response(
                         len(ctx.prompt),
                         len(tokens),
                         ctx.prompt_cache_count,
+                        timings=timings,
                     )
                     self.wfile.write(f"data: {json.dumps(resp)}\n\n".encode())
                     self.wfile.flush()
@@ -1538,6 +1579,7 @@ class APIHandler(BaseHTTPRequestHandler):
                     tokens=tokens,
                     reasoning_text=reasoning_text,
                     tool_calls=tool_formatter(tool_calls),
+                    timings=timings,
                 )
                 if logging.getLogger().isEnabledFor(logging.DEBUG):
                     response_debug = json.dumps(resp, indent="\t")
@@ -1556,6 +1598,7 @@ class APIHandler(BaseHTTPRequestHandler):
         prompt_token_count: Optional[int] = None,
         completion_token_count: Optional[int] = None,
         prompt_cache_count: Optional[int] = None,
+        timings: Optional[Dict[str, Any]] = None,
     ):
         response = {
             "id": self.request_id,
@@ -1574,6 +1617,8 @@ class APIHandler(BaseHTTPRequestHandler):
             response["usage"]["prompt_tokens_details"] = {
                 "cached_tokens": prompt_cache_count,
             }
+        if timings is not None:
+            response["timings"] = timings
         return response
 
     def handle_chat_completions(self) -> CompletionRequest:

--- a/mlx_lm/server.py
+++ b/mlx_lm/server.py
@@ -441,18 +441,20 @@ def _format_top_logprobs(logprobs, top_n, tokenizer) -> Tuple[Dict[str, Any]]:
 
 
 def _make_timings(ctx, prompt_n: int, predicted_n: int, cache_n: int) -> Dict[str, Any]:
-    def rate(n, start, end):
+    def elapsed(start, end):
         if start is None or end is None or end <= start:
             return 0
-        return n / (end - start)
+        return end - start
 
+    prompt_s = elapsed(ctx.prompt_start_at, ctx.prompt_end_at)
+    predicted_s = elapsed(ctx.prompt_end_at, ctx.decode_end_at)
     return {
-        "prompt_per_second": rate(prompt_n, ctx.prompt_start_at, ctx.prompt_end_at),
-        "predicted_per_second": rate(
-            predicted_n, ctx.prompt_end_at, ctx.decode_end_at
-        ),
         "prompt_n": prompt_n,
+        "prompt_ms": prompt_s * 1000,
+        "prompt_per_second": (prompt_n / prompt_s) if prompt_s else 0,
         "predicted_n": predicted_n,
+        "predicted_ms": predicted_s * 1000,
+        "predicted_per_second": (predicted_n / predicted_s) if predicted_s else 0,
         "cache_n": cache_n,
     }
 

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -37,11 +37,11 @@ def assert_usage_timings(test_case, response_body):
         response_body["usage"]["completion_tokens"],
     )
     test_case.assertEqual(timings["cache_n"], cached_tokens)
-    if timings["prompt_n"] > 0:
+    test_case.assertGreaterEqual(timings["prompt_ms"], 0)
+    test_case.assertGreaterEqual(timings["predicted_ms"], 0)
+    if timings["prompt_ms"] > 0:
         test_case.assertGreater(timings["prompt_per_second"], 0)
-    # predicted_per_second needs at least two tokens; with one, the
-    # first-token and last-token timestamps collapse.
-    if timings["predicted_n"] > 1:
+    if timings["predicted_ms"] > 0:
         test_case.assertGreater(timings["predicted_per_second"], 0)
 
 

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -21,6 +21,29 @@ from mlx_lm.server import (
 from mlx_lm.utils import load
 
 
+def assert_usage_timings(test_case, response_body):
+    test_case.assertIn("usage", response_body)
+    test_case.assertIn("timings", response_body)
+    timings = response_body["timings"]
+    cached_tokens = (
+        response_body["usage"].get("prompt_tokens_details", {}).get("cached_tokens", 0)
+    )
+    test_case.assertEqual(
+        timings["prompt_n"],
+        response_body["usage"]["prompt_tokens"] - cached_tokens,
+    )
+    test_case.assertEqual(
+        timings["predicted_n"],
+        response_body["usage"]["completion_tokens"],
+    )
+    if timings["prompt_n"] > 0:
+        test_case.assertGreater(timings["prompt_per_second"], 0)
+    # predicted_per_second needs at least two tokens; with one, the
+    # first-token and last-token timestamps collapse.
+    if timings["predicted_n"] > 1:
+        test_case.assertGreater(timings["predicted_per_second"], 0)
+
+
 class DummyModelProvider:
     def __init__(self, with_draft=False):
         HF_MODEL_PATH = "mlx-community/Qwen1.5-0.5B-Chat-4bit"
@@ -201,6 +224,7 @@ class TestServer(unittest.TestCase):
 
         self.assertIn("id", response_body)
         self.assertIn("choices", response_body)
+        assert_usage_timings(self, response_body)
         first_text = response_body["choices"][0]["text"]
         self.assertEqual(
             first_text,
@@ -221,9 +245,10 @@ class TestServer(unittest.TestCase):
             ],
         }
         response = requests.post(url, json=chat_post_data)
-        response_body = response.text
+        response_body = json.loads(response.text)
         self.assertIn("id", response_body)
         self.assertIn("choices", response_body)
+        assert_usage_timings(self, response_body)
 
     def test_handle_chat_completions_with_content_fragments(self):
         url = f"http://localhost:{self.port}/v1/chat/completions"
@@ -247,6 +272,38 @@ class TestServer(unittest.TestCase):
         response_body = response.text
         self.assertIn("id", response_body)
         self.assertIn("choices", response_body)
+
+    def test_streaming_include_usage_timings(self):
+        url = f"http://localhost:{self.port}/v1/chat/completions"
+        chat_post_data = {
+            "model": "chat_model",
+            "max_tokens": 10,
+            "temperature": 0.0,
+            "stream": True,
+            "stream_options": {"include_usage": True},
+            "messages": [
+                {"role": "system", "content": "You are a helpful assistant."},
+                {"role": "user", "content": "Hello!"},
+            ],
+        }
+
+        response = requests.post(url, json=chat_post_data, stream=True)
+        self.assertEqual(response.status_code, 200)
+
+        usage_count = 0
+        for chunk in response.iter_lines():
+            if not chunk:
+                continue
+            data = chunk.decode("utf-8")
+            if not data.startswith("data: ") or data == "data: [DONE]":
+                continue
+            chunk_data = json.loads(data[6:])
+            if chunk_data.get("usage"):
+                self.assertEqual(chunk_data["choices"], [])
+                assert_usage_timings(self, chunk_data)
+                usage_count += 1
+
+        self.assertEqual(usage_count, 1)
 
     def test_handle_chat_completions_with_null_tool_content(self):
         url = f"http://localhost:{self.port}/v1/chat/completions"
@@ -361,7 +418,7 @@ class TestServerWithDraftModel(unittest.TestCase):
         response_body = json.loads(response.text)
         self.assertIn("id", response_body)
         self.assertIn("choices", response_body)
-        self.assertIn("usage", response_body)
+        assert_usage_timings(self, response_body)
 
         # Check that tokens were generated
         self.assertTrue(response_body["usage"]["completion_tokens"] > 0)
@@ -385,7 +442,7 @@ class TestServerWithDraftModel(unittest.TestCase):
         response_body = json.loads(response.text)
         self.assertIn("id", response_body)
         self.assertIn("choices", response_body)
-        self.assertIn("usage", response_body)
+        assert_usage_timings(self, response_body)
 
         # Check that tokens were generated
         self.assertTrue(response_body["usage"]["completion_tokens"] > 0)
@@ -458,6 +515,8 @@ class TestServerWithDraftModel(unittest.TestCase):
 
         self.assertIn("choices", first_response_body)
         self.assertIn("choices", second_response_body)
+        assert_usage_timings(self, first_response_body)
+        assert_usage_timings(self, second_response_body)
         self.assertIn("message", first_response_body["choices"][0])
         self.assertIn("message", second_response_body["choices"][0])
         self.assertIn("content", first_response_body["choices"][0]["message"])

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -36,6 +36,7 @@ def assert_usage_timings(test_case, response_body):
         timings["predicted_n"],
         response_body["usage"]["completion_tokens"],
     )
+    test_case.assertEqual(timings["cache_n"], cached_tokens)
     if timings["prompt_n"] > 0:
         test_case.assertGreater(timings["prompt_per_second"], 0)
     # predicted_per_second needs at least two tokens; with one, the


### PR DESCRIPTION
Adds a `timings` object to `/v1/chat/completions` and `/v1/completions` responses so clients can measure prompt and generation throughput without instrumenting the server themselves. Useful for benchmarking, comparing models, and surfacing tps in UIs.

The shape mirrors llama.cpp's `timings` field for ecosystem compatibility:

```json
"timings": {
  "prompt_per_second": 412.3,
  "predicted_per_second": 78.9,
  "prompt_n": 128,
  "predicted_n": 64
}
```

### Behavior

Follows the existing `usage` conventions:
- Non-streaming: always included.
- Streaming: included in the final usage chunk when `stream_options.include_usage` is set.

### Implementation notes

- Measured server-side; reusing `GenerationResponse.prompt_tps` doesn't work because batched generation has no per-sequence equivalent.
- Both windows are stamped in the generation worker: prompt = prefill start → first generated token; predicted = first → last generated token. Excludes network I/O and pre-worker queue wait; includes a small amount of batch-tick overhead, so values are approximate.
- `prompt_n` excludes cached tokens. `predicted_per_second` is `0` when fewer than two tokens are generated.
- Includes a minor fix: streaming usage check uses `.get("include_usage")` instead of `["include_usage"]` to avoid `KeyError` when `stream_options` is passed without that key.