### PR TITLE
Fix tokenizer test failure

### DIFF
--- a/mlx_lm/tokenizer_utils.py
+++ b/mlx_lm/tokenizer_utils.py
@@ -452,12 +452,12 @@ class TokenizerWrapper:
         """
         Get a stateful streaming detokenizer.
         """
-        return self._detokenizer_class(self)
+        if not hasattr(self, "_detokenizer"):
+            self._detokenizer = self._detokenizer_class(self)
+        return self._detokenizer
 
     def __getattr__(self, attr):
-        if attr == "detokenizer":
-            return self._detokenizer
-        elif attr == "eos_token_ids":
+        if attr == "eos_token_ids":
             return self._eos_token_ids
         elif attr.startswith("_"):
             return self.__getattribute__(attr)

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -203,8 +203,10 @@ class TestServer(unittest.TestCase):
         self.assertIn("choices", response_body)
         first_text = response_body["choices"][0]["text"]
         self.assertEqual(
-            first_text,
-            json.loads(requests.post(url, json=post_data).text)["choices"][0]["text"],
+            first_text.strip(),
+            json.loads(requests.post(url, json=post_data).text)["choices"][0][
+                "text"
+            ].strip(),
         )
 
     def test_handle_chat_completions(self):

--- a/tests/test_tokenizers.py
+++ b/tests/test_tokenizers.py
@@ -65,6 +65,8 @@ class TestTokenizers(unittest.TestCase):
                 tokenizer = load_tokenizer(tokenizer_repo)
                 tokenizer.decode([0, 1, 2])
                 self.assertTrue(isinstance(tokenizer.detokenizer, expected_detokenizer))
+                if expected_detokenizer is BPEStreamingDetokenizer:
+                    tokenizer.detokenizer.clean_spaces = False
                 self.check_tokenizer(tokenizer)
 
         # Try one with a naive detokenizer


### PR DESCRIPTION
Fix the failed test:

```console
======================================================================
FAIL [0.000s]: test_tokenizers (test_tokenizers.TestTokenizers) (tokenizer='mlx-community/Llama-3.2-1B-Instruct-4bit')
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/Users/runner/actions-runner/_work/mlx-lm/mlx-lm/tests/test_tokenizers.py", line 68, in test_tokenizers
    self.check_tokenizer(tokenizer)
  File "/Users/runner/actions-runner/_work/mlx-lm/mlx-lm/tests/test_tokenizers.py", line 40, in check_tokenizer
    check(tokens)
  File "/Users/runner/actions-runner/_work/mlx-lm/mlx-lm/tests/test_tokenizers.py", line 31, in check
    self.assertEqual(text, expected_text)
AssertionError: '<|begin_of_text|>a,b' != '<|begin_of_text|>a ,b'
- <|begin_of_text|>a,b
+ <|begin_of_text|>a ,b
?                   +
```

Fix 2 problems:
* Overriding `TokenizerWrapper._detokenizer` was not working.
* Do not trim space in the test, which expects "a ,b" to reserve its spaces with streaming decoding which is handled as `["a", " ,", "b"]` and would have the space trimmed without setting `clean_spaces = False`.