### PR TITLE
Fix KeyError: 'name' in qwen3_coder tool parser

### DIFF
--- a/mlx_lm/tool_parsers/qwen3_coder.py
+++ b/mlx_lm/tool_parsers/qwen3_coder.py
@@ -26,7 +26,7 @@ def _get_arguments_config(func_name: str, tools: Optional[Any]) -> dict:
     for tool in tools:
         if not (function := tool.get("function", False)):
             continue
-        if function["name"] == func_name:
+        if function.get("name") == func_name:
             if not (params := function.get("parameters", False)):
                 return {}
             return params.get("properties", {})


### PR DESCRIPTION
# Fix KeyError: 'name' in qwen3_coder tool parser

## Summary

`qwen3_coder.py` raises `KeyError: 'name'` when the tool list contains a function dict that doesn't have `"name"` at the top level of the `"function"` object. This causes the entire request to fail with a 500-level exception rather than gracefully skipping the malformed entry.

## Root cause

In `_get_arguments_config` (line 29), the function dict is accessed with a hard bracket lookup:

```python
if function["name"] == func_name:
```

Some clients (including Pi and other agentic coding tools) send tool definitions where the `"function"` object structure doesn't always include `"name"` — for example, MCP-proxied tool definitions or tools with non-standard shapes. When this happens, Python raises `KeyError: 'name'` and the server throws an unhandled exception.

## Fix

Replace the hard lookup with `.get()`:

```python
if function.get("name") == func_name:
```

This is a one-line change. If `"name"` is absent, `function.get("name")` returns `None`, which won't match any `func_name`, so the loop simply continues to the next tool — the correct behaviour.

## Traceback

```
File ".../mlx_lm/tool_parsers/qwen3_coder.py", line 115, in parse_tool_call
    return _parse_xml_function_call(match[0], tools)
File ".../mlx_lm/tool_parsers/qwen3_coder.py", line 85, in _parse_xml_function_call
    param_config = _get_arguments_config(function_name, tools)
File ".../mlx_lm/tool_parsers/qwen3_coder.py", line 29, in _get_arguments_config
    if function["name"] == func_name:
       ~~~~~~~~^^^^^^^^
KeyError: 'name'
```

## Reproduction

1. Start `mlx_lm.server` with a Qwen3.6 or Qwen3-Coder model
2. Send a `/v1/chat/completions` request with tools via an agentic client (Pi, OpenCode, etc.)
3. The server crashes with `KeyError: 'name'` on the first tool call

## Related

- Issue #905 (similar tool parser failure on Qwen3.5)

## Testing

After applying the fix, tool calls from Pi (using MCP-proxied tool definitions) work correctly across multiple turns with no degradation.