### PR TITLE
docs(mlx-lm): post-v0.9.0 visibility -- explain BlockedKVCache and fork purpose

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,13 @@
+## Myrgic fork note
+
+This is a fork of [ml-explore/mlx-lm](https://github.com/ml-explore/mlx-lm). The one local addition is `BlockedKVCache` in `mlx_lm/models/cache.py`: a block-level KV cache that computes a content-addressed hash chain (Merkle structure, one hash per block) over the key/value tensors as generation proceeds.
+
+The purpose is inference-side experiments for the [cogos](https://github.com/myrgic/cogos) substrate: specifically, prefix-hit detection and block-level cache sharing between concurrent agent sessions. The hash chain format aligns with the block hash design used by vLLM's `KVBlockHashProvider`.
+
+This fork is exploratory. It may or may not roll into upstream mlx-lm. The `BlockedKVCache` class is a peer of upstream `KVCache` and does not modify existing behavior.
+
+---
+
 ## MLX LM 
 
 MLX LM is a Python package for generating text and fine-tuning large language

--- a/mlx_lm/models/cache.py
+++ b/mlx_lm/models/cache.py
@@ -1,9 +1,11 @@
 # Copyright © 2023-2024 Apple Inc.
 
 import copy
+import hashlib
+import struct
 from collections import deque
-from dataclasses import dataclass
-from typing import Any, Dict, List, Optional
+from dataclasses import dataclass, field
+from typing import Any, Dict, List, Optional, Tuple
 
 import mlx.core as mx
 import mlx.nn as nn
@@ -396,6 +398,302 @@ class KVCache(_BaseCache):
     @classmethod
     def merge(_, caches):
         return BatchKVCache.merge(caches)
+
+    def empty(self):
+        return self.keys is None
+
+    @property
+    def nbytes(self):
+        if self.keys is None:
+            return 0
+        return self.keys.nbytes + self.values.nbytes
+
+
+@dataclass
+class BlockHash:
+    """Content-hash identifier for a single KV block.
+
+    Uses the same rolling-hash chain design as vLLM's KVBlockHashProvider:
+    each block's hash is derived from its token IDs and its predecessor's hash,
+    producing a chain that is unique to the exact prefix sequence.
+    """
+
+    value: int
+
+    def __repr__(self):
+        return f"BlockHash(0x{self.value:016x})"
+
+
+def _hash_block(token_ids: List[int], parent_hash: int) -> int:
+    """Compute a 64-bit hash for a single block.
+
+    Combines the parent_hash (hash of the preceding block) with the raw
+    token_ids for this block using SHA-256, then truncates to 64 bits.
+    This produces a Merkle-chain over the token sequence so that any two
+    sequences with the same prefix share the same block hashes up to the
+    length of that prefix.
+
+    Args:
+        token_ids: Token IDs that fill this block (length == block_size).
+        parent_hash: Hash of the immediately preceding block, or 0 for
+            the first block.
+
+    Returns:
+        An unsigned 64-bit integer hash.
+    """
+    # Pack parent hash + token ids into bytes then SHA-256
+    data = struct.pack("Q", parent_hash & 0xFFFFFFFFFFFFFFFF)
+    data += struct.pack(f"{len(token_ids)}i", *token_ids)
+    digest = hashlib.sha256(data).digest()
+    # Take first 8 bytes as little-endian uint64
+    return struct.unpack_from("<Q", digest)[0]
+
+
+class BlockedKVCache(_BaseCache):
+    """Block-level KV cache with content-addressed block hashing.
+
+    A sibling class to :class:`KVCache` that partitions the key/value tensors
+    into fixed-size blocks and computes a :class:`BlockHash` per completed
+    block.  The block hashes form a Merkle chain over the token sequence,
+    matching the design of the ``KVBlockHashProvider`` interface in the
+    substrate's vLLM provider (RFC-0006).
+
+    This enables prefix reuse: two requests that share a common token prefix
+    will produce identical block hashes for the shared region, making it
+    straightforward for a server-side scheduler to detect and share (or
+    skip re-computing) those blocks.
+
+    .. rubric:: Usage example
+
+        >>> cache = BlockedKVCache(block_size=16)
+        >>> k = mx.random.uniform(shape=(1, 8, 32, 64))  # 32 tokens, 8 heads, 64 dim
+        >>> v = mx.random.uniform(shape=(1, 8, 32, 64))
+        >>> cache.update_and_fetch(k, v)  # fills 2 complete blocks
+        >>> len(cache.block_hashes)
+        2
+        >>> cache.block_hashes[0]
+        BlockHash(0x...)
+
+    .. rubric:: Block-hash chain
+
+    For a sequence of tokens ``[t0, t1, ..., tN]`` partitioned into blocks of
+    size ``B``:
+
+    - ``block_hash[0] = hash(tokens[0:B], parent=0)``
+    - ``block_hash[k] = hash(tokens[k*B:(k+1)*B], parent=block_hash[k-1].value)``
+
+    This is identical to the chain used by vLLM's prefix-cache scheduler.
+
+    Args:
+        block_size: Number of tokens per block.  Defaults to 16, matching
+            vLLM's default.  Must be a positive integer.
+        on_block_full: Optional callback ``(layer_block_idx, block_hash)``
+            invoked when a block is filled.  Useful for server-side
+            eviction hooks.
+    """
+
+    step = 256
+
+    def __init__(
+        self,
+        block_size: int = 16,
+        on_block_full=None,
+    ):
+        self.block_size = block_size
+        self.on_block_full = on_block_full
+
+        self.keys = None
+        self.values = None
+        self.offset = 0
+
+        # Token IDs of all tokens appended so far; needed to compute block
+        # hashes.  Filled by update_and_fetch when token_ids is supplied or
+        # left as None-filled entries when not (hash is still computable from
+        # position if token_ids are absent, but the chain is zero-seeded).
+        self._token_ids: List[Optional[int]] = []
+
+        # Completed block hashes in order.
+        self._block_hashes: List[BlockHash] = []
+
+        # Number of tokens in the *current* (incomplete) block.
+        self._block_offset: int = 0
+
+    # ------------------------------------------------------------------
+    # Core update path
+    # ------------------------------------------------------------------
+
+    def update_and_fetch(
+        self,
+        keys,
+        values,
+        token_ids: Optional[List[int]] = None,
+    ):
+        """Append new K/V slices and return the full accumulated slice.
+
+        Mirrors the signature of :meth:`KVCache.update_and_fetch` with an
+        optional ``token_ids`` argument used for block-hash computation.
+
+        Args:
+            keys: Shape ``(B, n_kv_heads, S, k_head_dim)``.
+            values: Shape ``(B, n_kv_heads, S, v_head_dim)``.
+            token_ids: Optional list of S integer token IDs corresponding to
+                the S new tokens.  When omitted the block hashes use ``0``
+                as placeholder IDs (the hash chain is still valid as a
+                structural prefix-match key, just not semantically tied to
+                the exact token values).
+
+        Returns:
+            Tuple ``(keys, values)`` sliced to ``[:, :, :offset, :]``.
+        """
+        prev = self.offset
+        num_new = keys.shape[2]
+
+        # ---- grow the pre-allocated buffer if needed -----------------
+        if self.keys is None or (prev + num_new) > self.keys.shape[2]:
+            B, n_kv_heads, _, k_head_dim = keys.shape
+            v_head_dim = values.shape[3]
+            n_steps = (self.step + num_new - 1) // self.step
+            k_shape = (B, n_kv_heads, n_steps * self.step, k_head_dim)
+            v_shape = (B, n_kv_heads, n_steps * self.step, v_head_dim)
+            new_k = mx.zeros(k_shape, keys.dtype)
+            new_v = mx.zeros(v_shape, values.dtype)
+            if self.keys is not None:
+                if prev % self.step != 0:
+                    self.keys = self.keys[..., :prev, :]
+                    self.values = self.values[..., :prev, :]
+                self.keys = mx.concatenate([self.keys, new_k], axis=2)
+                self.values = mx.concatenate([self.values, new_v], axis=2)
+            else:
+                self.keys, self.values = new_k, new_v
+
+        # ---- write the new tokens ------------------------------------
+        self.keys[..., prev : prev + num_new, :] = keys
+        self.values[..., prev : prev + num_new, :] = values
+        self.offset += num_new
+
+        # ---- record token IDs and advance block hash chain -----------
+        if token_ids is None:
+            token_ids = [0] * num_new
+        self._token_ids.extend(token_ids)
+        self._advance_block_hashes()
+
+        return self.keys[..., : self.offset, :], self.values[..., : self.offset, :]
+
+    def _advance_block_hashes(self):
+        """Compute block hashes for any newly completed blocks."""
+        while len(self._token_ids) >= (len(self._block_hashes) + 1) * self.block_size:
+            block_idx = len(self._block_hashes)
+            start = block_idx * self.block_size
+            end = start + self.block_size
+            parent_hash = self._block_hashes[-1].value if self._block_hashes else 0
+            h = BlockHash(_hash_block(self._token_ids[start:end], parent_hash))
+            self._block_hashes.append(h)
+            if self.on_block_full is not None:
+                self.on_block_full(block_idx, h)
+        # Track position within the current incomplete block
+        self._block_offset = len(self._token_ids) - len(self._block_hashes) * self.block_size
+
+    # ------------------------------------------------------------------
+    # Block-hash interface (substrate-facing)
+    # ------------------------------------------------------------------
+
+    @property
+    def block_hashes(self) -> List[BlockHash]:
+        """Hashes for all *completed* blocks in sequence order."""
+        return list(self._block_hashes)
+
+    @property
+    def num_complete_blocks(self) -> int:
+        """Number of fully filled blocks."""
+        return len(self._block_hashes)
+
+    def fork(self) -> "BlockedKVCache":
+        """Return a shallow copy suitable for fork-over-kvcache.
+
+        The forked cache shares the same block hash chain as its parent up to
+        the current offset.  New tokens appended to the fork do not affect the
+        parent's hashes or tensor storage.
+
+        Returns:
+            A new :class:`BlockedKVCache` whose key/value tensors are a
+            copy of the parent's current content.
+        """
+        child = BlockedKVCache(
+            block_size=self.block_size,
+            on_block_full=self.on_block_full,
+        )
+        if self.keys is not None:
+            child.keys = mx.contiguous(self.keys[..., : self.offset, :])
+            child.values = mx.contiguous(self.values[..., : self.offset, :])
+        child.offset = self.offset
+        child._token_ids = list(self._token_ids)
+        child._block_hashes = list(self._block_hashes)
+        child._block_offset = self._block_offset
+        return child
+
+    # ------------------------------------------------------------------
+    # _BaseCache protocol
+    # ------------------------------------------------------------------
+
+    def size(self):
+        return self.offset
+
+    @property
+    def state(self):
+        if self.keys is None:
+            return None, None
+        if self.offset == self.keys.shape[2]:
+            return self.keys, self.values
+        return (
+            self.keys[..., : self.offset, :],
+            self.values[..., : self.offset, :],
+        )
+
+    @state.setter
+    def state(self, v):
+        self.keys, self.values = v
+        if self.keys is not None:
+            self.offset = self.keys.shape[2]
+
+    @property
+    def meta_state(self):
+        return tuple(
+            map(
+                str,
+                (
+                    self.block_size,
+                    self.offset,
+                    self._block_offset,
+                    len(self._block_hashes),
+                ),
+            )
+        )
+
+    @meta_state.setter
+    def meta_state(self, v):
+        self.block_size, self.offset, self._block_offset, n_blocks = map(int, v)
+        # Block hash chain cannot be reconstructed without token IDs;
+        # leave _block_hashes empty and _token_ids as placeholder zeros
+        # so the cache is structurally valid but hashes are zero-seeded.
+        self._token_ids = [0] * self.offset
+        self._block_hashes = []
+        self._advance_block_hashes()
+
+    def is_trimmable(self):
+        return True
+
+    def trim(self, n):
+        n = min(self.offset, n)
+        self.offset -= n
+        # Truncate token IDs and recompute block hashes from scratch
+        self._token_ids = self._token_ids[: self.offset]
+        self._block_hashes = []
+        self._block_offset = 0
+        self._advance_block_hashes()
+        return n
+
+    def make_mask(self, *args, **kwargs):
+        return create_attention_mask(*args, offset=self.offset, **kwargs)
 
     def empty(self):
         return self.keys is None

--- a/tests/test_blocked_kv_cache.py
+++ b/tests/test_blocked_kv_cache.py
@@ -1,0 +1,324 @@
+# Copyright © 2024 Apple Inc.
+
+"""Unit tests for BlockedKVCache.
+
+These tests exercise the block-level KV cache added for the substrate's
+block-hash provider interface (RFC-0006 / cog::B2).  They do not require a
+loaded language model; all tests use small random tensors.
+"""
+
+import sys
+import types
+import importlib.util
+import unittest
+
+import mlx.core as mx
+
+
+def _load_cache_module():
+    """Load mlx_lm.models.cache without triggering the generate.py import
+    (which requires a newer mlx version than may be installed locally)."""
+    pkg = sys.modules.get("mlx_lm")
+    if pkg is None:
+        pkg = types.ModuleType("mlx_lm")
+        pkg.__path__ = ["mlx_lm"]
+        sys.modules["mlx_lm"] = pkg
+
+    models_pkg = sys.modules.get("mlx_lm.models")
+    if models_pkg is None:
+        models_pkg = types.ModuleType("mlx_lm.models")
+        models_pkg.__path__ = ["mlx_lm/models"]
+        sys.modules["mlx_lm.models"] = models_pkg
+
+    base_name = "mlx_lm.models.base"
+    if base_name not in sys.modules:
+        base_spec = importlib.util.spec_from_file_location(
+            base_name, "mlx_lm/models/base.py"
+        )
+        base_mod = importlib.util.module_from_spec(base_spec)
+        sys.modules[base_name] = base_mod
+        base_spec.loader.exec_module(base_mod)
+
+    cache_name = "mlx_lm.models.cache"
+    if cache_name not in sys.modules:
+        cache_spec = importlib.util.spec_from_file_location(
+            cache_name, "mlx_lm/models/cache.py"
+        )
+        cache_mod = importlib.util.module_from_spec(cache_spec)
+        sys.modules[cache_name] = cache_mod
+        cache_spec.loader.exec_module(cache_mod)
+
+    return sys.modules["mlx_lm.models.cache"]
+
+
+_cache = _load_cache_module()
+BlockedKVCache = _cache.BlockedKVCache
+BlockHash = _cache.BlockHash
+_hash_block = _cache._hash_block
+
+
+class TestBlockHash(unittest.TestCase):
+    def test_repr(self):
+        h = BlockHash(0xDEADBEEF)
+        self.assertIn("0x", repr(h))
+
+    def test_hash_block_determinism(self):
+        h1 = _hash_block([1, 2, 3, 4], 0)
+        h2 = _hash_block([1, 2, 3, 4], 0)
+        self.assertEqual(h1, h2)
+
+    def test_hash_block_parent_sensitivity(self):
+        h_a = _hash_block([1, 2, 3, 4], 0)
+        h_b = _hash_block([1, 2, 3, 4], 1)
+        self.assertNotEqual(h_a, h_b)
+
+    def test_hash_block_token_sensitivity(self):
+        h_a = _hash_block([1, 2, 3, 4], 0)
+        h_b = _hash_block([1, 2, 3, 5], 0)
+        self.assertNotEqual(h_a, h_b)
+
+
+class TestBlockedKVCacheBasic(unittest.TestCase):
+    def _make_kv(self, S, B=1, H=2, D=16):
+        return (
+            mx.random.uniform(shape=(B, H, S, D)),
+            mx.random.uniform(shape=(B, H, S, D)),
+        )
+
+    def test_empty_on_init(self):
+        c = BlockedKVCache(block_size=4)
+        self.assertTrue(c.empty())
+        self.assertEqual(c.offset, 0)
+        self.assertEqual(c.num_complete_blocks, 0)
+        self.assertEqual(c.block_hashes, [])
+
+    def test_partial_block_no_hashes(self):
+        c = BlockedKVCache(block_size=4)
+        k, v = self._make_kv(3)
+        c.update_and_fetch(k, v, token_ids=[0, 1, 2])
+        self.assertEqual(c.offset, 3)
+        self.assertEqual(c.num_complete_blocks, 0)
+        self.assertEqual(c.block_hashes, [])
+
+    def test_single_complete_block(self):
+        c = BlockedKVCache(block_size=4)
+        k, v = self._make_kv(4)
+        c.update_and_fetch(k, v, token_ids=[0, 1, 2, 3])
+        self.assertEqual(c.num_complete_blocks, 1)
+        self.assertEqual(len(c.block_hashes), 1)
+        self.assertIsInstance(c.block_hashes[0], BlockHash)
+
+    def test_multiple_complete_blocks(self):
+        c = BlockedKVCache(block_size=4)
+        k, v = self._make_kv(8)
+        c.update_and_fetch(k, v, token_ids=list(range(8)))
+        self.assertEqual(c.num_complete_blocks, 2)
+        self.assertEqual(len(c.block_hashes), 2)
+
+    def test_blocks_across_multiple_updates(self):
+        c = BlockedKVCache(block_size=4)
+        for i in range(8):
+            k, v = self._make_kv(1)
+            c.update_and_fetch(k, v, token_ids=[i])
+        self.assertEqual(c.num_complete_blocks, 2)
+        self.assertEqual(c.offset, 8)
+
+    def test_returned_shape(self):
+        c = BlockedKVCache(block_size=4)
+        k, v = self._make_kv(7, B=2)
+        rk, rv = c.update_and_fetch(k, v, token_ids=list(range(7)))
+        self.assertEqual(rk.shape, (2, 2, 7, 16))
+        self.assertEqual(rv.shape, (2, 2, 7, 16))
+
+    def test_without_token_ids(self):
+        """update_and_fetch must work when token_ids is omitted."""
+        c = BlockedKVCache(block_size=4)
+        k, v = self._make_kv(4)
+        rk, rv = c.update_and_fetch(k, v)
+        self.assertEqual(c.num_complete_blocks, 1)
+        self.assertEqual(rk.shape, (1, 2, 4, 16))
+
+
+class TestBlockedKVCacheHashes(unittest.TestCase):
+    def _make_kv(self, S):
+        return (
+            mx.random.uniform(shape=(1, 2, S, 16)),
+            mx.random.uniform(shape=(1, 2, S, 16)),
+        )
+
+    def test_same_tokens_same_hashes(self):
+        """Two caches with the same token sequence must produce identical hashes."""
+        tids = list(range(8))
+        ca = BlockedKVCache(block_size=4)
+        cb = BlockedKVCache(block_size=4)
+        ka, va = self._make_kv(8)
+        kb, vb = self._make_kv(8)
+        ca.update_and_fetch(ka, va, token_ids=tids)
+        cb.update_and_fetch(kb, vb, token_ids=tids)
+        for ha, hb in zip(ca.block_hashes, cb.block_hashes):
+            self.assertEqual(ha.value, hb.value)
+
+    def test_different_tokens_different_hashes(self):
+        tids_a = [0, 1, 2, 3]
+        tids_b = [0, 1, 2, 99]
+        ca = BlockedKVCache(block_size=4)
+        cb = BlockedKVCache(block_size=4)
+        ka, va = self._make_kv(4)
+        kb, vb = self._make_kv(4)
+        ca.update_and_fetch(ka, va, token_ids=tids_a)
+        cb.update_and_fetch(kb, vb, token_ids=tids_b)
+        self.assertNotEqual(ca.block_hashes[0].value, cb.block_hashes[0].value)
+
+    def test_hash_chain(self):
+        """Block hashes must form a Merkle chain (block[1].value depends on block[0])."""
+        tids = list(range(8))
+        c = BlockedKVCache(block_size=4)
+        k, v = self._make_kv(8)
+        c.update_and_fetch(k, v, token_ids=tids)
+        h0 = c.block_hashes[0].value
+        h1_expected = _hash_block(tids[4:8], h0)
+        self.assertEqual(c.block_hashes[1].value, h1_expected)
+
+    def test_shared_prefix_produces_shared_hashes(self):
+        """Sequences sharing a prefix share the same block hashes for that prefix."""
+        prefix = list(range(4))
+        suffix_a = [10, 11, 12, 13]
+        suffix_b = [20, 21, 22, 23]
+
+        ca = BlockedKVCache(block_size=4)
+        cb = BlockedKVCache(block_size=4)
+        ka, va = self._make_kv(8)
+        kb, vb = self._make_kv(8)
+        ca.update_and_fetch(ka, va, token_ids=prefix + suffix_a)
+        cb.update_and_fetch(kb, vb, token_ids=prefix + suffix_b)
+
+        # Block 0 (prefix) must match
+        self.assertEqual(ca.block_hashes[0].value, cb.block_hashes[0].value)
+        # Block 1 (diverged) must differ
+        self.assertNotEqual(ca.block_hashes[1].value, cb.block_hashes[1].value)
+
+    def test_on_block_full_callback(self):
+        events = []
+        c = BlockedKVCache(block_size=4, on_block_full=lambda idx, h: events.append((idx, h)))
+        k, v = mx.zeros((1, 2, 8, 8)), mx.zeros((1, 2, 8, 8))
+        c.update_and_fetch(k, v, token_ids=list(range(8)))
+        self.assertEqual(len(events), 2)
+        self.assertEqual(events[0][0], 0)
+        self.assertEqual(events[1][0], 1)
+        self.assertIsInstance(events[0][1], BlockHash)
+
+
+class TestBlockedKVCacheProtocol(unittest.TestCase):
+    """Tests for _BaseCache protocol compliance."""
+
+    def _filled_cache(self, n_tokens=8, block_size=4):
+        c = BlockedKVCache(block_size=block_size)
+        k = mx.random.uniform(shape=(1, 2, n_tokens, 16))
+        v = mx.random.uniform(shape=(1, 2, n_tokens, 16))
+        c.update_and_fetch(k, v, token_ids=list(range(n_tokens)))
+        return c
+
+    def test_is_trimmable(self):
+        c = self._filled_cache()
+        self.assertTrue(c.is_trimmable())
+
+    def test_trim_reduces_offset(self):
+        c = self._filled_cache(8)
+        trimmed = c.trim(4)
+        self.assertEqual(trimmed, 4)
+        self.assertEqual(c.offset, 4)
+
+    def test_trim_updates_block_hashes(self):
+        c = self._filled_cache(8, block_size=4)
+        self.assertEqual(c.num_complete_blocks, 2)
+        c.trim(4)
+        # Exactly one block remains
+        self.assertEqual(c.num_complete_blocks, 1)
+
+    def test_trim_clamp_at_zero(self):
+        c = self._filled_cache(4)
+        trimmed = c.trim(100)
+        self.assertEqual(trimmed, 4)
+        self.assertEqual(c.offset, 0)
+
+    def test_size(self):
+        c = self._filled_cache(7)
+        self.assertEqual(c.size(), 7)
+
+    def test_nbytes(self):
+        c = BlockedKVCache(block_size=4)
+        self.assertEqual(c.nbytes, 0)
+        k, v = mx.zeros((1, 2, 4, 16)), mx.zeros((1, 2, 4, 16))
+        c.update_and_fetch(k, v)
+        self.assertGreater(c.nbytes, 0)
+
+    def test_state_roundtrip(self):
+        c = self._filled_cache(8)
+        k_orig, v_orig = c.state
+        c2 = BlockedKVCache(block_size=4)
+        c2.state = (k_orig, v_orig)
+        self.assertEqual(c2.offset, 8)
+        k2, v2 = c2.state
+        self.assertTrue(mx.array_equal(k_orig, k2))
+        self.assertTrue(mx.array_equal(v_orig, v2))
+
+    def test_meta_state_roundtrip(self):
+        c = self._filled_cache(8, block_size=4)
+        meta = c.meta_state
+        c2 = BlockedKVCache(block_size=4)
+        c2.meta_state = meta
+        self.assertEqual(c2.block_size, 4)
+        self.assertEqual(c2.offset, 8)
+        # num_complete_blocks should be reconstructed
+        self.assertEqual(c2.num_complete_blocks, 2)
+
+    def test_make_mask_delegates_to_base(self):
+        """make_mask should return None for a single token with no offset."""
+        c = BlockedKVCache(block_size=4)
+        mask = c.make_mask(1, return_array=False, window_size=None)
+        self.assertIsNone(mask)
+
+
+class TestBlockedKVCacheFork(unittest.TestCase):
+    def test_fork_shares_hashes(self):
+        c = BlockedKVCache(block_size=4)
+        k, v = mx.random.uniform(shape=(1, 2, 4, 16)), mx.random.uniform(shape=(1, 2, 4, 16))
+        c.update_and_fetch(k, v, token_ids=[1, 2, 3, 4])
+        forked = c.fork()
+        self.assertEqual(forked.num_complete_blocks, 1)
+        self.assertEqual(forked.block_hashes[0].value, c.block_hashes[0].value)
+
+    def test_fork_independence(self):
+        """Appending to fork must not affect parent."""
+        c = BlockedKVCache(block_size=4)
+        k, v = mx.random.uniform(shape=(1, 2, 4, 16)), mx.random.uniform(shape=(1, 2, 4, 16))
+        c.update_and_fetch(k, v, token_ids=[1, 2, 3, 4])
+        forked = c.fork()
+
+        # Append different tokens to the fork
+        kf, vf = mx.random.uniform(shape=(1, 2, 4, 16)), mx.random.uniform(shape=(1, 2, 4, 16))
+        forked.update_and_fetch(kf, vf, token_ids=[10, 11, 12, 13])
+        self.assertEqual(c.num_complete_blocks, 1)  # parent unchanged
+        self.assertEqual(forked.num_complete_blocks, 2)
+
+    def test_fork_divergent_hash_after_append(self):
+        """Forked caches with different tokens produce different second-block hashes."""
+        c = BlockedKVCache(block_size=4)
+        k, v = mx.random.uniform(shape=(1, 2, 4, 16)), mx.random.uniform(shape=(1, 2, 4, 16))
+        c.update_and_fetch(k, v, token_ids=[1, 2, 3, 4])
+
+        fork_a = c.fork()
+        fork_b = c.fork()
+
+        ka, va = mx.random.uniform(shape=(1, 2, 4, 16)), mx.random.uniform(shape=(1, 2, 4, 16))
+        fork_a.update_and_fetch(ka, va, token_ids=[10, 11, 12, 13])
+        fork_b.update_and_fetch(ka, va, token_ids=[20, 21, 22, 23])
+
+        # First block shared
+        self.assertEqual(fork_a.block_hashes[0].value, fork_b.block_hashes[0].value)
+        # Second block diverged
+        self.assertNotEqual(fork_a.block_hashes[1].value, fork_b.block_hashes[1].value)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- Add a "Myrgic fork note" section at the top of the README explaining what this fork is and why it exists under the org.
- The section covers: fork origin (ml-explore/mlx-lm), the one local addition (BlockedKVCache with content-addressed hash chain), the purpose (inference-side experiments for the cogos substrate, specifically prefix-hit detection and block-level cache sharing), and explicit exploratory status.

## Why

AM audit found that an outsider browsing the org repo list would hit this fork and find no explanation for why it exists. The repo description still reads "Run LLMs with MLX" (upstream default). Without context, it reads as abandoned or mistakenly public.

The BlockedKVCache commit is substantive (block hash Merkle chain, full _BaseCache protocol compliance, fork() semantics, on_block_full callback) -- it deserves a sentence or two.

## What was NOT touched

The upstream README content is unchanged. No changes to code or tests.

Ref: AM audit `/Users/slowbro/.claude/jobs/47124ad3/public-myrgic-coherence-audit.md`