### PR TITLE
Log detected tool parser on server model load

### DIFF
--- a/mlx_lm/server.py
+++ b/mlx_lm/server.py
@@ -362,6 +362,14 @@ class ModelProvider:
         self.draft_model = draft_model
         self.is_batchable = is_batchable
 
+        if tokenizer.has_tool_calling:
+            logging.info(f"Tool calling enabled (parser: {tokenizer.tool_parser_type})")
+        elif tokenizer.has_chat_template:
+            logging.info(
+                "Tool calling not detected for this chat template; "
+                "any `tools` field on requests will be ignored."
+            )
+
     def load_default(self):
         if self._model_map["default_model"] is not None:
             self.load("default_model", None, "default_model")

--- a/mlx_lm/tokenizer_utils.py
+++ b/mlx_lm/tokenizer_utils.py
@@ -297,6 +297,7 @@ class TokenizerWrapper:
         tool_call_start=None,
         tool_call_end=None,
         tool_parser=None,
+        tool_parser_type=None,
     ):
         self._tokenizer = tokenizer
         self._detokenizer_class = detokenizer_class
@@ -317,6 +318,7 @@ class TokenizerWrapper:
             tokenizer.chat_template is not None or chat_template is not None
         )
         self._tool_parser = tool_parser
+        self._tool_parser_type = tool_parser_type
         self._tool_call_start = tool_call_start
         self._tool_call_end = tool_call_end
         self._tool_call_start_tokens = None
@@ -444,6 +446,10 @@ class TokenizerWrapper:
     @property
     def tool_parser(self):
         return self._tool_parser
+
+    @property
+    def tool_parser_type(self):
+        return self._tool_parser_type
 
     @property
     def detokenizer(self):
@@ -641,6 +647,7 @@ def load(
         eos_token_ids=eos_token_ids,
         chat_template=chat_template,
         tool_parser=tool_parser,
+        tool_parser_type=tool_parser_type,
         tool_call_start=tool_call_start,
         tool_call_end=tool_call_end,
     )

--- a/tests/test_tokenizers.py
+++ b/tests/test_tokenizers.py
@@ -90,10 +90,12 @@ class TestTokenizers(unittest.TestCase):
         self.assertTrue(tokenizer.has_tool_calling)
         self.assertEqual(tokenizer.tool_call_start, "<tool_call>")
         self.assertEqual(tokenizer.tool_call_end, "</tool_call>")
+        self.assertEqual(tokenizer.tool_parser_type, "json_tools")
 
         tokenizer_repo = "mlx-community/Llama-3.2-1B-Instruct-4bit"
         tokenizer = load_tokenizer(tokenizer_repo)
         self.assertFalse(tokenizer.has_tool_calling)
+        self.assertIsNone(tokenizer.tool_parser_type)
 
     def test_thinking(self):
         tokenizer_repo = "mlx-community/Qwen3-4B-4bit"


### PR DESCRIPTION
## Motivation

When `mlx_lm.server` loads a model, the chat-template-to-tool-parser inference happens silently — there's no signal to the operator about which parser (if any) got bound. If a client sends `tools=[...]` and no parser was detected, the request silently returns `content: ""` with no `tool_calls`, and there's no easy way to know why from the server logs.

#1293 is a recent example: the reporter assumed their Qwen 3.5/3.6 chat template lacked the required markers (it doesn't), filed an issue with an incorrect root cause, and there's currently no observable signal in the server that would have shown them the actual detected parser. This PR doesn't fix #1293 directly — the marker detection works correctly on current `main` for the public mlx-community Qwen 3.5/3.6 variants — but it would have prevented the issue from being filed.

## What changed

- `TokenizerWrapper` gains a `tool_parser_type` attribute exposing the parser name that `tokenizer_utils.load()` already computes via `_infer_tool_parser`. The computed name was previously discarded after the parser module was imported.
- `ModelProvider._load()` logs an `INFO` line after model load: either `Tool calling enabled (parser: <name>)` or a one-line note that no parser was detected for the chat template, so any `tools` field on requests will be ignored. Skipped for models with no chat template at all (e.g. base completion models) to keep the log focused.
- `test_tool_calling` extended to cover the new attribute for both the with-tool-calling and no-tool-calling branches.

Total diff is +17 / -0 across three files.

## Testing

- `python -m unittest tests.test_tokenizers.TestTokenizers.test_tool_calling` passes.
- `pre-commit run --files` passes on the three changed files (black + isort).
- `python -m mlx_lm.server --help` imports and parses cleanly, so the new log site doesn't break startup.
- The other three pre-existing failures in `tests.test_tokenizers` (BPE detokenizer whitespace round-trip) reproduce identically on unmodified `upstream/main` — unrelated to this change.