### PR TITLE
fix: add sanitize method to Granite model for tied embeddings

### DIFF
--- a/mlx_lm/models/granite.py
+++ b/mlx_lm/models/granite.py
@@ -191,3 +191,8 @@ class Model(nn.Module):
     @property
     def layers(self):
         return self.model.layers
+
+    def sanitize(self, weights):
+        if self.args.tie_word_embeddings:
+            weights.pop("lm_head.weight", None)
+        return weights


### PR DESCRIPTION
When tie_word_embeddings=True, the HF weights file contains lm_head.weight as an explicit key, but the MLX model class does not create a separate lm_head parameter (it reuses embed_tokens). This causes load_weights to fail with 'Received 1 parameters not in model: lm_head.weight'.

Add a sanitize() method to strip the redundant key before weight loading, consistent with how other models in mlx-lm handle tied embeddings.