### PR TITLE
generate: cache active samplers/processors in GenerationBatch hot path

### DIFF
--- a/mlx_lm/generate.py
+++ b/mlx_lm/generate.py
@@ -1265,16 +1265,21 @@ class GenerationBatch:
         self.prompt_cache = prompt_cache
         self.tokens = tokens
 
-        self.samplers = samplers
+        self.samplers = samplers if samplers else [None] * len(self.uids)
         self.fallback_sampler = fallback_sampler
-        self.logits_processors = logits_processors
+        self.logits_processors = (
+            [processors or [] for processors in logits_processors]
+            if logits_processors
+            else [[] for _ in self.uids]
+        )
         self.state_machines = state_machines
         self.max_tokens = max_tokens
 
-        if self.samplers and len(self.samplers) != len(self.uids):
+        if len(self.samplers) != len(self.uids):
             raise ValueError("Insufficient number of samplers provided")
-        if self.logits_processors and len(self.logits_processors) != len(self.uids):
+        if len(self.logits_processors) != len(self.uids):
             raise ValueError("Insufficient number of logits_processors provided")
+        self._refresh_active_paths()
 
         self._current_tokens = None
         self._current_logprobs = []
@@ -1289,6 +1294,17 @@ class GenerationBatch:
 
     def __len__(self):
         return len(self.uids)
+
+    def _refresh_active_paths(self):
+        self._active_samplers = [
+            sampler or self.fallback_sampler for sampler in self.samplers
+        ]
+        self._sampler_indices = [
+            i for i, sampler in enumerate(self.samplers) if sampler is not None
+        ]
+        self._logits_processor_indices = [
+            i for i, processors in enumerate(self.logits_processors) if processors
+        ]
 
     def extend(self, batch):
         """Extend this batch with another generation batch."""
@@ -1316,6 +1332,7 @@ class GenerationBatch:
         self._token_context.extend(batch._token_context)
         self._num_tokens.extend(batch._num_tokens)
         self._matcher_states.extend(batch._matcher_states)
+        self._refresh_active_paths()
 
     def _step(self) -> Tuple[List[int], List[mx.array]]:
         """
@@ -1334,29 +1351,32 @@ class GenerationBatch:
 
         # Logits processors
         token_context = []
-        if any(self.logits_processors):
+        if self._logits_processor_indices:
             # Update the token context that will be used by the logits processors
-            token_context = [
-                tc.update_and_fetch(inputs[i : i + 1])
-                for i, tc in enumerate(self._token_context)
-            ]
+            token_context_by_index = [None] * len(self.uids)
+            for i in self._logits_processor_indices:
+                token_context_by_index[i] = self._token_context[i].update_and_fetch(
+                    inputs[i : i + 1]
+                )
             processed_logits = []
             for e in range(len(self.uids)):
                 sample_logits = logits[e : e + 1]
                 for processor in self.logits_processors[e]:
-                    sample_logits = processor(token_context[e], sample_logits)
+                    sample_logits = processor(token_context_by_index[e], sample_logits)
                 processed_logits.append(sample_logits)
             logits = mx.concatenate(processed_logits, axis=0)
+            token_context = [
+                token_context_by_index[i] for i in self._logits_processor_indices
+            ]
 
         # Normalize the logits
         logprobs = logits - mx.logsumexp(logits, axis=-1, keepdims=True)
 
         # Sample
-        if any(self.samplers):
+        if self._sampler_indices:
             all_samples = []
             for e in range(len(self.uids)):
-                sample_sampler = self.samplers[e] or self.fallback_sampler
-                sampled = sample_sampler(logprobs[e : e + 1])
+                sampled = self._active_samplers[e](logprobs[e : e + 1])
                 all_samples.append(sampled)
             sampled = mx.concatenate(all_samples, axis=0)
         else:
@@ -1389,10 +1409,8 @@ class GenerationBatch:
             for c in self.prompt_cache:
                 c.filter(keep)
         self.tokens = [self.tokens[idx] for idx in keep]
-        if any(self.samplers):
-            self.samplers = [self.samplers[idx] for idx in keep]
-        if any(self.logits_processors):
-            self.logits_processors = [self.logits_processors[idx] for idx in keep]
+        self.samplers = [self.samplers[idx] for idx in keep]
+        self.logits_processors = [self.logits_processors[idx] for idx in keep]
         self.max_tokens = [self.max_tokens[idx] for idx in keep]
         self.state_machines = [self.state_machines[idx] for idx in keep]
 
@@ -1401,6 +1419,7 @@ class GenerationBatch:
         self._token_context = [self._token_context[idx] for idx in keep]
         self._num_tokens = [self._num_tokens[idx] for idx in keep]
         self._matcher_states = [self._matcher_states[idx] for idx in keep]
+        self._refresh_active_paths()
 
     def next(self) -> List[Response]:
         """

--- a/tests/test_generate.py
+++ b/tests/test_generate.py
@@ -421,6 +421,40 @@ class TestGenerate(unittest.TestCase):
         self.assertTrue(hasattr(seen[0], "shape"))
         self.assertEqual(seen[0].tolist(), prompt)
 
+    def test_batch_generate_with_sparse_logits_processors(self):
+        prompt_without_processor = self.tokenizer.encode("hello")
+        prompt_with_processor = self.tokenizer.encode("world")
+        seen = []
+        bias_processor = make_logits_processors({2: 2000.0})[0]
+
+        def processor(tokens, logits):
+            seen.append(tokens.tolist())
+            return bias_processor(tokens, logits)
+
+        batch_gen = BatchGenerator(self.model, max_tokens=1)
+        uid0 = batch_gen.insert([prompt_without_processor])[0]
+        uid1 = batch_gen.insert(
+            [prompt_with_processor], logits_processors=[[processor]]
+        )[0]
+
+        responses = {r.uid: r for r in batch_gen.next_generated()}
+
+        self.assertEqual(responses[uid1].token, 2)
+        self.assertIn(uid0, responses)
+        self.assertGreaterEqual(len(seen), 1)
+        self.assertTrue(
+            all(
+                tokens[: len(prompt_with_processor)] == prompt_with_processor
+                for tokens in seen
+            )
+        )
+        self.assertFalse(
+            any(
+                tokens[: len(prompt_without_processor)] == prompt_without_processor
+                for tokens in seen
+            )
+        )
+
     def test_batch_generate_function_with_logits_processors(self):
         """Test that batch_generate function with logits_processors produces correct results."""
         logit_bias = {0: 2000.0, 1: -2000.0}


### PR DESCRIPTION
### Summary

`GenerationBatch._step()` runs once per generated token across the batch. Today it does several pieces of redundant per-step work:

*   `any(self.samplers)` and `any(self.logits_processors)` — $O(N)$ scans on every step
*   `sampler` or `self.fallback_sampler` resolved per slot per step
*   `update_and_fetch(...)` called for every slot whenever any slot has a logits processor, even slots that don't

This PR lifts these into a cached representation that is refreshed only when batch membership/state actually changes.

### Change

`GenerationBatch` now normalizes `samplers` and `logits_processors` at the boundary (`__init__`) so they are always full-length lists with sentinels (`None` / `[]`). It maintains three cached structures:

*   `_active_samplers` — pre-resolved (sampler or fallback) per slot
*   `_sampler_indices` — indices of slots with a non-`None` sampler
*   `_logits_processor_indices` — indices of slots with a non-empty processor list

These are refreshed via `_refresh_active_paths()` at the three points where batch membership/state can change: `__init__`, `extend`, and `filter`.

`_step()` then:

*   replaces `any(self.logits_processors)` with `if self._logits_processor_indices:` ($O(1)$)
*   only calls `TokenBuffer.update_and_fetch(...)` for slots that actually have a processor (instead of all slots whenever any slot has one)
*   replaces `any(self.samplers)` with `if self._sampler_indices:` ($O(1)$)
*   replaces the per-slot `sampler or self.fallback_sampler` lookup with a direct `self._active_samplers[e]` index

### Why this is safe

The invariant the cache relies on is: after `__init__`, `samplers` and `logits_processors` are always lists of length `len(uids)`. This is established at the boundary and refreshed at every lifecycle method that mutates batch membership (`extend`, `filter`). No public API changes; no behavioral changes for valid input.

The simplification in `filter()` (dropping the `if any(...)` guards) is correct because the lists are guaranteed full-length now — the previous guard was only there to handle the "still None" case, which can no longer occur.

The `token_context` list passed to `mx.async_eval(...)` now contains only the active-processor slots rather than all slots. `mx.async_eval` only forces evaluation of the supplied arrays and does not index by position, so this is a strict reduction in async work, not a semantic change.

### Expected benefit

Per generated token, for batches with sparse or no logits processors / samplers:

*   avoids one `any()` scan per call type (2 per step)
*   avoids `len(uids) - active` redundant `TokenBuffer.update_and_fetch(...)` calls
*   avoids `len(uids)` redundant (sampler or fallback) resolutions

Wins scale with batch size and with how sparse samplers/processors are. Largest impact: heterogeneous batches where only some requests carry custom processors.

**Benchmarks:** not run — change is structural (fewer per-token branches and fewer per-token method calls) and preserves valid-input behavior. Happy to add a micro-benchmark if useful; let me know what shape of batch you'd want measured.

### Tests

Adds `test_batch_generate_with_sparse_logits_processors` covering the case where only some slots in a batch carry a logits processor, verifying:

*   the processor is invoked only for the corresponding slot
*   the non-processor slot still receives a response
*   the biased token is produced for the slot with the processor

### Out of scope

The older `BatchGenerator` (around `mlx_lm/generate.py:1025`) carries the same `if not any(self.samplers): self.samplers = [None] * len(self.uids)` shape in its `extend`/`filter`. I left it untouched here to keep the diff focused on the per-token `_step()` hot path, but it's a natural follow-up if maintainers want the same treatment applied for consistency.