### PR TITLE
Fix enable_thinking TypeError in deepseek_v32 chat template

### DIFF
--- a/mlx_lm/chat_templates/deepseek_v32.py
+++ b/mlx_lm/chat_templates/deepseek_v32.py
@@ -331,9 +331,19 @@ def encode_messages(
 
 
 def apply_chat_template(
-    messages, continue_final_message=False, add_generation_prompt=False, **kwargs
+    messages,
+    continue_final_message=False,
+    add_generation_prompt=False,
+    enable_thinking=None,
+    thinking_mode=None,
+    **kwargs,
 ):
-    out = encode_messages(messages, **kwargs)
+    if thinking_mode is None:
+        if enable_thinking is not None:
+            thinking_mode = "thinking" if enable_thinking else "chat"
+        else:
+            thinking_mode = "thinking"
+    out = encode_messages(messages, thinking_mode=thinking_mode, **kwargs)
     if continue_final_message and add_generation_prompt:
         raise ValueError(
             "Only one of continue_final_message or add_generation_prompt can be True"

--- a/tests/test_chat_templates.py
+++ b/tests/test_chat_templates.py
@@ -1,0 +1,64 @@
+import unittest
+
+from mlx_lm.chat_templates.deepseek_v32 import apply_chat_template
+
+
+class TestDeepSeekV32ChatTemplate(unittest.TestCase):
+
+    def setUp(self):
+        self.messages = [
+            {"role": "user", "content": "Hello"},
+        ]
+
+    def test_enable_thinking_true(self):
+        result = apply_chat_template(
+            self.messages,
+            add_generation_prompt=True,
+            enable_thinking=True,
+        )
+        self.assertIn("<think>", result)
+
+    def test_enable_thinking_false(self):
+        result = apply_chat_template(
+            self.messages,
+            add_generation_prompt=True,
+            enable_thinking=False,
+        )
+        self.assertNotIn("<think>", result)
+
+    def test_thinking_mode_kwarg_still_works(self):
+        result = apply_chat_template(
+            self.messages,
+            add_generation_prompt=True,
+            thinking_mode="chat",
+        )
+        self.assertNotIn("<think>", result)
+
+    def test_thinking_mode_takes_precedence(self):
+        result = apply_chat_template(
+            self.messages,
+            add_generation_prompt=True,
+            enable_thinking=True,
+            thinking_mode="chat",
+        )
+        self.assertNotIn("<think>", result)
+
+    def test_thinking_mode_overrides_contradictory_enable_thinking(self):
+        result = apply_chat_template(
+            self.messages,
+            add_generation_prompt=True,
+            enable_thinking=False,
+            thinking_mode="thinking",
+        )
+        self.assertIn("<think>", result)
+
+    def test_default_is_thinking(self):
+        result = apply_chat_template(
+            self.messages,
+            add_generation_prompt=True,
+        )
+        self.assertIn("<think>", result)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

`TokenizerWrapper.apply_chat_template()` unconditionally injects `enable_thinking` into kwargs before forwarding to the template function. Jinja templates silently ignore unknown kwargs, but `deepseek_v32` — the only Python chat template — forwards `**kwargs` directly to `encode_messages()`, which expects `thinking_mode` (a `str`) rather than `enable_thinking` (a `bool`). The result is a `TypeError` on any model with `chat_template_type: deepseek_v32` (e.g. `DeepSeek-V3.2-4bit`). The injection was added in #1114 and shipped in v0.31.2.

## Changes

- **`apply_chat_template()`** — `enable_thinking` and `thinking_mode` added as explicit named parameters instead of flowing through `**kwargs`. This prevents `enable_thinking` from reaching `encode_messages()`, which doesn't accept it.
- **Translation logic** — `enable_thinking=True` maps to `thinking_mode="thinking"`, `False` maps to `"chat"`. An explicit `thinking_mode` takes precedence over `enable_thinking`. When neither is provided, the existing default (`"thinking"`) is preserved.
- **`thinking_mode` passed as named argument** — passed directly to `encode_messages()` instead of relying on `**kwargs` forwarding, so the two parameter spaces are cleanly separated.

## Test plan

6 new tests in `TestDeepSeekV32ChatTemplate` covering `enable_thinking=True/False`, `thinking_mode` directly, both-provided precedence in both directions, and the default path. No model download required — the template is a pure function. Existing chat tests (4/4) pass. Pre-commit (black + isort) clean.

Fixes #1221