### PR TITLE
Add Gemma4 shared-KV sanitize regression

### DIFF
--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -1619,6 +1619,62 @@ class TestModels(unittest.TestCase):
             layer_idx = int(k.split("layers.")[1].split(".")[0])
             self.assertLess(layer_idx, 6)
 
+    def test_gemma4_sanitize_drops_redundant_shared_layer_kv_weights(self):
+        from mlx_lm.models import gemma4_text
+
+        args = gemma4_text.ModelArgs(
+            model_type="gemma4_text",
+            hidden_size=32,
+            num_hidden_layers=4,
+            intermediate_size=64,
+            num_attention_heads=2,
+            num_key_value_heads=1,
+            head_dim=16,
+            sliding_window=8,
+            sliding_window_pattern=1,
+            layer_types=[
+                "full_attention",
+                "full_attention",
+                "full_attention",
+                "full_attention",
+            ],
+            hidden_size_per_layer_input=0,
+            vocab_size=32,
+            vocab_size_per_layer_input=32,
+            num_kv_shared_layers=2,
+        )
+        model = gemma4_text.Model(args)
+
+        weights = {
+            "model.layers.1.self_attn.k_proj.weight": mx.zeros(
+                (16, 32), dtype=mx.float32
+            ),
+            "model.layers.1.self_attn.v_proj.weight": mx.zeros(
+                (16, 32), dtype=mx.float32
+            ),
+            "model.layers.2.self_attn.q_proj.weight": mx.zeros(
+                (32, 32), dtype=mx.float32
+            ),
+            "model.layers.2.self_attn.k_proj.weight": mx.zeros(
+                (16, 32), dtype=mx.float32
+            ),
+            "model.layers.2.self_attn.v_proj.weight": mx.zeros(
+                (16, 32), dtype=mx.float32
+            ),
+            "model.layers.2.self_attn.k_norm.weight": mx.zeros(
+                (16,), dtype=mx.float32
+            ),
+        }
+
+        sanitized = model.sanitize(weights)
+
+        self.assertIn("model.layers.1.self_attn.k_proj.weight", sanitized)
+        self.assertIn("model.layers.1.self_attn.v_proj.weight", sanitized)
+        self.assertIn("model.layers.2.self_attn.q_proj.weight", sanitized)
+        self.assertNotIn("model.layers.2.self_attn.k_proj.weight", sanitized)
+        self.assertNotIn("model.layers.2.self_attn.v_proj.weight", sanitized)
+        self.assertNotIn("model.layers.2.self_attn.k_norm.weight", sanitized)
+
     def test_gemma4_input_embeddings_reconstruct_per_layer_inputs(self):
         from mlx_lm.models import gemma4_text
 


### PR DESCRIPTION
## Summary

- add a focused regression test for Gemma4 checkpoints that include redundant K/V tensors for KV-shared layers
- verify non-shared layer K/V weights are preserved while shared-layer `k_proj`, `v_proj`, and `k_norm` weights are dropped by `sanitize()`

## Context

The runtime fix for this behavior already exists on `main`. I hit the original failure while converting a Gemma4 HF export where shared-KV layers still contained redundant K/V tensors. The conversion fails without the sanitize behavior covered here.

## Test

```bash
python -m unittest \
  tests.test_models.TestModels.test_gemma4_kv_shared_layers_omit_kv_projections \
  tests.test_models.TestModels.test_gemma4_sanitize_drops_redundant_shared_layer_kv_weights
```
