### PR TITLE
Fix `_rstrip_until` ValueError when `until` list is empty

### DIFF
--- a/mlx_lm/evaluate.py
+++ b/mlx_lm/evaluate.py
@@ -32,6 +32,8 @@ DEFAULT_MAX_TOKENS = 8192
 
 def _rstrip_until(s, untils):
     """Limit a string <s> to the first occurrence of any substring in untils."""
+    if not untils:
+        return s
     l = len(s)
     f = [s.find(u) for u in untils]
     f = [l if x < 0 else x for x in f]

--- a/tests/test_evaluate.py
+++ b/tests/test_evaluate.py
@@ -5,7 +5,7 @@ from unittest.mock import MagicMock, patch
 
 import mlx.core as mx
 
-from mlx_lm.evaluate import MLXLM
+from mlx_lm.evaluate import MLXLM, _rstrip_until
 
 
 class TestMLXLM(unittest.TestCase):
@@ -53,6 +53,27 @@ class TestMLXLM(unittest.TestCase):
         self.assertEqual(len(call_args_list[0][0][0]), 2)  # First batch: 2 items
         self.assertEqual(len(call_args_list[1][0][0]), 2)  # Second batch: 2 items
         self.assertEqual(len(call_args_list[2][0][0]), 1)  # Third batch: 1 item
+
+
+class TestRstripUntil(unittest.TestCase):
+    def test_returns_input_when_untils_empty(self):
+        """Some lm-eval tasks (e.g. IFEval) pass an empty `until` list. The
+        function previously called min() on the resulting empty list and
+        raised ValueError; it should now return the input unchanged."""
+        self.assertEqual(_rstrip_until("hello world", []), "hello world")
+        self.assertEqual(_rstrip_until("", []), "")
+
+    def test_truncates_at_first_match(self):
+        self.assertEqual(_rstrip_until("abc<stop>def", ["<stop>"]), "abc")
+
+    def test_truncates_at_earliest_of_multiple(self):
+        self.assertEqual(
+            _rstrip_until("abc<a>def<b>ghi", ["<b>", "<a>"]),
+            "abc",
+        )
+
+    def test_returns_input_when_no_match(self):
+        self.assertEqual(_rstrip_until("abcdef", ["xyz"]), "abcdef")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Problem

Some lm-eval tasks pass an empty `until` list to `generate_until`
(notably **IFEval**, which lets the model generate freely up to
`max_tokens`). `_rstrip_until` then calls `min()` on an empty sequence
and raises `ValueError`, terminating the whole evaluation:

```python
>>> from mlx_lm.evaluate import _rstrip_until
>>> _rstrip_until("hello", [])
ValueError: min() arg is an empty sequence
```

## Fix

One line: short-circuit and return the input unchanged when there are
no stop strings.

## Tests

Four new cases in `tests/test_evaluate.py`:
- empty `untils` → input returned unchanged (regression)
- single match → truncates at the stop
- multiple stops → truncates at the earliest
- no match → input returned unchanged

## Verification

Ran `lm_eval.simple_evaluate(model=MLXLM(...), tasks=['ifeval'], limit=20)`
on `mlx-community/SmolLM-135M-4bit`. Fails on `main`; with this patch
it returns the normal IFEval metrics (`prompt_level_strict_acc`,
`inst_level_strict_acc`, `prompt_level_loose_acc`,
`inst_level_loose_acc`).