### PR TITLE
feat(models): warn when MTP weights are discarded at load

### DIFF
--- a/mlx_lm/models/base.py
+++ b/mlx_lm/models/base.py
@@ -1,6 +1,7 @@
 # Copyright © 2023-2024 Apple Inc.
 
 import inspect
+import warnings
 from dataclasses import dataclass
 from typing import Any, Optional
 
@@ -135,3 +136,35 @@ def scaled_dot_product_attention(
             mask=mask,
             sinks=sinks,
         )
+
+def warn_discarded_weights(
+    n_discarded: int,
+    feature_name: str = "MTP",
+    model_name: Optional[str] = None,
+) -> None:
+    """Emit a one-time warning when feature-specific weights are dropped at loading time.
+
+    Some model checkpoints (e.g., Multi-Token Prediction variants) ship with
+    additional weight tensors that are discarded during loading because mlx-lm
+    does not currently use them at runtime. This warning surfaces the
+    discrepancy at load time so downstream benchmarks can interpret results
+    correctly.
+
+    Args:
+        n_discarded: Number of weight tensors filtered out by the caller.
+          The warning is only emitted when this is +ive.
+        feature_name: Name of the discarded feature.
+          Defaults to "MTP".
+        model_name: Optional.
+    """
+    if n_discarded <= 0:
+        return
+    suffix = f" for model '{model_name}'" if model_name else ""
+    warnings.warn(
+        f"Loaded {n_discarded} {feature_name} weight tensor(s){suffix}, "
+        f"discarded at runtime — mlx-lm does not currently support "
+        f"{feature_name}. The model will run as a standard autoregressive "
+        f"model.",
+        UserWarning,
+        stacklevel=2,  # warning come from the model file, not from base.py
+    )

--- a/mlx_lm/models/qwen3_5.py
+++ b/mlx_lm/models/qwen3_5.py
@@ -12,6 +12,7 @@ from .base import (
     BaseModelArgs,
     create_attention_mask,
     create_ssm_mask,
+    warn_discarded_weights,
 )
 from .cache import ArraysCache, KVCache
 from .gated_delta import gated_delta_update
@@ -310,7 +311,12 @@ class TextModel(nn.Module):
             "conv1d.weight" in k and v.shape[-1] != 1 for k, v in weights.items()
         )
         should_shift_norm_weights = has_mtp_weights or has_unsanitized_conv1d
+        n_mtp_weights = sum(1 for k in weights if "mtp." in k) if has_mtp_weights else 0
         weights = {k: v for k, v in weights.items() if "mtp." not in k}
+
+        warn_discarded_weights(
+            n_mtp_weights, feature_name="MTP", model_name=self.model_type
+        )
 
         if self.args.tie_word_embeddings:
             weights.pop("lm_head.weight", None)

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -2,13 +2,18 @@
 import copy
 import importlib
 import unittest
+import warnings
 
 import mlx.core as mx
 import mlx.nn as nn
 from mlx.utils import tree_flatten, tree_map
 
 from mlx_lm.models import rope_utils
-from mlx_lm.models.base import create_causal_mask, scaled_dot_product_attention
+from mlx_lm.models.base import (
+    create_causal_mask,
+    scaled_dot_product_attention,
+    warn_discarded_weights,
+)
 from mlx_lm.models.cache import KVCache, RotatingKVCache, make_prompt_cache
 from mlx_lm.models.gated_delta import (
     gated_delta_kernel,
@@ -3219,6 +3224,27 @@ class TestModels(unittest.TestCase):
                 y = y[:, s:e]
                 self.assertTrue(mx.allclose(y, y_gt, rtol=1e-4, atol=1e-4))
                 self.assertTrue(mx.allclose(st, st_gt, rtol=1e-4, atol=1e-3))
+
+    def test_no_warning_when_zero(self):
+        with warnings.catch_warnings(record=True) as w:
+            warnings.simplefilter("always")
+            warn_discarded_weights(0)
+            self.assertEqual(len(w), 0)
+
+    def test_warns_with_count(self):
+        with warnings.catch_warnings(record=True) as w:
+            warnings.simplefilter("always")
+            warn_discarded_weights(5, feature_name="MTP")
+            self.assertEqual(len(w), 1)
+            self.assertIn("5 MTP weight tensor", str(w[0].message))
+            self.assertIs(w[0].category, UserWarning)
+
+    def test_includes_model_name(self):
+        with warnings.catch_warnings(record=True) as w:
+            warnings.simplefilter("always")
+            warn_discarded_weights(3, feature_name="MTP", model_name="qwen3_5")
+            self.assertEqual(len(w), 1)
+            self.assertIn("qwen3_5", str(w[0].message))
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Test plan

- [x] `python -m unittest tests.test_models` — 79 tests pass, 1 pre-existing skip
- [x] `pre-commit run --all-files` clean
- [x] No behavioral change for non-MTP checkpoints (the existing
      `has_mtp_weights` short-circuits the count when no MTP weights present)
- [x] Warning correctly attributed to call site via `stacklevel=2`
      (verified during model tests: surfaces as `qwen3_5.py:317`, not
      `base.py`)
      
 fixes: #1292