### PR TITLE
Fix qwen3_coder tool parser crash on unparseable parameter values

### DIFF
--- a/mlx_lm/tool_parsers/qwen3_coder.py
+++ b/mlx_lm/tool_parsers/qwen3_coder.py
@@ -54,9 +54,15 @@ def _convert_param_value(param_value: str, param_name: str, param_config: dict) 
         or param_type.startswith("short")
         or param_type.startswith("unsigned")
     ):
-        return int(param_value)
+        try:
+            return int(param_value)
+        except ValueError:
+            return param_value
     elif param_type.startswith("num") or param_type.startswith("float"):
-        float_param_value = float(param_value)
+        try:
+            float_param_value = float(param_value)
+        except ValueError:
+            return param_value
         int_param_value = int(float_param_value)
         return (
             float_param_value
@@ -74,9 +80,15 @@ def _convert_param_value(param_value: str, param_name: str, param_config: dict) 
             try:
                 return json.loads(param_value)
             except json.JSONDecodeError:
-                return ast.literal_eval(param_value)
+                try:
+                    return ast.literal_eval(param_value)
+                except (ValueError, SyntaxError):
+                    return param_value
 
-        return ast.literal_eval(param_value)
+        try:
+            return ast.literal_eval(param_value)
+        except (ValueError, SyntaxError):
+            return param_value
 
 
 def _parse_xml_function_call(function_call_str: str, tools: Optional[Any]):

--- a/tests/test_tool_parsing.py
+++ b/tests/test_tool_parsing.py
@@ -197,6 +197,34 @@ class TestToolParsing(unittest.TestCase):
         self.assertEqual(tool_call["arguments"]["filters"], {"category": "books"})
         self.assertEqual(tool_call["arguments"]["tags"], ["fiction", "new"])
 
+    def test_qwen3_coder_unparseable_params(self):
+        # When the schema declares a typed field but the model emits a value
+        # that cannot be coerced into that type (e.g. an ISO 8601 date for an
+        # `integer` field, natural-language text for an `array` field), fall
+        # back to the raw string instead of raising and dropping the tool call.
+        cases = [
+            ("object", "when", "2026-01-15T10:30:00Z", "2026-01-15T10:30:00Z"),
+            ("array", "note", "Alex has written several books.", "Alex has written several books."),
+            ("datetime", "when", "2026-01-15T10:30:00Z", "2026-01-15T10:30:00Z"),
+            ("integer", "day", "2026-01-15", "2026-01-15"),
+            ("number", "ratio", "about three", "about three"),
+        ]
+        for ptype, pname, value, expected in cases:
+            with self.subTest(type=ptype):
+                tools = [{
+                    "type": "function",
+                    "function": {
+                        "name": "log_event",
+                        "parameters": {
+                            "type": "object",
+                            "properties": {pname: {"type": ptype}},
+                        },
+                    },
+                }]
+                xml = f"<function=log_event><parameter={pname}>{value}</parameter></function>"
+                tool_call = qwen3_coder.parse_tool_call(xml, tools)
+                self.assertEqual(tool_call["arguments"][pname], expected)
+
     def test_gemma4(self):
         # Nested object
         test_case = 'call:configure{settings:{enabled:true,name:<|"|>test<|"|>}}'


### PR DESCRIPTION
Fixes the case where a Qwen3-Coder model emits a parameter value that cannot be coerced into the schema-declared type (e.g. ISO 8601 dates, natural-language strings) — `_convert_param_value` raises and the entire tool call is dropped, even though the model output was well-formed XML.

Four branches in `_convert_param_value` were unguarded:
- `object` / `array` via `json.loads` -> `ast.literal_eval`
- fallback `ast.literal_eval` for unrecognised types
- `int()` coercion for integer-family types
- `float()` coercion for `number` / `float` types

Each is now wrapped with `try / except (ValueError, SyntaxError)` and falls back to the raw string, matching the behaviour for unrecognised schema types.

Tests added for all four branches.

The numeric branches were pointed out by @robertlangdonn ([comment](https://github.com/ml-explore/mlx-lm/pull/1310#issuecomment-4582322151)) — folded into this PR since it's the same function, same fallback pattern, and the same #1236 symptom.

Closes #1236