### PR TITLE
Fix Qwen3_5 mixed-bit per-tensor quantization keys not remapped through sanitize

### DIFF
--- a/mlx_lm/models/qwen3_5.py
+++ b/mlx_lm/models/qwen3_5.py
@@ -397,6 +397,23 @@ class Model(nn.Module):
             sanitized[key] = value
         return self.language_model.sanitize(sanitized)
 
+    def sanitize_quantization(self, quant_config):
+        remapped = {}
+        for key, value in quant_config.items():
+            if key in ("bits", "group_size", "mode"):
+                remapped[key] = value
+                continue
+            if key.startswith("vision_tower") or key.startswith("model.visual"):
+                continue
+            if key.startswith("model.language_model"):
+                new_key = key.replace("model.language_model", "language_model.model")
+            elif key.startswith("language_model."):
+                new_key = key
+            else:
+                new_key = "language_model." + key
+            remapped[new_key] = value
+        return remapped
+
     def shard(self, group=None):
         group = group or mx.distributed.init()
         N = group.size()

--- a/mlx_lm/utils.py
+++ b/mlx_lm/utils.py
@@ -363,6 +363,9 @@ def load_model(
         )
 
     if (quantization := config.get("quantization", None)) is not None:
+        if hasattr(model, "sanitize_quantization"):
+            quantization = model.sanitize_quantization(quantization)
+            config["quantization"] = quantization
         _quantize(quantization)
 
     elif quantization_config := config.get("quantization_config", False):

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -183,6 +183,190 @@ class TestUtils(unittest.TestCase):
             mx.eval(logits)
             self.assertEqual(logits.shape, (1, 3, args.vocab_size))
 
+    def test_load_model_qwen3_5_with_unsanitized_per_tensor_quantization(self):
+        from mlx_lm.models import qwen3_5
+
+        args = qwen3_5.ModelArgs.from_dict(
+            {
+                "model_type": "qwen3_5",
+                "text_config": {
+                    "model_type": "qwen3_5",
+                    "hidden_size": 128,
+                    "num_hidden_layers": 4,
+                    "intermediate_size": 128,
+                    "num_attention_heads": 8,
+                    "num_key_value_heads": 4,
+                    "vocab_size": 1000,
+                    "linear_num_value_heads": 4,
+                    "linear_num_key_heads": 4,
+                    "linear_key_head_dim": 32,
+                    "linear_value_head_dim": 32,
+                    "linear_conv_kernel_dim": 3,
+                    "rms_norm_eps": 1e-5,
+                    "head_dim": 64,
+                    "rope_theta": 1000.0,
+                    "partial_rotary_factor": 0.5,
+                    "max_position_embeddings": 1000,
+                },
+            }
+        )
+        model = qwen3_5.Model(args)
+        model, config = utils.quantize_model(
+            model,
+            {
+                "model_type": "qwen3_5",
+                "text_config": args.text_config,
+            },
+            group_size=32,
+            bits=4,
+        )
+
+        # Inject an UN-SANITIZED per-tensor override key (as a real AutoRound
+        # checkpoint would write it to config.json — before sanitize rewrites).
+        config["quantization"][
+            "model.language_model.layers.0.linear_attn.in_proj_qkv"
+        ] = {
+            "group_size": 32,
+            "bits": 4,
+        }
+
+        with tempfile.TemporaryDirectory(dir=self.test_dir) as mlx_path:
+            utils.save_model(mlx_path, model)
+            utils.save_config(config, os.path.join(mlx_path, "config.json"))
+
+            loaded, loaded_config = utils.load_model(Path(mlx_path))
+
+            # Hook fired through the load path — un-sanitized key was rewritten
+            self.assertIn(
+                "language_model.model.layers.0.linear_attn.in_proj_qkv",
+                loaded_config["quantization"],
+            )
+            self.assertNotIn(
+                "model.language_model.layers.0.linear_attn.in_proj_qkv",
+                loaded_config["quantization"],
+            )
+
+            # Smoke test: forward pass succeeds after load. The assertIn /
+            # assertNotIn above proves the remap hook fired; this proves
+            # load_weights did not raise on the rewritten quantization config.
+            logits = loaded(mx.array([[1, 2, 3]], dtype=mx.int32))
+            mx.eval(logits)
+            self.assertEqual(logits.shape, (1, 3, args.text_config["vocab_size"]))
+
+
+class TestQwen3_5SanitizeQuantization(unittest.TestCase):
+    def _make_model(self):
+        from mlx_lm.models import qwen3_5
+
+        args = qwen3_5.ModelArgs.from_dict(
+            {
+                "model_type": "qwen3_5",
+                "text_config": {
+                    "model_type": "qwen3_5",
+                    "hidden_size": 128,
+                    "num_hidden_layers": 4,
+                    "intermediate_size": 128,
+                    "num_attention_heads": 8,
+                    "num_key_value_heads": 4,
+                    "vocab_size": 1000,
+                    "linear_num_value_heads": 4,
+                    "linear_num_key_heads": 4,
+                    "linear_key_head_dim": 32,
+                    "linear_value_head_dim": 32,
+                    "linear_conv_kernel_dim": 3,
+                    "rms_norm_eps": 1e-5,
+                    "head_dim": 64,
+                    "rope_theta": 1000.0,
+                    "partial_rotary_factor": 0.5,
+                    "max_position_embeddings": 1000,
+                },
+            }
+        )
+        return qwen3_5.Model(args)
+
+    def test_remap_combines_all_key_shapes(self):
+        model = self._make_model()
+        quant_config = {
+            # Global keys (property 1)
+            "bits": 4,
+            "group_size": 128,
+            "mode": "affine",
+            # vision_tower drop (property 2)
+            "vision_tower.encoder.layer.0.attn.weight": False,
+            "model.visual.blocks.0.attn.qkv": False,
+            # model.language_model rewrite (property 3)
+            "model.language_model.layers.0.linear_attn.in_proj_qkv": {
+                "bits": 6,
+                "group_size": 32,
+            },
+            # language_model passthrough (property 4)
+            "language_model.model.layers.1.mlp.gate_proj": {
+                "bits": 8,
+                "group_size": 32,
+            },
+            # bare key prefix (property 5)
+            "model.layers.0.embed_tokens": {"bits": 6, "group_size": 32},
+        }
+
+        result = model.sanitize_quantization(quant_config)
+
+        # Property 1: globals pass through unchanged
+        self.assertEqual(result["bits"], 4)
+        self.assertEqual(result["group_size"], 128)
+        self.assertEqual(result["mode"], "affine")
+
+        # Property 2: vision_tower / model.visual entries dropped
+        self.assertNotIn("vision_tower.encoder.layer.0.attn.weight", result)
+        self.assertNotIn("model.visual.blocks.0.attn.qkv", result)
+
+        # Property 3: model.language_model → language_model.model
+        self.assertIn("language_model.model.layers.0.linear_attn.in_proj_qkv", result)
+        self.assertEqual(
+            result["language_model.model.layers.0.linear_attn.in_proj_qkv"],
+            {"bits": 6, "group_size": 32},
+        )
+        self.assertNotIn(
+            "model.language_model.layers.0.linear_attn.in_proj_qkv", result
+        )
+
+        # Property 4: language_model.* passthrough
+        self.assertIn("language_model.model.layers.1.mlp.gate_proj", result)
+        self.assertEqual(
+            result["language_model.model.layers.1.mlp.gate_proj"],
+            {"bits": 8, "group_size": 32},
+        )
+        self.assertNotIn(
+            "language_model.language_model.model.layers.1.mlp.gate_proj", result
+        )
+
+        # Property 5: bare key gets language_model. prefix
+        self.assertIn("language_model.model.layers.0.embed_tokens", result)
+        self.assertEqual(
+            result["language_model.model.layers.0.embed_tokens"],
+            {"bits": 6, "group_size": 32},
+        )
+        self.assertNotIn("model.layers.0.embed_tokens", result)
+
+    def test_input_not_mutated(self):
+        model = self._make_model()
+        quant_config = {
+            "bits": 4,
+            "group_size": 128,
+            "model.language_model.layers.0.linear_attn.in_proj_qkv": {
+                "bits": 6,
+                "group_size": 32,
+            },
+            "vision_tower.x.y": False,
+        }
+        original_copy = dict(quant_config)
+
+        result = model.sanitize_quantization(quant_config)
+
+        # Output is a new dict
+        self.assertIsNot(result, quant_config)
+        # Input dict unchanged
+        self.assertEqual(quant_config, original_copy)
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Problem

Loading an `Qwen3_5ForConditionalGeneration` checkpoint with non-uniform per-tensor `config["quantization"]` overrides — notably Intel's AutoRound mixed-bit MLX builds — fails on `main` with:

```
ValueError: Expected shape (10240, 640) but received shape (10240, 960)
for parameter language_model.model.layers.0.linear_attn.in_proj_qkv.weight
```

Reproduced against `Intel/Qwen3.6-27B-4.5b-mlx-AutoRound` (459 per-tensor entries, 128 of which are real 6-bit overrides on top of a 4-bit global).

## Root cause

`class_predicate` in `mlx_lm/utils.py` looks up paths in the **post-sanitize** namespace, but `config["quantization"]` keys are stored in the **pre-sanitize** namespace as they were written to `config.json`. For Qwen3.5_VL, `Model.sanitize` in `mlx_lm/models/qwen3_5.py` rewrites `model.language_model.*` → `language_model.model.*` (and drops `vision_tower.*` / `model.visual.*` entries), but the quantization config is never remapped to match. Every per-tensor override misses the lookup, falls back to the global bit-width, and the tensor is allocated at the wrong size — failing the shape check on load.

## Fix

Add a per-model `sanitize_quantization(quant_config)` method on `Qwen3_5ForConditionalGeneration` that mirrors the existing `sanitize(weights)` key transformation, and wire it via a `hasattr`-discovered opt-in call at the `_quantize` call site in `mlx_lm/utils.py` — the same shape as the existing `sanitize` invocation a few lines above. `Qwen3_5MoeForConditionalGeneration` inherits the method through its `class Model(Qwen3_5Model)` subclassing, so MoE checkpoints pick up the prefix remap without a separate implementation (MoE-specific expert-key remaps such as `experts.gate_up_proj` → `switch_mlp.gate_proj` are not in scope of this change — no MoE mixed-bit checkpoint with per-tensor expert overrides has been reported yet).

Models without the method are unaffected. The hook is scoped to the top-level `config["quantization"]` branch; the legacy `quantization_config` path (AWQ/GPTQ/mxfp4) carries flat global configs without per-tensor overrides and does not exercise this bug.

Credit to @ivanfioravanti for the local-fix observation in #1214's comments.

## Testing

- **Unit tests** (`TestQwen3_5SanitizeQuantization` in `tests/test_utils.py`): one table-driven test covering all five key shapes the method handles (globals passthrough, `vision_tower` / `model.visual` drops, `model.language_model.*` rewrite, `language_model.*` passthrough, bare-key prefix), plus a non-mutation test confirming the input dict is left intact.
- **Loader-path integration test** (`TestUtils.test_load_model_qwen3_5_with_unsanitized_per_tensor_quantization`): mirrors the existing `test_load_model_gemma4_with_per_layer_projection_quantization` pattern. Builds a tiny synthetic Qwen3.5 model, hand-edits `config["quantization"]` with an **un-sanitized** per-tensor override key, saves and reloads via `load_model`, and asserts the rewritten key appears in `loaded_config["quantization"]` (the un-sanitized form is gone), then runs a forward pass as a smoke test that `load_weights` doesn't raise on the rewritten config.
- **Real-checkpoint verification** on M5 Max (128 GB) against `Intel/Qwen3.6-27B-4.5b-mlx-AutoRound`:
  - Without this patch: `ValueError` as quoted above.
  - With this patch: load succeeds in 1.3 s; `generate(prompt="The capital of France is", max_tokens=8)` returns `"Paris.\n\n<think>\nHere's a"`.
- Full `python -m unittest discover tests/` shows no regressions (12 pre-existing failures, all verified to fail identically on `upstream/main`).

Fixes #1214.