### PR TITLE
Expose tunable Metal memory limits in the trainer

### DIFF
--- a/mlx_lm/lora.py
+++ b/mlx_lm/lora.py
@@ -70,6 +70,9 @@ CONFIG_DEFAULTS = {
     "grad_checkpoint": False,
     "grad_accumulation_steps": 1,
     "clear_cache_threshold": 0,
+    "wired_limit_ratio": 1.0,
+    "memory_limit_ratio": None,
+    "cache_limit_ratio": None,
     "lr_schedule": None,
     "lora_parameters": {"rank": 8, "dropout": 0.0, "scale": 20.0},
     "mask_prompt": False,
@@ -210,6 +213,35 @@ def build_parser():
         help="Project name for logging. Defaults to the name of the root directory.",
     )
     parser.add_argument("--seed", type=int, help="The PRNG seed")
+    parser.add_argument(
+        "--wired-limit-ratio",
+        type=float,
+        default=None,
+        help=(
+            "Fraction of max_recommended_working_set_size used as the wired "
+            "memory limit on Metal. Default is 1.0; try 0.9 if training "
+            "causes high memory pressure or system instability."
+        ),
+    )
+    parser.add_argument(
+        "--memory-limit-ratio",
+        type=float,
+        default=None,
+        help=(
+            "Fraction of max_recommended_working_set_size used as the total "
+            "memory limit on Metal. Unset uses MLX's default."
+        ),
+    )
+    parser.add_argument(
+        "--cache-limit-ratio",
+        type=float,
+        default=None,
+        help=(
+            "Fraction of max_recommended_working_set_size used as the "
+            "allocator cache limit on Metal. Lower values (e.g. 0.5) or 0.0 "
+            "reduce memory growth during training at a modest perf cost."
+        ),
+    )
     return parser
 
 
@@ -268,7 +300,11 @@ def train_model(
         adapter_file=adapter_file,
         max_seq_length=args.max_seq_length,
         grad_checkpoint=args.grad_checkpoint,
+        clear_cache_threshold=args.clear_cache_threshold,
         grad_accumulation_steps=args.grad_accumulation_steps,
+        wired_limit_ratio=args.wired_limit_ratio,
+        memory_limit_ratio=args.memory_limit_ratio,
+        cache_limit_ratio=args.cache_limit_ratio,
     )
 
     # Initialize the selected optimizer

--- a/mlx_lm/tuner/trainer.py
+++ b/mlx_lm/tuner/trainer.py
@@ -5,6 +5,7 @@ import time
 from dataclasses import dataclass, field
 from functools import partial
 from pathlib import Path
+from typing import Optional
 
 import mlx.core as mx
 import mlx.nn as nn
@@ -79,6 +80,37 @@ class TrainingArgs:
         default=0,
         metadata={
             "help": "Clear the allocator cache between steps if it grows too large."
+        },
+    )
+    wired_limit_ratio: float = field(
+        default=1.0,
+        metadata={
+            "help": (
+                "Fraction of max_recommended_working_set_size used as the "
+                "wired memory limit on Metal. Lower this (e.g. 0.9) if "
+                "training causes high memory pressure or system instability."
+            )
+        },
+    )
+    memory_limit_ratio: Optional[float] = field(
+        default=None,
+        metadata={
+            "help": (
+                "Optional fraction of max_recommended_working_set_size used "
+                "as the total memory limit on Metal. If unset, MLX's default "
+                "(~1.5x the wired limit) is used."
+            )
+        },
+    )
+    cache_limit_ratio: Optional[float] = field(
+        default=None,
+        metadata={
+            "help": (
+                "Optional fraction of max_recommended_working_set_size used "
+                "as the allocator cache limit on Metal. Lowering this "
+                "(e.g. 0.5) or setting it to 0 reduces memory growth during "
+                "training at a modest performance cost."
+            )
         },
     )
 
@@ -225,14 +257,41 @@ def train(
     iterate_batches: callable = iterate_batches,
     training_callback: TrainingCallback = None,
 ):
-    if mx.metal.is_available():
-        mx.set_wired_limit(mx.device_info()["max_recommended_working_set_size"])
     print(f"Starting training..., iters: {args.iters}")
     world = mx.distributed.init()
     world_size = world.size()
     rank = world.rank()
     if world_size > 1:
         print(f"Node {rank} of {world_size}")
+
+    if mx.metal.is_available():
+        # mx.set_wired_limit(mx.device_info()["max_recommended_working_set_size"])
+        max_recommended = mx.device_info()["max_recommended_working_set_size"]
+        wired_limit = int(max_recommended * args.wired_limit_ratio)
+        mx.set_wired_limit(wired_limit)
+        if rank == 0:
+            print(
+                f"Setting wired limit to {wired_limit / 1e9:.2f} GB",
+                flush=True,
+            )
+
+        if args.memory_limit_ratio is not None:
+            memory_limit = int(max_recommended * args.memory_limit_ratio)
+            mx.set_memory_limit(memory_limit)
+            if rank == 0:
+                print(
+                    f"Setting memory limit to {memory_limit / 1e9:.2f} GB",
+                    flush=True,
+                )
+
+        if args.cache_limit_ratio is not None:
+            cache_limit = int(max_recommended * args.cache_limit_ratio)
+            mx.set_cache_limit(cache_limit)
+            if rank == 0:
+                print(
+                    f"Setting cache limit to {cache_limit / 1e9:.2f} GB",
+                    flush=True,
+                )
 
     if args.grad_checkpoint:
         grad_checkpoint(model.layers[0])
@@ -300,9 +359,7 @@ def train(
             val_time = time.perf_counter() - tic
             if rank == 0:
                 print(
-                    f"Iter {it}: "
-                    f"Val loss {val_loss:.3f}, "
-                    f"Val took {val_time:.3f}s",
+                    f"Iter {it}: Val loss {val_loss:.3f}, Val took {val_time:.3f}s",
                     flush=True,
                 )
 


### PR DESCRIPTION
Adds wired_limit_ratio, memory_limit_ratio, and cache_limit_ratio to TrainingArgs and surfaces them as --wired-limit-ratio, --memory-limit-ratio, and --cache-limit-ratio CLI flags in mlx_lm.lora. Defaults preserve existing behavior; users can opt in to lower limits to avoid OOM/hard crashes during training on memory-constrained systems.

Also fixes train_model() to forward args.clear_cache_threshold into TrainingArgs — it was previously a silent no-op from the CLI.

Fixes #828