### PR TITLE
Keep model parameters for fuse GGUF export

### DIFF
--- a/mlx_lm/utils.py
+++ b/mlx_lm/utils.py
@@ -939,7 +939,7 @@ def save(
         hf_repo = None
 
     dst_path = Path(dst_path)
-    save_model(dst_path, model, donate_model=True)
+    save_model(dst_path, model, donate_model=donate_model)
     save_config(config, config_path=dst_path / "config.json")
     tokenizer.save_pretrained(dst_path)
 

--- a/tests/test_gguf.py
+++ b/tests/test_gguf.py
@@ -1,11 +1,15 @@
 import os
+import sys
 import tempfile
 import unittest
+from contextlib import ExitStack
 from pathlib import Path
 from unittest.mock import MagicMock, patch
 
 import mlx.core as mx
+import mlx.nn as nn
 
+import mlx_lm.fuse as fuse
 from mlx_lm.gguf import convert_to_gguf
 
 
@@ -56,6 +60,59 @@ class TestConvertToGGUFWithoutMocks(unittest.TestCase):
         convert_to_gguf(model_path, weights, config, output_file_path)
         called_args, _ = mock_save_gguf.call_args
         self.assertEqual(called_args[0], output_file_path)
+
+
+class TestFuseGGUFExport(unittest.TestCase):
+    def test_export_gguf_receives_preserved_model_weights(self):
+        class TinyTokenizer:
+            def save_pretrained(self, path):
+                Path(path, "tokenizer_config.json").write_text("{}\n")
+
+        model = nn.Linear(2, 2, bias=False)
+        mx.eval(model.parameters())
+
+        recorded = {}
+
+        def fake_convert_to_gguf(save_path, weights, config, output_path):
+            recorded["weights"] = {k: tuple(v.shape) for k, v in weights.items()}
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            source_path = Path(tmpdir) / "source_model"
+            source_path.mkdir()
+            save_path = Path(tmpdir) / "fused_model"
+            argv = [
+                "mlx_lm.fuse",
+                "--model",
+                str(source_path),
+                "--save-path",
+                str(save_path),
+                "--export-gguf",
+            ]
+
+            with ExitStack() as stack:
+                stack.enter_context(patch.object(sys, "argv", argv))
+                stack.enter_context(
+                    patch.object(
+                        fuse,
+                        "load",
+                        return_value=(
+                            model,
+                            TinyTokenizer(),
+                            {"model_type": "llama"},
+                        ),
+                    )
+                )
+                stack.enter_context(patch("mlx_lm.utils.create_model_card"))
+                stack.enter_context(
+                    patch.object(
+                        fuse,
+                        "convert_to_gguf",
+                        side_effect=fake_convert_to_gguf,
+                    )
+                )
+                fuse.main()
+
+        self.assertEqual(recorded["weights"], {"weight": (2, 2)})
 
 
 if __name__ == "__main__":

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -4,6 +4,7 @@ import os
 import tempfile
 import unittest
 from pathlib import Path
+from unittest.mock import patch
 
 import mlx.core as mx
 import mlx.nn as nn
@@ -58,6 +59,48 @@ class TestUtils(unittest.TestCase):
         gb = sum(p.nbytes for _, p in weights) // 2**30
         shards = utils.make_shards(dict(weights), 1)
         self.assertTrue(gb <= len(shards) <= gb + 1)
+
+    def test_save_respects_donate_model(self):
+        class TinyTokenizer:
+            def save_pretrained(self, path):
+                Path(path, "tokenizer_config.json").write_text("{}\n")
+
+        def make_model():
+            model = nn.Linear(2, 2, bias=False)
+            mx.eval(model.parameters())
+            return model
+
+        src_path = Path(self.test_dir) / "source_model"
+        src_path.mkdir(exist_ok=True)
+
+        with patch("mlx_lm.utils.create_model_card"):
+            model = make_model()
+            utils.save(
+                Path(self.test_dir) / "preserved_model",
+                src_path,
+                model,
+                TinyTokenizer(),
+                {"model_type": "tiny"},
+                donate_model=False,
+            )
+            self.assertEqual(
+                {k: tuple(v.shape) for k, v in tree_flatten(model.parameters())},
+                {"weight": (2, 2)},
+            )
+
+            model = make_model()
+            utils.save(
+                Path(self.test_dir) / "donated_model",
+                src_path,
+                model,
+                TinyTokenizer(),
+                {"model_type": "tiny"},
+                donate_model=True,
+            )
+            self.assertEqual(
+                {k: tuple(v.shape) for k, v in tree_flatten(model.parameters())},
+                {"weight": (0,)},
+            )
 
     def test_quantize(self):
         from mlx_lm.models import llama


### PR DESCRIPTION
## Summary

- Forward `donate_model` from `utils.save()` to `save_model()` instead of always donating the model.
- Add regression coverage for both `utils.save(..., donate_model=...)` behavior and the `mlx_lm.fuse --export-gguf` path.

## Why

`utils.save()` accepted a `donate_model` argument but ignored it and always called `save_model(..., donate_model=True)`. That clears the in-memory model parameters even when callers explicitly need them after saving.

`mlx_lm.fuse --export-gguf` passes `donate_model=False` because it saves the fused model first, then reads `model.parameters()` to export GGUF weights. When the flag is ignored, GGUF export receives empty model tensors.

Related to #353, specifically the path where the generated GGUF is missing expected tensors. This does not claim to cover the separate row-major serialization symptom mentioned there.

## Validation

- `python -m pre_commit run --files mlx_lm/utils.py tests/test_utils.py tests/test_gguf.py`
- `python -m unittest -v tests.test_utils.TestUtils.test_save_respects_donate_model tests.test_gguf`
- Real-world smoke test with `mlx-community/Llama-3.2-1B-Instruct-bf16`: trained a one-step LoRA adapter, ran `mlx_lm fuse --export-gguf`, and confirmed the produced GGUF contains `token_embd.weight`.
