### PR TITLE
Add BatchQuantizedKVCache

### DIFF
--- a/mlx_lm/generate.py
+++ b/mlx_lm/generate.py
@@ -30,6 +30,7 @@ from .models import cache
 from .models.cache import (
     ArraysCache,
     BatchKVCache,
+    BatchQuantizedKVCache,
     BatchRotatingKVCache,
     CacheList,
     KVCache,
@@ -842,6 +843,10 @@ def _make_cache(model, left_padding, max_kv_size):
     """
 
     def to_batch_cache(c):
+        if isinstance(c, QuantizedKVCache):
+            return BatchQuantizedKVCache(
+                left_padding, group_size=c.group_size, bits=c.bits
+            )
         if type(c) is KVCache:
             return BatchKVCache(left_padding)
         elif isinstance(c, ArraysCache):

--- a/mlx_lm/models/base.py
+++ b/mlx_lm/models/base.py
@@ -90,6 +90,8 @@ def quantized_scaled_dot_product_attention(
             q_indices = mx.arange(kL - qL, kL)
             k_indices = mx.arange(kL)
             mask = q_indices[:, None] >= k_indices[None]
+        elif n_repeats > 1 and mask.ndim == scores.ndim - 1:
+            mask = mx.expand_dims(mask, axis=-3)
         if mask.dtype == mx.bool_:
             scores = mx.where(mask, scores, mx.finfo(scores.dtype).min)
         else:

--- a/mlx_lm/models/cache.py
+++ b/mlx_lm/models/cache.py
@@ -303,6 +303,9 @@ class QuantizedKVCache(_BaseCache):
     def meta_state(self, v):
         self.offset, self.group_size, self.bits = map(int, v)
 
+    def size(self):
+        return self.offset
+
     def is_trimmable(self):
         return True
 
@@ -313,6 +316,10 @@ class QuantizedKVCache(_BaseCache):
 
     def make_mask(self, *args, **kwargs):
         return create_attention_mask(*args, offset=self.offset, **kwargs)
+
+    @classmethod
+    def merge(_, caches):
+        return BatchQuantizedKVCache.merge(caches)
 
     def empty(self):
         return self.keys is None
@@ -1128,6 +1135,238 @@ class BatchKVCache(_BaseCache):
         if self.keys is None:
             return 0
         return self.keys.nbytes + self.values.nbytes
+
+
+class BatchQuantizedKVCache(_BaseCache):
+    step = 256
+
+    def __init__(self, left_padding: List[int], group_size: int = 64, bits: int = 8):
+        self.keys = None
+        self.values = None
+        self.left_padding = mx.array(left_padding)
+        self.offset = mx.array([-l for l in left_padding])
+        self._idx = 0
+        self._right_padding = None
+        self.group_size = group_size
+        self.bits = bits
+
+    def _empty_like(self, x, batch_size):
+        return mx.array([], dtype=x.dtype).reshape(batch_size, *x.shape[1:2], 0, x.shape[-1])
+
+    def update_and_fetch(self, keys, values):
+        B, n_kv_heads, num_steps, k_head_dim = keys.shape
+        v_head_dim = values.shape[-1]
+        prev = self._idx
+
+        if self.keys is None or (prev + num_steps) > self.keys[0].shape[-2]:
+            el_per_int = 8 * mx.uint32.size // self.bits
+            new_steps = (self.step + num_steps - 1) // self.step * self.step
+            shape = (B, n_kv_heads, new_steps)
+
+            def init_quant(dim):
+                return (
+                    mx.zeros((*shape, dim // el_per_int), dtype=mx.uint32),
+                    mx.zeros((*shape, dim // self.group_size), dtype=keys.dtype),
+                    mx.zeros((*shape, dim // self.group_size), dtype=keys.dtype),
+                )
+
+            def expand_quant(x):
+                new_x = mx.zeros((*shape, x.shape[-1]), dtype=x.dtype)
+                return mx.concatenate([x, new_x], axis=-2)
+
+            if self.keys is not None:
+                if prev % self.step != 0:
+                    self.keys, self.values = tree_map(
+                        lambda x: x[..., :prev, :], (self.keys, self.values)
+                    )
+                self.keys, self.values = tree_map(
+                    expand_quant, (self.keys, self.values)
+                )
+            else:
+                self.keys, self.values = init_quant(k_head_dim), init_quant(v_head_dim)
+
+        self.offset += num_steps
+        self._idx += num_steps
+        keys = mx.quantize(keys, group_size=self.group_size, bits=self.bits)
+        values = mx.quantize(values, group_size=self.group_size, bits=self.bits)
+        for i in range(len(self.keys)):
+            self.keys[i][..., prev : self._idx, :] = keys[i]
+            self.values[i][..., prev : self._idx, :] = values[i]
+
+        return tree_map(lambda x: x[..., : self._idx, :], (self.keys, self.values))
+
+    def prepare(self, *, left_padding=None, lengths=None, right_padding=None):
+        if left_padding is not None:
+            if self.keys is not None:
+                raise ValueError(
+                    "Left padding can only be added to an empty BatchQuantizedKVCache"
+                )
+            left_padding = mx.array(left_padding)
+            self.left_padding += left_padding
+            self.offset -= left_padding
+        if right_padding is not None and max(right_padding) > 0:
+            self._right_padding = mx.array(right_padding)
+
+    def finalize(self):
+        if self._right_padding is not None:
+            padding = self._right_padding
+            self.keys, self.values = tree_map(
+                lambda x: dynamic_roll(x, padding[:, None], axis=2),
+                (self.keys, self.values),
+            )
+            self.offset -= padding
+            self.left_padding += padding
+            self._right_padding = None
+
+    @property
+    def state(self):
+        keys, values = self.keys, self.values
+        if self._idx < keys[0].shape[2]:
+            keys, values = tree_map(lambda x: x[..., : self._idx, :], (keys, values))
+        return keys, values, self.offset, self.left_padding
+
+    @state.setter
+    def state(self, v):
+        self.keys, self.values, self.offset, self.left_padding = v
+        self._idx = self.keys[0].shape[2]
+
+    def is_trimmable(self):
+        return True
+
+    def trim(self, n):
+        n = min(self._idx, n)
+        self._idx -= n
+        self.offset -= n
+        return n
+
+    def make_mask(self, N: int, return_array: bool = False, **kwargs):
+        return create_causal_mask(
+            N, offset=self._idx, left_padding=self.left_padding, **kwargs
+        )
+
+    def filter(self, batch_indices):
+        if self.keys is not None:
+            self.keys, self.values = tree_map(
+                lambda x: x[batch_indices], (self.keys, self.values)
+            )
+        self.offset = self.offset[batch_indices]
+        self.left_padding = self.left_padding[batch_indices]
+
+        min_left_pad = self.left_padding.min().item()
+        if min_left_pad > 0:
+            if self.keys is not None:
+                self.keys, self.values = tree_map(
+                    lambda x: x[..., min_left_pad:, :], (self.keys, self.values)
+                )
+            self._idx -= min_left_pad
+            self.left_padding -= min_left_pad
+
+    def extend(self, other):
+        if self.group_size != other.group_size or self.bits != other.bits:
+            raise ValueError("Cannot extend BatchQuantizedKVCache with different quantization settings")
+        if self.keys is None and other.keys is None:
+            self.left_padding = mx.concatenate([self.left_padding, other.left_padding])
+            self.offset = mx.concatenate([self.offset, other.offset])
+            return
+
+        max_idx = max(self._idx, other._idx)
+        L1 = L2 = 0
+        if self.keys is not None:
+            B, H, L1, Dk = self.keys[0].shape
+            Dv = self.values[0].shape[-1]
+        if other.keys is not None:
+            B, H, L2, Dk = other.keys[0].shape
+            Dv = other.values[0].shape[-1]
+        max_size = max(L1, L2)
+
+        def pad(c):
+            keys, values = c.keys, c.values
+            if keys is None:
+                batch_size = c.offset.shape[0]
+                keys = tuple(
+                    mx.array([], dtype=x.dtype).reshape(batch_size, H, 0, x.shape[-1])
+                    for x in (self.keys or other.keys)
+                )
+                values = tuple(
+                    mx.array([], dtype=x.dtype).reshape(batch_size, H, 0, x.shape[-1])
+                    for x in (self.values or other.values)
+                )
+            left = max_idx - c._idx
+            right = max_size - keys[0].shape[2] - left
+            if right < 0:
+                keys, values = tree_map(lambda x: x[..., :right, :], (keys, values))
+                right = 0
+            if left != 0 or right != 0:
+                pad_width = [(0, 0), (0, 0), (left, right), (0, 0)]
+                keys, values = tree_map(lambda x: mx.pad(x, pad_width), (keys, values))
+            left_padding = c.left_padding + left
+            return keys, values, c.offset, left_padding
+
+        self_keys, self_values, self_offset, self_left_padding = pad(self)
+        other_keys, other_values, other_offset, other_left_padding = pad(other)
+        self.keys = tuple(mx.concatenate(x) for x in zip(self_keys, other_keys))
+        self.values = tuple(mx.concatenate(x) for x in zip(self_values, other_values))
+        self.offset = mx.concatenate([self_offset, other_offset])
+        self.left_padding = mx.concatenate([self_left_padding, other_left_padding])
+        self._idx = max_idx
+
+    def extract(self, idx):
+        cache = QuantizedKVCache(group_size=self.group_size, bits=self.bits)
+        padding = self.left_padding[idx].item()
+        cache.keys, cache.values = tree_map(
+            lambda x: mx.contiguous(x[idx : idx + 1, :, padding : self._idx]),
+            (self.keys, self.values),
+        )
+        cache.offset = cache.keys[0].shape[2]
+        return cache
+
+    @classmethod
+    def merge(cls, caches):
+        group_size = caches[0].group_size
+        bits = caches[0].bits
+        if any(c.group_size != group_size or c.bits != bits for c in caches):
+            raise ValueError("Cannot merge QuantizedKVCache objects with different quantization settings")
+        lengths = [c.size() for c in caches]
+        max_length = max(lengths)
+        if max_length == 0:
+            return cls([0] * len(caches), group_size=group_size, bits=bits)
+
+        padding = [max_length - l for l in lengths]
+        B = len(caches)
+        template = next(c for c in caches if c.keys is not None)
+        keys = tuple(
+            mx.zeros((B, x.shape[1], max_length, x.shape[-1]), dtype=x.dtype)
+            for x in template.keys
+        )
+        values = tuple(
+            mx.zeros((B, x.shape[1], max_length, x.shape[-1]), dtype=x.dtype)
+            for x in template.values
+        )
+        for i, (p, c) in enumerate(zip(padding, caches)):
+            if c.keys is None:
+                continue
+            for j in range(len(keys)):
+                keys[j][i : i + 1, :, p : p + c.offset] = c.keys[j][..., : c.offset, :]
+                values[j][i : i + 1, :, p : p + c.offset] = c.values[j][..., : c.offset, :]
+
+        cache = cls(padding, group_size=group_size, bits=bits)
+        cache.keys = keys
+        cache.values = values
+        cache.offset += max_length
+        cache._idx = max_length
+        return cache
+
+    def size(self):
+        return self._idx
+
+    def empty(self):
+        return self.keys is None
+
+    @property
+    def nbytes(self):
+        if self.keys is None:
+            return 0
+        return tree_reduce(lambda a, x: a + x.nbytes, (self.keys, self.values), 0)
 
 
 class BatchRotatingKVCache(_BaseCache):

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -9,7 +9,7 @@ from mlx.utils import tree_flatten, tree_map
 
 from mlx_lm.models import rope_utils
 from mlx_lm.models.base import create_causal_mask, scaled_dot_product_attention
-from mlx_lm.models.cache import KVCache, RotatingKVCache, make_prompt_cache
+from mlx_lm.models.cache import KVCache, QuantizedKVCache, RotatingKVCache, make_prompt_cache
 from mlx_lm.models.gated_delta import (
     gated_delta_kernel,
     gated_delta_ops,
@@ -333,6 +333,36 @@ class TestModels(unittest.TestCase):
             q,
             qk_up,
             qv_up,
+            cache=quant_cache,
+            mask=mask,
+            scale=1.0,
+        )
+        self.assertTrue(mx.allclose(out, qout, rtol=1e-2, atol=1e-2))
+
+    def test_quantized_sdpa_with_batch_left_padding(self):
+        cache = KVCache()
+        quant_cache = QuantizedKVCache(group_size=32, bits=8)
+
+        k = 1e-1 * mx.random.normal(shape=(2, 4, 5, 32))
+        v = 1e-1 * mx.random.normal(shape=(2, 4, 5, 32))
+        k_up, v_up = cache.update_and_fetch(k, v)
+        qk, qv = quant_cache.update_and_fetch(k, v)
+
+        q = 1e-1 * mx.random.normal(shape=(2, 8, 1, 32))
+        mask = create_causal_mask(1, offset=4, left_padding=mx.array([0, 1]))
+
+        out = scaled_dot_product_attention(
+            q,
+            k_up,
+            v_up,
+            cache=cache,
+            mask=mask,
+            scale=1.0,
+        )
+        qout = scaled_dot_product_attention(
+            q,
+            qk,
+            qv,
             cache=quant_cache,
             mask=mask,
             scale=1.0,

--- a/tests/test_prompt_cache.py
+++ b/tests/test_prompt_cache.py
@@ -7,11 +7,12 @@ import unittest
 
 import mlx.core as mx
 
-from mlx_lm.generate import generate_step
+from mlx_lm.generate import _merge_caches, generate_step
 from mlx_lm.models.base import create_attention_mask, create_causal_mask
 from mlx_lm.models.cache import (
     ArraysCache,
     BatchKVCache,
+    BatchQuantizedKVCache,
     BatchRotatingKVCache,
     CacheList,
     ChunkedKVCache,
@@ -529,6 +530,65 @@ class TestPromptCache(unittest.TestCase):
         self.assertEqual(cache_a.values.shape[0], 5)
         self.assertEqual(cache_a.offset.tolist(), [6, 7, 6, 1, 4])
         self.assertEqual(cache_a.left_padding.tolist(), [2, 1, 2, 7, 4])
+
+    def test_batch_quantized_kv_cache(self):
+        c1 = QuantizedKVCache(bits=4, group_size=32)
+        c2 = QuantizedKVCache(bits=4, group_size=32)
+        c1.update_and_fetch(mx.ones((1, 1, 5, 32)), mx.ones((1, 1, 5, 32)))
+        c2.update_and_fetch(mx.ones((1, 1, 3, 32)), mx.ones((1, 1, 3, 32)))
+
+        batch = BatchQuantizedKVCache.merge([c1, c2])
+        self.assertEqual(batch.size(), 5)
+        self.assertEqual(batch.offset.tolist(), [5, 3])
+        self.assertEqual(batch.left_padding.tolist(), [0, 2])
+        self.assertEqual(batch.keys[0].shape, (2, 1, 5, 4))
+        self.assertEqual(batch.keys[1].shape, (2, 1, 5, 1))
+
+        extracted = batch.extract(1)
+        self.assertIsInstance(extracted, QuantizedKVCache)
+        self.assertEqual(extracted.offset, 3)
+        self.assertEqual(extracted.group_size, 32)
+        self.assertEqual(extracted.bits, 4)
+        self.assertEqual(extracted.keys[0].shape, (1, 1, 3, 4))
+
+        k, v = batch.update_and_fetch(
+            mx.zeros((2, 1, 2, 32)), mx.zeros((2, 1, 2, 32))
+        )
+        self.assertEqual(k[0].shape, (2, 1, 7, 4))
+        self.assertEqual(v[0].shape, (2, 1, 7, 4))
+        self.assertEqual(batch.offset.tolist(), [7, 5])
+
+        batch.filter([1])
+        self.assertEqual(batch.keys[0].shape[0], 1)
+        self.assertEqual(batch.left_padding.tolist(), [0])
+        self.assertEqual(batch.offset.tolist(), [5])
+
+    def test_merge_quantized_kv_cache_history(self):
+        c1 = QuantizedKVCache(bits=4, group_size=32)
+        c2 = QuantizedKVCache(bits=4, group_size=32)
+        c1.update_and_fetch(mx.ones((1, 1, 5, 32)), mx.ones((1, 1, 5, 32)))
+        c2.update_and_fetch(mx.ones((1, 1, 3, 32)), mx.ones((1, 1, 3, 32)))
+
+        batch = _merge_caches([[c1], [c2]])
+        self.assertIsInstance(batch[0], BatchQuantizedKVCache)
+        self.assertEqual(batch[0].offset.tolist(), [5, 3])
+        self.assertEqual(batch[0].left_padding.tolist(), [0, 2])
+
+    def test_batch_quantized_kv_cache_extend_with_empty(self):
+        c1 = QuantizedKVCache(bits=4, group_size=32)
+        c2 = QuantizedKVCache(bits=4, group_size=32)
+        c1.update_and_fetch(mx.ones((1, 1, 5, 32)), mx.ones((1, 1, 5, 32)))
+        c2.update_and_fetch(mx.ones((1, 1, 3, 32)), mx.ones((1, 1, 3, 32)))
+        batch_full = BatchQuantizedKVCache.merge([c1, c2])
+        batch_empty = BatchQuantizedKVCache.merge(
+            [QuantizedKVCache(bits=4, group_size=32) for _ in range(3)]
+        )
+
+        batch_full.extend(batch_empty)
+        self.assertEqual(batch_full.keys[0].shape[0], 5)
+        self.assertEqual(batch_full.offset.shape[0], 5)
+        self.assertEqual(batch_full.group_size, 32)
+        self.assertEqual(batch_full.bits, 4)
 
     def test_batch_rotating_kv_cache(self):
         cache = BatchRotatingKVCache(max_size=4, left_padding=[2, 0])


### PR DESCRIPTION
## Summary
- Add `BatchQuantizedKVCache` for non-rotating quantized KV histories.
- Allow quantized KV prompt caches to participate in continuous batching via merge, extract, filter, and extend operations.
- Fix quantized SDPA mask broadcasting for batched grouped-query attention with left-padded histories, which was exposed by a real Qwen3 batch decode smoke test.

## Reproduction
Before this change, `_merge_caches([[quantized_cache_1], [quantized_cache_2]])` fails because `QuantizedKVCache` has no batching support. After the initial cache support, a real Qwen3 batch decode with left-padded quantized histories exposed a second issue in quantized SDPA:

```text
ValueError: [broadcast_shapes] Shapes (2,1,1,66) and (2,8,2,1,66) cannot be broadcast.
```

The follow-up commit expands batched masks across the grouped-query repeat dimension before applying them to quantized attention scores.

## Environment
- macOS Darwin 25.4.0 arm64
- Apple M1 Max, 32 GB unified memory
- MLX / mlx-lm virtual environment on Apple Silicon
- Model: `mlx-community/Qwen3-0.6B-4bit`

## Real-weight benchmark

Protocol: two batched requests with existing prompt-cache histories, `prefill_step_size=2048`, 4-bit KV quantization with group size 64 for the quantized run. The 100K input / 10K output baseline run was attempted first and failed with Metal OOM, so the reported long-context comparison uses the requested fallback size: 50K input / 5K output per sequence.

| Mode | Input tokens | Output tokens | Prefill tokens | Prefill time | Decode time | Generated tokens | Decode TPS | KV cache bytes | Peak memory |
| --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: |
| BatchKVCache fp16 histories | 50,000 / 49,872 | 5,000 each | 99,870 | 131.87s | 389.12s | 10,000 | 25.70 tok/s | 11.48 GB | 25.00 GB |
| BatchQuantizedKVCache 4-bit histories | 50,000 / 49,872 | 5,000 each | 99,870 | 210.83s | 151.72s | 10,000 | 65.91 tok/s | 3.23 GB | 13.71 GB |

Observed deltas at 50K/5K:
- KV cache storage: 11.48 GB → 3.23 GB (71.9% lower)
- Peak memory: 25.00 GB → 13.71 GB (45.2% lower)
- Decode throughput: 25.70 → 65.91 tok/s (2.56x higher)
- Quantized prefill is slower because cache quantization is performed while building the histories.

## Test plan
- `python -m unittest discover -s tests -p test_models.py -k quantized`
- `python -m unittest discover -s tests -p test_prompt_cache.py -k quantized`
- Real Qwen3 smoke: batch decode two existing quantized prompt-cache histories with `mlx-community/Qwen3-0.6B-4bit`
- Real Qwen3 long-context benchmark above