### PR TITLE
Consolidate MLA kv_b_proj sanitize/shard into shared helpers

### DIFF
--- a/mlx_lm/models/deepseek_v3.py
+++ b/mlx_lm/models/deepseek_v3.py
@@ -11,7 +11,7 @@ from mlx.nn.layers.distributed import shard_inplace, shard_linear, sum_gradients
 
 from .activations import swiglu
 from .base import BaseModelArgs, create_attention_mask, scaled_dot_product_attention
-from .mla import MultiLinear
+from .mla import MultiLinear, shard_mla_projections, split_kv_b_proj_weights
 from .pipeline import PipelineMixin
 from .rope_utils import initialize_rope
 from .switch_layers import SwitchGLU
@@ -434,41 +434,14 @@ class Model(nn.Module):
                         ]
                         weights[f"{prefix}.mlp.switch_mlp.{m}.{k}"] = mx.stack(to_join)
             prefix = f"model.layers.{l}.self_attn"
-            if f"{prefix}.kv_b_proj.weight" in weights:
-                layer = self.model.layers[l].self_attn.embed_q
-                quantized = f"{prefix}.kv_b_proj.scales" in weights
-                v = weights.pop(f"{prefix}.kv_b_proj.weight")
-                head_dim = self.args.qk_nope_head_dim + self.args.v_head_dim
-
-                if quantized:
-                    dims = self.args.kv_lora_rank
-                    scales = weights.pop(f"{prefix}.kv_b_proj.scales")
-                    biases = weights.pop(f"{prefix}.kv_b_proj.biases")
-                    # Try to infer bits and group size
-                    bits = (v.shape[-1] * 32) // dims
-                    group_size = dims // scales.shape[-1]
-                    v = mx.dequantize(
-                        v, scales, biases, bits=bits, group_size=group_size
-                    )
-                num_heads = self.args.num_attention_heads
-                v = v.reshape(num_heads, head_dim, -1)
-                wk = mx.contiguous(
-                    v[:, : self.args.qk_nope_head_dim, :].swapaxes(-1, -2)
-                )
-                wv = mx.contiguous(v[:, self.args.qk_nope_head_dim :, :])
-                if quantized:
-                    wk, wk_scales, wk_biases = mx.quantize(
-                        wk, bits=bits, group_size=group_size
-                    )
-                    wv, wv_scales, wv_biases = mx.quantize(
-                        wv, bits=bits, group_size=group_size
-                    )
-                    weights[f"{prefix}.embed_q.scales"] = wk_scales
-                    weights[f"{prefix}.unembed_out.scales"] = wv_scales
-                    weights[f"{prefix}.embed_q.biases"] = wk_biases
-                    weights[f"{prefix}.unembed_out.biases"] = wv_biases
-                weights[f"{prefix}.embed_q.weight"] = wk
-                weights[f"{prefix}.unembed_out.weight"] = wv
+            split_kv_b_proj_weights(
+                weights,
+                prefix,
+                num_heads=self.args.num_attention_heads,
+                qk_nope_head_dim=self.args.qk_nope_head_dim,
+                v_head_dim=self.args.v_head_dim,
+                kv_lora_rank=self.args.kv_lora_rank,
+            )
 
         # Remove multi-token prediction layer and any unused precomputed rotary freqs
         return {
@@ -479,10 +452,9 @@ class Model(nn.Module):
 
     def shard(self, group: Optional[mx.distributed.Group] = None):
         group = group or mx.distributed.init()
-        N = group.size()
-        rank = group.rank()
         for layer in self.model.layers:
             # Shard the self attention
+            shard_mla_projections(layer.self_attn, group, "num_heads")
             if layer.self_attn.q_lora_rank is None:
                 layer.self_attn.q_proj = shard_linear(
                     layer.self_attn.q_proj, "all-to-sharded", group=group
@@ -491,16 +463,6 @@ class Model(nn.Module):
                 layer.self_attn.q_b_proj = shard_linear(
                     layer.self_attn.q_b_proj, "all-to-sharded", group=group
                 )
-            layer.self_attn.num_heads //= N
-            num_heads = layer.self_attn.num_heads
-            sh = rank * num_heads
-            eh = sh + num_heads
-
-            def shard_heads(w):
-                return w[sh:eh]
-
-            layer.self_attn.embed_q.apply(shard_heads)
-            layer.self_attn.unembed_out.apply(shard_heads)
 
             layer.self_attn.o_proj = shard_linear(
                 layer.self_attn.o_proj, "sharded-to-all", group=group

--- a/mlx_lm/models/deepseek_v32.py
+++ b/mlx_lm/models/deepseek_v32.py
@@ -11,7 +11,7 @@ from mlx.nn.layers.distributed import shard_inplace, shard_linear, sum_gradients
 from .activations import swiglu
 from .base import BaseModelArgs, create_attention_mask, scaled_dot_product_attention
 from .cache import CacheList, KVCache
-from .mla import MultiLinear
+from .mla import MultiLinear, shard_mla_projections, split_kv_b_proj_weights
 from .rope_utils import initialize_rope
 from .switch_layers import SwitchGLU
 
@@ -543,49 +543,21 @@ class Model(nn.Module):
                         ]
                         weights[f"{prefix}.mlp.switch_mlp.{m}.{k}"] = mx.stack(to_join)
             prefix = f"model.layers.{l}.self_attn"
-            if f"{prefix}.kv_b_proj.weight" in weights:
-                layer = self.model.layers[l].self_attn.embed_q
-                quantized = f"{prefix}.kv_b_proj.scales" in weights
-                v = weights.pop(f"{prefix}.kv_b_proj.weight")
-                head_dim = self.args.qk_nope_head_dim + self.args.v_head_dim
-
-                if quantized:
-                    dims = self.args.kv_lora_rank
-                    scales = weights.pop(f"{prefix}.kv_b_proj.scales")
-                    biases = weights.pop(f"{prefix}.kv_b_proj.biases")
-                    # Try to infer bits and group size
-                    bits = (v.shape[-1] * 32) // dims
-                    group_size = dims // scales.shape[-1]
-                    v = mx.dequantize(
-                        v, scales, biases, bits=bits, group_size=group_size
-                    )
-                num_heads = self.args.num_attention_heads
-                v = v.reshape(num_heads, head_dim, -1)
-                wk = mx.contiguous(
-                    v[:, : self.args.qk_nope_head_dim, :].swapaxes(-1, -2)
-                )
-                wv = mx.contiguous(v[:, self.args.qk_nope_head_dim :, :])
-                if quantized:
-                    wk, wk_scales, wk_biases = mx.quantize(
-                        wk, bits=bits, group_size=group_size
-                    )
-                    wv, wv_scales, wv_biases = mx.quantize(
-                        wv, bits=bits, group_size=group_size
-                    )
-                    weights[f"{prefix}.embed_q.scales"] = wk_scales
-                    weights[f"{prefix}.unembed_out.scales"] = wv_scales
-                    weights[f"{prefix}.embed_q.biases"] = wk_biases
-                    weights[f"{prefix}.unembed_out.biases"] = wv_biases
-                weights[f"{prefix}.embed_q.weight"] = wk
-                weights[f"{prefix}.unembed_out.weight"] = wv
+            split_kv_b_proj_weights(
+                weights,
+                prefix,
+                num_heads=self.args.num_attention_heads,
+                qk_nope_head_dim=self.args.qk_nope_head_dim,
+                v_head_dim=self.args.v_head_dim,
+                kv_lora_rank=self.args.kv_lora_rank,
+            )
 
         return weights
 
     def shard(self, group: Optional[mx.distributed.Group] = None):
         group = group or mx.distributed.init()
-        N = group.size()
-        rank = group.rank()
         for layer in self.model.layers:
+            shard_mla_projections(layer.self_attn, group, "num_heads")
             layer.self_attn.q_b_proj = shard_linear(
                 layer.self_attn.q_b_proj, "all-to-sharded", group=group
             )
@@ -593,16 +565,6 @@ class Model(nn.Module):
             layer.self_attn.o_proj = shard_linear(
                 layer.self_attn.o_proj, "sharded-to-all", group=group
             )
-            layer.self_attn.num_heads //= N
-            num_heads = layer.self_attn.num_heads
-            sh = rank * num_heads
-            eh = sh + num_heads
-
-            def shard_heads(w):
-                return w[sh:eh]
-
-            layer.self_attn.embed_q.apply(shard_heads)
-            layer.self_attn.unembed_out.apply(shard_heads)
 
             # Shard the MLP
             if isinstance(layer.mlp, DeepseekV32MLP):

--- a/mlx_lm/models/glm4_moe_lite.py
+++ b/mlx_lm/models/glm4_moe_lite.py
@@ -10,7 +10,7 @@ from mlx.nn.layers.distributed import shard_inplace, shard_linear, sum_gradients
 
 from .activations import swiglu
 from .base import BaseModelArgs, create_attention_mask, scaled_dot_product_attention
-from .mla import MultiLinear
+from .mla import MultiLinear, shard_mla_projections, split_kv_b_proj_weights
 from .pipeline import PipelineMixin
 from .rope_utils import initialize_rope
 from .switch_layers import SwitchGLU
@@ -410,50 +410,22 @@ class Model(nn.Module):
                         ]
                         weights[f"{prefix}.mlp.switch_mlp.{m}.{k}"] = mx.stack(to_join)
             prefix = f"model.layers.{l}.self_attn"
-            if f"{prefix}.kv_b_proj.weight" in weights:
-                layer = self.layers[l].self_attn.embed_q
-                quantized = f"{prefix}.kv_b_proj.scales" in weights
-                v = weights.pop(f"{prefix}.kv_b_proj.weight")
-                head_dim = self.args.qk_nope_head_dim + self.args.v_head_dim
-
-                if quantized:
-                    dims = self.args.kv_lora_rank
-                    scales = weights.pop(f"{prefix}.kv_b_proj.scales")
-                    biases = weights.pop(f"{prefix}.kv_b_proj.biases")
-                    # Try to infer bits and group size
-                    bits = (v.shape[-1] * 32) // dims
-                    group_size = dims // scales.shape[-1]
-                    v = mx.dequantize(
-                        v, scales, biases, bits=bits, group_size=group_size
-                    )
-                num_heads = self.args.num_attention_heads
-                v = v.reshape(num_heads, head_dim, -1)
-                wk = mx.contiguous(
-                    v[:, : self.args.qk_nope_head_dim, :].swapaxes(-1, -2)
-                )
-                wv = mx.contiguous(v[:, self.args.qk_nope_head_dim :, :])
-                if quantized:
-                    wk, wk_scales, wk_biases = mx.quantize(
-                        wk, bits=bits, group_size=group_size
-                    )
-                    wv, wv_scales, wv_biases = mx.quantize(
-                        wv, bits=bits, group_size=group_size
-                    )
-                    weights[f"{prefix}.embed_q.scales"] = wk_scales
-                    weights[f"{prefix}.unembed_out.scales"] = wv_scales
-                    weights[f"{prefix}.embed_q.biases"] = wk_biases
-                    weights[f"{prefix}.unembed_out.biases"] = wv_biases
-                weights[f"{prefix}.embed_q.weight"] = wk
-                weights[f"{prefix}.unembed_out.weight"] = wv
+            split_kv_b_proj_weights(
+                weights,
+                prefix,
+                num_heads=self.args.num_attention_heads,
+                qk_nope_head_dim=self.args.qk_nope_head_dim,
+                v_head_dim=self.args.v_head_dim,
+                kv_lora_rank=self.args.kv_lora_rank,
+            )
 
         return weights
 
     def shard(self, group: Optional[mx.distributed.Group] = None):
         group = group or mx.distributed.init()
-        rank = group.rank()
-        N = group.size()
         for layer in self.model.layers:
             # Shard the self attention
+            shard_mla_projections(layer.self_attn, group, "num_heads")
             if layer.self_attn.q_lora_rank is None:
                 layer.self_attn.q_proj = shard_linear(
                     layer.self_attn.q_proj, "all-to-sharded", group=group
@@ -462,16 +434,6 @@ class Model(nn.Module):
                 layer.self_attn.q_b_proj = shard_linear(
                     layer.self_attn.q_b_proj, "all-to-sharded", group=group
                 )
-            layer.self_attn.num_heads //= N
-            num_heads = layer.self_attn.num_heads
-            sh = rank * num_heads
-            eh = sh + num_heads
-
-            def shard_heads(w):
-                return w[sh:eh]
-
-            layer.self_attn.embed_q.apply(shard_heads)
-            layer.self_attn.unembed_out.apply(shard_heads)
 
             layer.self_attn.o_proj = shard_linear(
                 layer.self_attn.o_proj, "sharded-to-all", group=group

--- a/mlx_lm/models/kimi_linear.py
+++ b/mlx_lm/models/kimi_linear.py
@@ -15,7 +15,7 @@ from .base import (
 )
 from .cache import ArraysCache, KVCache
 from .gated_delta import gated_delta_update
-from .mla import MultiLinear
+from .mla import MultiLinear, split_kv_b_proj_weights
 from .switch_layers import SwitchGLU
 
 
@@ -553,40 +553,14 @@ class Model(nn.Module):
                         weights[dt_key] = mx.reshape(weights[dt_key], (-1,))
 
             attn_prefix = f"{prefix}.self_attn"
-            kv_b_key = f"{attn_prefix}.kv_b_proj.weight"
-            if kv_b_key in weights:
-                qk_nope = self.args.qk_nope_head_dim or self.args.head_dim
-                v_head = self.args.v_head_dim or self.args.head_dim
-                head_dim = qk_nope + v_head
-                num_heads = self.args.num_attention_heads
-
-                quantized = f"{attn_prefix}.kv_b_proj.scales" in weights
-                v = weights.pop(kv_b_key)
-
-                if quantized:
-                    dims = self.args.kv_lora_rank
-                    scales = weights.pop(f"{attn_prefix}.kv_b_proj.scales")
-                    biases = weights.pop(f"{attn_prefix}.kv_b_proj.biases")
-                    bits = (v.shape[-1] * 32) // dims
-                    group_size = dims // scales.shape[-1]
-                    v = mx.dequantize(
-                        v, scales, biases, bits=bits, group_size=group_size
-                    )
-
-                v = v.reshape(num_heads, head_dim, -1)
-                wk = mx.contiguous(v[:, :qk_nope, :].swapaxes(-1, -2))
-                wv = mx.contiguous(v[:, qk_nope:, :])
-
-                if quantized:
-                    wk, wk_s, wk_b = mx.quantize(wk, bits=bits, group_size=group_size)
-                    wv, wv_s, wv_b = mx.quantize(wv, bits=bits, group_size=group_size)
-                    weights[f"{attn_prefix}.embed_q.scales"] = wk_s
-                    weights[f"{attn_prefix}.embed_q.biases"] = wk_b
-                    weights[f"{attn_prefix}.unembed_out.scales"] = wv_s
-                    weights[f"{attn_prefix}.unembed_out.biases"] = wv_b
-
-                weights[f"{attn_prefix}.embed_q.weight"] = wk
-                weights[f"{attn_prefix}.unembed_out.weight"] = wv
+            split_kv_b_proj_weights(
+                weights,
+                attn_prefix,
+                num_heads=self.args.num_attention_heads,
+                qk_nope_head_dim=self.args.qk_nope_head_dim or self.args.head_dim,
+                v_head_dim=self.args.v_head_dim or self.args.head_dim,
+                kv_lora_rank=self.args.kv_lora_rank,
+            )
 
         return weights
 

--- a/mlx_lm/models/longcat_flash.py
+++ b/mlx_lm/models/longcat_flash.py
@@ -9,7 +9,7 @@ from mlx.nn.layers.distributed import shard_inplace, shard_linear, sum_gradients
 from .activations import swiglu
 from .base import BaseModelArgs, create_attention_mask, scaled_dot_product_attention
 from .cache import CacheList, KVCache
-from .mla import MultiLinear
+from .mla import MultiLinear, shard_mla_projections, split_kv_b_proj_weights
 from .rope_utils import initialize_rope
 from .switch_layers import SwitchGLU
 
@@ -403,43 +403,14 @@ class Model(nn.Module):
         for l in range(self.args.num_layers):
             for i in range(2):
                 prefix = f"model.layers.{l}.self_attn.{i}"
-                kv_b_key = f"{prefix}.kv_b_proj.weight"
-                if kv_b_key in weights:
-                    num_heads = self.args.num_attention_heads
-                    head_dim = self.args.qk_nope_head_dim + self.args.v_head_dim
-                    quantized = f"{prefix}.kv_b_proj.scales" in weights
-                    v = weights.pop(kv_b_key)
-
-                    if quantized:
-                        dims = self.args.kv_lora_rank
-                        scales = weights.pop(f"{prefix}.kv_b_proj.scales")
-                        biases = weights.pop(f"{prefix}.kv_b_proj.biases")
-                        bits = (v.shape[-1] * 32) // dims
-                        group_size = dims // scales.shape[-1]
-                        v = mx.dequantize(
-                            v, scales, biases, bits=bits, group_size=group_size
-                        )
-
-                    v = v.reshape(num_heads, head_dim, -1)
-                    wk = mx.contiguous(
-                        v[:, : self.args.qk_nope_head_dim, :].swapaxes(-1, -2)
-                    )
-                    wv = mx.contiguous(v[:, self.args.qk_nope_head_dim :, :])
-
-                    if quantized:
-                        wk, wk_s, wk_b = mx.quantize(
-                            wk, bits=bits, group_size=group_size
-                        )
-                        wv, wv_s, wv_b = mx.quantize(
-                            wv, bits=bits, group_size=group_size
-                        )
-                        weights[f"{prefix}.embed_q.scales"] = wk_s
-                        weights[f"{prefix}.embed_q.biases"] = wk_b
-                        weights[f"{prefix}.unembed_out.scales"] = wv_s
-                        weights[f"{prefix}.unembed_out.biases"] = wv_b
-
-                    weights[f"{prefix}.embed_q.weight"] = wk
-                    weights[f"{prefix}.unembed_out.weight"] = wv
+                split_kv_b_proj_weights(
+                    weights,
+                    prefix,
+                    num_heads=self.args.num_attention_heads,
+                    qk_nope_head_dim=self.args.qk_nope_head_dim,
+                    v_head_dim=self.args.v_head_dim,
+                    kv_lora_rank=self.args.kv_lora_rank,
+                )
 
         new_weights = {}
         for k, v in weights.items():
@@ -453,11 +424,10 @@ class Model(nn.Module):
 
     def shard(self, group: Optional[mx.distributed.Group] = None):
         group = group or mx.distributed.init()
-        N = group.size()
-        rank = group.rank()
 
         for layer in self.model.layers:
             for attn in layer.self_attn:
+                shard_mla_projections(attn, group, "num_attention_heads")
                 if attn.q_lora_rank is None:
                     attn.q_proj = shard_linear(
                         attn.q_proj, "all-to-sharded", group=group
@@ -467,16 +437,6 @@ class Model(nn.Module):
                         attn.q_b_proj, "all-to-sharded", group=group
                     )
                 attn.o_proj = shard_linear(attn.o_proj, "sharded-to-all", group=group)
-                attn.num_attention_heads //= N
-                num_heads = attn.num_attention_heads
-                sh = rank * num_heads
-                eh = sh + num_heads
-
-                def shard_heads(w):
-                    return w[sh:eh]
-
-                attn.embed_q.apply(shard_heads)
-                attn.unembed_out.apply(shard_heads)
 
             for mlp in layer.mlps:
                 mlp.gate_proj = shard_linear(

--- a/mlx_lm/models/mla.py
+++ b/mlx_lm/models/mla.py
@@ -83,3 +83,68 @@ class QuantizedMultiLinear(nn.Module):
             bits=self.bits,
             mode=self.mode,
         )
+
+
+def split_kv_b_proj_weights(
+    weights,
+    prefix: str,
+    *,
+    num_heads: int,
+    qk_nope_head_dim: int,
+    v_head_dim: int,
+    kv_lora_rank: int,
+):
+    kv_b_proj = f"{prefix}.kv_b_proj"
+    if f"{kv_b_proj}.weight" not in weights:
+        return weights
+
+    quantized = f"{kv_b_proj}.scales" in weights
+    weight = weights.pop(f"{kv_b_proj}.weight")
+    head_dim = qk_nope_head_dim + v_head_dim
+
+    if quantized:
+        scales = weights.pop(f"{kv_b_proj}.scales")
+        biases = weights.pop(f"{kv_b_proj}.biases", None)
+        # Infer bits and group size from the packed shapes.
+        bits = (weight.shape[-1] * 32) // kv_lora_rank
+        group_size = kv_lora_rank // scales.shape[-1]
+        if biases is None:
+            biases = mx.zeros_like(scales)
+        weight = mx.dequantize(weight, scales, biases, bits=bits, group_size=group_size)
+
+    weight = weight.reshape(num_heads, head_dim, -1)
+    wk = mx.contiguous(weight[:, :qk_nope_head_dim, :].swapaxes(-1, -2))
+    wv = mx.contiguous(weight[:, qk_nope_head_dim:, :])
+
+    if quantized:
+        # Re-quantize the split projections so they reload as QuantizedMultiLinear.
+        wk, wk_scales, wk_biases = mx.quantize(wk, bits=bits, group_size=group_size)
+        wv, wv_scales, wv_biases = mx.quantize(wv, bits=bits, group_size=group_size)
+        weights[f"{prefix}.embed_q.scales"] = wk_scales
+        weights[f"{prefix}.embed_q.biases"] = wk_biases
+        weights[f"{prefix}.unembed_out.scales"] = wv_scales
+        weights[f"{prefix}.unembed_out.biases"] = wv_biases
+
+    weights[f"{prefix}.embed_q.weight"] = wk
+    weights[f"{prefix}.unembed_out.weight"] = wv
+    return weights
+
+
+def shard_mla_projections(attn, group, num_heads_attr: str):
+    num_heads = getattr(attn, num_heads_attr)
+    group_size = group.size()
+    if num_heads % group_size != 0:
+        raise ValueError(
+            f"Cannot shard {num_heads_attr}={num_heads} across " f"{group_size} ranks."
+        )
+
+    local_heads = num_heads // group_size
+    sh = group.rank() * local_heads
+    eh = sh + local_heads
+
+    def shard_heads(w):
+        return w[sh:eh]
+
+    setattr(attn, num_heads_attr, local_heads)
+    attn.embed_q.apply(shard_heads)
+    attn.unembed_out.apply(shard_heads)

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -339,6 +339,67 @@ class TestModels(unittest.TestCase):
         )
         self.assertTrue(mx.allclose(out, qout, rtol=1e-2, atol=1e-2))
 
+    def test_mla_split_requantizes_affine_weight_without_biases(self):
+        from mlx_lm.models.mla import split_kv_b_proj_weights
+
+        prefix = "model.layers.0.self_attn"
+        num_heads, qk_nope, v_head, kv_lora = 2, 32, 32, 32
+        head_dim = qk_nope + v_head
+        weight = mx.random.normal(shape=(num_heads * head_dim, kv_lora))
+        q_weight, scales, *_ = mx.quantize(weight, group_size=32, bits=8)
+        # An affine checkpoint saved without biases (weight + scales only).
+        weights = {
+            f"{prefix}.kv_b_proj.weight": q_weight,
+            f"{prefix}.kv_b_proj.scales": scales,
+        }
+
+        split_kv_b_proj_weights(
+            weights,
+            prefix,
+            num_heads=num_heads,
+            qk_nope_head_dim=qk_nope,
+            v_head_dim=v_head,
+            kv_lora_rank=kv_lora,
+        )
+
+        # The split projections are re-quantized so they reload as
+        # QuantizedMultiLinear (the loader only quantizes modules whose
+        # matching .scales key is present in the checkpoint).
+        self.assertNotIn(f"{prefix}.kv_b_proj.weight", weights)
+        for proj in ("embed_q", "unembed_out"):
+            self.assertIn(f"{prefix}.{proj}.weight", weights)
+            self.assertIn(f"{prefix}.{proj}.scales", weights)
+            self.assertIn(f"{prefix}.{proj}.biases", weights)
+
+    def test_mla_sharding_requires_divisible_heads(self):
+        from mlx_lm.models.mla import MultiLinear, shard_mla_projections
+
+        class Group:
+            def __init__(self, size, rank=0):
+                self._size = size
+                self._rank = rank
+
+            def size(self):
+                return self._size
+
+            def rank(self):
+                return self._rank
+
+        class Attention(nn.Module):
+            def __init__(self, num_heads):
+                super().__init__()
+                self.num_heads = num_heads
+                self.embed_q = MultiLinear(4, 4, num_heads)
+                self.unembed_out = MultiLinear(4, 4, num_heads)
+
+        with self.assertRaises(ValueError):
+            shard_mla_projections(Attention(3), Group(2), "num_heads")
+
+        attention = Attention(4)
+        shard_mla_projections(attention, Group(2, rank=1), "num_heads")
+        self.assertEqual(attention.num_heads, 2)
+        self.assertEqual(attention.embed_q.weight.shape[0], 2)
+
     def model_test_runner(self, model, model_type, vocab_size, num_layers):
         self.assertEqual(len(model.layers), num_layers)
         self.assertEqual(model.model_type, model_type)


### PR DESCRIPTION
## Summary

Several MLA models (DeepSeek-V3, DeepSeek-V3.2, GLM-4 MoE Lite, Kimi Linear, LongCat Flash) carry near-identical copies of two pieces of logic:

- **`sanitize()`** — splitting the fused `kv_b_proj` weight into the absorbed `embed_q` / `unembed_out` (`MultiLinear`) projections, including the quantized-checkpoint path.
- **`shard()`** — slicing those per-head projections across a distributed group.

This PR extracts both into shared helpers in `mlx_lm/models/mla.py` (`split_kv_b_proj_weights` and `shard_mla_projections`) and updates the five models to call them, removing ~230 lines of duplicated code.

## Behavior

Behavior-preserving refactor — no functional change for existing checkpoints:

- The splitter dequantizes → splits → **re-quantizes** the projections exactly as the per-model code did, so quantized checkpoints still load as `QuantizedMultiLinear` (no silent fall back to full precision).
- It additionally tolerates affine checkpoints saved without explicit `biases`.
- `shard_mla_projections()` raises a clear error when the head count is not divisible across ranks, instead of silently producing wrong shapes.

Forward passes, the KV cache, LoRA/DoRA, AWQ and DeepSeek-V2 are intentionally left untouched.

## Tests

- Added `test_mla_split_requantizes_affine_weight_without_biases` (covers the quantized split round-trip and the no-`biases` case).
- Added `test_mla_sharding_requires_divisible_heads`.
- Existing MLA model tests (`test_deepseek_v3`, `test_deepseek_v32`, …) pass.

```bash
python -m unittest discover tests/
```
