### PR TITLE
Fix Qwen3-Coder tool parser and harden server against mid-stream client disconnects

### DIFF
--- a/mlx_lm/server.py
+++ b/mlx_lm/server.py
@@ -1548,6 +1548,11 @@ class APIHandler(BaseHTTPRequestHandler):
                 self.end_headers()
                 self.wfile.write(response_json)
                 self.wfile.flush()
+        except ConnectionError as e:
+            logging.info(
+                f"Client disconnected before response completed "
+                f"({type(e).__name__}); aborting generation."
+            )
         finally:
             ctx.stop()
 

--- a/mlx_lm/server.py
+++ b/mlx_lm/server.py
@@ -79,10 +79,10 @@ class ToolCallFormatter:
         for tool_text in tool_calls:
             try:
                 parsed = self._tool_parser(tool_text, self._tools)
-            except (ValueError, json.JSONDecodeError) as e:
+            except Exception as e:
                 logging.warning(
                     f"Failed to parse tool call ({type(e).__name__}: {e}) — "
-                    f"tool text was likely truncated mid-generation."
+                    f"tool text was likely malformed or truncated mid-generation."
                 )
                 continue
             if not isinstance(parsed, list):

--- a/mlx_lm/tool_parsers/qwen3_coder.py
+++ b/mlx_lm/tool_parsers/qwen3_coder.py
@@ -12,7 +12,15 @@ from typing import Any, Optional
 import regex as re
 
 _function_regex = re.compile(r"<function=(.*?)</function>$", re.DOTALL)
-_parameter_regex = re.compile(r"<parameter=(.*?)</parameter>", re.DOTALL)
+# Match <parameter=NAME>VALUE</parameter> where VALUE may itself contain
+# literal "<parameter=...>" or "</parameter>" substrings (common when the
+# model emits code or markdown that mentions the tool-call format). The
+# trailing lookahead anchors the closing tag to one that is followed by
+# either the next parameter, the function end, or end of input.
+_parameter_regex = re.compile(
+    r"<parameter=([^>]+?)>(.*?)</parameter>\s*(?=<parameter=|</function>|\Z)",
+    re.DOTALL,
+)
 
 _string_types = {"string", "str", "text", "varchar", "char", "enum"}
 _bool_types = {"boolean", "bool", "binary"}
@@ -85,10 +93,8 @@ def _parse_xml_function_call(function_call_str: str, tools: Optional[Any]):
     param_config = _get_arguments_config(function_name, tools)
     parameters = function_call_str[end_index + 1 :]
     param_dict = {}
-    for match_text in _parameter_regex.findall(parameters):
-        idx = match_text.index(">")
-        param_name = match_text[:idx]
-        param_value = str(match_text[idx + 1 :])
+    for param_name, param_value in _parameter_regex.findall(parameters):
+        param_name = param_name.strip()
         if param_value.startswith("\n"):
             param_value = param_value[1:]
         if param_value.endswith("\n"):

--- a/tests/test_tool_parsing.py
+++ b/tests/test_tool_parsing.py
@@ -154,6 +154,73 @@ class TestToolParsing(unittest.TestCase):
                 }
                 self.assertEqual(tool_call, expected)
 
+    def test_qwen3_coder_value_contains_parameter_tags(self):
+        """Value may contain literal <parameter=...> or </parameter> substrings
+        (e.g. when the model emits code/markdown that mentions the format).
+        These must not terminate the value early."""
+        tools = [
+            {
+                "type": "function",
+                "function": {
+                    "name": "str_replace_editor",
+                    "parameters": {
+                        "type": "object",
+                        "properties": {
+                            "command": {"type": "string"},
+                            "path": {"type": "string"},
+                            "file_text": {"type": "string"},
+                        },
+                    },
+                },
+            }
+        ]
+
+        # The file_text value contains both an opening <parameter=...> tag
+        # and a closing </parameter> tag as part of the string content.
+        test_case = (
+            "<function=str_replace_editor>\n"
+            "<parameter=command>\ncreate\n</parameter>\n"
+            "<parameter=path>\n/tmp/foo.py\n</parameter>\n"
+            "<parameter=file_text>\n"
+            "def example():\n"
+            "    # see <parameter=path>...</parameter> in the docs\n"
+            "    return '<parameter=path>nested</parameter>'\n"
+            "</parameter>\n"
+            "</function>"
+        )
+        tool_call = qwen3_coder.parse_tool_call(test_case, tools)
+        self.assertEqual(tool_call["name"], "str_replace_editor")
+        self.assertEqual(tool_call["arguments"]["command"], "create")
+        self.assertEqual(tool_call["arguments"]["path"], "/tmp/foo.py")
+        self.assertIn("<parameter=path>", tool_call["arguments"]["file_text"])
+        self.assertIn("</parameter>", tool_call["arguments"]["file_text"])
+
+        # Object-typed value carrying JSON whose text contains tool-call markup.
+        tools_obj = [
+            {
+                "type": "function",
+                "function": {
+                    "name": "set_filter",
+                    "parameters": {
+                        "type": "object",
+                        "properties": {"spec": {"type": "object"}},
+                    },
+                },
+            }
+        ]
+        test_case = (
+            "<function=set_filter>\n"
+            "<parameter=spec>\n"
+            '{"hint": "use <parameter=name>val</parameter>"}\n'
+            "</parameter>\n"
+            "</function>"
+        )
+        tool_call = qwen3_coder.parse_tool_call(test_case, tools_obj)
+        self.assertEqual(
+            tool_call["arguments"]["spec"],
+            {"hint": "use <parameter=name>val</parameter>"},
+        )
+
     def test_qwen3_coder_single_quoted_params(self):
         tools = [
             {


### PR DESCRIPTION
Two related server-resilience fixes triggered by an agent flow against `mlx-community/Qwen3-Coder-30B-A3B-Instruct-4bit` via `mlx_lm.server`.

## 1. Qwen3-Coder tool parser — nested `<parameter=...>` substrings in values

### Problem

`_parameter_regex` used `<parameter=(.*?)</parameter>` with non-greedy `.*?`. When a value contained text like:

```
<parameter=file_text>
def example():
    # see <parameter=path>...</parameter> in the docs
</parameter>
```

the regex stopped at the first inner `</parameter>`, splitting the value mid-content. The truncated tail was then no longer valid JSON or a valid Python literal, so `_convert_param_value` raised `SyntaxError` from `ast.literal_eval`. That `SyntaxError` is not a `ValueError`/`JSONDecodeError`, so the `except` in `ToolCallFormatter.__call__` did not catch it. The exception escaped into `socketserver.process_request_thread`, producing a noisy traceback in the server log and a half-sent response on the client side.

### Fix

- Rewrite `_parameter_regex` with two capture groups and a trailing lookahead that anchors the closing `</parameter>` to one followed by the next `<parameter=`, the closing `</function>`, or end of input. Literal `<parameter=...>` / `</parameter>` substrings inside a value no longer terminate the match.
- The manual `match_text.index(">")` split is gone — `findall` now returns `(name, value)` directly.
- `except (ValueError, json.JSONDecodeError)` → `except Exception` in `ToolCallFormatter`. Future parser bugs degrade gracefully (warn + skip) instead of corrupting the response.

## 2. `handle_completion` — graceful abort on client disconnect

### Problem

Long generations (large prompt cache + big model) can take many minutes. If the client times out and closes the socket mid-generation, the next `self.wfile.write(...)` raises `BrokenPipeError` (or another `ConnectionError` subclass). The exception bypasses the access-log layer and prints a long traceback. Worse, every retry from the same client repeated the cycle, and each retry kept the model busy generating tokens that nobody was going to read — monopolizing the generation lock and starving subsequent requests.

### Fix

Add `except ConnectionError` (covers `BrokenPipeError`, `ConnectionResetError`, `ConnectionAbortedError`) right before the existing `finally: ctx.stop()`. The teardown then aborts the generation cleanly: `ctx.stop()` halts the token stream, the model becomes available, and a single concise INFO line replaces the traceback in the log.

## Test plan

- [x] `python -m unittest tests.test_tool_parsing` — 6/6, including the new `test_qwen3_coder_value_contains_parameter_tags`.
- [x] `python -m unittest tests.test_server` — 20/20.
- [x] `black --check` clean on all touched files.
- [x] Manually verified against the original failing prompts: parser returns the correct value, server logs no exception when a client disconnects mid-stream, and the generation actually stops (no orphaned compute after disconnect).