### PR TITLE
Fix qwen3_coder tool parser crash on non-numeric int/number params

### DIFF
--- a/mlx_lm/tool_parsers/qwen3_coder.py
+++ b/mlx_lm/tool_parsers/qwen3_coder.py
@@ -54,9 +54,18 @@ def _convert_param_value(param_value: str, param_name: str, param_config: dict) 
         or param_type.startswith("short")
         or param_type.startswith("unsigned")
     ):
-        return int(param_value)
+        # Fall back to the raw string if the model emitted a value that is not a
+        # valid integer (e.g. an ISO 8601 date for an int-typed field). Dropping
+        # the whole tool call is far worse than a slightly mistyped argument.
+        try:
+            return int(param_value)
+        except ValueError:
+            return param_value
     elif param_type.startswith("num") or param_type.startswith("float"):
-        float_param_value = float(param_value)
+        try:
+            float_param_value = float(param_value)
+        except ValueError:
+            return param_value
         int_param_value = int(float_param_value)
         return (
             float_param_value

--- a/tests/test_tool_parsing.py
+++ b/tests/test_tool_parsing.py
@@ -197,6 +197,46 @@ class TestToolParsing(unittest.TestCase):
         self.assertEqual(tool_call["arguments"]["filters"], {"category": "books"})
         self.assertEqual(tool_call["arguments"]["tags"], ["fiction", "new"])
 
+    def test_qwen3_coder_unparseable_numeric_params(self):
+        # A non-numeric value for an int/number-typed field must fall back to the
+        # raw string instead of raising and dropping the whole tool call.
+        tools = [
+            {
+                "type": "function",
+                "function": {
+                    "name": "log_event",
+                    "parameters": {
+                        "type": "object",
+                        "properties": {
+                            "day": {"type": "integer"},
+                            "score": {"type": "number"},
+                        },
+                    },
+                },
+            }
+        ]
+        test_case = (
+            "<function=log_event>"
+            "<parameter=day>2026-01-15</parameter>"
+            "<parameter=score>not-a-number</parameter>"
+            "</function>"
+        )
+        tool_call = qwen3_coder.parse_tool_call(test_case, tools)
+        self.assertEqual(tool_call["name"], "log_event")
+        self.assertEqual(tool_call["arguments"]["day"], "2026-01-15")
+        self.assertEqual(tool_call["arguments"]["score"], "not-a-number")
+
+        # Valid numeric values must still be coerced to int/number.
+        test_case = (
+            "<function=log_event>"
+            "<parameter=day>15</parameter>"
+            "<parameter=score>3.5</parameter>"
+            "</function>"
+        )
+        tool_call = qwen3_coder.parse_tool_call(test_case, tools)
+        self.assertEqual(tool_call["arguments"]["day"], 15)
+        self.assertEqual(tool_call["arguments"]["score"], 3.5)
+
     def test_gemma4(self):
         # Nested object
         test_case = 'call:configure{settings:{enabled:true,name:<|"|>test<|"|>}}'


### PR DESCRIPTION
Relates to #1236.

## Summary

`qwen3_coder._convert_param_value` coerces parameter values to `int()`/`float()` based on the schema type, but those calls are unguarded. When a model emits a non-numeric string for an `integer`- or `number`-typed field, the coercion raises `ValueError`, which aborts parsing and **drops the entire tool call**.

```python
from mlx_lm.tool_parsers import qwen3_coder

tools = [{"function": {"name": "f", "parameters": {"properties": {"x": {"type": "integer"}}}}}]
out = "<function=f><parameter=x>2026-01-15</parameter></function>"
qwen3_coder.parse_tool_call(out, tools)
# ValueError: invalid literal for int() with base 10: '2026-01-15'
# (a "number"-typed field raises the analogous float() error)
```

## Fix

Fall back to the raw string when `int()`/`float()` coercion fails, matching how the object/array branch already tolerates values that are neither valid JSON nor valid Python literals. A slightly mistyped argument is far better than dropping the call.

This complements #1310 / #1239, which guard the `ast.literal_eval` branch of the same function; the `int()`/`float()` branches were the remaining unguarded coercions (I noted this while reviewing #1310). Together they close the crash class described in #1236.

## Testing

- New `test_qwen3_coder_unparseable_numeric_params`: a non-numeric value for an int/number field falls back to the raw string, while valid numeric values are still coerced to `int`/`float`.
- Full `tests/test_tool_parsing.py` suite passes.