### PR TITLE
Fix seeded stochastic completions in the server

### DIFF
--- a/mlx_lm/sample_utils.py
+++ b/mlx_lm/sample_utils.py
@@ -16,6 +16,7 @@ def make_sampler(
     xtc_probability: float = 0.0,
     xtc_threshold: float = 0.0,
     xtc_special_tokens: List[int] = [],
+    use_compiled_sampling: bool = True,
 ) -> Callable[[mx.array], mx.array]:
     """
     Make a sampler function for use with ``generate_step``.
@@ -37,6 +38,8 @@ def make_sampler(
             for being sampled.
         xtc_special_tokens (list(int), optional): List of special tokens IDs to
             be excluded from XTC sampling.
+        use_compiled_sampling (bool, optional): If ``False``, stochastic
+            sampling uses uncompiled random operations. Default: ``True``.
 
 
     Returns:
@@ -53,8 +56,9 @@ def make_sampler(
     if min_p != 0.0:
         sampling_methods.append(lambda x: apply_min_p(x, min_p, min_tokens_to_keep))
     if xtc_probability > 0.0:
+        xtc_fn = apply_xtc if use_compiled_sampling else apply_xtc_uncompiled
         sampling_methods.append(
-            lambda x: apply_xtc(x, xtc_probability, xtc_threshold, xtc_special_tokens)
+            lambda x: xtc_fn(x, xtc_probability, xtc_threshold, xtc_special_tokens)
         )
     if top_k > 0:
         sampling_methods.append(lambda x: apply_top_k(x, top_k))
@@ -64,7 +68,9 @@ def make_sampler(
         for method in sampling_methods:
             logprobs = method(logprobs)
         # Return the sampled token
-        return categorical_sampling(logprobs, temp)
+        if use_compiled_sampling:
+            return categorical_sampling(logprobs, temp)
+        return categorical_sampling_uncompiled(logprobs, temp)
 
     return sampler
 
@@ -276,6 +282,37 @@ def apply_xtc(
 
 @partial(mx.compile, inputs=mx.random.state, outputs=mx.random.state)
 def categorical_sampling(logits, temp):
+    return mx.random.categorical(logits * (1 / temp))
+
+
+def apply_xtc_uncompiled(
+    logits: mx.array,
+    xtc_probability: float,
+    xtc_threshold: float,
+    xtc_special_tokens: List[int],
+) -> mx.array:
+    if not (0 <= xtc_threshold <= 0.5):
+        raise ValueError(
+            f"`threshold` has to be a float in the [0, 0.5] interval, but is {xtc_threshold}"
+        )
+    if not (0 <= xtc_probability <= 1.0):
+        raise ValueError(
+            f"`probability` has to be a float in the [0, 1] interval, but is {xtc_probability}"
+        )
+
+    probs = mx.softmax(logits, -1)
+    mask = probs > mx.where(probs > xtc_threshold, probs, mx.inf).min()
+    if xtc_special_tokens:
+        mask[..., xtc_special_tokens] = False
+
+    return mx.where(
+        mx.random.uniform(0, 1) > xtc_probability,
+        logits,
+        mx.where(mask, -mx.inf, logits),
+    )
+
+
+def categorical_sampling_uncompiled(logits, temp):
     return mx.random.categorical(logits * (1 / temp))
 
 

--- a/mlx_lm/server.py
+++ b/mlx_lm/server.py
@@ -36,6 +36,7 @@ from ._version import __version__
 from .generate import (
     BatchGenerator,
     SequenceStateMachine,
+    generation_stream,
     stream_generate,
 )
 from .models.cache import (
@@ -408,6 +409,11 @@ def _make_sampler(args, tokenizer):
             tokenizer.eos_token_id,
             tokenizer.encode("\n"),
         ],
+        # Compiled random sampling captures RNG state and ignores per-request
+        # reseeding in server worker threads.
+        use_compiled_sampling=not (
+            args.seed is not None and args.sampling.temperature > 0
+        ),
     )
 
 
@@ -685,6 +691,12 @@ class ResponseGenerator:
     def _is_batchable(self, args):
         return self.model_provider.is_batchable and args.seed is None
 
+    def _uses_stochastic_sampling(self, args):
+        return args.sampling.temperature > 0
+
+    def _can_use_prompt_cache(self, args):
+        return not (args.seed is not None and self._uses_stochastic_sampling(args))
+
     def _generate(self):
         # Local thread stream that we 'll pass to the BatchGenerator to make
         # sure that all generation runs in the same stream as the
@@ -749,11 +761,16 @@ class ResponseGenerator:
                         initial_state,
                     )
 
-                    self._log_cache_stats()
-                    cache, rest = self.prompt_cache.fetch_nearest_cache(
-                        current_model_key, prompt
-                    )
-                    prompt_cache_count = len(prompt) - len(rest)
+                    use_prompt_cache = self._can_use_prompt_cache(args)
+                    if use_prompt_cache:
+                        self._log_cache_stats()
+                        cache, rest = self.prompt_cache.fetch_nearest_cache(
+                            current_model_key, prompt
+                        )
+                        prompt_cache_count = len(prompt) - len(rest)
+                    else:
+                        cache, rest = None, prompt
+                        prompt_cache_count = 0
                     N = prompt_cache_count
                     while N > 0:
                         if N >= len(segments[0]):
@@ -788,11 +805,15 @@ class ResponseGenerator:
                         "detokenizer": tokenizer.detokenizer,
                         "segment_types": segment_types[::-1],
                         "top_logprobs": args.top_logprobs,
+                        "use_prompt_cache": use_prompt_cache,
                     }
                     # just making sure we don't leave a reference around
                     del cache
 
-                    if self.model_provider.cli_args.prompt_cache_bytes is not None:
+                    if (
+                        use_prompt_cache
+                        and self.model_provider.cli_args.prompt_cache_bytes is not None
+                    ):
                         total = self.model_provider.cli_args.prompt_cache_bytes
                         active = batch_generator.prompt_cache_nbytes
                         self.prompt_cache.trim_to(n_bytes=total - active)
@@ -868,6 +889,7 @@ class ResponseGenerator:
                         if r.end_of_segment
                         and not r.end_of_prompt
                         and batch_results[r.uid]["segment_types"]
+                        and batch_results[r.uid]["use_prompt_cache"]
                     ]
                     caches = batch_generator.extract_cache(eos_ids)
                     for uid, (cache, cache_key) in caches.items():
@@ -900,12 +922,13 @@ class ResponseGenerator:
 
                         if r.finish_reason is not None:
                             result["rqueue"].put(None)
-                            self.prompt_cache.insert_cache(
-                                current_model_key,
-                                r.all_tokens[:],
-                                r.prompt_cache,
-                                cache_type="assistant",
-                            )
+                            if result["use_prompt_cache"]:
+                                self.prompt_cache.insert_cache(
+                                    current_model_key,
+                                    r.all_tokens[:],
+                                    r.prompt_cache,
+                                    cache_type="assistant",
+                                )
                             del batch_results[r.uid]
 
                         if result["ctx"]._should_stop:
@@ -954,18 +977,24 @@ class ResponseGenerator:
 
             # Seed if requested
             if args.seed is not None:
-                mx.random.seed(args.seed)
+                with mx.stream(generation_stream):
+                    mx.random.seed(args.seed)
 
             # Make the sampler and logit processor
             sampler = _make_sampler(args, tokenizer)
             logits_processors = _make_logits_processors(args)
 
             # Load the KV cache
-            self._log_cache_stats()
-            cache, rest = self.prompt_cache.fetch_nearest_cache(
-                self.model_provider.model_key, prompt
-            )
-            ctx.prompt_cache_count = len(prompt) - len(rest)
+            use_prompt_cache = self._can_use_prompt_cache(args)
+            if use_prompt_cache:
+                self._log_cache_stats()
+                cache, rest = self.prompt_cache.fetch_nearest_cache(
+                    self.model_provider.model_key, prompt
+                )
+                ctx.prompt_cache_count = len(prompt) - len(rest)
+            else:
+                cache, rest = None, prompt
+                ctx.prompt_cache_count = 0
             cache_key = prompt[:]
             if cache is None:
                 cache = make_prompt_cache(self.model_provider.model)
@@ -1016,9 +1045,10 @@ class ResponseGenerator:
             rqueue.put(None)
 
             # Save the KV cache again
-            self.prompt_cache.insert_cache(
-                self.model_provider.model_key, cache_key, cache
-            )
+            if use_prompt_cache:
+                self.prompt_cache.insert_cache(
+                    self.model_provider.model_key, cache_key, cache
+                )
 
         except Exception as e:
             rqueue.put(e)

--- a/tests/test_sample_utils.py
+++ b/tests/test_sample_utils.py
@@ -116,6 +116,50 @@ class TestSampleUtils(unittest.TestCase):
         new_probs = mx.softmax(apply_xtc(mx.log(probs), 0, 0.1, [0]), -1)
         self.assertTrue(mx.allclose(new_probs, probs))
 
+    def test_uncompiled_sampler_respects_seed_in_thread(self):
+        import queue
+        import threading
+
+        from mlx_lm.sample_utils import make_sampler
+
+        results = queue.Queue()
+        sampler_kwargs_list = [
+            {},
+            {"top_p": 0.9},
+            {"top_k": 2},
+            {"min_p": 0.05},
+            {"xtc_probability": 0.5, "xtc_threshold": 0.1},
+        ]
+
+        def worker():
+            logprobs = mx.array([[0.1, 0.2, 0.3, 0.4]])
+            for sampler_kwargs in sampler_kwargs_list:
+                sampler = make_sampler(
+                    temp=1.0,
+                    use_compiled_sampling=False,
+                    **sampler_kwargs,
+                )
+                for seed in [111, 222, 111]:
+                    mx.random.seed(seed)
+                    samples = [sampler(logprobs).item() for _ in range(5)]
+                    results.put((sampler_kwargs, seed, samples))
+
+        thread = threading.Thread(target=worker)
+        thread.start()
+        thread.join()
+
+        for _ in range(len(sampler_kwargs_list)):
+            first = results.get()
+            second = results.get()
+            third = results.get()
+
+            with self.subTest(sampler_kwargs=first[0]):
+                self.assertEqual(first[0], second[0])
+                self.assertEqual(first[0], third[0])
+                self.assertEqual(first[1], third[1])
+                self.assertEqual(first[2], third[2])
+                self.assertNotEqual(first[2], second[2])
+
     def test_presence_penalty(self):
         from mlx_lm.sample_utils import make_presence_penalty
 

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -207,6 +207,56 @@ class TestServer(unittest.TestCase):
             json.loads(requests.post(url, json=post_data).text)["choices"][0]["text"],
         )
 
+    def test_handle_completions_different_seeds_do_not_replay_cache(self):
+        url = f"http://localhost:{self.port}/v1/completions"
+
+        post_data = {
+            "model": "default_model",
+            "prompt": "Once upon a time",
+            "max_tokens": 10,
+            "temperature": 0.5,
+            "top_p": 0.9,
+            "repetition_penalty": 1.1,
+            "repetition_context_size": 20,
+            "stop": "stop sequence",
+        }
+
+        completions = []
+        for seed in [111, 222, 333]:
+            response = requests.post(url, json=dict(post_data, seed=seed))
+            response_body = json.loads(response.text)
+            completions.append(response_body["choices"][0]["text"])
+
+        self.assertGreater(len(set(completions)), 1)
+
+    def test_prompt_cache_policy_only_bypasses_seeded_stochastic_requests(self):
+        generator = self.response_generator
+
+        self.assertFalse(generator._is_batchable(types.SimpleNamespace(seed=999)))
+        self.assertTrue(generator._is_batchable(types.SimpleNamespace(seed=None)))
+
+        self.assertFalse(
+            generator._can_use_prompt_cache(
+                types.SimpleNamespace(
+                    seed=999, sampling=types.SimpleNamespace(temperature=0.5)
+                )
+            )
+        )
+        self.assertTrue(
+            generator._can_use_prompt_cache(
+                types.SimpleNamespace(
+                    seed=None, sampling=types.SimpleNamespace(temperature=0.5)
+                )
+            )
+        )
+        self.assertTrue(
+            generator._can_use_prompt_cache(
+                types.SimpleNamespace(
+                    seed=999, sampling=types.SimpleNamespace(temperature=0)
+                )
+            )
+        )
+
     def test_handle_chat_completions(self):
         url = f"http://localhost:{self.port}/v1/chat/completions"
         chat_post_data = {


### PR DESCRIPTION
## Summary

Fixes #1245.

The server accepts a `seed` parameter, but stochastic completions could still ignore per-request reseeding in a long-lived server process. The sampled path could keep using compiled random sampling across requests, and generated prompt-cache entries could replay a previous sampled assistant continuation for a later seeded request.

This keeps the default compiled sampler path for normal generation, but has the server use uncompiled random sampling only when a request is both seeded and stochastic. It also bypasses prompt-cache reuse for seeded stochastic requests to avoid reusing sampled assistant state across seed changes, while preserving the existing cache behavior for deterministic requests and unseeded stochastic requests.

## Changes

- Add a `use_compiled_sampling` option to `make_sampler()`, defaulting to the current compiled behavior.
- Add uncompiled random-sampling paths for categorical sampling and XTC so per-request `mx.random.seed()` is honored in the server's generation thread.
- Seed the server generation stream for requests that pass `seed`.
- Bypass prompt-cache fetch/insert for seeded stochastic requests only.
- Add regression coverage for threaded sampler seeding and server cache replay behavior.

## Verification

- `pytest tests/test_sample_utils.py::TestSampleUtils::test_uncompiled_sampler_respects_seed_in_thread tests/test_server.py::TestServer::test_handle_completions tests/test_server.py::TestServer::test_handle_completions_different_seeds_do_not_replay_cache tests/test_server.py::TestServer::test_prompt_cache_policy_only_bypasses_seeded_stochastic_requests -q`
- `pytest tests/test_sample_utils.py tests/test_server.py -q`
- `git diff --check`
