### PR TITLE
Fix LFM2.5 pythonic tool parser auto-detection

### DIFF
--- a/mlx_lm/tokenizer_utils.py
+++ b/mlx_lm/tokenizer_utils.py
@@ -559,7 +559,9 @@ def _infer_tool_parser(chat_template):
         return "longcat"
     elif "<arg_key>" in chat_template:
         return "glm47"
-    elif "<|tool_list_start|>" in chat_template:
+    elif (
+        "<|tool_list_start|>" in chat_template or "<|tool_call_start|>" in chat_template
+    ):
         return "pythonic"
     elif (
         "<tool_call>\\n<function=" in chat_template

--- a/tests/test_tokenizers.py
+++ b/tests/test_tokenizers.py
@@ -9,6 +9,7 @@ from mlx_lm.tokenizer_utils import (
     BPEStreamingDetokenizer,
     NaiveStreamingDetokenizer,
     SPMStreamingDetokenizer,
+    _infer_tool_parser,
 )
 from mlx_lm.utils import load_tokenizer
 
@@ -108,6 +109,30 @@ class TestTokenizers(unittest.TestCase):
         self.assertIsNone(tokenizer.think_end)
         self.assertIsNone(tokenizer.think_start_id)
         self.assertIsNone(tokenizer.think_end_id)
+
+    def test_infer_tool_parser(self):
+        # LFM2 (original) uses <|tool_list_start|> ... <|tool_list_end|>.
+        lfm2_template = (
+            "{%- if tools %}<|tool_list_start|>{{ tools | tojson }}"
+            "<|tool_list_end|>{% endif -%}"
+        )
+        self.assertEqual(_infer_tool_parser(lfm2_template), "pythonic")
+
+        # LFM2.5 renamed the tokens to <|tool_call_start|> ... <|tool_call_end|>
+        # while keeping the same pythonic call format inside.
+        # See https://huggingface.co/LiquidAI/LFM2.5-8B-A1B for the template.
+        lfm25_template = (
+            "{%- macro render_tool_calls(tool_calls) -%}"
+            "{{- '<|tool_call_start|>[' + "
+            "(tool_calls_ns.tool_calls | join(', ')) + "
+            "']<|tool_call_end|>' -}}"
+            "{%- endmacro -%}"
+        )
+        self.assertEqual(_infer_tool_parser(lfm25_template), "pythonic")
+
+        # Sanity: a template with neither token should not match pythonic.
+        self.assertIsNone(_infer_tool_parser("plain template, no tool tokens"))
+        self.assertIsNone(_infer_tool_parser(None))
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## What

`_infer_tool_parser()` in `tokenizer_utils.py` detects the pythonic tool-call
format via the chat-template token `<|tool_list_start|>`. LFM2.5 renamed those
delimiters to `<|tool_call_start|>` / `<|tool_call_end|>` (the inner pythonic
call format is unchanged), so the detection misses for every LFM2.5
checkpoint — including the official `LiquidAI/LFM2.5-8B-A1B`,
`LiquidAI/LFM2.5-8B-A1B-MLX-8bit`, `LiquidAI/LFM2.5-1.2B-Thinking`, etc.

Symptom: loading any LFM2.5 model gives `tokenizer.has_tool_calling == False`,
so `mlx_lm.server`'s `/v1/chat/completions` returns tool calls as raw
`<|tool_call_start|>[func(arg='val')]<|tool_call_end|>` text inside
`message.content`, with `tool_calls = []` and `finish_reason = "stop"`.
OpenAI-compatible clients (Mastra, LangChain, ai-sdk, …) see no tool call and
the agent loop breaks.

## Fix

Match either token. The `pythonic` parser already handles both formats — only
the auto-detection needed updating.

```python
elif (
    "<|tool_list_start|>" in chat_template
    or "<|tool_call_start|>" in chat_template
):
    return "pythonic"
```

Same root cause and fix shape as the parallel `llama.cpp` issue
[ggml-org/llama.cpp#23838](https://github.com/ggml-org/llama.cpp/issues/23838),
and the same class of token-rename detection lag that prompted the Gemma 4
auto-detect addition.

## Test

Added `TestTokenizers.test_infer_tool_parser` in `tests/test_tokenizers.py`
covering:

- LFM2 original template (`<|tool_list_start|>`) — still returns `"pythonic"`
- LFM2.5 template (`<|tool_call_start|>`) — now returns `"pythonic"` (was `None`)
- Negative path (no tool tokens, and `None` input)

This is a pure unit test against `_infer_tool_parser`, so no HF download —
fast and deterministic. Verified locally that the new test fails on `main`
without the fix and passes with it.

End-to-end verified against the real `LiquidAI/LFM2.5-8B-A1B-MLX-8bit`
tokenizer:

```python
>>> from mlx_lm.utils import load_tokenizer
>>> tok = load_tokenizer("LiquidAI/LFM2.5-8B-A1B-MLX-8bit")
>>> tok.has_tool_calling
True
>>> tok.tool_call_start, tok.tool_call_end
('<|tool_call_start|>', '<|tool_call_end|>')
```

And via `mlx_lm.server` `/v1/chat/completions` with a `tools` payload — after
the fix, the response now correctly returns:

```json
{
  "finish_reason": "tool_calls",
  "message": {
    "tool_calls": [{
      "function": {"name": "...", "arguments": "{\"query\": \"...\"}"},
      "type": "function",
      "id": "..."
    }]
  }
}
```

All existing `tests/test_tool_parsing.py` and `tests/test_tokenizers.py` tests
still pass; ran `black` (25.1.0) and `isort --profile=black` per
`CONTRIBUTING.md`.