### PR TITLE
Fix json_tools: match "<tool_call" prefix to survive ">" token merge

### DIFF
--- a/mlx_lm/tool_parsers/json_tools.py
+++ b/mlx_lm/tool_parsers/json_tools.py
@@ -2,10 +2,46 @@
 
 import json
 
-tool_call_start = "<tool_call>"
+# The start marker intentionally omits the closing ">". Tool-call markers are matched as
+# exact token-id sequences, and "<tool_call>" encodes to a run ending in a standalone ">"
+# token. Many tokenizers merge that ">" with the following byte (e.g. "<tool_call>\n" -> a
+# single ">\n" token), so the full-marker token run never appears in the generated stream
+# and the call is never captured. Matching the stable "<tool_call" prefix avoids this;
+# parse_tool_call() below tolerates the leftover ">" before the JSON.
+tool_call_start = "<tool_call"
 
 tool_call_end = "</tool_call>"
 
 
 def parse_tool_call(text, tools=None):
-    return json.loads(text.strip())
+    """Extract the first brace-balanced JSON object from the captured tool segment.
+
+    Robust to a leading ">"/newline left by the prefix start marker and to a trailing
+    "</tool_call>" if the end marker likewise merges. Output is identical to
+    json.loads(text.strip()) for a clean JSON-only segment.
+    """
+    start = text.find("{")
+    if start == -1:
+        raise ValueError("no JSON object in tool call segment")
+    depth = 0
+    in_str = False
+    esc = False
+    for i in range(start, len(text)):
+        c = text[i]
+        if in_str:
+            if esc:
+                esc = False
+            elif c == "\\":
+                esc = True
+            elif c == '"':
+                in_str = False
+            continue
+        if c == '"':
+            in_str = True
+        elif c == "{":
+            depth += 1
+        elif c == "}":
+            depth -= 1
+            if depth == 0:
+                return json.loads(text[start : i + 1])
+    raise ValueError("unbalanced JSON in tool call segment")

--- a/tests/test_tool_parsing.py
+++ b/tests/test_tool_parsing.py
@@ -207,6 +207,28 @@ class TestToolParsing(unittest.TestCase):
             {"settings": {"enabled": True, "name": "test"}},
         )
 
+    def test_json_tools_marker_merge(self):
+        # The start marker is "<tool_call" (without the closing ">", which many tokenizers
+        # merge with the next byte). The server therefore captures the tool segment starting
+        # at the leftover ">", and the segment may also include a trailing "</tool_call>" if
+        # that marker's tokens merge too. parse_tool_call must extract the JSON regardless.
+        expected = {"name": "get_weather", "arguments": {"city": "Paris"}}
+        variants = [
+            '{"name": "get_weather", "arguments": {"city": "Paris"}}',  # clean (backward-compat)
+            '>\n{"name": "get_weather", "arguments": {"city": "Paris"}}\n',  # leftover ">"
+            '>\n{"name": "get_weather", "arguments": {"city": "Paris"}}\n</tool_call>',  # + end marker
+        ]
+        for text in variants:
+            with self.subTest(text=text):
+                self.assertEqual(json_tools.parse_tool_call(text, None), expected)
+
+        # nested braces and a "}" inside a string value must not truncate extraction
+        text = '{"name": "f", "arguments": {"expr": "a{b}c", "n": {"k": 2}}}'
+        self.assertEqual(
+            json_tools.parse_tool_call(text, None),
+            {"name": "f", "arguments": {"expr": "a{b}c", "n": {"k": 2}}},
+        )
+
         # Array of strings
         test_case = 'call:tag{items:[<|"|>foo<|"|>,<|"|>bar<|"|>]}'
         tool_call = gemma4.parse_tool_call(test_case, None)


### PR DESCRIPTION
Fixes https://github.com/ml-explore/mlx-lm/issues/1335.

### Cause
Tool-call detection matches markers as **exact token-id sequences** (`SequenceStateMachine`, Aho-Corasick). `json_tools.tool_call_start = "<tool_call>"` encodes to a run ending in a **standalone `>` token** — but many tokenizers merge that `>` with the following byte (`<tool_call>\n` → a single `>\n` token), so the precomputed marker is never a contiguous subsequence of the generated stream. The state machine never enters the `tool` state and a valid tool call is returned as assistant content with `tool_calls = null`. (Token IDs + a deterministic reproducer in the issue.)

### Change
`mlx_lm/tool_parsers/json_tools.py`:
- Start marker → `"<tool_call"` (drop the volatile `>`; the `<`,`tool`,`_call` tokens are stable).
- `parse_tool_call` extracts the **first brace-balanced JSON object**, tolerating the leftover `>`/newline that the wider capture now includes and a trailing `</tool_call>` if that marker likewise merges.

### Why it's safe
- **Backward-compatible:** `<tool_call` is a subsequence of what currently-matching models emit, and brace extraction returns output **identical** to `json.loads(text.strip())` for clean segments. The existing `json_tools` cases in `tests/test_tool_parsing.py` (clean JSON, nested braces) still pass.
- **Streaming unaffected:** `server.py` accumulates the entire `tool` segment (`tool_text`) while in the tool state and only calls `parse_tool_call` after the transition back to `normal`, so the leftover `>` never leaks into a streamed delta.

### Tests
Adds `test_json_tools_marker_merge` (clean JSON, leftover-`>`, trailing-`</tool_call>`, nested-brace/`}`-in-string). `python -m unittest tests.test_tool_parsing` → all pass.

### Verification (end-to-end)
On `mlx-community/DeepSeek-V4-Flash-2bit-DQ` (markers not special tokens; `>` merges): tool-call parse rate **0/4 → 4/4** on a probe and **8/40 → 33/40** on jdhodges tool-calling — same checkpoint, no other change.

### Note for reviewers
This changes the shared `json_tools` parser. I validated output-identity for clean input and the streaming path, but couldn't test against a live Qwen2.5/Hermes model — happy to gate this behind a separate parser (e.g. `json_tools_lenient`) or adjust the approach if you'd prefer. Full analysis: [writeup](https://github.com/snagnever/macstudio-local-llm/blob/deepseek-v4-tool-template/docs/mlx-lm-tool-call-marker-merge-writeup.md).
