### PR TITLE
feat(gpt-oss): support unsloth BF16 layout + shared MoE LoRA adapters

### DIFF
--- a/mlx_lm/models/gpt_oss.py
+++ b/mlx_lm/models/gpt_oss.py
@@ -244,6 +244,15 @@ class Model(nn.Module):
         if any("gate_proj.weight" in k for k in weights.keys()):
             return weights  # already sanitized
 
+        hidden_size = self.args.hidden_size
+        intermediate_size = self.args.intermediate_size
+
+        def _ensure_weight_suffix(key):
+            # HF/unsloth BF16 checkpoints omit .weight on experts.{gate,up,down}_proj.
+            if key.endswith(".weight") or key.endswith(".scales"):
+                return key
+            return key + ".weight"
+
         new_weights = {}
         for k, v in weights.items():
             if "gate_up_proj" in k and "bias" not in k:
@@ -252,20 +261,46 @@ class Model(nn.Module):
                     k = k.replace("_blocks", ".weight")
                 if "_scales" in k:
                     k = k.replace("_scales", ".scales")
-                new_weights[k.replace("gate_up_proj", "gate_proj")] = mx.contiguous(
-                    v[..., ::2, :]
+                # Two known storage layouts for fused gate_up_proj, both
+                # interleaved (gate, up, gate, up, ...) along the 2*intermediate
+                # axis:
+                #  (a) openai/MXFP4   : (E, 2H, D)   interleaved on axis -2.
+                #  (b) unsloth/HF BF16: (E, D, 2H)  interleaved on axis -1.
+                # Normalize layout (b) to (a) via swapaxes(-1, -2), then split on -2.
+                if (
+                    v.shape[-1] == 2 * intermediate_size
+                    and v.shape[-2] == hidden_size
+                ):
+                    v = v.swapaxes(-1, -2)
+                gate_slice = v[..., ::2, :]
+                up_slice = v[..., 1::2, :]
+                gate_key = _ensure_weight_suffix(
+                    k.replace("gate_up_proj", "gate_proj")
                 )
-                new_weights[k.replace("gate_up_proj", "up_proj")] = mx.contiguous(
-                    v[..., 1::2, :]
+                up_key = _ensure_weight_suffix(
+                    k.replace("gate_up_proj", "up_proj")
                 )
+                new_weights[gate_key] = mx.contiguous(gate_slice)
+                new_weights[up_key] = mx.contiguous(up_slice)
             elif "down_proj" in k and "bias" not in k:
                 if "_blocks" in k:
                     v = v.view(mx.uint32).flatten(-2)
                     k = k.replace("_blocks", ".weight")
                 if "_scales" in k:
                     k = k.replace("_scales", ".scales")
-                new_weights[k] = v
+                # openai stores down_proj as (E, hidden, intermediate) i.e.
+                # (E, out, in). unsloth/HF BF16 stores (E, intermediate, hidden)
+                # i.e. (E, in, out) -> transpose to match SwitchLinear convention.
+                if (
+                    v.shape[-2] == intermediate_size
+                    and v.shape[-1] == hidden_size
+                    and intermediate_size != hidden_size
+                ):
+                    v = v.swapaxes(-1, -2)
+                k = _ensure_weight_suffix(k)
+                new_weights[k] = mx.contiguous(v)
             elif "gate_up_proj_bias" in k:
+                # Bias is interleaved on the 2*intermediate axis in both layouts.
                 new_weights[k.replace("gate_up_proj_bias", "gate_proj.bias")] = (
                     mx.contiguous(v[..., ::2])
                 )

--- a/mlx_lm/models/gpt_oss.py
+++ b/mlx_lm/models/gpt_oss.py
@@ -253,6 +253,25 @@ class Model(nn.Module):
                 return key
             return key + ".weight"
 
+        # Detect checkpoint layout up front. Two layouts are supported:
+        #   (a) openai/MXFP4   : keys carry `_blocks` / `_scales`; gate_up_proj
+        #       stored as (E, 2*intermediate, hidden); down_proj as
+        #       (E, hidden, intermediate). This is the original mlx-lm path.
+        #   (b) unsloth/HF BF16: bare experts.{gate_up_proj,down_proj} keys
+        #       (no .weight suffix, no _blocks/_scales); gate_up_proj stored as
+        #       (E, hidden, 2*intermediate); down_proj as (E, intermediate, hidden).
+        # Driving the layout off a single explicit signal — the bare gate_up_proj
+        # key whose trailing dim is 2*intermediate_size — avoids shape-arithmetic
+        # ambiguity when hidden_size == intermediate_size (the default GPT-OSS
+        # config), where the two down_proj layouts have identical shape and a
+        # per-tensor shape check would silently misinterpret the unsloth layout
+        # as openai and emit semantically incoherent generations at inference time.
+        is_unsloth_layout = any(
+            k.endswith("experts.gate_up_proj")
+            and weights[k].shape[-1] == 2 * intermediate_size
+            for k in weights.keys()
+        )
+
         new_weights = {}
         for k, v in weights.items():
             if "gate_up_proj" in k and "bias" not in k:
@@ -261,16 +280,11 @@ class Model(nn.Module):
                     k = k.replace("_blocks", ".weight")
                 if "_scales" in k:
                     k = k.replace("_scales", ".scales")
-                # Two known storage layouts for fused gate_up_proj, both
-                # interleaved (gate, up, gate, up, ...) along the 2*intermediate
-                # axis:
-                #  (a) openai/MXFP4   : (E, 2H, D)   interleaved on axis -2.
-                #  (b) unsloth/HF BF16: (E, D, 2H)  interleaved on axis -1.
-                # Normalize layout (b) to (a) via swapaxes(-1, -2), then split on -2.
-                if (
-                    v.shape[-1] == 2 * intermediate_size
-                    and v.shape[-2] == hidden_size
-                ):
+                # Both layouts interleave (gate, up, gate, up, ...) along the
+                # 2*intermediate axis. Layout (a) puts that axis at -2; layout
+                # (b) puts it at -1. Normalize (b) to (a) via swapaxes, then
+                # split on -2.
+                if is_unsloth_layout:
                     v = v.swapaxes(-1, -2)
                 gate_slice = v[..., ::2, :]
                 up_slice = v[..., 1::2, :]
@@ -288,14 +302,13 @@ class Model(nn.Module):
                     k = k.replace("_blocks", ".weight")
                 if "_scales" in k:
                     k = k.replace("_scales", ".scales")
-                # openai stores down_proj as (E, hidden, intermediate) i.e.
-                # (E, out, in). unsloth/HF BF16 stores (E, intermediate, hidden)
-                # i.e. (E, in, out) -> transpose to match SwitchLinear convention.
-                if (
-                    v.shape[-2] == intermediate_size
-                    and v.shape[-1] == hidden_size
-                    and intermediate_size != hidden_size
-                ):
+                # Layout (a) stores down_proj as (E, hidden, intermediate) =
+                # (E, out, in), which matches the SwitchLinear convention
+                # already. Layout (b) stores (E, intermediate, hidden) =
+                # (E, in, out) and must be transposed. Use the explicit
+                # layout signal so this is applied correctly even when
+                # hidden_size == intermediate_size.
+                if is_unsloth_layout:
                     v = v.swapaxes(-1, -2)
                 k = _ensure_weight_suffix(k)
                 new_weights[k] = mx.contiguous(v)

--- a/mlx_lm/tuner/lora.py
+++ b/mlx_lm/tuner/lora.py
@@ -135,8 +135,25 @@ class LoRASwitchLinear(nn.Module):
         num_experts, output_dims, input_dims = weight.shape
         fused_linear = SwitchLinear(input_dims, output_dims, num_experts, bias=bias)
 
-        lora_b = self.scale * self.lora_b
-        lora_a = self.lora_a.reshape(num_experts, -1, input_dims)
+        # Support two adapter formats:
+        #   (a) per-expert (mlx-lm native): lora_a (E, r, D), lora_b (E, out, r).
+        #   (b) shared / PEFT target_parameters: lora_a (r, D), lora_b (out, r).
+        #       Same low-rank update added to every expert -> broadcast to (E, ...).
+        lora_a = self.lora_a
+        lora_b = self.lora_b
+        if lora_a.ndim == 2:
+            # (r, D) -> (E, r, D); same matrix replicated across experts.
+            lora_a = mx.broadcast_to(
+                lora_a[None, :, :], (num_experts, lora_a.shape[0], lora_a.shape[1])
+            )
+        else:
+            lora_a = lora_a.reshape(num_experts, -1, input_dims)
+        if lora_b.ndim == 2:
+            lora_b = mx.broadcast_to(
+                lora_b[None, :, :], (num_experts, lora_b.shape[0], lora_b.shape[1])
+            )
+
+        lora_b = self.scale * lora_b
         fused_linear.weight = weight + (lora_b @ lora_a).astype(weight.dtype)
         if bias:
             fused_linear.bias = linear.bias
@@ -180,18 +197,24 @@ class LoRASwitchLinear(nn.Module):
 
     def __call__(self, x, indices, sorted_indices=False):
         y = self.linear(x, indices, sorted_indices=sorted_indices)
-        z = mx.gather_mm(
-            self.dropout(x),
-            self.lora_a.swapaxes(-1, -2),
-            rhs_indices=indices,
-            sorted_indices=sorted_indices,
-        )
-        z = mx.gather_mm(
-            z,
-            self.lora_b.swapaxes(-1, -2),
-            rhs_indices=indices,
-            sorted_indices=sorted_indices,
-        )
+        # Shared 2D adapter (PEFT target_parameters) -> dense matmul, broadcast to all routed experts.
+        if self.lora_a.ndim == 2 and self.lora_b.ndim == 2:
+            xd = self.dropout(x)
+            z = xd @ self.lora_a.swapaxes(-1, -2)
+            z = z @ self.lora_b.swapaxes(-1, -2)
+        else:
+            z = mx.gather_mm(
+                self.dropout(x),
+                self.lora_a.swapaxes(-1, -2),
+                rhs_indices=indices,
+                sorted_indices=sorted_indices,
+            )
+            z = mx.gather_mm(
+                z,
+                self.lora_b.swapaxes(-1, -2),
+                rhs_indices=indices,
+                sorted_indices=sorted_indices,
+            )
         return y + (self.scale * z).astype(x.dtype)
 
 

--- a/mlx_lm/tuner/lora.py
+++ b/mlx_lm/tuner/lora.py
@@ -139,8 +139,16 @@ class LoRASwitchLinear(nn.Module):
         #   (a) per-expert (mlx-lm native): lora_a (E, r, D), lora_b (E, out, r).
         #   (b) shared / PEFT target_parameters: lora_a (r, D), lora_b (out, r).
         #       Same low-rank update added to every expert -> broadcast to (E, ...).
+        # The two formats are tightly coupled; reject mixed ndim early with a
+        # clear error rather than letting it fail deep inside gather_mm.
         lora_a = self.lora_a
         lora_b = self.lora_b
+        if lora_a.ndim != lora_b.ndim:
+            raise ValueError(
+                "LoRASwitchLinear: lora_a and lora_b must have the same ndim "
+                f"(got {lora_a.ndim} and {lora_b.ndim}). Mix of shared (2D) "
+                "and per-expert (3D) adapters is not supported."
+            )
         if lora_a.ndim == 2:
             # (r, D) -> (E, r, D); same matrix replicated across experts.
             lora_a = mx.broadcast_to(
@@ -197,6 +205,12 @@ class LoRASwitchLinear(nn.Module):
 
     def __call__(self, x, indices, sorted_indices=False):
         y = self.linear(x, indices, sorted_indices=sorted_indices)
+        if self.lora_a.ndim != self.lora_b.ndim:
+            raise ValueError(
+                "LoRASwitchLinear: lora_a and lora_b must have the same ndim "
+                f"(got {self.lora_a.ndim} and {self.lora_b.ndim}). Mix of "
+                "shared (2D) and per-expert (3D) adapters is not supported."
+            )
         # Shared 2D adapter (PEFT target_parameters) -> dense matmul, broadcast to all routed experts.
         if self.lora_a.ndim == 2 and self.lora_b.ndim == 2:
             xd = self.dropout(x)

--- a/tests/test_gpt_oss_sanitize.py
+++ b/tests/test_gpt_oss_sanitize.py
@@ -69,6 +69,59 @@ class TestGptOssSanitize(unittest.TestCase):
         s = m.sanitize(weights)
         self.assertIs(s, weights)
 
+    def test_unsloth_bf16_down_proj_values_unequal_dims(self):
+        """down_proj values are transposed correctly when hidden_size != intermediate_size."""
+        E, D, H = 2, 5, 3
+        # unsloth down_proj layout: (E, intermediate=H, hidden=D).
+        # Mark each (intermediate, hidden) cell with a unique value so a wrong
+        # transpose is detectable.
+        dp = mx.zeros((E, H, D), dtype=mx.float32)
+        for i in range(H):
+            for j in range(D):
+                dp[:, i, j] = float(i * 10 + j)
+        weights = {
+            "model.layers.0.mlp.experts.gate_up_proj":      mx.zeros((E, D, 2 * H), dtype=mx.float32),
+            "model.layers.0.mlp.experts.down_proj":         dp,
+            "model.layers.0.mlp.experts.gate_up_proj_bias": mx.zeros((E, 2 * H),    dtype=mx.float32),
+            "model.layers.0.mlp.experts.down_proj_bias":    mx.zeros((E, D),        dtype=mx.float32),
+        }
+        args = _make_args(hidden_size=D, intermediate_size=H, num_local_experts=E)
+        m = Model(args)
+        s = m.sanitize(weights)
+        out = s["model.layers.0.mlp.experts.down_proj.weight"]
+        # SwitchLinear convention: (E, out=hidden=D, in=intermediate=H).
+        self.assertEqual(out.shape, (E, D, H))
+        # Verify the swap was applied: out[:, j, i] == i*10 + j.
+        for i in range(H):
+            for j in range(D):
+                self.assertEqual(out[0, j, i].item(), float(i * 10 + j))
+
+    def test_unsloth_bf16_down_proj_values_equal_dims(self):
+        """Regression guard: with hidden_size == intermediate_size the unsloth
+        down_proj must still be transposed (the previous shape-only guard
+        skipped it and emitted noise at inference time)."""
+        E, D = 2, 4
+        H = D  # equal dims — exactly the default GPT-OSS config.
+        # Asymmetric values so a missed transpose is detectable.
+        dp = mx.zeros((E, H, D), dtype=mx.float32)
+        for i in range(H):
+            for j in range(D):
+                dp[:, i, j] = float(i * 10 + j)
+        weights = {
+            "model.layers.0.mlp.experts.gate_up_proj":      mx.zeros((E, D, 2 * H), dtype=mx.float32),
+            "model.layers.0.mlp.experts.down_proj":         dp,
+            "model.layers.0.mlp.experts.gate_up_proj_bias": mx.zeros((E, 2 * H),    dtype=mx.float32),
+            "model.layers.0.mlp.experts.down_proj_bias":    mx.zeros((E, D),        dtype=mx.float32),
+        }
+        args = _make_args(hidden_size=D, intermediate_size=H, num_local_experts=E)
+        m = Model(args)
+        s = m.sanitize(weights)
+        out = s["model.layers.0.mlp.experts.down_proj.weight"]
+        self.assertEqual(out.shape, (E, D, H))
+        for i in range(H):
+            for j in range(D):
+                self.assertEqual(out[0, j, i].item(), float(i * 10 + j))
+
     def test_openai_interleaved_layout_preserved(self):
         """Layout (a): (E, 2H, D) — split on axis -2 as before."""
         E, D, H = 32, 2880, 2880

--- a/tests/test_gpt_oss_sanitize.py
+++ b/tests/test_gpt_oss_sanitize.py
@@ -1,0 +1,89 @@
+"""Tests for GPT-OSS sanitize() supporting both openai/MXFP4 and unsloth/HF BF16 layouts."""
+import unittest
+
+import mlx.core as mx
+
+from mlx_lm.models.gpt_oss import Model, ModelArgs
+
+
+def _make_args(hidden_size=2880, intermediate_size=2880, num_local_experts=32):
+    return ModelArgs(
+        num_hidden_layers=2,
+        layer_types=["sliding_attention", "full_attention"],
+        hidden_size=hidden_size,
+        intermediate_size=intermediate_size,
+        num_local_experts=num_local_experts,
+    )
+
+
+class TestGptOssSanitize(unittest.TestCase):
+    def test_unsloth_bf16_shapes_and_weight_suffix(self):
+        """Layout (b): (E, D, 2H) experts.gate_up_proj + missing .weight suffix."""
+        E, D, H = 32, 2880, 2880
+        weights = {
+            "model.layers.0.mlp.experts.gate_up_proj":      mx.zeros((E, D, 2 * H), dtype=mx.bfloat16),
+            "model.layers.0.mlp.experts.down_proj":         mx.zeros((E, D, D),     dtype=mx.bfloat16),
+            "model.layers.0.mlp.experts.gate_up_proj_bias": mx.zeros((E, 2 * H),    dtype=mx.bfloat16),
+            "model.layers.0.mlp.experts.down_proj_bias":    mx.zeros((E, D),        dtype=mx.bfloat16),
+        }
+        m = Model(_make_args())
+        s = m.sanitize(weights)
+        self.assertEqual(s["model.layers.0.mlp.experts.gate_proj.weight"].shape, (E, H, D))
+        self.assertEqual(s["model.layers.0.mlp.experts.up_proj.weight"].shape,   (E, H, D))
+        self.assertEqual(s["model.layers.0.mlp.experts.down_proj.weight"].shape, (E, D, H))
+        self.assertEqual(s["model.layers.0.mlp.experts.gate_proj.bias"].shape, (E, H))
+        self.assertEqual(s["model.layers.0.mlp.experts.up_proj.bias"].shape,   (E, H))
+
+    def test_unsloth_bf16_interleaved_split_values(self):
+        """Both layouts use interleaved gate/up split on the 2*H axis."""
+        E, D, H = 2, 4, 3
+        # Storage (E, D, 2H): along axis -1, mark even slots with 1.0 (gate)
+        # and odd slots with 2.0 (up).
+        v = mx.zeros((E, D, 2 * H), dtype=mx.float32)
+        idx_even = mx.arange(0, 2 * H, 2)
+        idx_odd = mx.arange(1, 2 * H, 2)
+        for i in idx_even.tolist():
+            v[:, :, i] = 1.0
+        for i in idx_odd.tolist():
+            v[:, :, i] = 2.0
+        weights = {
+            "model.layers.0.mlp.experts.gate_up_proj":      v,
+            "model.layers.0.mlp.experts.down_proj":         mx.zeros((E, D, D), dtype=mx.float32),
+            "model.layers.0.mlp.experts.gate_up_proj_bias": mx.zeros((E, 2 * H), dtype=mx.float32),
+            "model.layers.0.mlp.experts.down_proj_bias":    mx.zeros((E, D), dtype=mx.float32),
+        }
+        args = _make_args(hidden_size=D, intermediate_size=H, num_local_experts=E)
+        m = Model(args)
+        s = m.sanitize(weights)
+        g = s["model.layers.0.mlp.experts.gate_proj.weight"]
+        u = s["model.layers.0.mlp.experts.up_proj.weight"]
+        self.assertTrue(mx.all(g == 1.0).item())
+        self.assertTrue(mx.all(u == 2.0).item())
+
+    def test_already_sanitized_passthrough(self):
+        E, D, H = 32, 2880, 2880
+        weights = {
+            "model.layers.0.mlp.experts.gate_proj.weight": mx.zeros((E, H, D), dtype=mx.bfloat16),
+        }
+        m = Model(_make_args())
+        s = m.sanitize(weights)
+        self.assertIs(s, weights)
+
+    def test_openai_interleaved_layout_preserved(self):
+        """Layout (a): (E, 2H, D) — split on axis -2 as before."""
+        E, D, H = 32, 2880, 2880
+        weights = {
+            "model.layers.0.mlp.experts.gate_up_proj":      mx.zeros((E, 2 * H, D), dtype=mx.bfloat16),
+            "model.layers.0.mlp.experts.down_proj":         mx.zeros((E, H, D),     dtype=mx.bfloat16),
+            "model.layers.0.mlp.experts.gate_up_proj_bias": mx.zeros((E, 2 * H),    dtype=mx.bfloat16),
+            "model.layers.0.mlp.experts.down_proj_bias":    mx.zeros((E, D),        dtype=mx.bfloat16),
+        }
+        m = Model(_make_args())
+        s = m.sanitize(weights)
+        self.assertEqual(s["model.layers.0.mlp.experts.gate_proj.weight"].shape, (E, H, D))
+        self.assertEqual(s["model.layers.0.mlp.experts.up_proj.weight"].shape,   (E, H, D))
+        self.assertEqual(s["model.layers.0.mlp.experts.down_proj.weight"].shape, (E, H, D))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_lora_switch_linear_shared.py
+++ b/tests/test_lora_switch_linear_shared.py
@@ -62,5 +62,21 @@ class TestLoRASwitchLinearSharedAdapter(unittest.TestCase):
         self.assertTrue(mx.allclose(y_lora, y_fused, atol=1e-3).item())
 
 
+    def test_mixed_ndim_raises(self):
+        """Mixed 2D/3D adapters must raise a clear ValueError, not silently
+        take a partial code path."""
+        base = self._base()
+        lora = LoRASwitchLinear.from_base(base, r=self.r, scale=1.0)
+        # 2D lora_a paired with 3D lora_b -> invalid.
+        lora.lora_a = mx.random.normal(shape=(self.r, self.D))
+        lora.lora_b = mx.random.normal(shape=(self.E, self.H, self.r))
+        x = mx.random.normal(shape=(2, 1, self.D))
+        indices = mx.array([[0], [1]], dtype=mx.uint32)
+        with self.assertRaises(ValueError):
+            lora(x, indices)
+        with self.assertRaises(ValueError):
+            lora.fuse()
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_lora_switch_linear_shared.py
+++ b/tests/test_lora_switch_linear_shared.py
@@ -1,0 +1,66 @@
+"""Tests: LoRASwitchLinear supports PEFT shared 2D lora_a/lora_b (target_parameters)."""
+import unittest
+
+import mlx.core as mx
+
+from mlx_lm.models.switch_layers import SwitchLinear
+from mlx_lm.tuner.lora import LoRASwitchLinear
+
+
+class TestLoRASwitchLinearSharedAdapter(unittest.TestCase):
+    E = 4
+    D = 16
+    H = 16
+    r = 4
+
+    def _base(self):
+        return SwitchLinear(self.D, self.H, self.E, bias=False)
+
+    def test_fuse_per_expert(self):
+        """Original (E, r, D) / (E, out, r) layout still works."""
+        base = self._base()
+        lora = LoRASwitchLinear.from_base(base, r=self.r, scale=1.0)
+        lora.lora_a = mx.random.normal(shape=(self.E, self.r, self.D))
+        lora.lora_b = mx.random.normal(shape=(self.E, self.H, self.r))
+        fused = lora.fuse()
+        self.assertEqual(fused.weight.shape, (self.E, self.H, self.D))
+
+    def test_fuse_shared_2d(self):
+        """PEFT shared (r, D) / (out, r) layout fuses to same E experts."""
+        base = self._base()
+        lora = LoRASwitchLinear.from_base(base, r=self.r, scale=1.0)
+        a = mx.random.normal(shape=(self.r, self.D))
+        b = mx.random.normal(shape=(self.H, self.r))
+        lora.lora_a = a
+        lora.lora_b = b
+        fused = lora.fuse()
+        self.assertEqual(fused.weight.shape, (self.E, self.H, self.D))
+        # Each expert receives the SAME (B @ A) update on top of its base weight.
+        delta = (b @ a).astype(fused.weight.dtype)
+        for i in range(self.E):
+            self.assertTrue(
+                mx.allclose(
+                    fused.weight[i] - base.weight[i], delta, atol=1e-4
+                ).item()
+            )
+
+    def test_call_shared_2d_matches_fuse_then_call(self):
+        """Forward pass with shared adapter equals fuse-then-call equivalent."""
+        base = self._base()
+        lora = LoRASwitchLinear.from_base(base, r=self.r, scale=1.0)
+        a = mx.random.normal(shape=(self.r, self.D))
+        b = mx.random.normal(shape=(self.H, self.r))
+        lora.lora_a = a
+        lora.lora_b = b
+
+        x = mx.random.normal(shape=(2, 1, self.D))
+        indices = mx.array([[0], [1]], dtype=mx.uint32)
+
+        y_lora = lora(x, indices)
+        fused = lora.fuse()
+        y_fused = fused(x, indices)
+        self.assertTrue(mx.allclose(y_lora, y_fused, atol=1e-3).item())
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

Two independent fixes that together let mlx-lm consume the unsloth /
Hugging Face BF16 distribution of `openai/gpt-oss-20b` and fuse a PEFT
`target_parameters` MoE LoRA on top of it.

### 1. `gpt_oss.sanitize` — handle the BF16 expert weight layout

Two layouts exist for the fused `experts.gate_up_proj` tensor:

| layout            | shape         | key suffix |
|-------------------|---------------|------------|
| openai / MXFP4    | (E, 2H, D)    | `.weight` (post-dequant) |
| unsloth / HF BF16 | (E, D, 2H)    | (none, raw HF storage)   |

The old `sanitize()` assumed layout (a) and:
- split on axis -2 with `[::2, :]` / `[1::2, :]`, which on layout (b)
  halves the `hidden_size` axis and leaves the `2*intermediate` axis
  whole (`(32, 1440, 5760)` instead of `(32, 2880, 2880)`);
- emitted `experts.gate_proj` keys without the `.weight` suffix that
  `SwitchLinear` expects, so the weights silently fail to load.

The patch detects layout (b) by its trailing-axis signature
(`shape[-1] == 2*intermediate and shape[-2] == hidden`), normalises it
to (E, 2H, D) via `swapaxes(-1, -2)`, and then runs the existing
interleaved split — matching HF's forward (`gate, up = gate_up[..., ::2], gate_up[..., 1::2]`).
The `.weight` suffix is added where missing, including for the matching
`down_proj`. Layout (a) and the already-sanitized fast path are
unchanged.

### 2. `LoRASwitchLinear` — accept shared 2D adapters (PEFT `target_parameters`)

PEFT >= 0.13 supports fine-tuning the GPT-OSS MoE via
`target_parameters: ["<layer>.mlp.experts.gate_up_proj", ...]`. The
resulting adapter has a single shared low-rank update per expert
*parameter* rather than per expert:

```
lora_A.weight : (r, hidden_size)
lora_B.weight : (out_features, r)
```

`LoRASwitchLinear.from_base` builds 3-D tensors of shape
`(num_experts, r, in)` / `(num_experts, out, r)`, so assigning the
shared 2-D PEFT tensors and calling `fuse()` crashes at
`lora_b @ lora_a` (matmul shape mismatch).

`fuse()` and `__call__()` now detect 2-D adapter tensors:

- `fuse()` broadcasts `lora_a` and `lora_b` across the experts axis
  before the existing `(lora_b @ lora_a)` outer product, so every
  expert receives the same low-rank delta.
- `__call__()` uses a dense matmul instead of `gather_mm` when both
  tensors are 2-D — equivalent and avoids gathering identical rows
  `num_experts` times.

The pre-existing per-expert (3-D) layout continues to work through the
unchanged code path.

## Use case

We are fine-tuning gpt-oss-20b on a KiCad schematic-generation
dataset ("SchGen") via PEFT `target_parameters` on the MoE expert
fused projections, and serving the result through MLX-LM. Without
these two patches it is not possible to (a) convert the base
distribution at all, or (b) fuse the PEFT adapter into the converted
weights.

## Tests

```
$ python -m unittest tests.test_gpt_oss_sanitize tests.test_lora_switch_linear_shared -v
... 7 tests ok
$ python -m unittest tests.test_models tests.test_tuner_utils -v
... 78 tests ok (1 skipped)
```

New tests:
- `tests/test_gpt_oss_sanitize.py` — 4 cases covering both layouts,
  the already-sanitized fast path, and a value-level check that the
  interleaved split places even slots in `gate` and odd slots in `up`.
- `tests/test_lora_switch_linear_shared.py` — 3 cases covering the
  pre-existing per-expert layout, the new shared 2-D layout, and
  equivalence between the live forward pass and a fuse-then-call
  reference.

## Notes / scope

This PR is intentionally narrow:

- It does **not** change anything for openai's MXFP4 distribution.
- It does **not** add PEFT-adapter import (the caller is expected to
  produce mlx-lm-shaped tensors); it only ensures that a shared 2-D
  MoE LoRA tensor *does* fuse once present.
- The unsloth BF16 base model now loads, runs at native MLX speed
  (~80 tok/s on M3 Ultra) and accepts a SchGen MoE LoRA fuse; achieving
  bit-equivalent generation quality vs the HF transformers reference
  is tracked separately as it depends on attention-sinks / sliding-window
  details outside the `sanitize()` scope.