### PR TITLE
tokenizer_utils: prefer template-inferred tool parser over generic json_tools label

### DIFF
--- a/mlx_lm/tokenizer_utils.py
+++ b/mlx_lm/tokenizer_utils.py
@@ -575,6 +575,26 @@ def _infer_tool_parser(chat_template):
     return None
 
 
+def _resolve_tool_parser_type(configured, chat_template):
+    """Resolve which tool parser to use for a model.
+
+    Precedence: a deliberately-set, specific ``tool_parser_type`` from the
+    tokenizer config wins. But some repos ship the generic ``"json_tools"``
+    label even though their chat template emits a non-JSON tool-call grammar
+    (e.g. Qwen3-Coder's XML ``<tool_call>\\n<function=...>`` form). Parsing
+    that with ``json.loads`` raises ``JSONDecodeError`` and the tool call is
+    silently dropped. So when the explicit label is the generic default but
+    the template clearly identifies a specific parser, trust the template.
+    When nothing is configured, fall back to template inference.
+    """
+    inferred = _infer_tool_parser(chat_template)
+    if configured is None:
+        return inferred
+    if configured == "json_tools" and inferred is not None and inferred != "json_tools":
+        return inferred
+    return configured
+
+
 def load(
     model_path,
     tokenizer_config_extra: Optional[Dict[str, Any]] = None,
@@ -622,8 +642,8 @@ def load(
             f"mlx_lm.chat_templates.{chat_template_type}"
         ).apply_chat_template
 
-    tool_parser_type = tokenizer_config.get(
-        "tool_parser_type", _infer_tool_parser(tokenizer.chat_template)
+    tool_parser_type = _resolve_tool_parser_type(
+        tokenizer_config.get("tool_parser_type"), tokenizer.chat_template
     )
 
     if tool_parser_type is not None:

--- a/tests/test_tool_parsing.py
+++ b/tests/test_tool_parsing.py
@@ -1,6 +1,7 @@
 import unittest
 from pathlib import Path
 
+from mlx_lm.tokenizer_utils import _infer_tool_parser, _resolve_tool_parser_type
 from mlx_lm.tool_parsers import (
     function_gemma,
     gemma4,
@@ -13,6 +14,11 @@ from mlx_lm.tool_parsers import (
     pythonic,
     qwen3_coder,
 )
+
+# Minimal chat-template fragments carrying the markers _infer_tool_parser keys on.
+# Qwen3-Coder emits XML tool calls; Hermes-style emits JSON.
+_QWEN3_CODER_TEMPLATE = "{% for tool in tools %}<tool_call>\n<function={{ tool.name }}>{% endfor %}"
+_HERMES_JSON_TEMPLATE = '<tool_call>{"name": {{ tool_call.name }}}</tool_call>'
 
 
 class TestToolParsing(unittest.TestCase):
@@ -328,6 +334,108 @@ class TestToolParsing(unittest.TestCase):
         ]
         tool_calls = minimax_m2.parse_tool_call(test_case, None)
         self.assertEqual(expected, tool_calls)
+
+
+class TestToolParserSelection(unittest.TestCase):
+    """Regression guard for parser selection precedence (tokenizer_utils).
+
+    The Qwen3-Coder-Next repos ship a chat template that emits XML tool calls
+    but mislabel `tool_parser_type` as the generic "json_tools", which sent
+    the server into json.loads() on XML and silently dropped every tool call.
+    """
+
+    def test_template_inference(self):
+        # The marker the XML grammar is detected by.
+        self.assertEqual(_infer_tool_parser(_QWEN3_CODER_TEMPLATE), "qwen3_coder")
+        self.assertEqual(_infer_tool_parser(_HERMES_JSON_TEMPLATE), "json_tools")
+        self.assertIsNone(_infer_tool_parser("no tools here"))
+        self.assertIsNone(_infer_tool_parser(None))
+
+    def test_generic_label_yields_to_specific_template(self):
+        # The actual bug: config says json_tools, template is XML -> use XML.
+        self.assertEqual(
+            _resolve_tool_parser_type("json_tools", _QWEN3_CODER_TEMPLATE),
+            "qwen3_coder",
+        )
+
+    def test_missing_label_uses_inference(self):
+        self.assertEqual(
+            _resolve_tool_parser_type(None, _QWEN3_CODER_TEMPLATE), "qwen3_coder"
+        )
+        self.assertEqual(
+            _resolve_tool_parser_type(None, _HERMES_JSON_TEMPLATE), "json_tools"
+        )
+
+    def test_hermes_json_unchanged(self):
+        # A genuine Hermes/JSON model must be untouched: json_tools stays
+        # json_tools (only a *generic* label yields, and only to a *specific*
+        # template-inferred parser).
+        self.assertEqual(
+            _resolve_tool_parser_type("json_tools", _HERMES_JSON_TEMPLATE),
+            "json_tools",
+        )
+        self.assertEqual(
+            _resolve_tool_parser_type("json_tools", "no tool markers"),
+            "json_tools",
+        )
+
+    def test_deliberate_specific_label_wins(self):
+        # A specific, deliberately-set parser is never overridden by inference.
+        self.assertEqual(
+            _resolve_tool_parser_type("minimax_m2", _QWEN3_CODER_TEMPLATE),
+            "minimax_m2",
+        )
+        self.assertEqual(
+            _resolve_tool_parser_type("qwen3_coder", _HERMES_JSON_TEMPLATE),
+            "qwen3_coder",
+        )
+
+    def test_no_parser_anywhere(self):
+        self.assertIsNone(_resolve_tool_parser_type(None, "plain template"))
+
+
+class TestQwen3CoderServerHandoff(unittest.TestCase):
+    """Parse tool_text exactly as server.py's state machine hands it off:
+    <tool_call>/</tool_call> stripped, with the leading/trailing newlines the
+    model emits around the <function=...> block."""
+
+    def test_server_framed_tool_text(self):
+        tools = [
+            {
+                "type": "function",
+                "function": {
+                    "name": "read_file",
+                    "parameters": {
+                        "type": "object",
+                        "properties": {
+                            "path": {"type": "string"},
+                            "limit": {"type": "integer"},
+                            "verbose": {"type": "boolean"},
+                        },
+                    },
+                },
+            }
+        ]
+        tool_text = (
+            "\n<function=read_file>\n"
+            "<parameter=path>\n/tmp/x.txt\n</parameter>\n"
+            "<parameter=limit>\n42\n</parameter>\n"
+            "<parameter=verbose>\ntrue\n</parameter>\n"
+            "</function>\n"
+        )
+        tool_call = qwen3_coder.parse_tool_call(tool_text, tools)
+        self.assertEqual(tool_call["name"], "read_file")
+        self.assertEqual(
+            tool_call["arguments"],
+            {"path": "/tmp/x.txt", "limit": 42, "verbose": True},
+        )
+
+    def test_no_schema_defaults_to_string(self):
+        tool_text = "<function=ping>\n<parameter=host>\nlocalhost\n</parameter>\n</function>"
+        tool_call = qwen3_coder.parse_tool_call(tool_text, None)
+        self.assertEqual(
+            tool_call, {"name": "ping", "arguments": {"host": "localhost"}}
+        )
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Problem

`mlx_lm.server` silently drops every tool call for some models. A
`<system>` example: `inferencerlabs/Qwen3-Coder-Next-MLX-9bit` (and other
Qwen3-Coder repos) ship

```json
"tool_parser_type": "json_tools"
```

in `tokenizer_config.json`, but their chat template emits Qwen3-Coder's
**XML** tool-call grammar:

```
<tool_call>
<function=NAME>
<parameter=KEY>value</parameter>
</function>
</tool_call>
```

In `tokenizer_utils.load()` the explicit `tool_parser_type` from the
config takes precedence over `_infer_tool_parser(chat_template)`. So the
generic `json_tools` parser is selected, `json.loads()` is called on the
XML, raises `JSONDecodeError`, and the server logs
`Failed to parse tool call` and drops the call. The model's own template
already tells us (via `_infer_tool_parser`) that this should be the
`qwen3_coder` parser.

## Fix

Prefer the template-inferred parser when the configured label is the
generic `json_tools` default **and** inference identifies a specific
parser. A deliberately-set, specific `tool_parser_type` is never
overridden, and a genuine Hermes/JSON model (`json_tools` config + no
specific marker in the template) is unchanged. Resolution is factored
into `_resolve_tool_parser_type` for testability.

## Tests

`tests/test_tool_parsing.py` gains `TestToolParserSelection` (precedence
matrix: generic-yields-to-specific, missing-label-infers,
hermes-unchanged, deliberate-specific-wins) and a `TestQwen3CoderServerHandoff`
case parsing `tool_text` exactly as the server's state machine hands it
off. All pass.

Verified end-to-end against `Qwen3-Coder-Next-MLX-9bit` on
`mlx_lm.server`: before the fix the first tool call dropped with the
JSONDecodeError above; after, the request returns `finish_reason:
"tool_calls"` with correctly-typed arguments.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
