### PR TITLE
Fix load_model skipping to_quantized check for per-layer quantization config

### DIFF
--- a/mlx_lm/utils.py
+++ b/mlx_lm/utils.py
@@ -348,10 +348,10 @@ def load_model(
     def _quantize(quantization):
         def class_predicate(p, m):
             # Handle custom per layer quantizations
-            if p in config["quantization"]:
-                return config["quantization"][p]
             if not hasattr(m, "to_quantized"):
                 return False
+            if p in config["quantization"]:
+                return config["quantization"][p]
             return f"{p}.scales" in weights
 
         nn.quantize(

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -183,6 +183,54 @@ class TestUtils(unittest.TestCase):
             mx.eval(logits)
             self.assertEqual(logits.shape, (1, 3, args.vocab_size))
 
+    def test_class_predicate_skips_non_quantizable_modules_in_per_layer_config(self):
+        """load_model must not crash when per-layer quantization config lists a
+        module that lacks to_quantized() — regression for issue #1266 (MoEGate)."""
+        from mlx_lm.models import llama
+
+        args = llama.ModelArgs(
+            model_type="llama",
+            hidden_size=64,
+            num_hidden_layers=2,
+            intermediate_size=128,
+            num_attention_heads=2,
+            rms_norm_eps=1e-5,
+            vocab_size=256,
+        )
+        model_config = {
+            "model_type": "llama",
+            "hidden_size": 64,
+            "num_hidden_layers": 2,
+            "intermediate_size": 128,
+            "num_attention_heads": 2,
+            "rms_norm_eps": 1e-5,
+            "vocab_size": 256,
+        }
+        model = llama.Model(args)
+        model, config = utils.quantize_model(
+            model,
+            model_config,
+            group_size=32,
+            bits=4,
+        )
+
+        # Inject a path for a non-quantizable module (RMSNorm has no to_quantized).
+        # This simulates a pre-quantized config like nemotron_h whose quantization
+        # config includes MoEGate paths.
+        config["quantization"]["model.layers.0.input_layernorm"] = {
+            "group_size": 32,
+            "bits": 4,
+        }
+
+        with tempfile.TemporaryDirectory(dir=self.test_dir) as mlx_path:
+            utils.save_model(mlx_path, model)
+            utils.save_config(config, os.path.join(mlx_path, "config.json"))
+            # Should not raise: ValueError: Unable to quantize model of type RMSNorm
+            loaded, _ = utils.load_model(Path(mlx_path))
+            logits = loaded(mx.array([[1, 2, 3]], dtype=mx.int32))
+            mx.eval(logits)
+            self.assertEqual(logits.shape, (1, 3, args.vocab_size))
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary

`class_predicate` in `_quantize()` (inside `load_model`) checked whether a module path appeared in `config["quantization"]` **before** checking `hasattr(m, "to_quantized")`. For modules that lack `to_quantized()` — such as `MoEGate` in `nemotron_h.py`, which stores its routing weights as a raw `mx.zeros` tensor rather than `nn.Linear` — this caused the per-layer config dict to be returned, so `nn.quantize` would call `m.to_quantized(**kwargs)` and raise:

```
ValueError: Unable to quantize model of type <class 'mlx_lm.models.nemotron_h.MoEGate'>
```

## Fix

Move the `hasattr(m, "to_quantized")` guard before the per-layer config check so modules lacking `to_quantized()` are always skipped, regardless of quantization config entries. Two lines reordered in `utils.py`:

```python
def class_predicate(p, m):
    if not hasattr(m, "to_quantized"):   # check first
        return False
    if p in config["quantization"]:
        return config["quantization"][p]
    return f"{p}.scales" in weights
```

## Test

Added `test_class_predicate_skips_non_quantizable_modules_in_per_layer_config` in `tests/test_utils.py`. Builds a small llama model, injects an `RMSNorm` path into the quantization config (RMSNorm has no `to_quantized`), saves and reloads — verifying no `ValueError` is raised and the model runs correctly.

Fixes #1266.

AI assistance was used for investigation and code review; all changes reviewed and tested by me on M3 / 16 GB / macOS.