### PR TITLE
Apply max_kv_size to KVCache layers returned by make_cache()

### DIFF
--- a/mlx_lm/models/cache.py
+++ b/mlx_lm/models/cache.py
@@ -24,12 +24,25 @@ def make_prompt_cache(
 
     Args:
         model (nn.Module): The language model.
-        max_kv_size (Optional[int]): If provided and the model does not have a
-            ``make_cache`` method, a ``RotatingKVCache`` is used with a maximum
-            size of ``max_kv_size``
+        max_kv_size (Optional[int]): If provided, plain :class:`KVCache` entries
+            are replaced with :class:`RotatingKVCache` capped at ``max_kv_size``
+            tokens. This applies whether or not the model defines ``make_cache``.
+            Cache entries that are already a :class:`RotatingKVCache` (e.g.
+            sliding-window layers) or non-KV caches (e.g. SSM state) are left
+            unchanged.
     """
     if hasattr(model, "make_cache"):
-        return model.make_cache()
+        caches = model.make_cache()
+        if max_kv_size is not None:
+            return [
+                (
+                    RotatingKVCache(max_size=max_kv_size, keep=4)
+                    if type(c) is KVCache
+                    else c
+                )
+                for c in caches
+            ]
+        return caches
 
     num_layers = len(model.layers)
     if max_kv_size is not None:

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -3252,5 +3252,79 @@ class TestModels(unittest.TestCase):
                 self.assertTrue(mx.allclose(st, st_gt, rtol=1e-4, atol=1e-3))
 
 
+class TestMakePromptCache(unittest.TestCase):
+    """make_prompt_cache must apply max_kv_size for all models, including those
+    that define make_cache() for custom per-layer cache structure."""
+
+    def _tiny_llama(self):
+        from mlx_lm.models import llama
+
+        args = llama.ModelArgs(
+            model_type="llama",
+            hidden_size=64,
+            num_hidden_layers=4,
+            intermediate_size=128,
+            num_attention_heads=4,
+            rms_norm_eps=1e-5,
+            vocab_size=256,
+        )
+        return llama.Model(args)
+
+    def test_without_max_kv_size_returns_kvcache(self):
+        model = self._tiny_llama()
+        caches = make_prompt_cache(model)
+        self.assertTrue(all(type(c) is KVCache for c in caches))
+
+    def test_with_max_kv_size_returns_rotating_for_model_with_make_cache(self):
+        # Llama defines make_cache() — previously max_kv_size was silently ignored.
+        model = self._tiny_llama()
+        self.assertTrue(
+            hasattr(model, "make_cache"), "test requires a model with make_cache()"
+        )
+        caches = make_prompt_cache(model, max_kv_size=512)
+        self.assertEqual(len(caches), 4)
+        for c in caches:
+            self.assertIsInstance(
+                c, RotatingKVCache, f"expected RotatingKVCache, got {type(c)}"
+            )
+            self.assertEqual(c.max_size, 512)
+            self.assertEqual(c.keep, 4)
+
+    def test_mixed_cache_model_only_replaces_plain_kvcache(self):
+        # Simulate a model whose make_cache() returns a mix of KVCache and
+        # RotatingKVCache (e.g. sliding-window layers). Only the plain KVCache
+        # layers should be upgraded; the RotatingKVCache layers must stay intact.
+        class MixedCacheModel(nn.Module):
+            def __init__(self):
+                super().__init__()
+
+            def make_cache(self):
+                return [KVCache(), RotatingKVCache(max_size=256, keep=0), KVCache()]
+
+        model = MixedCacheModel()
+        caches = make_prompt_cache(model, max_kv_size=1024)
+        self.assertIsInstance(caches[0], RotatingKVCache)
+        self.assertEqual(caches[0].max_size, 1024)  # replaced
+        self.assertEqual(caches[0].keep, 4)
+        self.assertIsInstance(caches[1], RotatingKVCache)
+        self.assertEqual(caches[1].max_size, 256)  # untouched — already rotating
+        self.assertEqual(caches[1].keep, 0)  # original keep preserved
+        self.assertIsInstance(caches[2], RotatingKVCache)
+        self.assertEqual(caches[2].max_size, 1024)  # replaced
+
+    def test_with_max_kv_size_without_make_cache(self):
+        # Models without make_cache() — existing behaviour unchanged.
+        class SimpleCacheModel(nn.Module):
+            def __init__(self):
+                super().__init__()
+                self.layers = [nn.Linear(4, 4) for _ in range(3)]
+
+        model = SimpleCacheModel()
+        self.assertFalse(hasattr(model, "make_cache"))
+        caches = make_prompt_cache(model, max_kv_size=512)
+        self.assertTrue(all(isinstance(c, RotatingKVCache) for c in caches))
+        self.assertTrue(all(c.max_size == 512 for c in caches))
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Motivation

Today, `max_kv_size` is not applied to models that implement `make_cache()` — which includes many modern architectures (Llama, Gemma, Qwen, Mistral, and others). The current behavior is documented and preserves each architecture's intended cache strategy. It also means that a user who explicitly requests `max_kv_size` does **not** receive a bounded KV cache for those models.

## What this changes

After calling `model.make_cache()`, plain `KVCache` instances are replaced with `RotatingKVCache(max_size=max_kv_size, keep=4)` — the same pattern already used for models without `make_cache()`. Entries that are already a `RotatingKVCache` (sliding-window layers) or non-KV caches (e.g. SSM/Mamba state) are left unchanged. The guard is `type(c) is KVCache`, so `KVCache` subclasses are intentionally preserved.

## Tradeoff (measured)

In interleaved-attention models, the plain `KVCache` entries are precisely the **global / full-attention layers**. Capping them replaces global attention with a sliding window.

Measured on `mlx-community/gemma-3-1b-it-4bit` (26 layers; global-attention layers at indices 5, 11, 17, 23), with a fact planted at the start of an 837-token prompt:

| Cache | KV memory | Recall of early-context fact |
|---|---|---|
| `make_cache()` default (current) | higher | **preserved** |
| `max_kv_size=128` (this PR) | bounded | **lost** — early tokens evicted |

This is expected when old KV entries are evicted, and it is the same tradeoff `max_kv_size` already makes for models without `make_cache()`. It is not a correctness bug; it is a behavioral consequence of bounding the cache.

## Question for maintainers

The real question is one of intent: when a user explicitly passes `max_kv_size`, should the requested **memory bound** win, or should **architecture-specific cache behavior** win for models that construct their own cache?

If bounding memory consistently (including global-attention layers) is the desired interpretation, this PR implements it. If the current scoping to non-`make_cache()` models is deliberate, I'm happy to gate it behind an opt-in, narrow it, or close it.

The included tests cover the type-replacement logic; the recall measurement above is from a manual run on M3.
