### PR TITLE
New UI for chat and lora

### DIFF
--- a/mlx_lm/chat.py
+++ b/mlx_lm/chat.py
@@ -1,9 +1,16 @@
 # Copyright © 2023-2024 Apple Inc.
 
 import argparse
+import sys
 
 import mlx.core as mx
 
+from .cli_ui import (
+    make_console,
+    make_corridor_prompt,
+    print_chat_help,
+    print_header_panel,
+)
 from .generate import stream_generate
 from .models.cache import make_prompt_cache
 from .sample_utils import make_sampler
@@ -16,6 +23,19 @@ DEFAULT_XTC_THRESHOLD = 0.0
 DEFAULT_SEED = 0
 DEFAULT_MAX_TOKENS = 256
 DEFAULT_MODEL = "mlx-community/Llama-3.2-3B-Instruct-4bit"
+
+
+def _print_chat_header(args, console):
+    rows = [("model", str(args.model))]
+    if args.adapter_path:
+        rows.append(("adapter", str(args.adapter_path)))
+    rows.append(("max tokens", f"{args.max_tokens:,}"))
+    if args.system_prompt:
+        sp = args.system_prompt
+        if len(sp) > 60:
+            sp = sp[:57] + "..."
+        rows.append(("system", sp))
+    print_header_panel(console, "mlx_lm.chat", rows)
 
 
 def setup_arg_parser():
@@ -96,6 +116,8 @@ def main():
     pipeline_group = group if args.pipeline else None
     tensor_group = group if not args.pipeline else None
 
+    console = make_console()
+
     def rprint(*args, **kwargs):
         if rank == 0:
             print(*args, **kwargs)
@@ -115,24 +137,38 @@ def main():
             },
         )
 
-    def print_help():
-        rprint("The command list:")
-        rprint("- 'q' to exit")
-        rprint("- 'r' to reset the chat")
-        rprint("- 'h' to display these commands")
+    if rank == 0:
+        _print_chat_header(args, console)
+        print_chat_help(console)
 
-    rprint(f"[INFO] Starting chat session with {args.model}.")
-    print_help()
+    if rank == 0:
+        prompt_console = make_console(force_terminal=True, color_system="truecolor")
+        _draw_corridor_prompt = make_corridor_prompt(prompt_console)
+    else:
+        _draw_corridor_prompt = lambda: ""
+
     prompt_cache = make_prompt_cache(model, args.max_kv_size)
     while True:
-        query = input(">> " if rank == 0 else "")
+        prompt = _draw_corridor_prompt()
+        query = input(prompt)
+        if rank == 0:
+            # Cursor is now on the bottom-rule row; advance past it.
+            sys.stdout.write("\n")
+            sys.stdout.flush()
         if query == "q":
+            if rank == 0:
+                console.print("[ui.muted]bye[/ui.muted]")
             break
         if query == "r":
             prompt_cache = make_prompt_cache(model, args.max_kv_size)
+            if rank == 0:
+                console.print(
+                    "  [ui.good]reset[/ui.good] [ui.muted]context cleared[/ui.muted]"
+                )
             continue
         if query == "h":
-            print_help()
+            if rank == 0:
+                print_chat_help(console)
             continue
         messages = []
         if args.system_prompt is not None:
@@ -142,6 +178,7 @@ def main():
             messages,
             add_generation_prompt=True,
         )
+        last_response = None
         for response in stream_generate(
             model,
             tokenizer,
@@ -159,7 +196,15 @@ def main():
             prompt_cache=prompt_cache,
         ):
             rprint(response.text, flush=True, end="")
+            last_response = response
         rprint()
+        if rank == 0 and last_response is not None:
+            console.print(
+                f"  [ui.muted]{last_response.generation_tokens} tokens · "
+                f"{last_response.generation_tps:.1f} tok/s · "
+                f"prompt {last_response.prompt_tps:.1f} tok/s · "
+                f"peak {last_response.peak_memory:.2f} GB[/ui.muted]"
+            )
 
 
 if __name__ == "__main__":

--- a/mlx_lm/chat.py
+++ b/mlx_lm/chat.py
@@ -6,6 +6,7 @@ import sys
 import mlx.core as mx
 
 from .cli_ui import (
+    init_theme,
     make_console,
     make_corridor_prompt,
     print_chat_help,
@@ -116,6 +117,7 @@ def main():
     pipeline_group = group if args.pipeline else None
     tensor_group = group if not args.pipeline else None
 
+    init_theme(probe=(rank == 0))
     console = make_console()
 
     def rprint(*args, **kwargs):

--- a/mlx_lm/chat.py
+++ b/mlx_lm/chat.py
@@ -6,7 +6,6 @@ import sys
 import mlx.core as mx
 
 from .cli_ui import (
-    init_theme,
     make_console,
     make_corridor_prompt,
     print_chat_help,
@@ -117,7 +116,6 @@ def main():
     pipeline_group = group if args.pipeline else None
     tensor_group = group if not args.pipeline else None
 
-    init_theme(probe=(rank == 0))
     console = make_console()
 
     def rprint(*args, **kwargs):

--- a/mlx_lm/chat.py
+++ b/mlx_lm/chat.py
@@ -1,15 +1,15 @@
 # Copyright © 2023-2024 Apple Inc.
 
 import argparse
-import sys
 
 import mlx.core as mx
 
 from .cli_ui import (
+    corridor_input,
     make_console,
-    make_corridor_prompt,
     print_chat_help,
     print_header_panel,
+    printf,
 )
 from .generate import stream_generate
 from .models.cache import make_prompt_cache
@@ -118,10 +118,6 @@ def main():
 
     console = make_console()
 
-    def rprint(*args, **kwargs):
-        if rank == 0:
-            print(*args, **kwargs)
-
     mx.random.seed(args.seed)
 
     if group.size() > 1:
@@ -141,20 +137,12 @@ def main():
         _print_chat_header(args, console)
         print_chat_help(console)
 
-    if rank == 0:
-        prompt_console = make_console(force_terminal=True, color_system="truecolor")
-        _draw_corridor_prompt = make_corridor_prompt(prompt_console)
-    else:
-        _draw_corridor_prompt = lambda: ""
-
     prompt_cache = make_prompt_cache(model, args.max_kv_size)
     while True:
-        prompt = _draw_corridor_prompt()
-        query = input(prompt)
         if rank == 0:
-            # Cursor is now on the bottom-rule row; advance past it.
-            sys.stdout.write("\n")
-            sys.stdout.flush()
+            query = corridor_input(console)
+        else:
+            query = input("")
         if query == "q":
             if rank == 0:
                 console.print("[ui.muted]bye[/ui.muted]")
@@ -195,9 +183,9 @@ def main():
             ),
             prompt_cache=prompt_cache,
         ):
-            rprint(response.text, flush=True, end="")
+            printf(response.text, flush=True, end="")
             last_response = response
-        rprint()
+        printf()
         if rank == 0 and last_response is not None:
             console.print(
                 f"  [ui.muted]{last_response.generation_tokens} tokens · "

--- a/mlx_lm/chat.py
+++ b/mlx_lm/chat.py
@@ -4,13 +4,7 @@ import argparse
 
 import mlx.core as mx
 
-from .cli_ui import (
-    corridor_input,
-    make_console,
-    print_chat_help,
-    print_header_panel,
-    printf,
-)
+from .cli_ui import ChatUI
 from .generate import stream_generate
 from .models.cache import make_prompt_cache
 from .sample_utils import make_sampler
@@ -23,19 +17,6 @@ DEFAULT_XTC_THRESHOLD = 0.0
 DEFAULT_SEED = 0
 DEFAULT_MAX_TOKENS = 256
 DEFAULT_MODEL = "mlx-community/Llama-3.2-3B-Instruct-4bit"
-
-
-def _print_chat_header(args, console):
-    rows = [("model", str(args.model))]
-    if args.adapter_path:
-        rows.append(("adapter", str(args.adapter_path)))
-    rows.append(("max tokens", f"{args.max_tokens:,}"))
-    if args.system_prompt:
-        sp = args.system_prompt
-        if len(sp) > 60:
-            sp = sp[:57] + "..."
-        rows.append(("system", sp))
-    print_header_panel(console, "mlx_lm.chat", rows)
 
 
 def setup_arg_parser():
@@ -116,8 +97,6 @@ def main():
     pipeline_group = group if args.pipeline else None
     tensor_group = group if not args.pipeline else None
 
-    console = make_console()
-
     mx.random.seed(args.seed)
 
     if group.size() > 1:
@@ -133,66 +112,48 @@ def main():
             },
         )
 
-    if rank == 0:
-        _print_chat_header(args, console)
-        print_chat_help(console)
-
-    prompt_cache = make_prompt_cache(model, args.max_kv_size)
-    while True:
-        if rank == 0:
-            query = corridor_input(console)
-        else:
-            query = input("")
-        if query == "q":
-            if rank == 0:
-                console.print("[ui.muted]bye[/ui.muted]")
-            break
-        if query == "r":
-            prompt_cache = make_prompt_cache(model, args.max_kv_size)
-            if rank == 0:
-                console.print(
-                    "  [ui.good]reset[/ui.good] [ui.muted]context cleared[/ui.muted]"
-                )
-            continue
-        if query == "h":
-            if rank == 0:
-                print_chat_help(console)
-            continue
-        messages = []
-        if args.system_prompt is not None:
-            messages.append({"role": "system", "content": args.system_prompt})
-        messages.append({"role": "user", "content": query})
-        prompt = tokenizer.apply_chat_template(
-            messages,
-            add_generation_prompt=True,
-        )
-        last_response = None
-        for response in stream_generate(
-            model,
-            tokenizer,
-            prompt,
-            max_tokens=args.max_tokens,
-            sampler=make_sampler(
-                args.temp,
-                args.top_p,
-                xtc_threshold=args.xtc_threshold,
-                xtc_probability=args.xtc_probability,
-                xtc_special_tokens=(
-                    tokenizer.encode("\n") + list(tokenizer.eos_token_ids)
-                ),
-            ),
-            prompt_cache=prompt_cache,
-        ):
-            printf(response.text, flush=True, end="")
-            last_response = response
-        printf()
-        if rank == 0 and last_response is not None:
-            console.print(
-                f"  [ui.muted]{last_response.generation_tokens} tokens · "
-                f"{last_response.generation_tps:.1f} tok/s · "
-                f"prompt {last_response.prompt_tps:.1f} tok/s · "
-                f"peak {last_response.peak_memory:.2f} GB[/ui.muted]"
+    with ChatUI(args, rank=rank) as ui:
+        prompt_cache = make_prompt_cache(model, args.max_kv_size)
+        while True:
+            query = ui.prompt()
+            if query == "q":
+                ui.say_bye()
+                break
+            if query == "r":
+                prompt_cache = make_prompt_cache(model, args.max_kv_size)
+                ui.say_reset()
+                continue
+            if query == "h":
+                ui.say_help()
+                continue
+            messages = []
+            if args.system_prompt is not None:
+                messages.append({"role": "system", "content": args.system_prompt})
+            messages.append({"role": "user", "content": query})
+            prompt = tokenizer.apply_chat_template(
+                messages,
+                add_generation_prompt=True,
             )
+            last_response = None
+            for response in stream_generate(
+                model,
+                tokenizer,
+                prompt,
+                max_tokens=args.max_tokens,
+                sampler=make_sampler(
+                    args.temp,
+                    args.top_p,
+                    xtc_threshold=args.xtc_threshold,
+                    xtc_probability=args.xtc_probability,
+                    xtc_special_tokens=(
+                        tokenizer.encode("\n") + list(tokenizer.eos_token_ids)
+                    ),
+                ),
+                prompt_cache=prompt_cache,
+            ):
+                ui.stream_token(response.text)
+                last_response = response
+            ui.end_turn(last_response)
 
 
 if __name__ == "__main__":

--- a/mlx_lm/cli_ui.py
+++ b/mlx_lm/cli_ui.py
@@ -27,12 +27,64 @@ from rich.text import Text
 from rich.theme import Theme
 
 
-def _osc11_to_rgb(timeout: float = 0.1):
+def _is_distributed_non_root() -> bool:
+    """True when running as a non-rank-0 worker under a launcher.
+
+    We use environment variables exported by common launchers (mlx.launch,
+    OpenMPI, MPICH, SLURM, torchrun) instead of ``mlx.distributed`` so this
+    module stays independent of the heavy mlx import path.
+    """
+    for var in (
+        "OMPI_COMM_WORLD_RANK",
+        "PMI_RANK",
+        "PMIX_RANK",
+        "SLURM_PROCID",
+        "RANK",
+    ):
+        value = os.environ.get(var)
+        if value and value.strip() != "0":
+            return True
+    return False
+
+
+def _running_under_launcher() -> bool:
+    """True when any multi-process launcher signature is detected.
+
+    We can't reliably tell our rank from env vars alone (different launchers
+    use different keys). When this returns True we skip auto-detection at
+    import time and wait for the caller to opt in via :func:`init_theme`.
+    """
+    explicit = {
+        "WORLD_SIZE",
+        "LOCAL_RANK",
+        "RANK",
+        "PMI_RANK",
+        "PMIX_RANK",
+        "SLURM_PROCID",
+        "OMPI_COMM_WORLD_SIZE",
+    }
+    if any(k in os.environ for k in explicit):
+        return True
+    prefixes = ("OMPI_", "PMI_", "PMIX_", "SLURM_", "MLX_LAUNCH")
+    for k in os.environ:
+        if k.startswith(prefixes):
+            return True
+    return False
+
+
+def _osc11_to_rgb(timeout: float = 0.5):
     """Ask the terminal for its background color via OSC 11.
 
     Returns an (r, g, b) tuple in the 0-255 range, or None if the terminal
-    does not respond (non-TTY, unsupported terminal, redirected stdio, ...).
+    does not respond (non-TTY, unsupported terminal, redirected stdio,
+    non-rank-0 in a distributed launch, ...). The default timeout is generous
+    enough to survive an SSH round trip.
     """
+    # In a distributed launch, all ranks share the same TTY. If every worker
+    # sends an OSC query, only one read wins and the rest of the responses
+    # leak onto the screen. Skip the probe on non-root ranks.
+    if _is_distributed_non_root():
+        return None
     if not (sys.stdin.isatty() and sys.stdout.isatty()):
         return None
     try:
@@ -112,11 +164,47 @@ def _detect_dark_background() -> bool:
     return True
 
 
-IS_DARK_BACKGROUND = _detect_dark_background()
+# Lazy theme state. We avoid auto-detecting at import time when running under
+# a multi-process launcher because every worker would otherwise emit an OSC
+# query against the shared terminal, leaking the responses to the screen.
+# Single-process callers fall through to auto-detection on first use.
+_is_dark = True
+_is_dark_initialized = False
+
+
+def init_theme(probe: bool = True) -> None:
+    """Initialize the terminal theme.
+
+    Pass ``probe=False`` on non-root ranks of distributed launches so the
+    theme gets marked as initialized without sending an OSC query that would
+    leak its response onto the shared terminal.
+    """
+    global _is_dark, _is_dark_initialized
+    _is_dark_initialized = True
+    if probe:
+        _is_dark = _detect_dark_background()
+
+
+def _ensure_theme_initialized() -> None:
+    global _is_dark_initialized
+    if _is_dark_initialized:
+        return
+    if _running_under_launcher():
+        # Caller hasn't opted in via init_theme(); stay on the default theme
+        # rather than risk a probe across all ranks.
+        _is_dark_initialized = True
+        return
+    init_theme(probe=True)
+
+
+def is_dark_background() -> bool:
+    """Whether the active theme is for a dark terminal background."""
+    _ensure_theme_initialized()
+    return _is_dark
 
 
 def _make_theme() -> Theme:
-    if IS_DARK_BACKGROUND:
+    if is_dark_background():
         styles = {
             "ui.strong": "bold white",
             "ui.label": "grey70",

--- a/mlx_lm/cli_ui.py
+++ b/mlx_lm/cli_ui.py
@@ -1,0 +1,266 @@
+# Copyright © 2024 Apple Inc.
+
+"""Shared UI helpers for the mlx_lm command-line tools.
+
+Centralizes the rich-based panel/progress/prompt rendering used by the chat
+and training entry points and exposes an adaptive theme so the same markup
+reads well on both light and dark terminal backgrounds.
+"""
+
+import os
+import re
+import shutil
+import sys
+import time
+
+from rich.box import ROUNDED
+from rich.console import Console
+from rich.panel import Panel
+from rich.progress import (
+    Progress,
+    ProgressColumn,
+    TextColumn,
+    TimeElapsedColumn,
+    TimeRemainingColumn,
+)
+from rich.text import Text
+from rich.theme import Theme
+
+
+def _osc11_to_rgb(timeout: float = 0.1):
+    """Ask the terminal for its background color via OSC 11.
+
+    Returns an (r, g, b) tuple in the 0-255 range, or None if the terminal
+    does not respond (non-TTY, unsupported terminal, redirected stdio, ...).
+    """
+    if not (sys.stdin.isatty() and sys.stdout.isatty()):
+        return None
+    try:
+        import select
+        import termios
+        import tty
+    except ImportError:
+        return None  # Windows / restricted environments
+
+    fd = sys.stdin.fileno()
+    try:
+        saved = termios.tcgetattr(fd)
+    except termios.error:
+        return None
+
+    try:
+        tty.setraw(fd)
+        sys.stdout.write("\033]11;?\033\\")
+        sys.stdout.flush()
+
+        deadline = time.monotonic() + timeout
+        buf = b""
+        while True:
+            remaining = deadline - time.monotonic()
+            if remaining <= 0:
+                break
+            if not select.select([fd], [], [], remaining)[0]:
+                break
+            chunk = os.read(fd, 64)
+            if not chunk:
+                break
+            buf += chunk
+            if buf.endswith(b"\x07") or buf.endswith(b"\x1b\\"):
+                break
+    finally:
+        termios.tcsetattr(fd, termios.TCSADRAIN, saved)
+
+    match = re.search(rb"rgb:([0-9a-fA-F]+)/([0-9a-fA-F]+)/([0-9a-fA-F]+)", buf)
+    if not match:
+        return None
+
+    def _to_byte(hex_bytes: bytes) -> int:
+        # OSC 11 components are typically 4 hex digits (16-bit) but some
+        # terminals reply with 2. Normalize to 8 bits by scaling.
+        digits = hex_bytes.decode("ascii")
+        value = int(digits, 16)
+        full = (1 << (4 * len(digits))) - 1
+        return round(value * 255 / full) if full else 0
+
+    return tuple(_to_byte(g) for g in match.groups())
+
+
+def _detect_dark_background() -> bool:
+    override = os.environ.get("MLX_LM_THEME", "").strip().lower()
+    if override in ("dark", "light"):
+        return override == "dark"
+
+    rgb = _osc11_to_rgb()
+    if rgb is not None:
+        r, g, b = rgb
+        # Perceived luminance (Rec. 601). < 128 ≈ dark background.
+        return (0.299 * r + 0.587 * g + 0.114 * b) < 128
+
+    # COLORFGBG is "fg;bg" or "fg;default;bg" with ANSI color indices.
+    cfb = os.environ.get("COLORFGBG", "")
+    if cfb:
+        last = cfb.split(";")[-1].strip()
+        try:
+            bg = int(last)
+            # 0-6 are the dim base colors and 8 is dark grey; 7 and 9-15
+            # are the bright/light variants.
+            return bg in (0, 1, 2, 3, 4, 5, 6, 8)
+        except ValueError:
+            pass
+
+    # No signal from the terminal — assume dark, which is the modern default.
+    return True
+
+
+IS_DARK_BACKGROUND = _detect_dark_background()
+
+
+def _make_theme() -> Theme:
+    if IS_DARK_BACKGROUND:
+        styles = {
+            "ui.strong": "bold white",
+            "ui.label": "grey70",
+            "ui.muted": "grey62",
+            "ui.heading": "bold grey62",
+            "ui.dim": "grey50",
+        }
+    else:
+        styles = {
+            "ui.strong": "bold #000000",
+            "ui.label": "#2a2a2a",
+            "ui.muted": "grey42",
+            "ui.heading": "bold #1a1a1a",
+            "ui.dim": "grey62",
+        }
+    styles.update(
+        {
+            "ui.accent": "bold purple",
+            "ui.border": "blue",
+            "ui.good": "bold green",
+            "ui.warn": "yellow",
+            "progress.elapsed": "default",
+            "progress.remaining": "default",
+            "progress.percentage": "bold blue",
+        }
+    )
+    return Theme(styles)
+
+
+def make_console(**kwargs) -> Console:
+    """Return a rich Console pre-loaded with the adaptive mlx_lm theme."""
+    kwargs.setdefault("highlight", False)
+    # Force truecolor so hex values in the theme survive instead of being
+    # downgraded to ANSI colors that the terminal may remap.
+    kwargs.setdefault("color_system", "truecolor")
+    return Console(theme=_make_theme(), **kwargs)
+
+
+def print_header_panel(
+    console: Console, title: str, rows: list[tuple[str, str]]
+) -> None:
+    """Render the boxed header used by the chat and training entry points."""
+    label_w = max(len(k) for k, _ in rows)
+    body = "\n".join(
+        f"  [ui.label]{k.ljust(label_w)}[/ui.label]   [ui.strong]{v}[/ui.strong]"
+        for k, v in rows
+    )
+    console.print(
+        Panel(
+            body,
+            title=f"[ui.accent]{title}[/ui.accent]",
+            title_align="left",
+            border_style="ui.border",
+            box=ROUNDED,
+            padding=(0, 2),
+        )
+    )
+
+
+def print_chat_help(console: Console) -> None:
+    console.print(
+        "  [ui.label]commands[/ui.label]    "
+        "[ui.strong]q[/ui.strong] [ui.muted]exit[/ui.muted]   "
+        "[ui.strong]r[/ui.strong] [ui.muted]reset[/ui.muted]   "
+        "[ui.strong]h[/ui.strong] [ui.muted]help[/ui.muted]"
+    )
+
+
+def make_corridor_prompt(console: Console):
+    """Return a callable that draws the chat input corridor.
+
+    The returned callable draws the top/bottom rules around the input line,
+    repositions the cursor onto the middle line, and returns the styled
+    "›" prompt string. Pass that string to ``input()`` so readline treats
+    the marker as part of the prompt — otherwise backspace will erase it.
+    """
+
+    _ANSI_RE = re.compile(r"\x1b\[[0-9;]*[A-Za-z]")
+
+    def _readline_safe(text: str) -> str:
+        # Wrap escape sequences in \x01..\x02 so readline doesn't count
+        # them when computing the prompt's visible width.
+        return _ANSI_RE.sub(lambda m: f"\x01{m.group(0)}\x02", text)
+
+    def _draw() -> str:
+        width = shutil.get_terminal_size((80, 24)).columns
+        dashes = "─" * max(width - 1, 10)
+        with console.capture() as cap:
+            console.print(f"[ui.muted]{dashes}[/ui.muted]")
+            console.print()
+            console.print(f"[ui.muted]{dashes}[/ui.muted]")
+        sys.stdout.write(cap.get())
+        # Move the cursor up two rows back onto the blank middle line.
+        sys.stdout.write("\033[2A\r")
+        sys.stdout.flush()
+        with console.capture() as cap2:
+            console.print("[ui.accent]›[/ui.accent] ", end="")
+        return _readline_safe(cap2.get())
+
+    return _draw
+
+
+class SquareBar(ProgressColumn):
+    """Progress bar rendered with █/░ blocks plus eighth-block sub-precision."""
+
+    _EIGHTHS = "▏▎▍▌▋▊▉"  # 1/8 .. 7/8
+
+    def __init__(self, bar_width: int = 40, complete_style: str = "blue"):
+        super().__init__()
+        self.bar_width = bar_width
+        self.complete_style = complete_style
+
+    def render(self, task):
+        if not task.total:
+            return Text("░" * self.bar_width, style="ui.dim")
+        pct = min(max(task.completed / task.total, 0.0), 1.0)
+        total_eighths = int(pct * self.bar_width * 8)
+        full = total_eighths // 8
+        rem = total_eighths % 8
+        text = Text()
+        text.append("█" * full, style=self.complete_style)
+        used = full
+        if rem > 0 and full < self.bar_width:
+            text.append(self._EIGHTHS[rem - 1], style=self.complete_style)
+            used += 1
+        text.append("░" * (self.bar_width - used), style="ui.dim")
+        return text
+
+
+def make_train_progress(console: Console, *, disable: bool = False) -> Progress:
+    return Progress(
+        TextColumn("[bold blue]train[/bold blue]"),
+        SquareBar(bar_width=30, complete_style="blue"),
+        TextColumn("[progress.percentage]{task.percentage:>3.0f}%"),
+        TextColumn("[ui.muted]·[/ui.muted]"),
+        TextColumn(
+            "[bold blue]{task.completed:>5,}[/bold blue]"
+            "[ui.muted]/{task.total:,}[/ui.muted]"
+        ),
+        TextColumn("[ui.muted]·[/ui.muted]"),
+        TimeElapsedColumn(),
+        TextColumn("[ui.muted]<[/ui.muted]"),
+        TimeRemainingColumn(),
+        console=console,
+        transient=False,
+        disable=disable,
+    )

--- a/mlx_lm/cli_ui.py
+++ b/mlx_lm/cli_ui.py
@@ -4,6 +4,7 @@ import re
 import shutil
 import sys
 from contextlib import contextmanager
+from functools import lru_cache
 
 import mlx.core as mx
 from rich.box import ROUNDED
@@ -43,12 +44,15 @@ def _make_theme() -> Theme:
     )
 
 
-def make_console(**kwargs) -> Console:
-    """Return a rich Console pre-loaded with the mlx_lm theme."""
-    kwargs.setdefault("highlight", False)
-    kwargs.setdefault("color_system", "truecolor")
-    kwargs.setdefault("width", _terminal_width())
-    return Console(theme=_make_theme(), **kwargs)
+@lru_cache(maxsize=1)
+def make_console() -> Console:
+    """Return the shared rich Console pre-loaded with the mlx_lm theme."""
+    return Console(
+        theme=_make_theme(),
+        highlight=False,
+        color_system="truecolor",
+        width=_terminal_width(),
+    )
 
 
 def print_header_panel(
@@ -79,6 +83,31 @@ def print_chat_help(console: Console) -> None:
         "[ui.strong]r[/ui.strong] [ui.muted]reset[/ui.muted]   "
         "[ui.strong]h[/ui.strong] [ui.muted]help[/ui.muted]"
     )
+
+
+def print_lora_run_header(console: Console, args) -> None:
+    """Render the lora-run startup panel from a parsed args namespace."""
+    type_label = args.fine_tune_type
+    if args.fine_tune_type in ("lora", "dora"):
+        lora_rank = args.lora_parameters.get("rank", "?")
+        type_label = (
+            f"{args.fine_tune_type} · {args.num_layers} layers · rank {lora_rank}"
+        )
+    elif args.fine_tune_type == "full":
+        type_label = f"full · {args.num_layers} layers"
+
+    lr = args.learning_rate if isinstance(args.learning_rate, (int, float)) else None
+    lr_str = f"{lr:.1e}" if lr is not None else "schedule"
+
+    rows = [
+        ("model", str(args.model)),
+        ("type", type_label),
+        ("dataset", str(args.data)),
+        ("optimizer", f"{args.optimizer} · lr {lr_str}"),
+        ("batch · iters", f"{args.batch_size} · {args.iters:,}"),
+        ("max seq", f"{args.max_seq_length:,}"),
+    ]
+    print_header_panel(console, "mlx_lm.lora", rows)
 
 
 def corridor_input(console: Console) -> str:
@@ -133,7 +162,7 @@ class SquareBar(ProgressColumn):
 
 def make_train_progress(console: Console, *, disable: bool = False) -> Progress:
     return Progress(
-        TextColumn("[bold blue]train[/bold blue]"),
+        TextColumn("[bold blue]{task.description:<5}[/bold blue]"),
         SquareBar(bar_width=30, complete_style="blue"),
         TextColumn("[progress.percentage]{task.percentage:>3.0f}%"),
         TextColumn("[ui.muted]·[/ui.muted]"),
@@ -189,9 +218,7 @@ class TrainUI:
     @contextmanager
     def val_task(self, total: int):
         task_id = (
-            self._progress.add_task("[bold blue]val  [/bold blue]", total=total)
-            if self._rank == 0
-            else None
+            self._progress.add_task("val", total=total) if self._rank == 0 else None
         )
 
         def advance():

--- a/mlx_lm/cli_ui.py
+++ b/mlx_lm/cli_ui.py
@@ -1,54 +1,58 @@
 # Copyright © 2024 Apple Inc.
 
-"""Shared UI helpers for the mlx_lm command-line tools.
-
-Centralizes the rich-based panel/progress/prompt rendering used by the chat
-and training entry points. The theme is hardcoded for a light terminal
-background.
-"""
-
 import os
 import re
 import shutil
 import sys
 
+import mlx.core as mx
 from rich.box import ROUNDED
 from rich.console import Console
 from rich.panel import Panel
-from rich.progress import (
-    Progress,
-    ProgressColumn,
-    TextColumn,
-)
+from rich.progress import Progress, ProgressColumn, TextColumn
 from rich.text import Text
 from rich.theme import Theme
+
+_ANSI_RE = re.compile(r"\x1b\[[0-9;]*[A-Za-z]")
+
+
+def printf(*args, **kwargs):
+    """Print on rank 0 only; no-op on every other distributed worker."""
+    if mx.distributed.init().rank() == 0:
+        print(*args, **kwargs)
 
 
 def _terminal_width(default: int = 120) -> int:
     """Best-effort terminal width.
 
-    Under launchers like ``mlx.launch`` the worker's stdout is a pipe, so
-    Rich's auto-detection falls back to 80 columns. Honor an explicit
-    ``MLX_LM_WIDTH`` override, then ``COLUMNS``, then a real TTY query, and
-    finally a generous default that's nicer than 80 on modern terminals.
+    ``shutil.get_terminal_size`` already honors ``COLUMNS`` and queries
+    stdout's fd. Under launchers like ``mlx.launch`` rank-0's stdout can be
+    piped, so as a last resort we open the controlling terminal directly.
     """
-    for var in ("MLX_LM_WIDTH", "COLUMNS"):
-        value = os.environ.get(var)
-        if value and value.isdigit():
-            return int(value)
     width = shutil.get_terminal_size(fallback=(0, 0)).columns
-    return width if width > 0 else default
+    if width > 0:
+        return width
+    try:
+        fd = os.open("/dev/tty", os.O_RDONLY)
+    except OSError:
+        return default
+    try:
+        return os.get_terminal_size(fd).columns or default
+    except OSError:
+        return default
+    finally:
+        os.close(fd)
 
 
 def _make_theme() -> Theme:
     return Theme(
         {
-            "ui.strong": "bold #000000",
-            "ui.label": "#2a2a2a",
-            "ui.muted": "grey42",
-            "ui.heading": "bold #1a1a1a",
-            "ui.dim": "grey62",
-            "ui.accent": "bold purple",
+            "ui.strong": "bold",
+            "ui.label": "default",
+            "ui.muted": "grey50",
+            "ui.heading": "bold",
+            "ui.dim": "grey50",
+            "ui.accent": "bold magenta",
             "ui.border": "blue",
             "ui.good": "bold green",
             "ui.warn": "yellow",
@@ -95,38 +99,27 @@ def print_chat_help(console: Console) -> None:
     )
 
 
-def make_corridor_prompt(console: Console):
-    """Return a callable that draws the chat input corridor.
+def corridor_input(console: Console) -> str:
 
-    The returned callable draws the top/bottom rules around the input line,
-    repositions the cursor onto the middle line, and returns the styled
-    "›" prompt string. Pass that string to ``input()`` so readline treats
-    the marker as part of the prompt — otherwise backspace will erase it.
-    """
+    width = console.width
+    dashes = "─" * max(width - 1, 10)
+    with console.capture() as cap:
+        console.print(f"[ui.muted]{dashes}[/ui.muted]")
+        console.print()
+        console.print(f"[ui.muted]{dashes}[/ui.muted]")
+    sys.stdout.write(cap.get())
+    sys.stdout.write("\033[2A\r")  # cursor up two rows onto the blank middle line
+    sys.stdout.flush()
 
-    _ANSI_RE = re.compile(r"\x1b\[[0-9;]*[A-Za-z]")
-
-    def _readline_safe(text: str) -> str:
-        # Wrap escape sequences in \x01..\x02 so readline doesn't count
-        # them when computing the prompt's visible width.
-        return _ANSI_RE.sub(lambda m: f"\x01{m.group(0)}\x02", text)
-
-    def _draw() -> str:
-        width = console.width
-        dashes = "─" * max(width - 1, 10)
-        with console.capture() as cap:
-            console.print(f"[ui.muted]{dashes}[/ui.muted]")
-            console.print()
-            console.print(f"[ui.muted]{dashes}[/ui.muted]")
-        sys.stdout.write(cap.get())
-        # Move the cursor up two rows back onto the blank middle line.
-        sys.stdout.write("\033[2A\r")
+    with console.capture() as cap2:
+        console.print("[ui.accent]›[/ui.accent] ", end="")
+    prompt = _ANSI_RE.sub(lambda m: f"\x01{m.group(0)}\x02", cap2.get())
+    try:
+        return input(prompt)
+    finally:
+        # Cursor sits on the bottom-rule row; advance past it.
+        sys.stdout.write("\n")
         sys.stdout.flush()
-        with console.capture() as cap2:
-            console.print("[ui.accent]›[/ui.accent] ", end="")
-        return _readline_safe(cap2.get())
-
-    return _draw
 
 
 class SquareBar(ProgressColumn):

--- a/mlx_lm/cli_ui.py
+++ b/mlx_lm/cli_ui.py
@@ -7,6 +7,7 @@ and training entry points. The theme is hardcoded for a light terminal
 background.
 """
 
+import os
 import re
 import shutil
 import sys
@@ -18,11 +19,25 @@ from rich.progress import (
     Progress,
     ProgressColumn,
     TextColumn,
-    TimeElapsedColumn,
-    TimeRemainingColumn,
 )
 from rich.text import Text
 from rich.theme import Theme
+
+
+def _terminal_width(default: int = 120) -> int:
+    """Best-effort terminal width.
+
+    Under launchers like ``mlx.launch`` the worker's stdout is a pipe, so
+    Rich's auto-detection falls back to 80 columns. Honor an explicit
+    ``MLX_LM_WIDTH`` override, then ``COLUMNS``, then a real TTY query, and
+    finally a generous default that's nicer than 80 on modern terminals.
+    """
+    for var in ("MLX_LM_WIDTH", "COLUMNS"):
+        value = os.environ.get(var)
+        if value and value.isdigit():
+            return int(value)
+    width = shutil.get_terminal_size(fallback=(0, 0)).columns
+    return width if width > 0 else default
 
 
 def _make_theme() -> Theme:
@@ -37,8 +52,6 @@ def _make_theme() -> Theme:
             "ui.border": "blue",
             "ui.good": "bold green",
             "ui.warn": "yellow",
-            "progress.elapsed": "default",
-            "progress.remaining": "default",
             "progress.percentage": "bold blue",
         }
     )
@@ -48,6 +61,7 @@ def make_console(**kwargs) -> Console:
     """Return a rich Console pre-loaded with the mlx_lm theme."""
     kwargs.setdefault("highlight", False)
     kwargs.setdefault("color_system", "truecolor")
+    kwargs.setdefault("width", _terminal_width())
     return Console(theme=_make_theme(), **kwargs)
 
 
@@ -98,7 +112,7 @@ def make_corridor_prompt(console: Console):
         return _ANSI_RE.sub(lambda m: f"\x01{m.group(0)}\x02", text)
 
     def _draw() -> str:
-        width = shutil.get_terminal_size((80, 24)).columns
+        width = console.width
         dashes = "─" * max(width - 1, 10)
         with console.capture() as cap:
             console.print(f"[ui.muted]{dashes}[/ui.muted]")
@@ -152,10 +166,6 @@ def make_train_progress(console: Console, *, disable: bool = False) -> Progress:
             "[bold blue]{task.completed:>5,}[/bold blue]"
             "[ui.muted]/{task.total:,}[/ui.muted]"
         ),
-        TextColumn("[ui.muted]·[/ui.muted]"),
-        TimeElapsedColumn(),
-        TextColumn("[ui.muted]<[/ui.muted]"),
-        TimeRemainingColumn(),
         console=console,
         transient=False,
         disable=disable,

--- a/mlx_lm/cli_ui.py
+++ b/mlx_lm/cli_ui.py
@@ -238,7 +238,7 @@ class TrainUI:
             f"  [ui.muted]{it:>4}[/ui.muted]    "
             f"[ui.accent]val[/ui.accent] "
             f"[ui.strong]{val_loss:>5.3f}[/ui.strong]    "
-            f"[ui.muted]({val_time:.2f}s)[/ui.muted]"
+            f"[ui.muted]{val_time:.2f}s[/ui.muted]"
         )
 
     def report_save(self, checkpoint):

--- a/mlx_lm/cli_ui.py
+++ b/mlx_lm/cli_ui.py
@@ -1,6 +1,5 @@
 # Copyright © 2024 Apple Inc.
 
-import os
 import re
 import shutil
 import sys
@@ -23,25 +22,7 @@ def printf(*args, **kwargs):
 
 
 def _terminal_width(default: int = 120) -> int:
-    """Best-effort terminal width.
-
-    ``shutil.get_terminal_size`` already honors ``COLUMNS`` and queries
-    stdout's fd. Under launchers like ``mlx.launch`` rank-0's stdout can be
-    piped, so as a last resort we open the controlling terminal directly.
-    """
-    width = shutil.get_terminal_size(fallback=(0, 0)).columns
-    if width > 0:
-        return width
-    try:
-        fd = os.open("/dev/tty", os.O_RDONLY)
-    except OSError:
-        return default
-    try:
-        return os.get_terminal_size(fd).columns or default
-    except OSError:
-        return default
-    finally:
-        os.close(fd)
+    return shutil.get_terminal_size(fallback=(default, 0)).columns or default
 
 
 def _make_theme() -> Theme:

--- a/mlx_lm/cli_ui.py
+++ b/mlx_lm/cli_ui.py
@@ -3,15 +3,13 @@
 """Shared UI helpers for the mlx_lm command-line tools.
 
 Centralizes the rich-based panel/progress/prompt rendering used by the chat
-and training entry points and exposes an adaptive theme so the same markup
-reads well on both light and dark terminal backgrounds.
+and training entry points. The theme is hardcoded for a light terminal
+background.
 """
 
-import os
 import re
 import shutil
 import sys
-import time
 
 from rich.box import ROUNDED
 from rich.console import Console
@@ -27,201 +25,14 @@ from rich.text import Text
 from rich.theme import Theme
 
 
-def _is_distributed_non_root() -> bool:
-    """True when running as a non-rank-0 worker under a launcher.
-
-    We use environment variables exported by common launchers (mlx.launch,
-    OpenMPI, MPICH, SLURM, torchrun) instead of ``mlx.distributed`` so this
-    module stays independent of the heavy mlx import path.
-    """
-    for var in (
-        "OMPI_COMM_WORLD_RANK",
-        "PMI_RANK",
-        "PMIX_RANK",
-        "SLURM_PROCID",
-        "RANK",
-    ):
-        value = os.environ.get(var)
-        if value and value.strip() != "0":
-            return True
-    return False
-
-
-def _running_under_launcher() -> bool:
-    """True when any multi-process launcher signature is detected.
-
-    We can't reliably tell our rank from env vars alone (different launchers
-    use different keys). When this returns True we skip auto-detection at
-    import time and wait for the caller to opt in via :func:`init_theme`.
-    """
-    explicit = {
-        "WORLD_SIZE",
-        "LOCAL_RANK",
-        "RANK",
-        "PMI_RANK",
-        "PMIX_RANK",
-        "SLURM_PROCID",
-        "OMPI_COMM_WORLD_SIZE",
-    }
-    if any(k in os.environ for k in explicit):
-        return True
-    prefixes = ("OMPI_", "PMI_", "PMIX_", "SLURM_", "MLX_LAUNCH")
-    for k in os.environ:
-        if k.startswith(prefixes):
-            return True
-    return False
-
-
-def _osc11_to_rgb(timeout: float = 0.5):
-    """Ask the terminal for its background color via OSC 11.
-
-    Returns an (r, g, b) tuple in the 0-255 range, or None if the terminal
-    does not respond (non-TTY, unsupported terminal, redirected stdio,
-    non-rank-0 in a distributed launch, ...). The default timeout is generous
-    enough to survive an SSH round trip.
-    """
-    # In a distributed launch, all ranks share the same TTY. If every worker
-    # sends an OSC query, only one read wins and the rest of the responses
-    # leak onto the screen. Skip the probe on non-root ranks.
-    if _is_distributed_non_root():
-        return None
-    if not (sys.stdin.isatty() and sys.stdout.isatty()):
-        return None
-    try:
-        import select
-        import termios
-        import tty
-    except ImportError:
-        return None  # Windows / restricted environments
-
-    fd = sys.stdin.fileno()
-    try:
-        saved = termios.tcgetattr(fd)
-    except termios.error:
-        return None
-
-    try:
-        tty.setraw(fd)
-        sys.stdout.write("\033]11;?\033\\")
-        sys.stdout.flush()
-
-        deadline = time.monotonic() + timeout
-        buf = b""
-        while True:
-            remaining = deadline - time.monotonic()
-            if remaining <= 0:
-                break
-            if not select.select([fd], [], [], remaining)[0]:
-                break
-            chunk = os.read(fd, 64)
-            if not chunk:
-                break
-            buf += chunk
-            if buf.endswith(b"\x07") or buf.endswith(b"\x1b\\"):
-                break
-    finally:
-        termios.tcsetattr(fd, termios.TCSADRAIN, saved)
-
-    match = re.search(rb"rgb:([0-9a-fA-F]+)/([0-9a-fA-F]+)/([0-9a-fA-F]+)", buf)
-    if not match:
-        return None
-
-    def _to_byte(hex_bytes: bytes) -> int:
-        # OSC 11 components are typically 4 hex digits (16-bit) but some
-        # terminals reply with 2. Normalize to 8 bits by scaling.
-        digits = hex_bytes.decode("ascii")
-        value = int(digits, 16)
-        full = (1 << (4 * len(digits))) - 1
-        return round(value * 255 / full) if full else 0
-
-    return tuple(_to_byte(g) for g in match.groups())
-
-
-def _detect_dark_background() -> bool:
-    override = os.environ.get("MLX_LM_THEME", "").strip().lower()
-    if override in ("dark", "light"):
-        return override == "dark"
-
-    rgb = _osc11_to_rgb()
-    if rgb is not None:
-        r, g, b = rgb
-        # Perceived luminance (Rec. 601). < 128 ≈ dark background.
-        return (0.299 * r + 0.587 * g + 0.114 * b) < 128
-
-    # COLORFGBG is "fg;bg" or "fg;default;bg" with ANSI color indices.
-    cfb = os.environ.get("COLORFGBG", "")
-    if cfb:
-        last = cfb.split(";")[-1].strip()
-        try:
-            bg = int(last)
-            # 0-6 are the dim base colors and 8 is dark grey; 7 and 9-15
-            # are the bright/light variants.
-            return bg in (0, 1, 2, 3, 4, 5, 6, 8)
-        except ValueError:
-            pass
-
-    # No signal from the terminal — assume dark, which is the modern default.
-    return True
-
-
-# Lazy theme state. We avoid auto-detecting at import time when running under
-# a multi-process launcher because every worker would otherwise emit an OSC
-# query against the shared terminal, leaking the responses to the screen.
-# Single-process callers fall through to auto-detection on first use.
-_is_dark = True
-_is_dark_initialized = False
-
-
-def init_theme(probe: bool = True) -> None:
-    """Initialize the terminal theme.
-
-    Pass ``probe=False`` on non-root ranks of distributed launches so the
-    theme gets marked as initialized without sending an OSC query that would
-    leak its response onto the shared terminal.
-    """
-    global _is_dark, _is_dark_initialized
-    _is_dark_initialized = True
-    if probe:
-        _is_dark = _detect_dark_background()
-
-
-def _ensure_theme_initialized() -> None:
-    global _is_dark_initialized
-    if _is_dark_initialized:
-        return
-    if _running_under_launcher():
-        # Caller hasn't opted in via init_theme(); stay on the default theme
-        # rather than risk a probe across all ranks.
-        _is_dark_initialized = True
-        return
-    init_theme(probe=True)
-
-
-def is_dark_background() -> bool:
-    """Whether the active theme is for a dark terminal background."""
-    _ensure_theme_initialized()
-    return _is_dark
-
-
 def _make_theme() -> Theme:
-    if is_dark_background():
-        styles = {
-            "ui.strong": "bold white",
-            "ui.label": "grey70",
-            "ui.muted": "grey62",
-            "ui.heading": "bold grey62",
-            "ui.dim": "grey50",
-        }
-    else:
-        styles = {
+    return Theme(
+        {
             "ui.strong": "bold #000000",
             "ui.label": "#2a2a2a",
             "ui.muted": "grey42",
             "ui.heading": "bold #1a1a1a",
             "ui.dim": "grey62",
-        }
-    styles.update(
-        {
             "ui.accent": "bold purple",
             "ui.border": "blue",
             "ui.good": "bold green",
@@ -231,14 +42,11 @@ def _make_theme() -> Theme:
             "progress.percentage": "bold blue",
         }
     )
-    return Theme(styles)
 
 
 def make_console(**kwargs) -> Console:
-    """Return a rich Console pre-loaded with the adaptive mlx_lm theme."""
+    """Return a rich Console pre-loaded with the mlx_lm theme."""
     kwargs.setdefault("highlight", False)
-    # Force truecolor so hex values in the theme survive instead of being
-    # downgraded to ANSI colors that the terminal may remap.
     kwargs.setdefault("color_system", "truecolor")
     return Console(theme=_make_theme(), **kwargs)
 

--- a/mlx_lm/cli_ui.py
+++ b/mlx_lm/cli_ui.py
@@ -16,7 +16,7 @@ from rich.theme import Theme
 _ANSI_RE = re.compile(r"\x1b\[[0-9;]*[A-Za-z]")
 
 
-def printf(*args, **kwargs):
+def rprint(*args, **kwargs):
     """Print on rank 0 only; no-op on every other distributed worker."""
     if mx.distributed.init().rank() == 0:
         print(*args, **kwargs)
@@ -219,4 +219,64 @@ class TrainUI:
             return
         self._console.print(
             f"  [ui.good]save[/ui.good]  " f"[ui.muted]{checkpoint.name}[/ui.muted]"
+        )
+
+
+class ChatUI:
+    """Helper class for rendering the chat UI and streaming responses."""
+
+    def __init__(self, args, rank: int = 0):
+        self._rank = rank
+        self._args = args
+        self._console = make_console()
+
+    def __enter__(self):
+        if self._rank == 0:
+            rows = [("model", str(self._args.model))]
+            if self._args.adapter_path:
+                rows.append(("adapter", str(self._args.adapter_path)))
+            rows.append(("max tokens", f"{self._args.max_tokens:,}"))
+            if self._args.system_prompt:
+                sp = self._args.system_prompt
+                if len(sp) > 60:
+                    sp = sp[:57] + "..."
+                rows.append(("system", sp))
+            print_header_panel(self._console, "mlx_lm.chat", rows)
+            print_chat_help(self._console)
+        return self
+
+    def __exit__(self, *exc):
+        return False
+
+    def prompt(self) -> str:
+        if self._rank == 0:
+            return corridor_input(self._console)
+        return input("")
+
+    def say_bye(self):
+        if self._rank == 0:
+            self._console.print("[ui.muted]bye[/ui.muted]")
+
+    def say_reset(self):
+        if self._rank == 0:
+            self._console.print(
+                "  [ui.good]reset[/ui.good] [ui.muted]context cleared[/ui.muted]"
+            )
+
+    def say_help(self):
+        if self._rank == 0:
+            print_chat_help(self._console)
+
+    def stream_token(self, text: str):
+        rprint(text, flush=True, end="")
+
+    def end_turn(self, response):
+        rprint()  # newline after the streamed line
+        if self._rank != 0 or response is None:
+            return
+        self._console.print(
+            f"  [ui.muted]{response.generation_tokens} tokens · "
+            f"{response.generation_tps:.1f} tok/s · "
+            f"prompt {response.prompt_tps:.1f} tok/s · "
+            f"peak {response.peak_memory:.2f} GB[/ui.muted]"
         )

--- a/mlx_lm/cli_ui.py
+++ b/mlx_lm/cli_ui.py
@@ -3,6 +3,7 @@
 import re
 import shutil
 import sys
+from contextlib import contextmanager
 
 import mlx.core as mx
 from rich.box import ROUNDED
@@ -144,3 +145,78 @@ def make_train_progress(console: Console, *, disable: bool = False) -> Progress:
         transient=False,
         disable=disable,
     )
+
+
+class TrainUI:
+    """Helper class for rendering training progress and metrics."""
+
+    def __init__(self, total_iters: int, rank: int = 0):
+        self._rank = rank
+        self._console = make_console()
+        self._progress = make_train_progress(self._console, disable=(rank != 0))
+        self._task = self._progress.add_task("train", total=total_iters)
+        self._prev_train_loss = None
+
+    def __enter__(self):
+        if self._rank == 0:
+            self._console.print(
+                "  [ui.heading]iter   train_loss     tok/s     tokens[/ui.heading]"
+            )
+        self._progress.__enter__()
+        return self
+
+    def __exit__(self, *exc):
+        return self._progress.__exit__(*exc)
+
+    def advance(self):
+        self._progress.advance(self._task)
+
+    def report_train(self, it, train_loss, tokens_sec, trained_tokens):
+        if self._rank != 0:
+            return
+        if self._prev_train_loss is None or train_loss <= self._prev_train_loss:
+            arrow, style = "▼", "green"
+        else:
+            arrow, style = "▲", "yellow"
+        self._prev_train_loss = train_loss
+        self._console.print(
+            f"  [ui.muted]{it:>4}[/ui.muted]    "
+            f"[bold {style}]{train_loss:>5.3f} {arrow}[/bold {style}]    "
+            f"[ui.strong]{tokens_sec:>5,.0f}[/ui.strong]    "
+            f"[ui.muted]{trained_tokens / 1000:>5.1f}k[/ui.muted]"
+        )
+
+    @contextmanager
+    def val_task(self, total: int):
+        task_id = (
+            self._progress.add_task("[bold blue]val  [/bold blue]", total=total)
+            if self._rank == 0
+            else None
+        )
+
+        def advance():
+            if task_id is not None:
+                self._progress.advance(task_id)
+
+        try:
+            yield advance
+        finally:
+            if task_id is not None:
+                self._progress.remove_task(task_id)
+
+    def report_val(self, it, val_loss, val_time):
+        if self._rank != 0:
+            return
+        self._console.print(
+            f"  [ui.muted]{it:>4}[/ui.muted]    "
+            f"[ui.accent]val[/ui.accent] "
+            f"[ui.strong]{val_loss:>5.3f}[/ui.strong]    "
+            f"[ui.muted]({val_time:.2f}s)[/ui.muted]"
+        )
+
+    def report_save(self, checkpoint):
+        if self._rank != 0:
+            return
+        self._console.print(
+            f"  [ui.good]save[/ui.good]  " f"[ui.muted]{checkpoint.name}[/ui.muted]"
+        )

--- a/mlx_lm/lora.py
+++ b/mlx_lm/lora.py
@@ -24,6 +24,12 @@ from .tuner.utils import (
 )
 from .utils import _parse_size, load, save_config
 
+
+def printf(*args, **kwargs):
+    if mx.distributed.init().rank() == 0:
+        print(*args, **kwargs)
+
+
 yaml_loader = yaml.SafeLoader
 yaml_loader.add_implicit_resolver(
     "tag:yaml.org,2002:float",
@@ -247,7 +253,7 @@ def train_model(
 
     # Resume from weights if provided
     if args.resume_adapter_file is not None:
-        print(f"Loading fine-tuned weights from {args.resume_adapter_file}")
+        printf(f"Loading fine-tuned weights from {args.resume_adapter_file}")
         model.load_weights(args.resume_adapter_file, strict=False)
 
     print_trainable_parameters(model)
@@ -336,17 +342,19 @@ def _print_run_header(args):
 
 
 def evaluate_model(args, model: nn.Module, test_set):
+    rank = mx.distributed.init().rank()
     test_loss = evaluate(
         model=model,
         dataset=CacheDataset(test_set),
         batch_size=args.batch_size,
         num_batches=args.test_batches,
         max_seq_length=args.max_seq_length,
+        progress=(rank == 0),
     )
 
     test_ppl = math.exp(test_loss)
 
-    print(f"Test loss {test_loss:.3f}, Test ppl {test_ppl:.3f}.")
+    printf(f"Test loss {test_loss:.3f}, Test ppl {test_ppl:.3f}.")
 
 
 def run(args, training_callback: TrainingCallback = None):
@@ -358,10 +366,10 @@ def run(args, training_callback: TrainingCallback = None):
         config=vars(args),
     )
 
-    print("Loading pretrained model")
+    printf("Loading pretrained model")
     model, tokenizer = load(args.model, tokenizer_config={"trust_remote_code": True})
 
-    print("Loading datasets")
+    printf("Loading datasets")
     train_set, valid_set, test_set = load_dataset(args, tokenizer)
 
     if args.test and not args.train:
@@ -370,13 +378,13 @@ def run(args, training_callback: TrainingCallback = None):
             load_adapters(model, args.adapter_path)
 
     elif args.train:
-        print("Training")
+        printf("Training")
         train_model(args, model, train_set, valid_set, training_callback)
     else:
         raise ValueError("Must provide at least one of --train or --test")
 
     if args.test:
-        print("Testing")
+        printf("Testing")
         evaluate_model(args, model, test_set)
 
 
@@ -384,10 +392,11 @@ def main():
     os.environ["TOKENIZERS_PARALLELISM"] = "true"
     parser = build_parser()
     args = parser.parse_args()
+
     config = args.config
     args = vars(args)
     if config:
-        print("Loading configuration file", config)
+        printf("Loading configuration file", config)
         with open(config, "r") as file:
             config = yaml.load(file, yaml_loader)
         # Prefer parameters from command-line arguments

--- a/mlx_lm/lora.py
+++ b/mlx_lm/lora.py
@@ -12,7 +12,7 @@ import mlx.optimizers as optim
 import numpy as np
 import yaml
 
-from .cli_ui import make_console, print_header_panel
+from .cli_ui import make_console, print_header_panel, printf
 from .tuner.callbacks import get_reporting_callbacks
 from .tuner.datasets import CacheDataset, load_dataset
 from .tuner.trainer import TrainingArgs, TrainingCallback, evaluate, train
@@ -23,12 +23,6 @@ from .tuner.utils import (
     print_trainable_parameters,
 )
 from .utils import _parse_size, load, save_config
-
-
-def printf(*args, **kwargs):
-    if mx.distributed.init().rank() == 0:
-        print(*args, **kwargs)
-
 
 yaml_loader = yaml.SafeLoader
 yaml_loader.add_implicit_resolver(
@@ -312,14 +306,15 @@ def train_model(
 
 
 def _print_run_header(args):
-    rank = mx.distributed.init().rank()
-    if rank != 0:
+    if mx.distributed.init().rank() != 0:
         return
 
     type_label = args.fine_tune_type
     if args.fine_tune_type in ("lora", "dora"):
-        rank = args.lora_parameters.get("rank", "?")
-        type_label = f"{args.fine_tune_type} · {args.num_layers} layers · rank {rank}"
+        lora_rank = args.lora_parameters.get("rank", "?")
+        type_label = (
+            f"{args.fine_tune_type} · {args.num_layers} layers · rank {lora_rank}"
+        )
     elif args.fine_tune_type == "full":
         type_label = f"full · {args.num_layers} layers"
 

--- a/mlx_lm/lora.py
+++ b/mlx_lm/lora.py
@@ -11,8 +11,9 @@ import mlx.nn as nn
 import mlx.optimizers as optim
 import numpy as np
 import yaml
+from tqdm import tqdm
 
-from .cli_ui import make_console, print_header_panel, rprint
+from .cli_ui import make_console, print_lora_run_header, rprint
 from .tuner.callbacks import get_reporting_callbacks
 from .tuner.datasets import CacheDataset, load_dataset
 from .tuner.trainer import TrainingArgs, TrainingCallback, evaluate, train
@@ -250,6 +251,8 @@ def train_model(
         rprint(f"Loading fine-tuned weights from {args.resume_adapter_file}")
         model.load_weights(args.resume_adapter_file, strict=False)
 
+    if mx.distributed.init().rank() == 0:
+        print_lora_run_header(make_console(), args)
     print_trainable_parameters(model)
 
     adapter_path = Path(args.adapter_path)
@@ -292,8 +295,6 @@ def train_model(
 
     opt = opt_class(learning_rate=lr, **optimizer_config)
 
-    _print_run_header(args)
-
     # Train model
     train(
         model=model,
@@ -305,47 +306,22 @@ def train_model(
     )
 
 
-def _print_run_header(args):
-    if mx.distributed.init().rank() != 0:
-        return
-
-    type_label = args.fine_tune_type
-    if args.fine_tune_type in ("lora", "dora"):
-        lora_rank = args.lora_parameters.get("rank", "?")
-        type_label = (
-            f"{args.fine_tune_type} · {args.num_layers} layers · rank {lora_rank}"
-        )
-    elif args.fine_tune_type == "full":
-        type_label = f"full · {args.num_layers} layers"
-
-    lr = (
-        args.learning_rate
-        if isinstance(args.learning_rate, (int, float))
-        else "schedule"
-    )
-    lr_str = f"{lr:.1e}" if isinstance(lr, (int, float)) else lr
-
-    rows = [
-        ("model", str(args.model)),
-        ("type", type_label),
-        ("dataset", str(args.data)),
-        ("optimizer", f"{args.optimizer} · lr {lr_str}"),
-        ("batch · iters", f"{args.batch_size} · {args.iters:,}"),
-        ("max seq", f"{args.max_seq_length:,}"),
-    ]
-    print_header_panel(make_console(), "mlx_lm.lora", rows)
-
-
 def evaluate_model(args, model: nn.Module, test_set):
     rank = mx.distributed.init().rank()
+    n_batches = len(test_set) // args.batch_size
+    if args.test_batches != -1:
+        n_batches = min(n_batches, args.test_batches)
+    pbar = tqdm(total=n_batches, desc="Calculating loss...") if rank == 0 else None
     test_loss = evaluate(
         model=model,
         dataset=CacheDataset(test_set),
         batch_size=args.batch_size,
         num_batches=args.test_batches,
         max_seq_length=args.max_seq_length,
-        progress=(rank == 0),
+        progress_callback=pbar.update if pbar else None,
     )
+    if pbar is not None:
+        pbar.close()
 
     test_ppl = math.exp(test_loss)
 

--- a/mlx_lm/lora.py
+++ b/mlx_lm/lora.py
@@ -12,7 +12,7 @@ import mlx.optimizers as optim
 import numpy as np
 import yaml
 
-from .cli_ui import init_theme, make_console, print_header_panel
+from .cli_ui import make_console, print_header_panel
 from .tuner.callbacks import get_reporting_callbacks
 from .tuner.datasets import CacheDataset, load_dataset
 from .tuner.trainer import TrainingArgs, TrainingCallback, evaluate, train
@@ -307,7 +307,6 @@ def train_model(
 
 def _print_run_header(args):
     rank = mx.distributed.init().rank()
-    init_theme(probe=(rank == 0))
     if rank != 0:
         return
 

--- a/mlx_lm/lora.py
+++ b/mlx_lm/lora.py
@@ -12,6 +12,7 @@ import mlx.optimizers as optim
 import numpy as np
 import yaml
 
+from .cli_ui import make_console, print_header_panel
 from .tuner.callbacks import get_reporting_callbacks
 from .tuner.datasets import CacheDataset, load_dataset
 from .tuner.trainer import TrainingArgs, TrainingCallback, evaluate, train
@@ -291,6 +292,8 @@ def train_model(
 
     opt = opt_class(learning_rate=lr, **optimizer_config)
 
+    _print_run_header(args)
+
     # Train model
     train(
         model=model,
@@ -300,6 +303,32 @@ def train_model(
         val_dataset=CacheDataset(valid_set),
         training_callback=training_callback,
     )
+
+
+def _print_run_header(args):
+    type_label = args.fine_tune_type
+    if args.fine_tune_type in ("lora", "dora"):
+        rank = args.lora_parameters.get("rank", "?")
+        type_label = f"{args.fine_tune_type} · {args.num_layers} layers · rank {rank}"
+    elif args.fine_tune_type == "full":
+        type_label = f"full · {args.num_layers} layers"
+
+    lr = (
+        args.learning_rate
+        if isinstance(args.learning_rate, (int, float))
+        else "schedule"
+    )
+    lr_str = f"{lr:.1e}" if isinstance(lr, (int, float)) else lr
+
+    rows = [
+        ("model", str(args.model)),
+        ("type", type_label),
+        ("dataset", str(args.data)),
+        ("optimizer", f"{args.optimizer} · lr {lr_str}"),
+        ("batch · iters", f"{args.batch_size} · {args.iters:,}"),
+        ("max seq", f"{args.max_seq_length:,}"),
+    ]
+    print_header_panel(make_console(), "mlx_lm.lora", rows)
 
 
 def evaluate_model(args, model: nn.Module, test_set):

--- a/mlx_lm/lora.py
+++ b/mlx_lm/lora.py
@@ -12,7 +12,7 @@ import mlx.optimizers as optim
 import numpy as np
 import yaml
 
-from .cli_ui import make_console, print_header_panel, printf
+from .cli_ui import make_console, print_header_panel, rprint
 from .tuner.callbacks import get_reporting_callbacks
 from .tuner.datasets import CacheDataset, load_dataset
 from .tuner.trainer import TrainingArgs, TrainingCallback, evaluate, train
@@ -247,7 +247,7 @@ def train_model(
 
     # Resume from weights if provided
     if args.resume_adapter_file is not None:
-        printf(f"Loading fine-tuned weights from {args.resume_adapter_file}")
+        rprint(f"Loading fine-tuned weights from {args.resume_adapter_file}")
         model.load_weights(args.resume_adapter_file, strict=False)
 
     print_trainable_parameters(model)
@@ -349,7 +349,7 @@ def evaluate_model(args, model: nn.Module, test_set):
 
     test_ppl = math.exp(test_loss)
 
-    printf(f"Test loss {test_loss:.3f}, Test ppl {test_ppl:.3f}.")
+    rprint(f"Test loss {test_loss:.3f}, Test ppl {test_ppl:.3f}.")
 
 
 def run(args, training_callback: TrainingCallback = None):
@@ -361,10 +361,10 @@ def run(args, training_callback: TrainingCallback = None):
         config=vars(args),
     )
 
-    printf("Loading pretrained model")
+    rprint("Loading pretrained model")
     model, tokenizer = load(args.model, tokenizer_config={"trust_remote_code": True})
 
-    printf("Loading datasets")
+    rprint("Loading datasets")
     train_set, valid_set, test_set = load_dataset(args, tokenizer)
 
     if args.test and not args.train:
@@ -373,13 +373,13 @@ def run(args, training_callback: TrainingCallback = None):
             load_adapters(model, args.adapter_path)
 
     elif args.train:
-        printf("Training")
+        rprint("Training")
         train_model(args, model, train_set, valid_set, training_callback)
     else:
         raise ValueError("Must provide at least one of --train or --test")
 
     if args.test:
-        printf("Testing")
+        rprint("Testing")
         evaluate_model(args, model, test_set)
 
 
@@ -390,7 +390,7 @@ def main():
     config = args.config
     args = vars(args)
     if config:
-        printf("Loading configuration file", config)
+        rprint("Loading configuration file", config)
         with open(config, "r") as file:
             config = yaml.load(file, yaml_loader)
         # Prefer parameters from command-line arguments

--- a/mlx_lm/lora.py
+++ b/mlx_lm/lora.py
@@ -12,7 +12,7 @@ import mlx.optimizers as optim
 import numpy as np
 import yaml
 
-from .cli_ui import make_console, print_header_panel
+from .cli_ui import init_theme, make_console, print_header_panel
 from .tuner.callbacks import get_reporting_callbacks
 from .tuner.datasets import CacheDataset, load_dataset
 from .tuner.trainer import TrainingArgs, TrainingCallback, evaluate, train
@@ -306,6 +306,11 @@ def train_model(
 
 
 def _print_run_header(args):
+    rank = mx.distributed.init().rank()
+    init_theme(probe=(rank == 0))
+    if rank != 0:
+        return
+
     type_label = args.fine_tune_type
     if args.fine_tune_type in ("lora", "dora"):
         rank = args.lora_parameters.get("rank", "?")

--- a/mlx_lm/lora.py
+++ b/mlx_lm/lora.py
@@ -387,7 +387,6 @@ def main():
     os.environ["TOKENIZERS_PARALLELISM"] = "true"
     parser = build_parser()
     args = parser.parse_args()
-
     config = args.config
     args = vars(args)
     if config:

--- a/mlx_lm/tuner/datasets.py
+++ b/mlx_lm/tuner/datasets.py
@@ -5,7 +5,13 @@ import types
 from pathlib import Path
 from typing import Any, Dict, List
 
+import mlx.core as mx
 from transformers import PreTrainedTokenizer
+
+
+def printf(*args, **kwargs):
+    if mx.distributed.init().rank() == 0:
+        print(*args, **kwargs)
 
 
 class TextDataset:
@@ -264,7 +270,7 @@ def load_custom_hf_dataset(args, tokenizer: PreTrainedTokenizer):
     collection = []
     for ds in dataset_collection:
         ds_path = ds["path"]
-        print(f"Loading Hugging Face dataset {ds_path}.")
+        printf(f"Loading Hugging Face dataset {ds_path}.")
         ds["mask_prompt"] = getattr(args, "mask_prompt", False)
         config = types.SimpleNamespace(**ds)
         hf_config = ds.get("config", {})
@@ -314,7 +320,7 @@ def load_dataset(args, tokenizer: PreTrainedTokenizer):
         if data_path.exists():
             train, valid, test = load_local_dataset(data_path, tokenizer, args)
         else:
-            print(f"Loading Hugging Face dataset {args.data}.")
+            printf(f"Loading Hugging Face dataset {args.data}.")
             train, valid, test = load_hf_dataset(args.data, tokenizer, args)
 
     if args.train and len(train) == 0:
@@ -322,7 +328,7 @@ def load_dataset(args, tokenizer: PreTrainedTokenizer):
             "Training set not found or empty. Must provide training set for fine-tuning."
         )
     if args.train and len(valid) == 0:
-        print(
+        printf(
             "Warning: Validation set not found or empty. Training will proceed without validation."
         )
     if args.test and len(test) == 0:

--- a/mlx_lm/tuner/datasets.py
+++ b/mlx_lm/tuner/datasets.py
@@ -7,7 +7,7 @@ from typing import Any, Dict, List
 
 from transformers import PreTrainedTokenizer
 
-from ..cli_ui import printf
+from ..cli_ui import rprint
 
 
 class TextDataset:
@@ -266,7 +266,7 @@ def load_custom_hf_dataset(args, tokenizer: PreTrainedTokenizer):
     collection = []
     for ds in dataset_collection:
         ds_path = ds["path"]
-        printf(f"Loading Hugging Face dataset {ds_path}.")
+        rprint(f"Loading Hugging Face dataset {ds_path}.")
         ds["mask_prompt"] = getattr(args, "mask_prompt", False)
         config = types.SimpleNamespace(**ds)
         hf_config = ds.get("config", {})
@@ -316,7 +316,7 @@ def load_dataset(args, tokenizer: PreTrainedTokenizer):
         if data_path.exists():
             train, valid, test = load_local_dataset(data_path, tokenizer, args)
         else:
-            printf(f"Loading Hugging Face dataset {args.data}.")
+            rprint(f"Loading Hugging Face dataset {args.data}.")
             train, valid, test = load_hf_dataset(args.data, tokenizer, args)
 
     if args.train and len(train) == 0:
@@ -324,7 +324,7 @@ def load_dataset(args, tokenizer: PreTrainedTokenizer):
             "Training set not found or empty. Must provide training set for fine-tuning."
         )
     if args.train and len(valid) == 0:
-        printf(
+        rprint(
             "Warning: Validation set not found or empty. Training will proceed without validation."
         )
     if args.test and len(test) == 0:

--- a/mlx_lm/tuner/datasets.py
+++ b/mlx_lm/tuner/datasets.py
@@ -5,13 +5,9 @@ import types
 from pathlib import Path
 from typing import Any, Dict, List
 
-import mlx.core as mx
 from transformers import PreTrainedTokenizer
 
-
-def printf(*args, **kwargs):
-    if mx.distributed.init().rank() == 0:
-        print(*args, **kwargs)
+from ..cli_ui import printf
 
 
 class TextDataset:

--- a/mlx_lm/tuner/trainer.py
+++ b/mlx_lm/tuner/trainer.py
@@ -13,6 +13,7 @@ from mlx.nn.utils import average_gradients
 from mlx.utils import tree_flatten, tree_map
 from tqdm import tqdm
 
+from ..cli_ui import make_console, make_train_progress
 from .callbacks import TrainingCallback
 from .datasets import CacheDataset
 
@@ -182,6 +183,8 @@ def evaluate(
     loss: callable = default_loss,
     iterate_batches: callable = iterate_batches,
     clear_cache_threshold: int = 0,
+    progress: bool = True,
+    batch_callback: callable = None,
 ):
     model.eval()
     all_losses = mx.array(0.0)
@@ -189,24 +192,30 @@ def evaluate(
 
     index_iterator = iter(range(num_batches)) if num_batches != -1 else iter(int, 1)
 
-    for _, batch in tqdm(
-        zip(
-            index_iterator,
-            iterate_batches(
-                dataset=dataset,
-                batch_size=batch_size,
-                max_seq_length=max_seq_length,
-                comm_group=mx.distributed.init(),
-            ),
+    batch_iter = zip(
+        index_iterator,
+        iterate_batches(
+            dataset=dataset,
+            batch_size=batch_size,
+            max_seq_length=max_seq_length,
+            comm_group=mx.distributed.init(),
         ),
-        desc="Calculating loss...",
-        total=min(len(dataset) // batch_size, num_batches),
-    ):
+    )
+    if progress:
+        batch_iter = tqdm(
+            batch_iter,
+            desc="Calculating loss...",
+            total=min(len(dataset) // batch_size, num_batches),
+        )
+
+    for _, batch in batch_iter:
         losses, toks = loss(model, *batch)
         all_losses += losses * toks
         ntokens += toks
         mx.eval(all_losses, ntokens)
         _clear_cache(clear_cache_threshold)
+        if batch_callback is not None:
+            batch_callback()
 
     all_losses = mx.distributed.all_sum(all_losses, stream=mx.cpu)
     ntokens = mx.distributed.all_sum(ntokens, stream=mx.cpu)
@@ -227,12 +236,13 @@ def train(
 ):
     if mx.metal.is_available():
         mx.set_wired_limit(mx.device_info()["max_recommended_working_set_size"])
-    print(f"Starting training..., iters: {args.iters}")
     world = mx.distributed.init()
     world_size = world.size()
     rank = world.rank()
-    if world_size > 1:
-        print(f"Node {rank} of {world_size}")
+
+    console = make_console()
+    if rank == 0 and world_size > 1:
+        console.print(f"[ui.muted]node {rank} of {world_size}[/ui.muted]")
 
     if args.grad_checkpoint:
         grad_checkpoint(model.layers[0])
@@ -269,119 +279,153 @@ def train(
     train_time = 0
     grad_accum = None
 
-    # Main training loop
-    for it, batch in zip(
-        range(1, args.iters + 1),
-        iterate_batches(
-            dataset=train_dataset,
-            batch_size=args.batch_size,
-            max_seq_length=args.max_seq_length,
-            loop=True,
-            comm_group=world,
-        ),
-    ):
-        tic = time.perf_counter()
-        # Report validation loss if needed, the first validation loss
-        # is always measured before any training.
-        if val_dataset and (
-            it == 1 or it % args.steps_per_eval == 0 or it == args.iters
+    progress = make_train_progress(console, disable=(rank != 0))
+    task = progress.add_task("train", total=args.iters)
+
+    if rank == 0:
+        console.print(
+            "  [ui.heading]iter   train_loss     tok/s     tokens[/ui.heading]"
+        )
+    progress.start()
+
+    prev_train_loss = None
+    try:
+        # Main training loop
+        for it, batch in zip(
+            range(1, args.iters + 1),
+            iterate_batches(
+                dataset=train_dataset,
+                batch_size=args.batch_size,
+                max_seq_length=args.max_seq_length,
+                loop=True,
+                comm_group=world,
+            ),
         ):
             tic = time.perf_counter()
-            val_loss = evaluate(
-                model=model,
-                dataset=val_dataset,
-                loss=loss,
-                batch_size=args.batch_size,
-                num_batches=args.val_batches,
-                max_seq_length=args.max_seq_length,
-                iterate_batches=iterate_batches,
-            )
-            model.train()
-            val_time = time.perf_counter() - tic
-            if rank == 0:
-                print(
-                    f"Iter {it}: "
-                    f"Val loss {val_loss:.3f}, "
-                    f"Val took {val_time:.3f}s",
-                    flush=True,
+            # Run validation periodically (skip iter 1).
+            if val_dataset and (it % args.steps_per_eval == 0 or it == args.iters):
+                if args.val_batches == -1:
+                    val_total = len(val_dataset) // args.batch_size
+                else:
+                    val_total = min(
+                        len(val_dataset) // args.batch_size, args.val_batches
+                    )
+                val_task = (
+                    progress.add_task("[bold blue]val  [/bold blue]", total=val_total)
+                    if rank == 0
+                    else None
                 )
 
-            if training_callback is not None:
-                val_info = {
-                    "iteration": it - 1,
-                    "val_loss": val_loss,
-                    "val_time": val_time,
-                }
-                training_callback.on_val_loss_report(val_info)
+                def _advance_val():
+                    if val_task is not None:
+                        progress.advance(val_task)
 
-            tic = time.perf_counter()
-
-        lvalue, toks, grad_accum = step(
-            batch,
-            grad_accum,
-            it % grad_accum_steps == 0,
-        )
-
-        losses += lvalue
-        n_tokens += toks
-        steps += 1
-        mx.eval(state, losses, n_tokens, grad_accum)
-        _clear_cache(args.clear_cache_threshold)
-        train_time += time.perf_counter() - tic
-
-        # Report training loss if needed
-        if it % args.steps_per_report == 0 or it == args.iters:
-            train_loss = mx.distributed.all_sum(losses, stream=mx.cpu).item()
-            train_loss /= steps * world_size
-            n_tokens = mx.distributed.all_sum(n_tokens, stream=mx.cpu).item()
-            learning_rate = optimizer.learning_rate.item()
-            it_sec = args.steps_per_report / train_time
-            tokens_sec = float(n_tokens) / train_time
-            trained_tokens += n_tokens
-            peak_mem = mx.get_peak_memory() / 1e9
-            if rank == 0:
-                print(
-                    f"Iter {it}: Train loss {train_loss:.3f}, "
-                    f"Learning Rate {learning_rate:.3e}, "
-                    f"It/sec {it_sec:.3f}, "
-                    f"Tokens/sec {tokens_sec:.3f}, "
-                    f"Trained Tokens {trained_tokens}, "
-                    f"Peak mem {peak_mem:.3f} GB",
-                    flush=True,
+                tic = time.perf_counter()
+                val_loss = evaluate(
+                    model=model,
+                    dataset=val_dataset,
+                    loss=loss,
+                    batch_size=args.batch_size,
+                    num_batches=args.val_batches,
+                    max_seq_length=args.max_seq_length,
+                    iterate_batches=iterate_batches,
+                    progress=False,
+                    batch_callback=_advance_val,
                 )
+                model.train()
+                val_time = time.perf_counter() - tic
+                if val_task is not None:
+                    progress.remove_task(val_task)
+                if rank == 0:
+                    progress.console.print(
+                        f"  [ui.muted]{it:>4}[/ui.muted]    "
+                        f"[ui.accent]val[/ui.accent] "
+                        f"[ui.strong]{val_loss:>5.3f}[/ui.strong]    "
+                        f"[ui.muted]({val_time:.2f}s)[/ui.muted]"
+                    )
 
-            if training_callback is not None:
-                train_info = {
-                    "iteration": it,
-                    "train_loss": train_loss,
-                    "learning_rate": learning_rate,
-                    "iterations_per_second": it_sec,
-                    "tokens_per_second": tokens_sec,
-                    "trained_tokens": trained_tokens,
-                    "peak_memory": peak_mem,
-                }
-                training_callback.on_train_loss_report(train_info)
+                if training_callback is not None:
+                    val_info = {
+                        "iteration": it - 1,
+                        "val_loss": val_loss,
+                        "val_time": val_time,
+                    }
+                    training_callback.on_val_loss_report(val_info)
 
-            losses = 0
-            n_tokens = 0
-            steps = 0
-            train_time = 0
+                tic = time.perf_counter()
 
-        # Save adapter weights
-        if it % args.steps_per_save == 0 and rank == 0:
-            adapter_weights = dict(tree_flatten(model.trainable_parameters()))
-            mx.save_safetensors(str(args.adapter_file), adapter_weights)
-            checkpoint = (
-                Path(args.adapter_file).parent / f"{it:07d}_adapters.safetensors"
+            lvalue, toks, grad_accum = step(
+                batch,
+                grad_accum,
+                it % grad_accum_steps == 0,
             )
-            mx.save_safetensors(str(checkpoint), adapter_weights)
-            print(
-                f"Iter {it}: Saved adapter weights to "
-                f"{args.adapter_file} and {checkpoint}."
-            )
+
+            losses += lvalue
+            n_tokens += toks
+            steps += 1
+            mx.eval(state, losses, n_tokens, grad_accum)
+            _clear_cache(args.clear_cache_threshold)
+            train_time += time.perf_counter() - tic
+
+            progress.advance(task)
+
+            # Report training loss if needed
+            if it % args.steps_per_report == 0 or it == args.iters:
+                train_loss = mx.distributed.all_sum(losses, stream=mx.cpu).item()
+                train_loss /= steps * world_size
+                n_tokens = mx.distributed.all_sum(n_tokens, stream=mx.cpu).item()
+                learning_rate = optimizer.learning_rate.item()
+                it_sec = args.steps_per_report / train_time
+                tokens_sec = float(n_tokens) / train_time
+                trained_tokens += n_tokens
+                peak_mem = mx.get_peak_memory() / 1e9
+                if rank == 0:
+                    if prev_train_loss is None or train_loss <= prev_train_loss:
+                        arrow, arrow_style = "▼", "green"
+                    else:
+                        arrow, arrow_style = "▲", "yellow"
+                    prev_train_loss = train_loss
+                    progress.console.print(
+                        f"  [ui.muted]{it:>4}[/ui.muted]    "
+                        f"[bold {arrow_style}]{train_loss:>5.3f} {arrow}"
+                        f"[/bold {arrow_style}]    "
+                        f"[ui.strong]{tokens_sec:>5,.0f}[/ui.strong]    "
+                        f"[ui.muted]{trained_tokens / 1000:>5.1f}k[/ui.muted]"
+                    )
+
+                if training_callback is not None:
+                    train_info = {
+                        "iteration": it,
+                        "train_loss": train_loss,
+                        "learning_rate": learning_rate,
+                        "iterations_per_second": it_sec,
+                        "tokens_per_second": tokens_sec,
+                        "trained_tokens": trained_tokens,
+                        "peak_memory": peak_mem,
+                    }
+                    training_callback.on_train_loss_report(train_info)
+
+                losses = 0
+                n_tokens = 0
+                steps = 0
+                train_time = 0
+
+            # Save adapter weights
+            if it % args.steps_per_save == 0 and rank == 0:
+                adapter_weights = dict(tree_flatten(model.trainable_parameters()))
+                mx.save_safetensors(str(args.adapter_file), adapter_weights)
+                checkpoint = (
+                    Path(args.adapter_file).parent / f"{it:07d}_adapters.safetensors"
+                )
+                mx.save_safetensors(str(checkpoint), adapter_weights)
+                progress.console.print(
+                    f"  [ui.good]save[/ui.good]  "
+                    f"[ui.muted]{checkpoint.name}[/ui.muted]"
+                )
+    finally:
+        progress.stop()
 
     # Save final weights
     if rank == 0:
         adapter_weights = dict(tree_flatten(model.trainable_parameters()))
         mx.save_safetensors(str(args.adapter_file), adapter_weights)
-        print(f"Saved final weights to {args.adapter_file}.")

--- a/mlx_lm/tuner/trainer.py
+++ b/mlx_lm/tuner/trainer.py
@@ -13,7 +13,7 @@ from mlx.nn.utils import average_gradients
 from mlx.utils import tree_flatten, tree_map
 from tqdm import tqdm
 
-from ..cli_ui import init_theme, make_console, make_train_progress
+from ..cli_ui import make_console, make_train_progress
 from .callbacks import TrainingCallback
 from .datasets import CacheDataset
 
@@ -240,7 +240,6 @@ def train(
     world_size = world.size()
     rank = world.rank()
 
-    init_theme(probe=(rank == 0))
     console = make_console()
     if rank == 0 and world_size > 1:
         console.print(f"[ui.muted]node {rank} of {world_size}[/ui.muted]")

--- a/mlx_lm/tuner/trainer.py
+++ b/mlx_lm/tuner/trainer.py
@@ -13,7 +13,7 @@ from mlx.nn.utils import average_gradients
 from mlx.utils import tree_flatten, tree_map
 from tqdm import tqdm
 
-from ..cli_ui import make_console, make_train_progress
+from ..cli_ui import init_theme, make_console, make_train_progress
 from .callbacks import TrainingCallback
 from .datasets import CacheDataset
 
@@ -240,6 +240,7 @@ def train(
     world_size = world.size()
     rank = world.rank()
 
+    init_theme(probe=(rank == 0))
     console = make_console()
     if rank == 0 and world_size > 1:
         console.print(f"[ui.muted]node {rank} of {world_size}[/ui.muted]")

--- a/mlx_lm/tuner/trainer.py
+++ b/mlx_lm/tuner/trainer.py
@@ -11,7 +11,6 @@ import mlx.nn as nn
 import numpy as np
 from mlx.nn.utils import average_gradients
 from mlx.utils import tree_flatten, tree_map
-from tqdm import tqdm
 
 from ..cli_ui import TrainUI, rprint
 from .callbacks import TrainingCallback
@@ -183,8 +182,7 @@ def evaluate(
     loss: callable = default_loss,
     iterate_batches: callable = iterate_batches,
     clear_cache_threshold: int = 0,
-    progress: bool = True,
-    batch_callback: callable = None,
+    progress_callback: callable = None,
 ):
     model.eval()
     all_losses = mx.array(0.0)
@@ -201,12 +199,6 @@ def evaluate(
             comm_group=mx.distributed.init(),
         ),
     )
-    if progress:
-        batch_iter = tqdm(
-            batch_iter,
-            desc="Calculating loss...",
-            total=min(len(dataset) // batch_size, num_batches),
-        )
 
     for _, batch in batch_iter:
         losses, toks = loss(model, *batch)
@@ -214,8 +206,8 @@ def evaluate(
         ntokens += toks
         mx.eval(all_losses, ntokens)
         _clear_cache(clear_cache_threshold)
-        if batch_callback is not None:
-            batch_callback()
+        if progress_callback is not None:
+            progress_callback()
 
     all_losses = mx.distributed.all_sum(all_losses, stream=mx.cpu)
     ntokens = mx.distributed.all_sum(ntokens, stream=mx.cpu)
@@ -309,8 +301,7 @@ def train(
                         num_batches=args.val_batches,
                         max_seq_length=args.max_seq_length,
                         iterate_batches=iterate_batches,
-                        progress=False,
-                        batch_callback=advance_val,
+                        progress_callback=advance_val,
                     )
                 model.train()
                 val_time = time.perf_counter() - tic

--- a/mlx_lm/tuner/trainer.py
+++ b/mlx_lm/tuner/trainer.py
@@ -13,14 +13,9 @@ from mlx.nn.utils import average_gradients
 from mlx.utils import tree_flatten, tree_map
 from tqdm import tqdm
 
-from ..cli_ui import make_console, make_train_progress
+from ..cli_ui import make_console, make_train_progress, printf
 from .callbacks import TrainingCallback
 from .datasets import CacheDataset
-
-
-def printf(*args, **kwargs):
-    if mx.distributed.init().rank() == 0:
-        print(*args, **kwargs)
 
 
 def _clear_cache(threshold: int):
@@ -246,8 +241,6 @@ def train(
     rank = world.rank()
 
     console = make_console()
-    if rank == 0 and world_size > 1:
-        console.print(f"[ui.muted]node {rank} of {world_size}[/ui.muted]")
 
     if args.grad_checkpoint:
         grad_checkpoint(model.layers[0])

--- a/mlx_lm/tuner/trainer.py
+++ b/mlx_lm/tuner/trainer.py
@@ -13,7 +13,7 @@ from mlx.nn.utils import average_gradients
 from mlx.utils import tree_flatten, tree_map
 from tqdm import tqdm
 
-from ..cli_ui import TrainUI, printf
+from ..cli_ui import TrainUI, rprint
 from .callbacks import TrainingCallback
 from .datasets import CacheDataset
 
@@ -148,7 +148,7 @@ def iterate_batches(
                 offsets = [0] * len(batch)
             lengths = [len(x) for x in batch]
             if max(lengths) > max_seq_length:
-                printf(
+                rprint(
                     f"[WARNING] Some sequences are longer than {max_seq_length} tokens. "
                     f"The longest sentence {max(lengths)} will be truncated to {max_seq_length}. "
                     "Consider pre-splitting your data to save memory."

--- a/mlx_lm/tuner/trainer.py
+++ b/mlx_lm/tuner/trainer.py
@@ -18,6 +18,11 @@ from .callbacks import TrainingCallback
 from .datasets import CacheDataset
 
 
+def printf(*args, **kwargs):
+    if mx.distributed.init().rank() == 0:
+        print(*args, **kwargs)
+
+
 def _clear_cache(threshold: int):
     if mx.get_cache_memory() > threshold:
         mx.clear_cache()
@@ -148,7 +153,7 @@ def iterate_batches(
                 offsets = [0] * len(batch)
             lengths = [len(x) for x in batch]
             if max(lengths) > max_seq_length:
-                print(
+                printf(
                     f"[WARNING] Some sequences are longer than {max_seq_length} tokens. "
                     f"The longest sentence {max(lengths)} will be truncated to {max_seq_length}. "
                     "Consider pre-splitting your data to save memory."

--- a/mlx_lm/tuner/trainer.py
+++ b/mlx_lm/tuner/trainer.py
@@ -13,7 +13,7 @@ from mlx.nn.utils import average_gradients
 from mlx.utils import tree_flatten, tree_map
 from tqdm import tqdm
 
-from ..cli_ui import make_console, make_train_progress, printf
+from ..cli_ui import TrainUI, printf
 from .callbacks import TrainingCallback
 from .datasets import CacheDataset
 
@@ -240,8 +240,6 @@ def train(
     world_size = world.size()
     rank = world.rank()
 
-    console = make_console()
-
     if args.grad_checkpoint:
         grad_checkpoint(model.layers[0])
 
@@ -277,17 +275,8 @@ def train(
     train_time = 0
     grad_accum = None
 
-    progress = make_train_progress(console, disable=(rank != 0))
-    task = progress.add_task("train", total=args.iters)
-
-    if rank == 0:
-        console.print(
-            "  [ui.heading]iter   train_loss     tok/s     tokens[/ui.heading]"
-        )
-    progress.start()
-
-    prev_train_loss = None
-    try:
+    ui = TrainUI(args.iters, rank=rank)
+    with ui:
         # Main training loop
         for it, batch in zip(
             range(1, args.iters + 1),
@@ -300,55 +289,41 @@ def train(
             ),
         ):
             tic = time.perf_counter()
-            # Run validation periodically (skip iter 1).
-            if val_dataset and (it % args.steps_per_eval == 0 or it == args.iters):
+            if val_dataset and (
+                it == 1 or it % args.steps_per_eval == 0 or it == args.iters
+            ):
                 if args.val_batches == -1:
                     val_total = len(val_dataset) // args.batch_size
                 else:
                     val_total = min(
                         len(val_dataset) // args.batch_size, args.val_batches
                     )
-                val_task = (
-                    progress.add_task("[bold blue]val  [/bold blue]", total=val_total)
-                    if rank == 0
-                    else None
-                )
-
-                def _advance_val():
-                    if val_task is not None:
-                        progress.advance(val_task)
 
                 tic = time.perf_counter()
-                val_loss = evaluate(
-                    model=model,
-                    dataset=val_dataset,
-                    loss=loss,
-                    batch_size=args.batch_size,
-                    num_batches=args.val_batches,
-                    max_seq_length=args.max_seq_length,
-                    iterate_batches=iterate_batches,
-                    progress=False,
-                    batch_callback=_advance_val,
-                )
+                with ui.val_task(val_total) as advance_val:
+                    val_loss = evaluate(
+                        model=model,
+                        dataset=val_dataset,
+                        loss=loss,
+                        batch_size=args.batch_size,
+                        num_batches=args.val_batches,
+                        max_seq_length=args.max_seq_length,
+                        iterate_batches=iterate_batches,
+                        progress=False,
+                        batch_callback=advance_val,
+                    )
                 model.train()
                 val_time = time.perf_counter() - tic
-                if val_task is not None:
-                    progress.remove_task(val_task)
-                if rank == 0:
-                    progress.console.print(
-                        f"  [ui.muted]{it:>4}[/ui.muted]    "
-                        f"[ui.accent]val[/ui.accent] "
-                        f"[ui.strong]{val_loss:>5.3f}[/ui.strong]    "
-                        f"[ui.muted]({val_time:.2f}s)[/ui.muted]"
-                    )
+                ui.report_val(it, val_loss, val_time)
 
                 if training_callback is not None:
-                    val_info = {
-                        "iteration": it - 1,
-                        "val_loss": val_loss,
-                        "val_time": val_time,
-                    }
-                    training_callback.on_val_loss_report(val_info)
+                    training_callback.on_val_loss_report(
+                        {
+                            "iteration": it - 1,
+                            "val_loss": val_loss,
+                            "val_time": val_time,
+                        }
+                    )
 
                 tic = time.perf_counter()
 
@@ -365,7 +340,7 @@ def train(
             _clear_cache(args.clear_cache_threshold)
             train_time += time.perf_counter() - tic
 
-            progress.advance(task)
+            ui.advance()
 
             # Report training loss if needed
             if it % args.steps_per_report == 0 or it == args.iters:
@@ -377,31 +352,20 @@ def train(
                 tokens_sec = float(n_tokens) / train_time
                 trained_tokens += n_tokens
                 peak_mem = mx.get_peak_memory() / 1e9
-                if rank == 0:
-                    if prev_train_loss is None or train_loss <= prev_train_loss:
-                        arrow, arrow_style = "▼", "green"
-                    else:
-                        arrow, arrow_style = "▲", "yellow"
-                    prev_train_loss = train_loss
-                    progress.console.print(
-                        f"  [ui.muted]{it:>4}[/ui.muted]    "
-                        f"[bold {arrow_style}]{train_loss:>5.3f} {arrow}"
-                        f"[/bold {arrow_style}]    "
-                        f"[ui.strong]{tokens_sec:>5,.0f}[/ui.strong]    "
-                        f"[ui.muted]{trained_tokens / 1000:>5.1f}k[/ui.muted]"
-                    )
+                ui.report_train(it, train_loss, tokens_sec, trained_tokens)
 
                 if training_callback is not None:
-                    train_info = {
-                        "iteration": it,
-                        "train_loss": train_loss,
-                        "learning_rate": learning_rate,
-                        "iterations_per_second": it_sec,
-                        "tokens_per_second": tokens_sec,
-                        "trained_tokens": trained_tokens,
-                        "peak_memory": peak_mem,
-                    }
-                    training_callback.on_train_loss_report(train_info)
+                    training_callback.on_train_loss_report(
+                        {
+                            "iteration": it,
+                            "train_loss": train_loss,
+                            "learning_rate": learning_rate,
+                            "iterations_per_second": it_sec,
+                            "tokens_per_second": tokens_sec,
+                            "trained_tokens": trained_tokens,
+                            "peak_memory": peak_mem,
+                        }
+                    )
 
                 losses = 0
                 n_tokens = 0
@@ -416,12 +380,7 @@ def train(
                     Path(args.adapter_file).parent / f"{it:07d}_adapters.safetensors"
                 )
                 mx.save_safetensors(str(checkpoint), adapter_weights)
-                progress.console.print(
-                    f"  [ui.good]save[/ui.good]  "
-                    f"[ui.muted]{checkpoint.name}[/ui.muted]"
-                )
-    finally:
-        progress.stop()
+                ui.report_save(checkpoint)
 
     # Save final weights
     if rank == 0:

--- a/mlx_lm/tuner/utils.py
+++ b/mlx_lm/tuner/utils.py
@@ -9,15 +9,11 @@ import mlx.nn as nn
 import mlx.optimizers as opt
 from mlx.utils import tree_flatten, tree_unflatten
 
+from ..cli_ui import printf
 from ..models.switch_layers import QuantizedSwitchLinear, SwitchLinear
 from ..utils import get_total_parameters
 from .dora import DoRAEmbedding, DoRALinear
 from .lora import LoRAEmbedding, LoRALinear, LoRASwitchLinear
-
-
-def printf(*args, **kwargs):
-    if mx.distributed.init().rank() == 0:
-        print(*args, **kwargs)
 
 
 def build_schedule(schedule_config: Dict):

--- a/mlx_lm/tuner/utils.py
+++ b/mlx_lm/tuner/utils.py
@@ -15,6 +15,11 @@ from .dora import DoRAEmbedding, DoRALinear
 from .lora import LoRAEmbedding, LoRALinear, LoRASwitchLinear
 
 
+def printf(*args, **kwargs):
+    if mx.distributed.init().rank() == 0:
+        print(*args, **kwargs)
+
+
 def build_schedule(schedule_config: Dict):
     """
     Build a learning rate schedule from the given config.
@@ -162,7 +167,7 @@ def print_trainable_parameters(model):
     trainable_p = (
         sum(v.size for _, v in tree_flatten(model.trainable_parameters())) / 1e6
     )
-    print(
+    printf(
         f"Trainable parameters: {(trainable_p * 100 / total_p):.3f}% "
         f"({trainable_p:.3f}M/{total_p:.3f}M)"
     )

--- a/mlx_lm/tuner/utils.py
+++ b/mlx_lm/tuner/utils.py
@@ -4,7 +4,6 @@ import types
 from pathlib import Path
 from typing import Dict
 
-import mlx.core as mx
 import mlx.nn as nn
 import mlx.optimizers as opt
 from mlx.utils import tree_flatten, tree_unflatten

--- a/mlx_lm/tuner/utils.py
+++ b/mlx_lm/tuner/utils.py
@@ -8,7 +8,7 @@ import mlx.nn as nn
 import mlx.optimizers as opt
 from mlx.utils import tree_flatten, tree_unflatten
 
-from ..cli_ui import printf
+from ..cli_ui import rprint
 from ..models.switch_layers import QuantizedSwitchLinear, SwitchLinear
 from ..utils import get_total_parameters
 from .dora import DoRAEmbedding, DoRALinear
@@ -162,7 +162,7 @@ def print_trainable_parameters(model):
     trainable_p = (
         sum(v.size for _, v in tree_flatten(model.trainable_parameters())) / 1e6
     )
-    printf(
+    rprint(
         f"Trainable parameters: {(trainable_p * 100 / total_p):.3f}% "
         f"({trainable_p:.3f}M/{total_p:.3f}M)"
     )

--- a/mlx_lm/utils.py
+++ b/mlx_lm/utils.py
@@ -342,7 +342,7 @@ def load_model(
 
     model = model_class(model_args)
 
-    if hasattr(model, "sanitize"):
+    if weights and hasattr(model, "sanitize"):
         weights = model.sanitize(weights)
 
     def _quantize(quantization):

--- a/mlx_lm/utils.py
+++ b/mlx_lm/utils.py
@@ -342,7 +342,7 @@ def load_model(
 
     model = model_class(model_args)
 
-    if weights and hasattr(model, "sanitize"):
+    if hasattr(model, "sanitize"):
         weights = model.sanitize(weights)
 
     def _quantize(quantization):

--- a/tests/test_chat.py
+++ b/tests/test_chat.py
@@ -84,6 +84,10 @@ class TestChat(unittest.TestCase):
         # Mock stream_generate to return some responses
         mock_response = MagicMock()
         mock_response.text = "Hello there!"
+        mock_response.generation_tokens = 1
+        mock_response.generation_tps = 1.0
+        mock_response.prompt_tps = 1.0
+        mock_response.peak_memory = 1.0
         mock_stream_generate.return_value = [mock_response]
 
         # Mock user input: first a question, then 'q' to quit
@@ -139,6 +143,10 @@ class TestChat(unittest.TestCase):
         # Mock stream_generate to return some responses
         mock_response = MagicMock()
         mock_response.text = "Hello there!"
+        mock_response.generation_tokens = 1
+        mock_response.generation_tps = 1.0
+        mock_response.prompt_tps = 1.0
+        mock_response.peak_memory = 1.0
         mock_stream_generate.return_value = [mock_response]
 
         # Mock user input: first a question, then 'q' to quit


### PR DESCRIPTION
As the title.

Work for both light / dark themes.
Chat on a single machine:
<p align="center">
  <img width="49%" alt="Dark theme" src="https://github.com/user-attachments/assets/30a80164-de8e-4cbe-bc14-b8031b94fffa" />
  <img width="49%" alt="Light theme" src="https://github.com/user-attachments/assets/21ec95b1-5799-4c8b-84ee-01cd6bba5c6a" />
</p>

Lora on 4 m3-ultra:
https://github.com/user-attachments/assets/c4bf85c8-8f13-400e-8a72-3c501a606056

**Code changes**: diff might look large but it is mostly because chat and training pipeline were wrapped with `TrainUI(…)` / with `ChatUI(…)` blocks , main training loop and generation are unchanged. 
Also in distibuted setting I log process (loading model, dataset) only on rank 0, because I felt that it is sufficient. 

**Important note on terminal width**:
For distributed launch, because processes a piped, we can't easily get terminal size. After experimenting with different approaches, I decided that the easiest way to set a correct terminal size will be by adding environmental variables in mlx.launch (see this [PR](https://github.com/ml-explore/mlx/pull/3618)).


