### PR TITLE
Fix cleanup space

### DIFF
--- a/mlx_lm/tokenizer_utils.py
+++ b/mlx_lm/tokenizer_utils.py
@@ -69,6 +69,8 @@ class NaiveStreamingDetokenizer(StreamingDetokenizer):
     def __init__(self, tokenizer):
         self._tokenizer = tokenizer
         self._tokenizer.decode([0])
+        probe = tokenizer.encode("a ,b", add_special_tokens=False)
+        self._clean_spaces = " ," not in tokenizer.decode(probe)
         self.reset()
 
     def reset(self):
@@ -92,7 +94,7 @@ class NaiveStreamingDetokenizer(StreamingDetokenizer):
         if self._current_tokens:
             self._current_text = self._tokenizer.decode(self._current_tokens)
             if self._current_text.endswith("\ufffd") or (
-                self._tokenizer.clean_up_tokenization_spaces
+                self._clean_spaces
                 and len(self._current_text) > 0
                 and self._current_text[-1] == " "
             ):
@@ -163,7 +165,8 @@ class BPEStreamingDetokenizer(StreamingDetokenizer):
     _space_matches = (".", "?", "!", ",", "n't", "'m", "'s", "'ve", "'re")
 
     def __init__(self, tokenizer):
-        self.clean_spaces = tokenizer.clean_up_tokenization_spaces
+        probe = tokenizer.encode("a ,b", add_special_tokens=False)
+        self.clean_spaces = " ," not in tokenizer.decode(probe)
 
         # Extract the tokens in a list from id to text
         self.tokenmap = [None] * len(tokenizer.vocab)

--- a/mlx_lm/tokenizer_utils.py
+++ b/mlx_lm/tokenizer_utils.py
@@ -162,12 +162,8 @@ class BPEStreamingDetokenizer(StreamingDetokenizer):
     """
 
     _byte_decoder = None
-    _space_matches = (".", "?", "!", ",", "n't", "'m", "'s", "'ve", "'re")
 
     def __init__(self, tokenizer):
-        probe = tokenizer.encode("a ,b", add_special_tokens=False)
-        self.clean_spaces = " ," not in tokenizer.decode(probe)
-
         # Extract the tokens in a list from id to text
         self.tokenmap = [None] * len(tokenizer.vocab)
         for value, tokenid in tokenizer.vocab.items():
@@ -201,8 +197,6 @@ class BPEStreamingDetokenizer(StreamingDetokenizer):
         elif current_text[0] != " ":
             return current_text
         elif not self.text:
-            return current_text[1:]
-        elif self.clean_spaces and current_text[1:].startswith(self._space_matches):
             return current_text[1:]
         return current_text
 


### PR DESCRIPTION
Starting from transformers==5.7,  `clean_up_tokenization_spaces` is ignored for BPE tokenizer:

> [transformers] Ignoring clean_up_tokenization_spaces=True for BPE tokenizer TokenizersBackend. The clean_up_tokenization post-processing step is designed for WordPiece tokenizers and is destructive for BPE (it strips spaces before punctuation). Set clean_up_tokenization_spaces=False to suppress this warning, or set clean_up_tokenization_spaces_for_bpe_even_though_it_will_corrupt_output=True to force cleanup anyway.

Therefore we have a mismatch between streaming decoding and tokeniser.decode() for BPE.
My solution is the following:
- We always clean spaces in BPE tokenisation
- We probe HF tokenizer and:
```
probe = tokenizer.encode("a ,b", add_special_tokens=False)
self._clean_spaces = " ," not in tokenizer.decode(probe)
```
 for `NaiveStreamingTokenizer` (since this one should work with anything). 
 
 Probably the second point is a bit ugly and the first one will raise an error if `transformers.__version__<=5.6`. 
Not sure what will be an ideal fix. 

`clean_up_tokenization_spaces_for_bpe_even_though_it_will_corrupt_output` feels like Java. 