### PR TITLE
Fix gemma4_unified model type not supported

### DIFF
--- a/mlx_lm/models/gemma4.py
+++ b/mlx_lm/models/gemma4.py
@@ -65,6 +65,7 @@ class Model(nn.Module):
                     "audio_tower",
                     "embed_audio",
                     "embed_vision",
+                    "vision_embedder",  # gemma4_unified encoder-free vision
                 )
             ):
                 continue

--- a/mlx_lm/utils.py
+++ b/mlx_lm/utils.py
@@ -52,6 +52,7 @@ MODEL_REMAPPING = {
     "qwen2_5_vl": "qwen2_vl",
     "minimax_m2": "minimax",
     "iquestcoder": "llama",
+    "gemma4_unified": "gemma4",  # encoder-free multimodal variant; vision/audio weights stripped by sanitize()
 }
 
 MAX_FILE_SIZE_GB = 5


### PR DESCRIPTION
## Problem

Loading a `gemma4_unified` checkpoint (e.g. `mlx-community/gemma-4-12B-it-4bit`) fails with:

```
ValueError: Model type gemma4_unified not supported.
```

After adding the remapping, a second failure surfaces at weight load: `gemma4.sanitize()` does not strip the encoder-free `vision_embedder.*` weights (11 tensors in this checkpoint), so they are rejected as parameters not present in the text model (`Received N parameters not in model: vision_embedder.*`).

## Root cause

`gemma4_unified` is the encoder-free multimodal variant of Gemma 4. Its text path is the same architecture as `gemma4` — it ships a `text_config` block that `gemma4.Model` feeds into `gemma4_text.Model`, so no model-code changes are needed — but it carries an encoder-free `vision_embedder` module not present in the standard variant. Two gaps:

1. `MODEL_REMAPPING` has no `gemma4_unified` entry, so `load_model` falls through to a failed dynamic import.
2. `gemma4.sanitize()` skips `vision_tower` / `audio_tower` / `embed_audio` / `embed_vision`, but not `vision_embedder`, so those weights fail to load.

## Fix

- Add `"gemma4_unified": "gemma4"` to `MODEL_REMAPPING` (`utils.py`).
- Add `"vision_embedder"` to the prefix skip list in `gemma4.sanitize()` (`gemma4.py`).

The checkpoint's audio weights load via the existing `embed_audio` skip, so no audio-specific change is needed for the checkpoints available.

## Tested

Verified with `mlx-community/gemma-4-12B-it-4bit` (`model_type: gemma4_unified`) on an M3 MacBook Air, 16 GB:

- Loads with strict weight checking — no missing or unexpected keys.
- Generates correct answers, e.g. `17 × 23 → 391`, `capital of Japan → Tokyo`.
- Peak RAM 11.07 GB at 4-bit; ~2.3 tok/s.
