### PR TITLE
Fix LFM2 MoE routing to match the HF reference (sigmoid gating)

### DIFF
--- a/mlx_lm/models/lfm2_moe.py
+++ b/mlx_lm/models/lfm2_moe.py
@@ -36,6 +36,7 @@ class ModelArgs(BaseModelArgs):
     conv_bias: bool
     conv_L_cache: int
     rope_theta: float = 1000000.0
+    routed_scaling_factor: float = 1.0
     rope_parameters: Optional[dict] = None
     full_attn_idxs: Optional[List[int]] = None
     layer_types: Optional[List[str]] = None
@@ -196,6 +197,7 @@ class Lfm2MoeSparseMoeBlock(nn.Module):
         self.top_k = args.num_experts_per_tok
         self.norm_topk_prob = args.norm_topk_prob
         self.use_expert_bias = args.use_expert_bias
+        self.routed_scaling_factor = args.routed_scaling_factor
 
         self.gate = nn.Linear(dim, num_experts, bias=False)
         self.switch_mlp = SwitchGLU(dim, intermediate_size, num_experts)
@@ -206,18 +208,23 @@ class Lfm2MoeSparseMoeBlock(nn.Module):
         self,
         x: mx.array,
     ):
-        gates = self.gate(x).astype(mx.float32)
-        gates = mx.softmax(gates, axis=-1)
-
-        if self.use_expert_bias:
-            gates += self.expert_bias
+        # Sigmoid-gated routing (matches the HF Transformers Lfm2Moe reference):
+        # the expert_bias is used only to select the top-k experts; the routing
+        # weights are gathered from the unbiased sigmoid scores and then scaled by
+        # routed_scaling_factor.
+        routing_weights = mx.sigmoid(self.gate(x))
 
         k = self.top_k
-        inds = mx.argpartition(gates, kth=-k, axis=-1)[..., -k:]
+        if self.use_expert_bias:
+            scores_for_routing = routing_weights.astype(mx.float32) + self.expert_bias
+            inds = mx.argpartition(scores_for_routing, kth=-k, axis=-1)[..., -k:]
+        else:
+            inds = mx.argpartition(routing_weights, kth=-k, axis=-1)[..., -k:]
 
-        scores = mx.take_along_axis(gates, inds, axis=-1)
+        scores = mx.take_along_axis(routing_weights, inds, axis=-1)
         if self.norm_topk_prob:
-            scores /= mx.sum(scores, axis=-1, keepdims=True) + 1e-20
+            scores = scores / (mx.sum(scores, axis=-1, keepdims=True) + 1e-6)
+        scores = scores * self.routed_scaling_factor
         scores = scores.astype(x.dtype)
 
         y = self.switch_mlp(x, inds)


### PR DESCRIPTION
LFM2 MoE routing does not match the HF Transformers reference.

Lfm2Moe is a sigmoid-gated MoE, but the router uses softmax, folds expert_bias into the combination weights, and does not apply routed_scaling_factor.

This change makes it match the reference: the router scores are sigmoid(gate(x)), expert_bias is used only to select the top-k experts, the combination weights are gathered from the unbiased sigmoid scores, and they are scaled by routed_scaling_factor. routed_scaling_factor is added to ModelArgs with a default of 1.0, so existing configs are unaffected.

Validated against the HF reference on LiquidAI/LFM2.5-8B-A1B.
