### PR TITLE
fix(tokenizer): clamp negative start in _find to prevent 404 on short prompts

### DIFF
--- a/mlx_lm/tokenizer_utils.py
+++ b/mlx_lm/tokenizer_utils.py
@@ -355,7 +355,7 @@ class TokenizerWrapper:
         self._eos_token_ids.add(token_id)
 
     def _find(self, tokens, sequence, start=None, end=None, reverse=False):
-        start = start or 0
+        start = max(0, start or 0)
         end = end or len(tokens)
         outer_loop = (
             range(end - len(sequence), start - 1, -1)

--- a/tests/test_tokenizers.py
+++ b/tests/test_tokenizers.py
@@ -109,6 +109,20 @@ class TestTokenizers(unittest.TestCase):
         self.assertIsNone(tokenizer.think_start_id)
         self.assertIsNone(tokenizer.think_end_id)
 
+    def test_find_negative_start(self):
+        # Regression test for #1326: rfind_think_start should not raise IndexError
+        # when the prompt is shorter than the think-token lookahead window (11 tokens).
+        tokenizer_repo = "mlx-community/Qwen3-4B-4bit"
+        tokenizer = load_tokenizer(tokenizer_repo)
+        self.assertTrue(tokenizer.has_thinking)
+
+        # A short prompt is shorter than the 11-token lookahead; before the fix
+        # this caused a negative start index, Python negative-index wrap-around, and
+        # an IndexError surfaced as HTTP 404 by the server.
+        short_prompt = tokenizer.encode("hi")
+        result = tokenizer.rfind_think_start(short_prompt)
+        self.assertEqual(result, -1)  # not found, no crash
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Problem

`mlx_lm.server` returns `HTTP 404 {"error": "list index out of range"}` for any prompt shorter than 11 tokens (e.g. `"hi"`, `"hello"`). Reproduces with any thinking-capable model.

Root cause: `_tokenize` calls `rfind_think_start(prompt, start=tail_start - 11)`. When the prompt is shorter than 11 tokens, `start` goes negative. Python's negative indexing wraps to the tail of the list, producing a false match, and `tokens[i + j]` then escapes bounds → `IndexError` → 404.

Full traceback in #1326.

## Fix

One character change in `_find`:

```python
- start = start or 0
+ start = max(0, start or 0)
```

Applied at the canonical location (`tokenizer_utils.py`) so all current and future callers (`rfind_think_start`, `rfind_think_end`, `find_think_start`, `find_think_end`) are covered without touching call sites.

## Verification

```bash
mlx_lm.server --model <thinking-capable model> &
curl -s -X POST http://127.0.0.1:8080/v1/chat/completions \
  -H 'Content-Type: application/json' \
  -d '{"messages":[{"role":"user","content":"hi"}],"max_tokens":20}'
# Before: HTTP 404
# After:  HTTP 200 with completion
```

Fixes #1326