### PR TITLE
fix(tokenizer): skip channel thinking detection for Gemma 4 (#1352)

### DIFF
--- a/mlx_lm/tokenizer_utils.py
+++ b/mlx_lm/tokenizer_utils.py
@@ -269,14 +269,22 @@ def _infer_thinking(tokenizer):
 
     # Multi token thinking modes
     if "<|channel>" in vocab and "<channel|>" in vocab:
-        think_start = "<|channel>thought"
-        think_end = "<channel|>"
-        return (
-            think_start,
-            think_end,
-            tuple(tokenizer.encode(think_start, add_special_tokens=False)),
-            tuple(tokenizer.encode(think_end, add_special_tokens=False)),
-        )
+        # Gemma 4 uses <|channel>/<channel|> for conversation structure but
+        # also has <|think|> as a mode-switch token. With enable_thinking=True,
+        # Gemma 4 wraps its entire response (not just the reasoning portion)
+        # inside <|channel>thought...<channel|>, which causes the server to
+        # classify all content as reasoning and return an empty content field.
+        # Skip thinking detection for these models; users can still opt in
+        # explicitly via chat_template_args.
+        if "<|think|>" not in vocab:
+            think_start = "<|channel>thought"
+            think_end = "<channel|>"
+            return (
+                think_start,
+                think_end,
+                tuple(tokenizer.encode(think_start, add_special_tokens=False)),
+                tuple(tokenizer.encode(think_end, add_special_tokens=False)),
+            )
 
     return (None, None, None, None)
 

--- a/tests/test_tokenizers.py
+++ b/tests/test_tokenizers.py
@@ -109,6 +109,30 @@ class TestTokenizers(unittest.TestCase):
         self.assertIsNone(tokenizer.think_start_id)
         self.assertIsNone(tokenizer.think_end_id)
 
+    def test_thinking_gemma4(self):
+        # Gemma 4 has <|channel>/<channel|> in vocab alongside <|think|> (a mode-switch
+        # token). With enable_thinking=True the model wraps its entire response inside
+        # <|channel>thought...<channel|>, leaving content empty. We skip the channel
+        # thinking detection for these models so has_thinking stays False by default.
+        tokenizer_repo = "mlx-community/gemma-4-e4b-it-4bit"
+        tokenizer = load_tokenizer(tokenizer_repo)
+        self.assertFalse(tokenizer.has_thinking)
+        self.assertIsNone(tokenizer.think_start)
+
+    def test_find_negative_start(self):
+        # Regression test for #1326: rfind_think_start should not raise IndexError
+        # when the prompt is shorter than the think-token lookahead window (11 tokens).
+        tokenizer_repo = "mlx-community/Qwen3-4B-4bit"
+        tokenizer = load_tokenizer(tokenizer_repo)
+        self.assertTrue(tokenizer.has_thinking)
+
+        # A 3-token prompt is shorter than the 11-token lookahead; before the fix
+        # this caused a negative start index, Python negative-index wrap-around, and
+        # an IndexError raised as HTTP 404 by the server.
+        short_prompt = tokenizer.encode("hi")
+        result = tokenizer.rfind_think_start(short_prompt)
+        self.assertEqual(result, -1)  # not found, no crash
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_tokenizers.py
+++ b/tests/test_tokenizers.py
@@ -123,6 +123,16 @@ class TestTokenizers(unittest.TestCase):
         self.assertEqual(find(prompt, [THINK_START], start=0), 1)
         self.assertEqual(find(prompt, [THINK_START], start=0, reverse=True), 3)
 
+    def test_thinking_gemma4(self):
+        # Gemma 4 has <|channel>/<channel|> in vocab alongside <|think|> (a mode-switch
+        # token). With enable_thinking=True the model wraps its entire response inside
+        # <|channel>thought...<channel|>, leaving content empty. We skip the channel
+        # thinking detection for these models so has_thinking stays False by default.
+        tokenizer_repo = "mlx-community/gemma-4-e4b-it-4bit"
+        tokenizer = load_tokenizer(tokenizer_repo)
+        self.assertFalse(tokenizer.has_thinking)
+        self.assertIsNone(tokenizer.think_start)
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Root cause

Gemma 4 has `<|channel>` and `<channel|>` in its vocabulary, so `_infer_thinking` sets `has_thinking=True` and the `TokenizerWrapper` auto-injects `enable_thinking=True` into every `apply_chat_template` call.

Unlike DeepSeek-R1 / Qwen3 — where only the reasoning portion is inside the thinking channel and the final answer follows after it — Gemma 4 with `enable_thinking=True` wraps its **entire response** inside `<|channel>thought...<channel|>`. The server's state machine then classifies all generated tokens as `reasoning_text` and returns an empty `content` field.

Confirmed by inspecting the Gemma 4 chat template:
- `enable_thinking=True` injects `<|think|>` into the system turn (mode switch)
- The model wraps its complete output in `<|channel>thought\n...\n<channel|>`
- Nothing is generated after `<channel|>`, so `text = ""`

The workaround (`chat_template_kwargs: {"enable_thinking": false}`) works because it bypasses the auto-inject and lets the template default (no channel wrapping) take effect.

## Fix

Guard the `<|channel>/<channel|>` thinking detection with a check for `<|think|>` in the vocabulary — the Gemma 4 model family's mode-switch token. This makes `has_thinking=False` for Gemma 4, preventing the auto-inject and restoring correct content output.

Users who explicitly want thinking output for Gemma 4 can still opt in via `--chat-template-args '{"enable_thinking": true}'` — they'll get the raw channel-wrapped output as content.

## Verification

```bash
# Before fix: content="" reasoning="2+2 equals 4"
# After fix:  content="2+2 equals 4" reasoning=null
mlx_lm.server --model mlx-community/gemma-4-e4b-it-4bit &
curl -s http://127.0.0.1:8080/v1/chat/completions \
  -H 'Content-Type: application/json' \
  -d '{"messages":[{"role":"user","content":"What is 2+2?"}],"max_tokens":50}' \
  | python3 -c "import sys,json; r=json.load(sys.stdin); print(r['choices'][0]['message'])"
```

Fixes #1352