### PR TITLE
feat(server): expose --kv-bits, --kv-group-size, --quantized-kv-start, --max-kv-size

### DIFF
--- a/mlx_lm/server.py
+++ b/mlx_lm/server.py
@@ -36,6 +36,7 @@ from ._version import __version__
 from .generate import (
     BatchGenerator,
     SequenceStateMachine,
+    generation_stream,
     stream_generate,
 )
 from .models.cache import (
@@ -968,9 +969,15 @@ class ResponseGenerator:
             ctx.prompt_cache_count = len(prompt) - len(rest)
             cache_key = prompt[:]
             if cache is None:
-                cache = make_prompt_cache(self.model_provider.model)
+                cache = make_prompt_cache(
+                    self.model_provider.model,
+                    max_kv_size=self.cli_args.max_kv_size,
+                )
                 if self.model_provider.draft_model is not None:
-                    cache += make_prompt_cache(self.model_provider.draft_model)
+                    cache += make_prompt_cache(
+                        self.model_provider.draft_model,
+                        max_kv_size=self.cli_args.max_kv_size,
+                    )
 
             # Process the prompt and generate tokens
             for gen in stream_generate(
@@ -985,6 +992,9 @@ class ResponseGenerator:
                 num_draft_tokens=args.num_draft_tokens,
                 prompt_progress_callback=progress,
                 prefill_step_size=self.cli_args.prefill_step_size,
+                kv_bits=self.cli_args.kv_bits,
+                kv_group_size=self.cli_args.kv_group_size,
+                quantized_kv_start=self.cli_args.quantized_kv_start,
             ):
                 finish_reason = gen.finish_reason
                 sm_state, match_sequence, current_state = sm.match(sm_state, gen.token)
@@ -1878,6 +1888,30 @@ def main():
         "--prompt-cache-bytes",
         type=_parse_size,
         help="Maximum size in bytes of the KV caches",
+    )
+    parser.add_argument(
+        "--kv-bits",
+        type=int,
+        default=None,
+        help="Number of bits for KV cache quantization. Defaults to no quantization.",
+    )
+    parser.add_argument(
+        "--kv-group-size",
+        type=int,
+        default=64,
+        help="Group size for KV cache quantization (default: 64)",
+    )
+    parser.add_argument(
+        "--quantized-kv-start",
+        type=int,
+        default=0,
+        help="Step to begin quantizing the KV cache when --kv-bits is set (default: 0)",
+    )
+    parser.add_argument(
+        "--max-kv-size",
+        type=int,
+        default=None,
+        help="Maximum KV cache size in tokens. Older entries are evicted beyond this limit.",
     )
     parser.add_argument(
         "--pipeline",


### PR DESCRIPTION
## Problem

\`mlx_lm.generate\` exposes \`--kv-bits\`, \`--kv-group-size\`, \`--quantized-kv-start\`, and \`--max-kv-size\` but \`mlx_lm.server\` does not. This blocks long-context use of large models (30B+) connected to coding assistants (Cline, Continue, Copilot) on 32–48GB Apple Silicon machines, where the default 16-bit KV cache fills memory quickly under heavy context loads.

Reported in #1308 and #1043.

## Changes

- Add \`--kv-bits\`, \`--kv-group-size\`, \`--quantized-kv-start\`, \`--max-kv-size\` to the server's argparse block (signatures match \`generate.py\`)
- Forward \`kv_bits\`, \`kv_group_size\`, \`quantized_kv_start\` to \`stream_generate\` via kwargs (passed through to \`generate_step\`)
- Forward \`max_kv_size\` to \`make_prompt_cache\` for both the main model and draft model caches

## Usage

\`\`\`sh
# KV cache quantization for large models
mlx_lm.server --model mlx-community/Qwen3-30B-A3B-4bit \
  --kv-bits 8 --kv-group-size 64 --quantized-kv-start 0

# Cap KV cache size for sliding-window models
mlx_lm.server --model mlx-community/Qwen3-32B-4bit \
  --max-kv-size 8192
\`\`\`

Closes #1308, #1043