### PR TITLE
fix(gemma4): include per-layer projection in default LoRA targets

### DIFF
--- a/mlx_lm/LORA.md
+++ b/mlx_lm/LORA.md
@@ -9,7 +9,7 @@ LoRA (QLoRA).[^qlora] LoRA fine-tuning works with the following model families:
 - Phi2
 - Mixtral
 - Qwen2
-- Gemma
+- Gemma, Gemma 2, Gemma 3, and Gemma 4
 - OLMo
 - MiniCPM
 - InternLM2

--- a/mlx_lm/models/gemma4.py
+++ b/mlx_lm/models/gemma4.py
@@ -86,6 +86,12 @@ class Model(nn.Module):
         return self.language_model.layers
 
     @property
+    def lora_default_keys(self):
+        return [
+            f"language_model.{key}" for key in self.language_model.lora_default_keys
+        ]
+
+    @property
     def quant_predicate(self):
         return self.language_model.quant_predicate
 

--- a/mlx_lm/models/gemma4_text.py
+++ b/mlx_lm/models/gemma4_text.py
@@ -665,6 +665,12 @@ class Model(nn.Module):
         return self.model.layers
 
     @property
+    def lora_default_keys(self):
+        if self.model.per_layer_model_projection is None:
+            return []
+        return ["model.per_layer_model_projection"]
+
+    @property
     def head_dim(self):
         return self.args.head_dim
 

--- a/mlx_lm/tuner/utils.py
+++ b/mlx_lm/tuner/utils.py
@@ -100,6 +100,9 @@ def linear_to_lora_layers(
         for l in model.layers:
             l.apply_to_modules(get_keys_for_lora)
 
+        if extra_keys := getattr(model, "lora_default_keys", None):
+            keys.update(extra_keys() if callable(extra_keys) else extra_keys)
+
     for l in model.layers[-max(num_layers, 0) :]:
         lora_layers = [(k, to_lora(m)) for k, m in l.named_modules() if k in keys]
         if lora_layers:

--- a/tests/test_finetune.py
+++ b/tests/test_finetune.py
@@ -109,6 +109,45 @@ class TestLora(unittest.TestCase):
         model.freeze()
         tuner.utils.linear_to_lora_layers(model, num_lora_layers, params)
 
+    def test_gemma4_lora_includes_per_layer_model_projection(self):
+        from mlx_lm.models import gemma4
+
+        args = gemma4.ModelArgs.from_dict(
+            {
+                "model_type": "gemma4",
+                "vocab_size": 128,
+                "text_config": {
+                    "model_type": "gemma4_text",
+                    "hidden_size": 32,
+                    "num_hidden_layers": 2,
+                    "intermediate_size": 64,
+                    "num_attention_heads": 2,
+                    "num_key_value_heads": 1,
+                    "num_global_key_value_heads": 1,
+                    "head_dim": 16,
+                    "global_head_dim": 16,
+                    "sliding_window": 8,
+                    "sliding_window_pattern": 1,
+                    "layer_types": ["full_attention", "full_attention"],
+                    "hidden_size_per_layer_input": 8,
+                    "vocab_size": 128,
+                    "vocab_size_per_layer_input": 128,
+                    "num_kv_shared_layers": 0,
+                },
+            }
+        )
+        model = gemma4.Model(args)
+        model.freeze()
+
+        tuner.utils.linear_to_lora_layers(
+            model,
+            -1,
+            {"rank": 2, "dropout": 0.0, "scale": 1.0},
+        )
+
+        projection = model.language_model.model.per_layer_model_projection
+        self.assertIsInstance(projection, LoRALinear)
+
     def test_lora_embedding(self):
         num_embeddings = 256
         dims = 512


### PR DESCRIPTION
## Summary

- Add a model hook for extra default LoRA target keys.
- Use it for Gemma4's top-level `per_layer_model_projection`.
- Add a Gemma4 regression test.
- Update LoRA docs to explicitly list Gemma 4 support.

## Why

Gemma4 2B/4B text models include `per_layer_model_projection` outside the decoder layers. The existing default LoRA target discovery only scans `model.layers`, so this projection was not adapted unless users supplied explicit full keys.

This made Gemma4 LoRA support incomplete: training could run, but one Gemma4-specific projection was left out of the default adapter.

## Validation

- `pytest tests/test_finetune.py::TestLora -q`
- `pytest tests/test_models.py::TestModels::test_gemma4_text tests/test_models.py::TestModels::test_gemma4_kv_shared_layers_omit_kv_projections -q`
- Ran a 1-step LoRA smoke test on local `gemma-4-e2b-it-4bit`
- Verified saved adapter includes:
  - `language_model.model.per_layer_model_projection.lora_a`
  - `language_model.model.per_layer_model_projection.lora_b`
- Loaded the saved adapter and ran a short generation smoke test