### PR TITLE
fix(server): keep tool_call arguments as JSON string (OpenAI spec)

### DIFF
--- a/mlx_lm/server.py
+++ b/mlx_lm/server.py
@@ -143,11 +143,10 @@ def process_message_content(messages):
         elif content is None:
             message["content"] = ""
 
-        if tool_calls := message.get("tool_calls"):
-            for tool_call in tool_calls:
-                if func := tool_call.get("function"):
-                    if args := func.get("arguments"):
-                        func["arguments"] = json.loads(args)
+        # Leave tool_call arguments as a JSON string per the OpenAI spec.
+        # Pre-decoding to a dict breaks chat templates that call json.loads()
+        # themselves (e.g. deepseek_v32, DSML-format models) because
+        # json.loads() on an already-decoded dict raises TypeError.
 
 
 @dataclass


### PR DESCRIPTION
## Problem
`process_message_content()` called `json.loads()` on the `arguments` field of incoming assistant `tool_call` messages, converting the JSON string to a Python dict. Chat templates that call `json.loads()` themselves (deepseek_v32, DSML-format models) then received a dict and raised `TypeError`, silently breaking multi-turn tool use.

The OpenAI spec mandates `arguments` is always a JSON-encoded string. Chat templates that need a dict can use the `|fromjson` Jinja filter.

## Fix
Remove the pre-decode. The comment explains why for future readers.

Fixes #1065