### PR TITLE
fix(server): --adapter-path silently ignored at startup

### DIFF
--- a/mlx_lm/server.py
+++ b/mlx_lm/server.py
@@ -385,8 +385,9 @@ class ModelProvider:
             self.load("default_model", None, "default_model")
 
     def load(self, model_path, adapter_path=None, draft_model_path=None):
+        alias = model_path
         model_path = self._model_map.get(model_path, model_path)
-        adapter_path = self._adapter_map.get(model_path, adapter_path)
+        adapter_path = self._adapter_map.get(alias, adapter_path)
         draft_model_path = self._draft_model_map.get(draft_model_path, draft_model_path)
 
         model_key = (model_path, adapter_path, draft_model_path)


### PR DESCRIPTION
## Problem
`ModelProvider.load()` resolved the model alias to the real path *before* querying `_adapter_map`, so the lookup always used the resolved path as the key and found nothing (`_adapter_map` is keyed on the original alias, e.g. `"default_model"`). Anyone serving a LoRA adapter via `--adapter-path` was silently getting the unmodified base model.

## Fix
```python
  def load(self, model_path, adapter_path=None, draft_model_path=None):
+     alias = model_path
      model_path = self._model_map.get(model_path, model_path)
-     adapter_path = self._adapter_map.get(model_path, adapter_path)
+     adapter_path = self._adapter_map.get(alias, adapter_path)
```

Fixes #1248