### PR TITLE
fix(cache): bool('False') == True corrupts BatchRotatingKVCache on reload

### DIFF
--- a/mlx_lm/models/cache.py
+++ b/mlx_lm/models/cache.py
@@ -1312,7 +1312,7 @@ class BatchRotatingKVCache(_BaseCache):
             int,
             v[:3],
         )
-        self.rotated = bool(v[3])
+        self.rotated = v[3] == "True"
 
     def is_trimmable(self):
         return self._offset < self.max_size

--- a/tests/test_prompt_cache.py
+++ b/tests/test_prompt_cache.py
@@ -768,6 +768,26 @@ class TestPromptCache(unittest.TestCase):
         expected = create_causal_mask(1, offset=32, window_size=4)
         self.assertTrue(mx.array_equal(mask, expected))
 
+    def test_batch_rotating_cache_meta_state_roundtrip(self):
+        # Regression for #1250: bool('False') == True in Python, so a cache
+        # with rotated=False would reload as rotated=True after save/load,
+        # silently corrupting sliding-window KV reuse.
+        cache = BatchRotatingKVCache(max_size=4, left_padding=[0])
+
+        # rotated=False — the broken case
+        self.assertFalse(cache.rotated)
+        state = cache.meta_state
+        cache.rotated = True  # corrupt it, then restore via meta_state
+        cache.meta_state = state
+        self.assertFalse(cache.rotated)
+
+        # rotated=True — must also survive the round-trip
+        cache.rotated = True
+        state = cache.meta_state
+        cache.rotated = False
+        cache.meta_state = state
+        self.assertTrue(cache.rotated)
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Problem
`bool('False')` is `True` in Python. `BatchRotatingKVCache.meta_state.setter` stored the rotation flag as the string `'True'` or `'False'`, then loaded it back with `bool(v[3])`. Any cache saved with `rotated=False` reloaded as `rotated=True`, silently corrupting sliding-window KV reuse after every `save_prompt_cache` / `load_prompt_cache` round-trip.

## Fix
```python
- self.rotated = bool(v[3])
+ self.rotated = v[3] == 'True'
```

## Test
Added `test_batch_rotating_cache_meta_state_roundtrip` in `tests/test_prompt_cache.py` that round-trips both `rotated=False` and `rotated=True` and asserts the flag survives.

Fixes #1250