### PR TITLE
fix(sampler): change xtc_threshold default from 0.0 to 0.1

### DIFF
--- a/mlx_lm/sample_utils.py
+++ b/mlx_lm/sample_utils.py
@@ -14,7 +14,7 @@ def make_sampler(
     min_tokens_to_keep: int = 1,
     top_k: int = 0,
     xtc_probability: float = 0.0,
-    xtc_threshold: float = 0.0,
+    xtc_threshold: float = 0.1,
     xtc_special_tokens: List[int] = [],
 ) -> Callable[[mx.array], mx.array]:
     """


### PR DESCRIPTION
## Problem
With `xtc_threshold=0.0` (old default) and `xtc_probability>0`, `apply_xtc()` masks every token above probability 0.0 — i.e. all tokens except the single least-probable one. This is the opposite of the intended behaviour and produces degenerate output whenever a user sets `xtc_probability` without an explicit threshold.

## Fix
Change the default to `0.1`, matching the threshold recommended in the original XTC paper and used in all documented examples.

Fixes #1036