### PR TITLE
fix(server): log confirmation when speculative decoding is active

### DIFF
--- a/mlx_lm/server.py
+++ b/mlx_lm/server.py
@@ -366,6 +366,10 @@ class ModelProvider:
                     "Draft model tokenizer does not match model tokenizer. "
                     "Speculative decoding may not work as expected."
                 )
+            else:
+                logging.info(
+                    f"Speculative decoding active: draft model '{draft_model_path}'"
+                )
 
         # Compute batchability
         is_batchable = draft_model is None


### PR DESCRIPTION
## Problem
When `--draft-model` is provided and tokenizers match, the server emits no startup message. Users have no way to confirm speculative decoding is actually running short of adding `--log-level DEBUG`.

## Fix
Add an `INFO` log confirming the draft model path when setup succeeds, symmetric with the existing warning when tokenizers don't match.

Fixes #1131