### PR TITLE
fix(server): keep tool_call arguments as JSON string (OpenAI spec)

### DIFF
--- a/mlx_lm/server.py
+++ b/mlx_lm/server.py
@@ -143,12 +143,6 @@ def process_message_content(messages):
         elif content is None:
             message["content"] = ""
 
-        if tool_calls := message.get("tool_calls"):
-            for tool_call in tool_calls:
-                if func := tool_call.get("function"):
-                    if args := func.get("arguments"):
-                        func["arguments"] = json.loads(args)
-
 
 @dataclass
 class ModelDescription:


### PR DESCRIPTION
## Problem

`process_message_content()` decoded the `arguments` field of incoming assistant `tool_call` messages from a JSON string to a Python dict. Chat templates that call `json.loads()` on `arguments` themselves (deepseek_v32, DSML-format models) then received a dict and raised `TypeError`, silently breaking multi-turn tool use for those models.

## Root cause

The [OpenAI Chat Completions spec](https://platform.openai.com/docs/api-reference/chat/object) specifies that `function.arguments` is always a **JSON-encoded string**, not a parsed object. Pre-decoding it violated this contract. Chat templates that need the arguments as a dict should parse them with the Jinja `|fromjson` filter internally — not rely on the server to pre-decode them.

## Fix

Remove the `json.loads()` call. No callers in the codebase depend on `arguments` being a dict at this layer.

Fixes #1065