### PR TITLE
fix(sampler): change xtc_threshold default from 0.0 to 0.1 everywhere

### DIFF
--- a/mlx_lm/generate.py
+++ b/mlx_lm/generate.py
@@ -133,7 +133,7 @@ def setup_arg_parser():
     parser.add_argument(
         "--xtc-threshold",
         type=float,
-        default=0.0,
+        default=0.1,
         help="Thresold the probs of each next token candidate to be sampled by XTC",
     )
     parser.add_argument(

--- a/mlx_lm/sample_utils.py
+++ b/mlx_lm/sample_utils.py
@@ -14,7 +14,7 @@ def make_sampler(
     min_tokens_to_keep: int = 1,
     top_k: int = 0,
     xtc_probability: float = 0.0,
-    xtc_threshold: float = 0.0,
+    xtc_threshold: float = 0.1,
     xtc_special_tokens: List[int] = [],
 ) -> Callable[[mx.array], mx.array]:
     """

--- a/mlx_lm/server.py
+++ b/mlx_lm/server.py
@@ -1184,7 +1184,7 @@ class APIHandler(BaseHTTPRequestHandler):
         self.frequency_penalty = self.body.get("frequency_penalty", 0.0)
         self.frequency_context_size = self.body.get("frequency_context_size", 20)
         self.xtc_probability = self.body.get("xtc_probability", 0.0)
-        self.xtc_threshold = self.body.get("xtc_threshold", 0.0)
+        self.xtc_threshold = self.body.get("xtc_threshold", 0.1)
         self.logit_bias = self.body.get("logit_bias", None)
         self.logprobs = self.body.get("logprobs", False)
         self.top_logprobs = self.body.get("top_logprobs", -1)


### PR DESCRIPTION
## Problem
With `xtc_threshold=0.0` and `xtc_probability>0`, `apply_xtc()` masks every token above probability 0.0 — all tokens except the least-probable one. This is the opposite of intended behaviour and produces degenerate output whenever `xtc_probability` is set without an explicit threshold.

## Fix
Change the default to `0.1` (XTC paper's recommendation) in all three places it appears:
- `make_sampler()` in `sample_utils.py`
- `--xtc-threshold` CLI default in `generate.py`
- API body default in `server.py`

Fixes #1036