### PR TITLE
Fix tool calls dropped when closed by EOS without an end marker

### DIFF
--- a/mlx_lm/server.py
+++ b/mlx_lm/server.py
@@ -1497,7 +1497,11 @@ class APIHandler(BaseHTTPRequestHandler):
 
                 prev_state = gen.state
 
-            if prev_state == "tool" and tool_text:
+            # Flush a tool call still open when generation ends. With no
+            # tool-call end marker (e.g. Mistral) the EOS token closes it and
+            # moves the final token out of "tool", so a prev_state == "tool"
+            # check would drop the buffered text and return an empty message.
+            if tool_text:
                 tool_calls.append(tool_text)
                 made_tool_call = True
 

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -6,6 +6,7 @@ import json
 import threading
 import types
 import unittest
+from unittest.mock import patch
 
 import mlx.core as mx
 import requests
@@ -18,6 +19,7 @@ from mlx_lm.server import (
     ResponseGenerator,
     _process_control_tokens,
 )
+from mlx_lm.tool_parsers import mistral
 from mlx_lm.utils import load
 
 
@@ -306,6 +308,66 @@ class TestServer(unittest.TestCase):
             self.assertEqual(s, "tool")
         state, _, s = sm.match(state, 2)
         self.assertIsNone(s)
+
+    def test_tool_call_without_end_marker_is_not_dropped(self):
+        # Regression: a tool call from a model with no tool-call end marker
+        # (Mistral-style, empty tool_call_end) is closed by the EOS token.
+        # The EOS moves the state machine out of "tool" on the final token,
+        # so the buffered tool text must still be flushed afterwards instead
+        # of being dropped (which returned an empty message with a "stop"
+        # finish reason). Here the generation is mocked, so the test only
+        # exercises the response handler and not a real model.
+        stream = [
+            Response("", 100, "tool", (100,), 0.0, None, ()),
+            Response('add[ARGS]{"a": 2, "b": 3}', 50, "tool", None, 0.0, None, ()),
+            Response("", 2, None, (2,), 0.0, "stop", ()),
+        ]
+        fake_ctx = types.SimpleNamespace(
+            tool_parser=mistral.parse_tool_call,
+            prompt=[0],
+            prompt_cache_count=0,
+            stop=lambda: None,
+        )
+
+        def fake_generate(*args, **kwargs):
+            return fake_ctx, iter(stream)
+
+        url = f"http://localhost:{self.port}/v1/chat/completions"
+        post_data = {
+            "model": "default_model",
+            "stream": False,
+            "messages": [{"role": "user", "content": "what is 2+3?"}],
+            "tools": [
+                {
+                    "type": "function",
+                    "function": {
+                        "name": "add",
+                        "description": "Add two numbers.",
+                        "parameters": {
+                            "type": "object",
+                            "properties": {
+                                "a": {"type": "number"},
+                                "b": {"type": "number"},
+                            },
+                            "required": ["a", "b"],
+                        },
+                    },
+                }
+            ],
+        }
+        with patch.object(
+            self.response_generator, "generate", side_effect=fake_generate
+        ):
+            response = requests.post(url, json=post_data)
+
+        choice = json.loads(response.text)["choices"][0]
+        self.assertEqual(choice["finish_reason"], "tool_calls")
+        tool_calls = choice["message"].get("tool_calls")
+        self.assertTrue(tool_calls)
+        self.assertEqual(tool_calls[0]["function"]["name"], "add")
+        self.assertEqual(
+            json.loads(tool_calls[0]["function"]["arguments"]), {"a": 2, "b": 3}
+        )
 
     def test_handle_models(self):
         url = f"http://localhost:{self.port}/v1/models"


### PR DESCRIPTION
### What

When a model with no tool-call end marker (the Mistral family, where `tool_call_end_tokens` is empty) emits a tool call, `mlx_lm.server` returns an empty assistant message with `finish_reason: "stop"`, even though the model generated a valid `[TOOL_CALLS] ...` sequence and `completion_tokens` is non-zero.

### Why

The state machine transitions `normal -> tool` on the `[TOOL_CALLS]` token and buffers everything after it into `tool_text`. With no end marker the tool call is closed by the EOS token, which transitions `tool -> None`, so the last token of the generation reports its state as `None`.

The flush after the accumulation loop in `handle_completion` is guarded by `prev_state == "tool"`, which is `None` at that point, so the buffered tool call is never appended. `made_tool_call` stays `False`, `finish_reason` stays `"stop"`, and the message comes back empty. The parser is never reached, which is why there is no `Failed to parse tool call` warning either.

### Fix

Flush whenever `tool_text` is non-empty. It can only be non-empty when a tool call was opened and not yet flushed, so this is also safe for models that do have an end marker, since their `tool_text` is reset to `""` on the `tool -> normal` transition.

### Test

Added `test_tool_call_without_end_marker_is_not_dropped` in `tests/test_server.py`. It mocks generation with a scripted token stream that ends in the EOS to `None` transition and asserts the tool call is returned with `finish_reason: "tool_calls"`. It fails on `main` and passes with the fix. The full `test_server.py` suite passes and `pre-commit` (black, isort) is clean.

### Notes

I could not run the 24B model from the report on a 16 GB machine, so I reproduced the empty-message behavior on `Ministral-8B-Instruct-2410-4bit` (same empty `tool_call_end_tokens`). To confirm the report's model is the same case, I checked the tokenizer and chat template of `mlx-community/mistralai_Devstral-Small-2-24B-Instruct-2512-MLX-MXFP4`: `tool_call_end_tokens` is empty, the template renders tool calls as `[TOOL_CALLS]<name>[ARGS]<json_args>` which the current `mistral.py` parser already handles, and there is no tool-call-id length constraint. So for that model this is purely the flush bug.

Fixes #1307.
