### PR TITLE
fix: stream_generate raises UnboundLocalError when max_tokens=0

### DIFF
--- a/mlx_lm/generate.py
+++ b/mlx_lm/generate.py
@@ -713,6 +713,7 @@ def stream_generate(
         )
     with wired_limit(model, [generation_stream]):
         tic = time.perf_counter()
+        n = -1
         for n, (token, logprobs, from_draft) in enumerate(token_generator):
             if n == 0:
                 prompt_time = time.perf_counter() - tic
@@ -737,6 +738,11 @@ def stream_generate(
                 peak_memory=mx.get_peak_memory() / 1e9,
                 finish_reason=None,
             )
+
+        if n < 0:
+            # No tokens were generated (e.g. max_tokens=0); there is no final
+            # token to report, so end the stream without a final response.
+            return
 
         detokenizer.finalize()
         yield GenerationResponse(

--- a/tests/test_generate.py
+++ b/tests/test_generate.py
@@ -63,6 +63,19 @@ class TestGenerate(unittest.TestCase):
             tokens.append(response.token)
         self.assertEqual(len(tokens), 4)
 
+    def test_stream_generate_zero_max_tokens(self):
+        prompt = self.tokenizer.apply_chat_template(
+            [{"role": "user", "content": "Write a story about Einstein"}],
+            tokenize=True,
+            add_generation_prompt=True,
+        )
+
+        # max_tokens=0 must not raise; it generates nothing.
+        responses = list(
+            stream_generate(self.model, self.tokenizer, prompt, max_tokens=0)
+        )
+        self.assertEqual(responses, [])
+
     def test_generate_with_processor(self):
         init_toks = self.tokenizer.encode("hello")
 


### PR DESCRIPTION
## Summary

`stream_generate(..., max_tokens=0)` raises `UnboundLocalError` instead of producing an empty generation.

With `max_tokens=0`, `generate_step` hits its `if n == max_tokens: break` before the first `yield`, so the token generator yields nothing. The `for n, (token, logprobs, from_draft) in enumerate(token_generator)` loop in `stream_generate` therefore never runs, and the unconditional final `GenerationResponse` after the loop references `token`, `logprobs`, `from_draft`, and `n`:

```
UnboundLocalError: cannot access local variable 'token' where it is not associated with a value
```

`max_tokens=0` is reachable: the public API and CLI accept it, and the server validates `max_tokens` with `min_val=0` (`server.py`), so a request with `{"max_tokens": 0}` reaches this path.

## Fix

Track whether any token was generated and return without emitting a final response when none were. An empty generation now yields an empty stream rather than crashing. `generate()` already handles empty output (it accumulates into `text = ""`), and the server's generation loops simply iterate zero times.

```python
n = -1
for n, (token, logprobs, from_draft) in enumerate(token_generator):
    ...
if n < 0:
    return
```

## Tests

Added `test_stream_generate_zero_max_tokens` in `tests/test_generate.py`: `list(stream_generate(model, tokenizer, prompt, max_tokens=0))` must not raise and returns `[]`. It fails before the change (UnboundLocalError) and passes after.

Verified the real `stream_generate`/`generate_step` path with a tiny Llama model (no download): `max_tokens=0` goes from raising to returning 0 responses, while `max_tokens=2` still returns 2.
