### PR TITLE
Add ParoQuant (pairwise rotation quantization) support

### DIFF
--- a/mlx_lm/models/paroquant.py
+++ b/mlx_lm/models/paroquant.py
@@ -1,0 +1,359 @@
+# Copyright © 2025 Apple Inc.
+
+"""ParoQuant (Pairwise Rotation Quantization) inference layers.
+
+ParoQuant [ICLR 2026, arXiv:2511.10645] applies a learned sequence of pairwise
+Givens rotations to the activations before an affine-quantized matmul. The
+rotation decorrelates channels so that low-bit (e.g. 4-bit) quantization keeps
+more of the signal. At inference the rotation is a cheap Metal kernel followed by
+the standard ``mx.quantized_matmul``.
+
+This module provides the inference-time layers; weight loading and layer
+swapping live in ``mlx_lm.utils`` (``_transform_paro_weights`` /
+``_patch_paro_layers``), dispatched from ``load_model`` when a model's
+``quantization_config`` has ``"quant_method": "paroquant"``.
+"""
+
+import math
+from functools import lru_cache
+
+import mlx.core as mx
+import mlx.nn as nn
+
+_MAX_GROUP_SIZE = 128
+_MAX_KROT = 16
+
+_ROTATION_SOURCE = """
+    constexpr int ROWS_PER_TILE = {ROWS_PER_TILE};
+    constexpr int MAX_KROT      = {MAX_KROT};
+
+    const int batch_size  = params[0];
+    const int hidden_size = params[1];
+    const int krot        = params[2];
+    const int group_size  = params[3];
+
+    const int half_gs     = group_size / 2;
+    const int half_hidden = hidden_size / 2;
+
+    const int tile_idx  = threadgroup_position_in_grid.x;
+    const int group_idx = threadgroup_position_in_grid.y;
+    const int tid       = thread_index_in_threadgroup;
+
+    if (tid >= half_gs) return;
+
+    // ---- Load rotation coefficients into registers ----
+    float cos_vals[MAX_KROT], sin_vals[MAX_KROT];
+    int   pair_vals[MAX_KROT];
+
+    for (int k = 0; k < krot; k++) {{
+        int idx = k * half_hidden + group_idx * half_gs + tid;
+        cos_vals[k]  = float(cos_theta[idx]);
+        sin_vals[k]  = float(sin_theta[idx]);
+        pair_vals[k] = int(packed_pairs[idx]);
+    }}
+
+    // ---- Load activation tile into shared memory (fuse channel scales) ----
+    threadgroup float tile[{MAX_GROUP_SIZE} * ROWS_PER_TILE];
+
+    const int ch_lo = group_idx * group_size + tid;
+    const int ch_hi = ch_lo + half_gs;
+    float scale_lo = float(channel_scales[ch_lo]);
+    float scale_hi = float(channel_scales[ch_hi]);
+
+    for (int r = 0; r < ROWS_PER_TILE; r++) {{
+        int row = tile_idx * ROWS_PER_TILE + r;
+        if (row < batch_size) {{
+            tile[tid * ROWS_PER_TILE + r]              = float(x[row * hidden_size + ch_lo]) * scale_lo;
+            tile[(tid + half_gs) * ROWS_PER_TILE + r]  = float(x[row * hidden_size + ch_hi]) * scale_hi;
+        }}
+    }}
+    threadgroup_barrier(mem_flags::mem_threadgroup);
+
+    // ---- Apply pairwise Givens rotations in-place ----
+    for (int k = 0; k < krot; k++) {{
+        int i_local = pair_vals[k] & 0xFFFF;
+        int j_local = pair_vals[k] >> 16;
+        float c = cos_vals[k], s = sin_vals[k];
+
+        for (int m = 0; m < ROWS_PER_TILE; m++) {{
+            float a = tile[i_local * ROWS_PER_TILE + m];
+            float b = tile[j_local * ROWS_PER_TILE + m];
+            tile[i_local * ROWS_PER_TILE + m] = a * c + b * s;
+            tile[j_local * ROWS_PER_TILE + m] = b * c - a * s;
+        }}
+        threadgroup_barrier(mem_flags::mem_threadgroup);
+    }}
+
+    // ---- Write results back ----
+    for (int r = 0; r < ROWS_PER_TILE; r++) {{
+        int row = tile_idx * ROWS_PER_TILE + r;
+        if (row < batch_size) {{
+            out[row * hidden_size + ch_lo] = tile[tid * ROWS_PER_TILE + r];
+            out[row * hidden_size + ch_hi] = tile[(tid + half_gs) * ROWS_PER_TILE + r];
+        }}
+    }}
+"""
+
+
+def _check_kernel_limits(krot: int, group_size: int):
+    """The Metal kernel statically sizes its register arrays (MAX_KROT) and
+    threadgroup memory (MAX_GROUP_SIZE) at compile time, so these are hard upper
+    bounds — exceeding them would silently corrupt memory. Fail loudly instead.
+    """
+    if krot > _MAX_KROT:
+        raise ValueError(
+            f"ParoQuant krot={krot} exceeds the kernel limit MAX_KROT={_MAX_KROT}; "
+            "raise _MAX_KROT in paroquant.py and recompile."
+        )
+    if group_size > _MAX_GROUP_SIZE:
+        raise ValueError(
+            f"ParoQuant group_size={group_size} exceeds the kernel limit "
+            f"MAX_GROUP_SIZE={_MAX_GROUP_SIZE}; raise _MAX_GROUP_SIZE in paroquant.py."
+        )
+
+
+@lru_cache(maxsize=None)
+def _get_rotation_kernel(rows_per_tile: int):
+    """Compile and cache the Metal rotation kernel for a given tile size."""
+    return mx.fast.metal_kernel(
+        name=f"paro_rotate_r{rows_per_tile}",
+        input_names=[
+            "x",
+            "packed_pairs",
+            "cos_theta",
+            "sin_theta",
+            "channel_scales",
+            "params",
+        ],
+        output_names=["out"],
+        source=_ROTATION_SOURCE.format(
+            ROWS_PER_TILE=rows_per_tile,
+            MAX_GROUP_SIZE=_MAX_GROUP_SIZE,
+            MAX_KROT=_MAX_KROT,
+        ),
+    )
+
+
+def pack_pairs(pairs: mx.array, group_size: int) -> mx.array:
+    """Pack int16 pair indices into int32 (two per lane) for the Metal kernel."""
+    krot, hidden = int(pairs.shape[0]), int(pairs.shape[1])
+    p = pairs.reshape(krot, hidden // group_size, group_size).astype(mx.int32)
+    return (p[:, :, 0::2] | (p[:, :, 1::2] << 16)).reshape(krot, -1)
+
+
+def apply_rotation(
+    x: mx.array,
+    packed_pairs: mx.array,
+    cos: mx.array,
+    sin: mx.array,
+    scales_flat: mx.array,
+    dim: int,
+    krot: int,
+    group_size: int,
+) -> mx.array:
+    """Dispatch the pairwise-rotation kernel on a 2-D (batch, dim) tensor."""
+    batch = x.shape[0]
+    if batch == 0:
+        return x
+    tile = 1 if batch <= 1 else 4
+    half_group = group_size // 2
+    num_groups = dim // group_size
+    params = mx.array([batch, dim, krot, group_size], dtype=mx.int32)
+    grid = (math.ceil(batch / tile) * half_group, num_groups, 1)
+    return _get_rotation_kernel(tile)(
+        inputs=[x, packed_pairs, cos, sin, scales_flat, params],
+        output_shapes=[x.shape],
+        output_dtypes=[x.dtype],
+        grid=grid,
+        threadgroup=(half_group, 1, 1),
+    )[0]
+
+
+class RotateQuantizedLinear(nn.Module):
+    """Pairwise Givens rotation followed by an affine quantized matmul.
+
+    The rotation parameters (``theta``, ``pairs``, ``channel_scales``) and the
+    quantized weight (``weight``, ``scales``, ``biases``) are filled in by
+    ``model.load_weights`` after this layer replaces an ``nn.Linear``.
+    """
+
+    def __init__(
+        self,
+        input_dims: int,
+        output_dims: int,
+        bias: bool = True,
+        group_size: int = 128,
+        bits: int = 4,
+        krot: int = 8,
+    ):
+        super().__init__()
+        _check_kernel_limits(krot, group_size)
+        self.group_size = group_size
+        self.bits = bits
+
+        self.theta = mx.zeros((krot, input_dims // 2))
+        self.pairs = mx.zeros((krot, input_dims), dtype=mx.int16)
+        self.channel_scales = mx.ones((1, input_dims))
+
+        self.weight = mx.zeros((output_dims, input_dims * bits // 32), dtype=mx.uint32)
+        self.scales = mx.zeros((output_dims, input_dims // group_size))
+        self.biases = mx.zeros((output_dims, input_dims // group_size))
+
+        if bias:
+            self.bias = mx.zeros((output_dims,))
+
+        self._cached = False
+        # Match nn.QuantizedLinear / QuantizedSwitchLinear: quantized + rotation
+        # params are not trainable, so tuner/LoRA skips them like any quant layer.
+        self.freeze()
+
+    def _cache_rotation(self):
+        """Pre-compute sin/cos and pack pairs (called once on first forward)."""
+        self._dim = self.theta.shape[1] * 2
+        self._krot = int(self.theta.shape[0])
+        self._cos = mx.cos(self.theta)
+        self._sin = mx.sin(self.theta)
+        self._packed_pairs = pack_pairs(self.pairs, self.group_size)
+        self._scales_flat = self.channel_scales.reshape(-1)
+        self._cached = True
+
+    def __call__(self, x: mx.array) -> mx.array:
+        if not self._cached:
+            self._cache_rotation()
+
+        shape = x.shape
+        rotated = apply_rotation(
+            x.reshape(-1, self._dim),
+            self._packed_pairs,
+            self._cos,
+            self._sin,
+            self._scales_flat,
+            self._dim,
+            self._krot,
+            self.group_size,
+        )
+
+        y = mx.quantized_matmul(
+            rotated.reshape(shape),
+            self.weight,
+            scales=self.scales,
+            biases=self.biases,
+            transpose=True,
+            group_size=self.group_size,
+            bits=self.bits,
+        )
+        if "bias" in self:
+            y = y + self.bias
+        return y
+
+
+class _CachedRotation:
+    """Helper for modules that own one or more named rotations.
+
+    A "rotation" is the triple (theta, pairs, channel_scales) plus the cached
+    sin/cos and packed pairs derived from them. ``prefix`` namespaces multiple
+    rotations on the same module (e.g. ``gate_up_rot`` and ``down_rot``).
+    """
+
+    def _init_rotation(self, krot: int, dim: int, group_size: int, prefix: str = ""):
+        _check_kernel_limits(krot, group_size)
+        pfx = f"{prefix}_" if prefix else ""
+        setattr(self, f"{pfx}theta", mx.zeros((krot, dim // 2)))
+        setattr(self, f"{pfx}pairs", mx.zeros((krot, dim), dtype=mx.int16))
+        setattr(self, f"{pfx}channel_scales", mx.ones((1, dim)))
+        self._rot_group_size = group_size
+
+    def _cache_single_rotation(self, prefix: str = ""):
+        pfx = f"{prefix}_" if prefix else ""
+        theta = getattr(self, f"{pfx}theta")
+        dim = int(theta.shape[1]) * 2
+        krot = int(theta.shape[0])
+        tag = f"_{prefix}" if prefix else ""
+        setattr(self, f"_rot{tag}_dim", dim)
+        setattr(self, f"_rot{tag}_krot", krot)
+        setattr(self, f"_rot{tag}_cos", mx.cos(theta))
+        setattr(self, f"_rot{tag}_sin", mx.sin(theta))
+        setattr(
+            self,
+            f"_rot{tag}_packed_pairs",
+            pack_pairs(getattr(self, f"{pfx}pairs"), self._rot_group_size),
+        )
+        setattr(
+            self,
+            f"_rot{tag}_scales_flat",
+            getattr(self, f"{pfx}channel_scales").reshape(-1),
+        )
+
+    def _rotate(self, x: mx.array, prefix: str = "") -> mx.array:
+        tag = f"_{prefix}" if prefix else ""
+        dim = getattr(self, f"_rot{tag}_dim")
+        shape = x.shape
+        rotated = apply_rotation(
+            x.reshape(-1, dim),
+            getattr(self, f"_rot{tag}_packed_pairs"),
+            getattr(self, f"_rot{tag}_cos"),
+            getattr(self, f"_rot{tag}_sin"),
+            getattr(self, f"_rot{tag}_scales_flat"),
+            dim,
+            getattr(self, f"_rot{tag}_krot"),
+            self._rot_group_size,
+        )
+        return rotated.reshape(shape)
+
+
+class RotateSwitchGLU(nn.Module, _CachedRotation):
+    """``SwitchGLU`` with a shared pairwise rotation before each projection.
+
+    All experts share one rotation per projection: ``gate_up_rot`` is applied to
+    the input before gate/up, and ``down_rot`` is applied to the activation
+    before the down projection. The expert weights themselves are quantized
+    ``QuantizedSwitchLinear`` layers.
+    """
+
+    def __init__(self, glu: nn.Module, group_size: int, krot: int):
+        super().__init__()
+        self.gate_proj = glu.gate_proj
+        self.up_proj = glu.up_proj
+        self.down_proj = glu.down_proj
+        self.activation = glu.activation
+
+        self._init_rotation(krot, glu.gate_proj.input_dims, group_size, "gate_up_rot")
+        self._init_rotation(krot, glu.down_proj.input_dims, group_size, "down_rot")
+        self._cached = False
+        # Rotation params (and the already-frozen quantized experts) are not
+        # trainable; freeze to match the standard quantized switch layers.
+        self.freeze()
+
+    def _cache_rotation(self):
+        self._cache_single_rotation("gate_up_rot")
+        self._cache_single_rotation("down_rot")
+        self._cached = True
+
+    def __call__(self, x, indices) -> mx.array:
+        if not self._cached:
+            self._cache_rotation()
+
+        from .switch_layers import _gather_sort, _scatter_unsort
+
+        x = mx.expand_dims(x, (-2, -3))
+
+        do_sort = indices.size >= 64
+        idx = indices
+        inv_order = None
+        if do_sort:
+            x, idx, inv_order = _gather_sort(x, indices)
+
+        x = self._rotate(x, "gate_up_rot")
+
+        x_up = self.up_proj(x, idx, sorted_indices=do_sort)
+        x_gate = self.gate_proj(x, idx, sorted_indices=do_sort)
+
+        act = self.activation(x_up, x_gate)
+        act = self._rotate(act, "down_rot")
+
+        x = self.down_proj(act, idx, sorted_indices=do_sort)
+
+        if do_sort:
+            x = _scatter_unsort(x, inv_order, indices.shape)
+
+        return x.squeeze(-2)

--- a/mlx_lm/utils.py
+++ b/mlx_lm/utils.py
@@ -6,6 +6,7 @@ import importlib
 import inspect
 import json
 import os
+import re
 import resource
 import shutil
 from pathlib import Path
@@ -171,6 +172,170 @@ def _transform_awq_weights(
     }
 
     return new_weights, mlx_quantization
+
+
+_PARO_EXPERT_RE = re.compile(r"^(.+)\.experts\.(\d+)\.(\w+)\.(\w+)$")
+_PARO_STACKABLE = ("weight", "scales", "biases")
+_PARO_SHARED_ROT_RE = re.compile(
+    r"^(.+)\.experts\.(gate_up_weight|down_weight)_(theta|pairs|channel_scales)$"
+)
+
+
+def _transform_paro_weights(
+    weights: Dict[str, mx.array],
+    quantization_config: Dict[str, Any],
+) -> Dict[str, mx.array]:
+    """Convert a ParoQuant checkpoint to the layout consumed by the inference
+    layers in ``mlx_lm.models.paroquant``.
+
+    Public ParoQuant checkpoints ship AutoAWQ-packed weights
+    (``prefix.qweight``/``qzeros``/``scales``) plus rotation params
+    (``prefix.theta``/``pairs``/``channel_scales``). The packed weights are
+    converted with the shared :func:`_transform_awq_weights`; the rotation keys
+    pass through. Then per-expert weights are stacked into the ``switch_mlp``
+    namespace and shared MoE rotations are remapped to
+    ``gate_up_rot`` / ``down_rot``.
+    """
+    if any(k.endswith(".qweight") for k in weights):
+        out, _ = _transform_awq_weights(weights, quantization_config)
+    else:
+        out = dict(weights)
+
+    out = _stack_paro_moe_experts(out)
+    out = _remap_paro_shared_rotation(out)
+    return out
+
+
+def _stack_paro_moe_experts(weights: Dict[str, mx.array]) -> Dict[str, mx.array]:
+    """Stack per-expert params into the ``switch_mlp`` format for ``SwitchGLU``.
+
+    ``...experts.{e}.{proj}.{suffix}`` -> ``...switch_mlp.{proj}.{suffix}``.
+    """
+    groups: Dict[str, Dict[int, Dict[str, str]]] = {}
+    for key in list(weights):
+        m = _PARO_EXPERT_RE.match(key)
+        if m is None:
+            continue
+        base, expert_str, proj, suffix = m.groups()
+        if suffix not in _PARO_STACKABLE:
+            continue
+        group_key = f"{base}.switch_mlp.{proj}"
+        groups.setdefault(group_key, {}).setdefault(int(expert_str), {})[suffix] = key
+
+    for group_key, experts_dict in groups.items():
+        num_experts = max(experts_dict) + 1
+        for suffix in _PARO_STACKABLE:
+            dest = f"{group_key}.{suffix}"
+            if dest in weights:
+                continue
+            src = [experts_dict.get(e, {}).get(suffix) for e in range(num_experts)]
+            if all(src):
+                weights[dest] = mx.stack([weights.pop(k) for k in src])
+    return weights
+
+
+def _remap_paro_shared_rotation(weights: Dict[str, mx.array]) -> Dict[str, mx.array]:
+    """Remap shared expert rotation keys into the ``switch_mlp`` namespace.
+
+    ``...experts.gate_up_weight_{s}`` -> ``...switch_mlp.gate_up_rot_{s}``
+    ``...experts.down_weight_{s}``    -> ``...switch_mlp.down_rot_{s}``
+    """
+    remap = {"gate_up_weight": "gate_up_rot", "down_weight": "down_rot"}
+    for key in list(weights):
+        m = _PARO_SHARED_ROT_RE.match(key)
+        if m is None:
+            continue
+        base, proj, suffix = m.groups()
+        weights[f"{base}.switch_mlp.{remap[proj]}_{suffix}"] = weights.pop(key)
+    return weights
+
+
+def _paro_get_module(root, path: str):
+    node = root
+    for part in path.split("."):
+        node = (
+            node[int(part)] if isinstance(node, (list, tuple)) else getattr(node, part)
+        )
+    return node
+
+
+def _paro_set_module(root, path: str, value):
+    parts = path.split(".")
+    parent = _paro_get_module(root, ".".join(parts[:-1])) if len(parts) > 1 else root
+    if isinstance(parent, list):
+        parent[int(parts[-1])] = value
+    else:
+        setattr(parent, parts[-1], value)
+
+
+def _patch_paro_layers(
+    model: nn.Module,
+    weights: Dict[str, mx.array],
+    bits: int,
+    group_size: int,
+):
+    """Replace linear layers with their ParoQuant variants before loading weights.
+
+    - Dense ``nn.Linear`` with a ``.theta`` rotation -> ``RotateQuantizedLinear``
+    - ``SwitchLinear`` with a stacked uint32 weight  -> ``QuantizedSwitchLinear``
+    - ``SwitchGLU`` with shared rotation keys        -> ``RotateSwitchGLU``
+    """
+    from .models.paroquant import RotateQuantizedLinear, RotateSwitchGLU
+    from .models.switch_layers import (
+        QuantizedSwitchLinear,
+        SwitchGLU,
+        SwitchLinear,
+    )
+
+    # Dense rotation layers
+    for prefix in sorted(k[: -len(".theta")] for k in weights if k.endswith(".theta")):
+        try:
+            original = _paro_get_module(model, prefix)
+        except (AttributeError, IndexError):
+            continue
+        if not isinstance(original, nn.Linear):
+            continue
+        _paro_set_module(
+            model,
+            prefix,
+            RotateQuantizedLinear(
+                input_dims=original.weight.shape[-1],
+                output_dims=original.weight.shape[0],
+                bias="bias" in original,
+                group_size=group_size,
+                bits=bits,
+                krot=weights[f"{prefix}.theta"].shape[0],
+            ),
+        )
+
+    # Quantized MoE experts (no rotation on the expert matmul itself)
+    for path, mod in model.named_modules():
+        if not isinstance(mod, SwitchLinear):
+            continue
+        w = weights.get(f"{path}.weight")
+        if w is not None and w.dtype in (mx.uint32, mx.uint16, mx.uint8):
+            _paro_set_module(
+                model,
+                path,
+                QuantizedSwitchLinear(
+                    mod.input_dims,
+                    mod.output_dims,
+                    mod.num_experts,
+                    bias="bias" in mod,
+                    group_size=group_size,
+                    bits=bits,
+                ),
+            )
+
+    # SwitchGLU -> RotateSwitchGLU where shared rotation keys are present
+    for path, mod in model.named_modules():
+        if not isinstance(mod, SwitchGLU):
+            continue
+        rot_key = f"{path}.gate_up_rot_theta"
+        if rot_key in weights:
+            _paro_set_module(
+                model, path, RotateSwitchGLU(mod, group_size, weights[rot_key].shape[0])
+            )
 
 
 def _get_classes(config: dict):
@@ -389,6 +554,19 @@ def load_model(
             config["quantization"] = quantization
             config["quantization_config"] = quantization
             _quantize(quantization)
+        elif quant_method == "paroquant":
+            # ParoQuant (pairwise rotation quantization): transform the packed
+            # checkpoint and swap in the rotation-aware layers. Layers are patched
+            # explicitly (not via nn.quantize) because the rotation step is not
+            # part of the standard QuantizedLinear; embed_tokens/lm_head are kept
+            # in their checkpoint (float) form and load as-is.
+            bits = quantization_config.get("bits", 4)
+            group_size = quantization_config.get("group_size", 128)
+            weights = _transform_paro_weights(weights, quantization_config)
+            _patch_paro_layers(model, weights, bits, group_size)
+            quantization = {"group_size": group_size, "bits": bits, "mode": "affine"}
+            config["quantization"] = quantization
+            config["quantization_config"] = quantization
 
     if config.get("quantize_activations", False):
 

--- a/tests/test_paroquant.py
+++ b/tests/test_paroquant.py
@@ -1,0 +1,273 @@
+# Copyright © 2025 Apple Inc.
+import unittest
+
+import mlx.core as mx
+import mlx.nn as nn
+import numpy as np
+
+from mlx_lm.models.paroquant import (
+    RotateQuantizedLinear,
+    RotateSwitchGLU,
+    apply_rotation,
+    pack_pairs,
+)
+from mlx_lm.models.switch_layers import QuantizedSwitchLinear, SwitchGLU
+from mlx_lm.utils import (
+    _patch_paro_layers,
+    _stack_paro_moe_experts,
+    _transform_paro_weights,
+)
+
+
+def _valid_pairs(krot, in_features, group_size):
+    """Within-group perfect matching: thread t handles disjoint pair (2t, 2t+1)."""
+    num_groups = in_features // group_size
+    base = np.arange(group_size, dtype=np.int16)
+    return mx.array(np.tile(base, (krot, num_groups)))
+
+
+def _random_valid_pairs(rng, krot, in_features, group_size):
+    """Random within-group perfect matching (a random permutation per group).
+
+    Each group stores a permutation of [0, group_size); consecutive entries
+    form the disjoint (i, j) pairs, so lanes never alias -> deterministic.
+    """
+    num_groups = in_features // group_size
+    pairs = np.empty((krot, in_features), dtype=np.int16)
+    for k in range(krot):
+        for g in range(num_groups):
+            pairs[k, g * group_size : (g + 1) * group_size] = rng.permutation(
+                group_size
+            )
+    return mx.array(pairs)
+
+
+def _numpy_rotation(x, theta, channel_scales, pairs, group_size):
+    """Faithful reference that reads the (i, j) local indices out of ``pairs``."""
+    krot, half_hidden = theta.shape
+    in_f = half_hidden * 2
+    num_groups = in_f // group_size
+    half_gs = group_size // 2
+    cos, sin = np.cos(theta), np.sin(theta)
+    pairs = np.asarray(pairs)
+    xr = x.astype(np.float64) * channel_scales.astype(np.float64)
+    for k in range(krot):
+        for g in range(num_groups):
+            ci = g * group_size
+            for t in range(half_gs):
+                i_local = int(pairs[k, ci + 2 * t])
+                j_local = int(pairs[k, ci + 2 * t + 1])
+                col = g * half_gs + t
+                c, s = cos[k, col], sin[k, col]
+                a, b = xr[:, ci + i_local].copy(), xr[:, ci + j_local].copy()
+                xr[:, ci + i_local] = a * c + b * s
+                xr[:, ci + j_local] = b * c - a * s
+    return xr
+
+
+class TestParoQuant(unittest.TestCase):
+    def setUp(self):
+        self.rng = np.random.default_rng(0)
+        self.gs, self.krot, self.bits = 128, 8, 4
+        self.in_f, self.out_f = 512, 256
+
+    def _check_rotation(self, pairs):
+        theta = self.rng.standard_normal((self.krot, self.in_f // 2)).astype(np.float32)
+        cscales = self.rng.standard_normal((self.in_f,)).astype(np.float32)
+        x = self.rng.standard_normal((4, self.in_f)).astype(np.float32)
+        out = apply_rotation(
+            mx.array(x),
+            pack_pairs(pairs, self.gs),
+            mx.cos(mx.array(theta)),
+            mx.sin(mx.array(theta)),
+            mx.array(cscales),
+            self.in_f,
+            self.krot,
+            self.gs,
+        )
+        ref = _numpy_rotation(x, theta, cscales, np.array(pairs), self.gs)
+        self.assertTrue(np.allclose(np.array(out), ref, atol=1e-4))
+
+    def test_rotation_matches_numpy(self):
+        # Fixed (2t, 2t+1) matching.
+        self._check_rotation(_valid_pairs(self.krot, self.in_f, self.gs))
+
+    def test_rotation_random_pairs(self):
+        # Random within-group matchings exercise arbitrary (i, j) index values.
+        self._check_rotation(
+            _random_valid_pairs(self.rng, self.krot, self.in_f, self.gs)
+        )
+
+    def test_rotate_quantized_linear_forward(self):
+        layer = RotateQuantizedLinear(
+            self.in_f,
+            self.out_f,
+            bias=True,
+            group_size=self.gs,
+            bits=self.bits,
+            krot=self.krot,
+        )
+        layer.theta = mx.array(
+            self.rng.standard_normal(layer.theta.shape).astype(np.float32)
+        )
+        layer.pairs = _valid_pairs(self.krot, self.in_f, self.gs)
+        layer.channel_scales = mx.array(
+            self.rng.standard_normal((1, self.in_f)).astype(np.float32)
+        )
+        layer.weight = mx.array(
+            self.rng.integers(0, 2**32, size=layer.weight.shape, dtype=np.uint32)
+        )
+        layer.scales = mx.array(
+            (self.rng.standard_normal(layer.scales.shape) * 0.05).astype(np.float32)
+        )
+        layer.biases = mx.array(
+            (self.rng.standard_normal(layer.biases.shape) * 0.05).astype(np.float32)
+        )
+        layer.bias = mx.array(
+            self.rng.standard_normal((self.out_f,)).astype(np.float32)
+        )
+
+        x = mx.array(self.rng.standard_normal((2, 7, self.in_f)).astype(np.float32))
+        y = layer(x)
+        mx.eval(y)
+        self.assertEqual(y.shape, (2, 7, self.out_f))
+        self.assertTrue(bool(mx.all(mx.isfinite(y)).item()))
+
+    def test_transform_paro_weights_awq_packed(self):
+        # Public ParoQuant checkpoints ship AWQ-packed weights + rotation params.
+        prefix = "model.layers.0.self_attn.q_proj"
+        pf = 32 // self.bits
+        n_groups = self.in_f // self.gs
+        weights = {
+            f"{prefix}.qweight": mx.array(
+                self.rng.integers(
+                    0, 2**31, size=(self.in_f, self.out_f // pf), dtype=np.int32
+                )
+            ),
+            f"{prefix}.qzeros": mx.array(
+                self.rng.integers(
+                    0, 2**31, size=(n_groups, self.out_f // pf), dtype=np.int32
+                )
+            ),
+            f"{prefix}.scales": mx.array(
+                (self.rng.standard_normal((n_groups, self.out_f)) * 0.02).astype(
+                    np.float16
+                )
+            ),
+            f"{prefix}.theta": mx.array(
+                self.rng.standard_normal((self.krot, self.in_f // 2)).astype(np.float16)
+            ),
+            f"{prefix}.pairs": _valid_pairs(self.krot, self.in_f, self.gs),
+            f"{prefix}.channel_scales": mx.array(
+                self.rng.standard_normal((1, self.in_f)).astype(np.float16)
+            ),
+            "model.embed_tokens.weight": mx.zeros((100, self.in_f), dtype=mx.float16),
+        }
+        out = _transform_paro_weights(
+            weights, {"bits": self.bits, "group_size": self.gs}
+        )
+
+        self.assertEqual(out[f"{prefix}.weight"].dtype, mx.uint32)
+        self.assertEqual(
+            out[f"{prefix}.weight"].shape, (self.out_f, self.in_f * self.bits // 32)
+        )
+        self.assertEqual(out[f"{prefix}.scales"].shape, (self.out_f, n_groups))
+        self.assertEqual(out[f"{prefix}.biases"].shape, (self.out_f, n_groups))
+        # rotation params pass through untouched
+        for r in ("theta", "pairs", "channel_scales"):
+            self.assertIn(f"{prefix}.{r}", out)
+        self.assertNotIn(f"{prefix}.qweight", out)
+        self.assertIn("model.embed_tokens.weight", out)
+
+    def test_patch_dense_layer(self):
+        class Tiny(nn.Module):
+            def __init__(self, in_f, out_f):
+                super().__init__()
+                self.proj = nn.Linear(in_f, out_f, bias=False)
+
+        model = Tiny(self.in_f, self.out_f)
+        weights = {
+            "proj.theta": mx.zeros((self.krot, self.in_f // 2)),
+            "proj.weight": mx.zeros(
+                (self.out_f, self.in_f * self.bits // 32), dtype=mx.uint32
+            ),
+        }
+        _patch_paro_layers(model, weights, self.bits, self.gs)
+        self.assertIsInstance(model.proj, RotateQuantizedLinear)
+        self.assertEqual(model.proj.bits, self.bits)
+        self.assertEqual(model.proj.group_size, self.gs)
+
+    def test_patch_moe_switchglu(self):
+        n_experts, hidden, ffn = 4, 256, 512
+        glu = SwitchGLU(hidden, ffn, n_experts)
+        weights = {
+            "switch_mlp.gate_up_rot_theta": mx.zeros((self.krot, hidden // 2)),
+            "switch_mlp.gate_up_rot_pairs": _valid_pairs(self.krot, hidden, self.gs),
+            "switch_mlp.gate_up_rot_channel_scales": mx.ones((1, hidden)),
+            "switch_mlp.down_rot_theta": mx.zeros((self.krot, ffn // 2)),
+            "switch_mlp.down_rot_pairs": _valid_pairs(self.krot, ffn, self.gs),
+            "switch_mlp.down_rot_channel_scales": mx.ones((1, ffn)),
+        }
+
+        class Wrap(nn.Module):
+            def __init__(self, glu):
+                super().__init__()
+                self.switch_mlp = glu
+
+        model = Wrap(glu)
+        _patch_paro_layers(model, weights, self.bits, self.gs)
+        self.assertIsInstance(model.switch_mlp, RotateSwitchGLU)
+
+    def test_moe_stack_and_forward(self):
+        # Per-expert quantized weights -> _stack_paro_moe_experts -> patched
+        # RotateSwitchGLU over QuantizedSwitchLinear experts -> forward smoke.
+        n_experts, hidden, ffn = 4, 256, 512
+        base = "mlp"
+        weights = {}
+        for proj, (out_d, in_d) in [
+            ("gate_proj", (ffn, hidden)),
+            ("up_proj", (ffn, hidden)),
+            ("down_proj", (hidden, ffn)),
+        ]:
+            for e in range(n_experts):
+                w = mx.random.normal((out_d, in_d)) * 0.05
+                qw, sc, bi = mx.quantize(w, group_size=self.gs, bits=self.bits)
+                weights[f"{base}.experts.{e}.{proj}.weight"] = qw
+                weights[f"{base}.experts.{e}.{proj}.scales"] = sc
+                weights[f"{base}.experts.{e}.{proj}.biases"] = bi
+        for rot, dim in [("gate_up_rot", hidden), ("down_rot", ffn)]:
+            weights[f"{base}.switch_mlp.{rot}_theta"] = mx.zeros((self.krot, dim // 2))
+            weights[f"{base}.switch_mlp.{rot}_pairs"] = _valid_pairs(
+                self.krot, dim, self.gs
+            )
+            weights[f"{base}.switch_mlp.{rot}_channel_scales"] = mx.ones((1, dim))
+
+        weights = _stack_paro_moe_experts(weights)
+        # 4 experts stacked into one (E, out, in/pack) tensor per projection
+        gw = weights[f"{base}.switch_mlp.gate_proj.weight"]
+        self.assertEqual(gw.shape[0], n_experts)
+        self.assertNotIn(f"{base}.experts.0.gate_proj.weight", weights)
+
+        class Wrap(nn.Module):
+            def __init__(self, glu):
+                super().__init__()
+                self.mlp = nn.Module()
+                self.mlp.switch_mlp = glu
+
+        model = Wrap(SwitchGLU(hidden, ffn, n_experts))
+        _patch_paro_layers(model, weights, self.bits, self.gs)
+        self.assertIsInstance(model.mlp.switch_mlp, RotateSwitchGLU)
+        self.assertIsInstance(model.mlp.switch_mlp.gate_proj, QuantizedSwitchLinear)
+        model.load_weights(list(weights.items()), strict=False)
+
+        n_tok, top_k = 6, 2
+        x = mx.random.normal((n_tok, hidden))
+        idx = mx.array(self.rng.integers(0, n_experts, size=(n_tok, top_k)))
+        y = model.mlp.switch_mlp(x, idx)
+        mx.eval(y)
+        self.assertEqual(y.shape, (n_tok, top_k, hidden))
+        self.assertTrue(bool(mx.all(mx.isfinite(y)).item()))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
<!-- PR title -->
# Add ParoQuant (pairwise rotation quantization) support

<!-- PR body below -->

Closes #977.

## Summary

Adds inference support for **ParoQuant** (Pairwise Rotation Quantization,
[ICLR 2026, arXiv:2511.10645](https://arxiv.org/abs/2511.10645)). ParoQuant
applies a learned sequence of pairwise Givens rotations to the activations
*before* an affine-quantized matmul; the rotation decorrelates channels so 4-bit
quantization keeps more of the signal, at near-AWQ speed.

Loading a public ParoQuant checkpoint now works with no extra arguments:

```python
from mlx_lm import load, generate

model, tok = load("z-lab/Meta-Llama-3-8B-PARO")   # auto-detected as paroquant
print(generate(model, tok, "The capital of France is", max_tokens=40))
```

`generate` / `chat` / `server` all work out of the box.

## What's added

- **`mlx_lm/models/paroquant.py`** — the inference layers and the rotation kernel:
  - `RotateQuantizedLinear`: `rotate(x)` (Metal kernel) → `mx.quantized_matmul`.
  - `RotateSwitchGLU`: a `SwitchGLU` with a shared rotation before gate/up and
    before down, wrapping the standard `QuantizedSwitchLinear` experts.
  - A JIT-compiled, cached `mx.fast.metal_kernel` for the pairwise rotation
    (inline source, in the style of `ssm.py` / `gated_delta.py`), with a guard
    that raises if a checkpoint's `krot`/`group_size` exceeds the kernel's
    compile-time limits.
  - The layers `freeze()` like `nn.QuantizedLinear` / `QuantizedSwitchLinear`, so
    the tuner/LoRA treats them as ordinary quantized layers.

- **`mlx_lm/utils.py`** — a `quant_method == "paroquant"` branch in `load_model`,
  parallel to the AWQ branch:
  - Public z-lab checkpoints ship **AutoAWQ-packed** weights
    (`qweight`/`qzeros`/`scales`), so weight conversion **reuses the existing
    `_transform_awq_weights`** (bit-exact vs. the reference converter); rotation
    params pass through.
  - `_patch_paro_layers` swaps `nn.Linear` (with a `.theta`) → `RotateQuantizedLinear`,
    `SwitchLinear` → `QuantizedSwitchLinear`, and `SwitchGLU` (with shared
    rotations) → `RotateSwitchGLU` before `load_weights`.
  - Per-expert MoE weights are stacked into the `switch_mlp` layout and shared
    rotations are remapped to `gate_up_rot` / `down_rot`.
  - `embed_tokens` / `lm_head` are kept in their checkpoint (float) form.

## How this differs from AWQ

The integration point and the weight *layout* conversion mirror AWQ (which is why
`_transform_awq_weights` is reused, bit-exact). But ParoQuant is a different
quantization *method*: the pairwise rotation has no AWQ counterpart, so it needs a
new layer (`RotateQuantizedLinear`) and the Metal kernel rather than loading as a
plain `QuantizedLinear`.

## Testing

`tests/test_paroquant.py` (unit):
- rotation kernel vs. a NumPy reference, for both fixed and random within-group
  matchings;
- AWQ-packed weight transform shapes / dtypes / rotation pass-through;
- dense and MoE layer patching;
- a MoE forward smoke (`_stack_paro_moe_experts` → `QuantizedSwitchLinear` →
  `RotateSwitchGLU` → finite output).

End-to-end on real public z-lab checkpoints (coherent generation, no NaNs):

| Model | Architecture |
|---|---|
| `z-lab/Meta-Llama-3-8B-PARO` | dense attention |
| `z-lab/Llama-3.1-8B-Instruct-PARO` | dense attention (chat template) |
| `z-lab/Qwen3.5-2B-PARO` | dense linear-attention (gated delta) |
| `z-lab/Qwen3.5-35B-A3B-PARO` | MoE + gated delta (multimodal text path) |
| `z-lab/gemma-4-31B-it-PARO` | Gemma 4 (per-layer embeddings, multimodal text path) |

Weight conversion was checked bit-exact against ParoQuant's own reference
converter on real Llama-8B weights (`max|diff| = 0` for weight/scales/biases).

## Notes

- No changes to the mlx framework or to `convert.py`; ParoQuant models are
  produced by ParoQuant's own tooling, and mlx-lm only loads and runs them.
- 4-bit only (matches the published checkpoints and the reused AWQ path).
- Instruction-tuned checkpoints need their chat template to generate coherently
  (e.g. Gemma 4 produces repetition on a raw prompt, as noted in #1123); this is
  not specific to ParoQuant.
