### PR TITLE
Fix arange type error in Llama-4 attention by converting offset and L to int

### DIFF
--- a/mlx_lm/models/llama4.py
+++ b/mlx_lm/models/llama4.py
@@ -115,7 +115,7 @@ class Attention(nn.Module):
         if self.attn_temperature_tuning and not self.use_rope:
             attn_scales = (
                 mx.log(
-                    mx.floor(mx.arange(offset + 1, offset + L + 1) / self.floor_scale)
+                    mx.floor(mx.arange(int(offset + 1), int(offset + L + 1)) / self.floor_scale)
                     + 1.0
                 )
                 * self.attn_scale


### PR DESCRIPTION
**Problem**
When offset or L is an mx.array scalar, mx.arange(offset + 1, offset + L + 1) passes two array arguments to mx.arange, causing a TypeError because mx.arange expects Python integers or floats.

**Fix**
Wrap offset + 1 and offset + L + 1 with int() to force conversion to Python integers. This works for both array scalars and plain integers.

**File changed**
mlx_lm/models/llama4.py

**Code change** (around line 118)
```
- mx.floor(mx.arange(offset + 1, offset + L + 1) / self.floor_scale)
+ mx.floor(mx.arange(int(offset + 1), int(offset + L + 1)) / self.floor_scale)
```

**Testing**

- Successfully tested with oMLX + Llama-4: chat responses are generated without errors.
- Works correctly when offset and L are already Python integers.

**Impact**
Only affects positional computation in Llama-4 attention. No change to model logic or output.

**Additional Note**
If mx.arange ever supports array scalars in the future, this fix remains safe and will still work.