### PR TITLE
Fix Gemma 3n shared-KV layer unpacking with batched caches

### DIFF
--- a/mlx_lm/models/gemma3n.py
+++ b/mlx_lm/models/gemma3n.py
@@ -129,8 +129,10 @@ class Gemma3nAttention(nn.Module):
 
         offset = 0
         if self.is_kv_shared_layer and cache is not None:
-            # For shared layers, retrieve KV from the designated cache layer
-            keys, values = cache.state
+            # For shared layers, retrieve KV from the designated cache layer.
+            # Batched caches (BatchKVCache / BatchRotatingKVCache) return extra
+            # metadata after (keys, values), so unpack only the first two.
+            keys, values, *_ = cache.state
             offset = cache.offset
 
         else:


### PR DESCRIPTION
## Summary

The shared-KV layers in Gemma 3n unpack the cache state with
`keys, values = cache.state`, assuming the legacy 2-tuple `(keys, values)` format. Batched caches return an N-tuple — e.g. `BatchRotatingKVCache.state` returns `(keys, values, offset, left_padding)` — so this raises:

```
ValueError: too many values to unpack (expected 2)
  File ".../mlx_lm/models/gemma3n.py", line 133, in __call__
    keys, values = cache.state
```

This breaks `mlx_lm.server` for **every** Gemma 3n model, because the server runs through the batched generator (`BatchGenerator`), which uses `BatchKVCache` / `BatchRotatingKVCache`.

The fix unpacks with `keys, values, *_ = cache.state`, which works for both the legacy 2-tuple caches and the batched N-tuple caches.

## Reproduction

```bash
mlx_lm.server --model mlx-community/gemma-3n-E4B-it-lm-4bit --port 8080

curl -s http://127.0.0.1:8080/v1/chat/completions \
  -H "Content-Type: application/json" \
  -d '{"model":"mlx-community/gemma-3n-E4B-it-lm-4bit",
       "messages":[{"role":"user","content":"hi"}],"max_tokens":32}'
```

Before: the request fails with the `ValueError` above in the generation thread.
After: the request completes and returns a normal chat completion.

## Notes

The same `keys, values, *_` pattern matches how the codebase has generalized `cache.state` from a 2-tuple to an N-tuple elsewhere. Verified with the text-only `mlx-community/gemma-3n-E4B-it-lm-4bit`; the change is confined to the shared-KV unpacking and is format-agnostic.