### PR TITLE
Fix CVE-2026-5843: gate model_file execution behind trust_remote_code

### DIFF
--- a/mlx_lm/benchmark.py
+++ b/mlx_lm/benchmark.py
@@ -73,6 +73,11 @@ def setup_arg_parser():
         default=0,
         help="Delay between each test in seconds (default: 0)",
     )
+    parser.add_argument(
+        "--trust-remote-code",
+        action="store_true",
+        help="Enable trusting remote code for tokenizer/model loading.",
+    )
     return parser
 
 
@@ -94,7 +99,11 @@ def main():
 
     if group.size() > 1:
         model, tokenizer, config = sharded_load(
-            model_path, pipeline_group, tensor_group, return_config=True
+            model_path,
+            pipeline_group,
+            tensor_group,
+            return_config=True,
+            trust_remote_code=args.trust_remote_code,
         )
     else:
         model, tokenizer, config = load(
@@ -102,6 +111,7 @@ def main():
             return_config=True,
             tokenizer_config={"trust_remote_code": True},
             model_config={"quantize_activations": args.quantize_activations},
+            trust_remote_code=args.trust_remote_code,
         )
 
     # Empty to avoid early stopping

--- a/mlx_lm/cache_prompt.py
+++ b/mlx_lm/cache_prompt.py
@@ -85,7 +85,7 @@ def main():
     args = parser.parse_args()
 
     # Building tokenizer_config
-    tokenizer_config = {"trust_remote_code": True if args.trust_remote_code else None}
+    tokenizer_config = {"trust_remote_code": args.trust_remote_code}
     if args.eos_token is not None:
         tokenizer_config["eos_token"] = args.eos_token
 

--- a/mlx_lm/cache_prompt.py
+++ b/mlx_lm/cache_prompt.py
@@ -93,6 +93,7 @@ def main():
         args.model,
         adapter_path=args.adapter_path,
         tokenizer_config=tokenizer_config,
+        trust_remote_code=args.trust_remote_code,
     )
 
     args.prompt = sys.stdin.read() if args.prompt == "-" else args.prompt

--- a/mlx_lm/chat.py
+++ b/mlx_lm/chat.py
@@ -102,7 +102,12 @@ def main():
     if group.size() > 1:
         if args.adapter_path:
             parser.error("Adapters not supported in distributed mode")
-        model, tokenizer = sharded_load(args.model, pipeline_group, tensor_group)
+        model, tokenizer = sharded_load(
+            args.model,
+            pipeline_group,
+            tensor_group,
+            trust_remote_code=args.trust_remote_code,
+        )
     else:
         model, tokenizer = load(
             args.model,
@@ -110,6 +115,7 @@ def main():
             tokenizer_config={
                 "trust_remote_code": True if args.trust_remote_code else None
             },
+            trust_remote_code=args.trust_remote_code,
         )
 
     with ChatUI(args, rank=rank) as ui:

--- a/mlx_lm/chat.py
+++ b/mlx_lm/chat.py
@@ -112,9 +112,7 @@ def main():
         model, tokenizer = load(
             args.model,
             adapter_path=args.adapter_path,
-            tokenizer_config={
-                "trust_remote_code": True if args.trust_remote_code else None
-            },
+            tokenizer_config={"trust_remote_code": args.trust_remote_code},
             trust_remote_code=args.trust_remote_code,
         )
 

--- a/mlx_lm/convert.py
+++ b/mlx_lm/convert.py
@@ -115,6 +115,7 @@ def convert(
         return_config=True,
         tokenizer_config={"trust_remote_code": trust_remote_code},
         lazy=True,
+        trust_remote_code=trust_remote_code,
     )
 
     if isinstance(quant_predicate, str):

--- a/mlx_lm/evaluate.py
+++ b/mlx_lm/evaluate.py
@@ -85,7 +85,9 @@ class MLXLM(LM):
         super().__init__()
         tokenizer_config = {"trust_remote_code": True if trust_remote_code else None}
         self._model, self.tokenizer = load(
-            path_or_hf_repo, tokenizer_config=tokenizer_config
+            path_or_hf_repo,
+            tokenizer_config=tokenizer_config,
+            trust_remote_code=trust_remote_code,
         )
         self._max_tokens = max_tokens
         self._batch_size = batch_size

--- a/mlx_lm/evaluate.py
+++ b/mlx_lm/evaluate.py
@@ -83,7 +83,7 @@ class MLXLM(LM):
         sampler: Optional[Callable[[mx.array], mx.array]] = None,
     ) -> None:
         super().__init__()
-        tokenizer_config = {"trust_remote_code": True if trust_remote_code else None}
+        tokenizer_config = {"trust_remote_code": trust_remote_code}
         self._model, self.tokenizer = load(
             path_or_hf_repo,
             tokenizer_config=tokenizer_config,

--- a/mlx_lm/fuse.py
+++ b/mlx_lm/fuse.py
@@ -54,6 +54,11 @@ def parse_arguments() -> argparse.Namespace:
         default="ggml-model-f16.gguf",
         type=str,
     )
+    parser.add_argument(
+        "--trust-remote-code",
+        action="store_true",
+        help="Enable trusting remote code for tokenizer/model loading.",
+    )
     return parser.parse_args()
 
 
@@ -62,7 +67,10 @@ def main() -> None:
     args = parse_arguments()
 
     model, tokenizer, config = load(
-        args.model, adapter_path=args.adapter_path, return_config=True
+        args.model,
+        adapter_path=args.adapter_path,
+        return_config=True,
+        trust_remote_code=args.trust_remote_code,
     )
 
     fused_linears = [

--- a/mlx_lm/generate.py
+++ b/mlx_lm/generate.py
@@ -2010,6 +2010,7 @@ def main():
         adapter_path=args.adapter_path,
         tokenizer_config=tokenizer_config,
         model_config={"quantize_activations": args.quantize_activations},
+        trust_remote_code=args.trust_remote_code,
     )
     for eos_token in args.extra_eos_token:
         tokenizer.add_eos_token(eos_token)

--- a/mlx_lm/generate.py
+++ b/mlx_lm/generate.py
@@ -1991,7 +1991,7 @@ def main():
     tokenizer_config = (
         {} if not using_cache else json.loads(metadata["tokenizer_config"])
     )
-    tokenizer_config["trust_remote_code"] = True if args.trust_remote_code else None
+    tokenizer_config["trust_remote_code"] = args.trust_remote_code
 
     model_path = args.model
     if using_cache:

--- a/mlx_lm/lora.py
+++ b/mlx_lm/lora.py
@@ -77,6 +77,7 @@ CONFIG_DEFAULTS = {
     "mask_prompt": False,
     "report_to": None,
     "project_name": None,
+    "trust_remote_code": False,
 }
 
 
@@ -212,6 +213,11 @@ def build_parser():
         help="Project name for logging. Defaults to the name of the root directory.",
     )
     parser.add_argument("--seed", type=int, help="The PRNG seed")
+    parser.add_argument(
+        "--trust-remote-code",
+        action="store_true",
+        help="Enable trusting remote code for tokenizer/model loading.",
+    )
     return parser
 
 
@@ -338,7 +344,13 @@ def run(args, training_callback: TrainingCallback = None):
     )
 
     rprint("Loading pretrained model")
-    model, tokenizer = load(args.model, tokenizer_config={"trust_remote_code": True})
+    model, tokenizer = load(
+        args.model,
+        tokenizer_config={
+            "trust_remote_code": True if args.trust_remote_code else None
+        },
+        trust_remote_code=args.trust_remote_code,
+    )
 
     rprint("Loading datasets")
     train_set, valid_set, test_set = load_dataset(args, tokenizer)

--- a/mlx_lm/lora.py
+++ b/mlx_lm/lora.py
@@ -346,9 +346,7 @@ def run(args, training_callback: TrainingCallback = None):
     rprint("Loading pretrained model")
     model, tokenizer = load(
         args.model,
-        tokenizer_config={
-            "trust_remote_code": True if args.trust_remote_code else None
-        },
+        tokenizer_config={"trust_remote_code": args.trust_remote_code},
         trust_remote_code=args.trust_remote_code,
     )
 

--- a/mlx_lm/perplexity.py
+++ b/mlx_lm/perplexity.py
@@ -144,7 +144,7 @@ def main():
 
     # Load model
     print(f"Loading model from {args.model}...")
-    tokenizer_config = {"trust_remote_code": True if args.trust_remote_code else None}
+    tokenizer_config = {"trust_remote_code": args.trust_remote_code}
     model, tokenizer = load(
         args.model,
         tokenizer_config=tokenizer_config,

--- a/mlx_lm/perplexity.py
+++ b/mlx_lm/perplexity.py
@@ -145,7 +145,11 @@ def main():
     # Load model
     print(f"Loading model from {args.model}...")
     tokenizer_config = {"trust_remote_code": True if args.trust_remote_code else None}
-    model, tokenizer = load(args.model, tokenizer_config=tokenizer_config)
+    model, tokenizer = load(
+        args.model,
+        tokenizer_config=tokenizer_config,
+        trust_remote_code=args.trust_remote_code,
+    )
 
     # Count parameters
     total_params = get_total_parameters(model)

--- a/mlx_lm/quant/awq.py
+++ b/mlx_lm/quant/awq.py
@@ -544,6 +544,11 @@ def main():
     parser.add_argument("--sequence-length", type=int, default=512)
     parser.add_argument("--n-grid", type=int, default=20)
     parser.add_argument("--seed", type=int, default=123)
+    parser.add_argument(
+        "--trust-remote-code",
+        action="store_true",
+        help="Enable trusting remote code for tokenizer/model loading.",
+    )
     args = parser.parse_args()
 
     group = mx.distributed.init()
@@ -554,7 +559,12 @@ def main():
 
     mx.random.seed(args.seed)
 
-    model, tokenizer, config = load(args.model, lazy=True, return_config=True)
+    model, tokenizer, config = load(
+        args.model,
+        lazy=True,
+        return_config=True,
+        trust_remote_code=args.trust_remote_code,
+    )
 
     model_type = config["model_type"]
     if (awq_config := AWQ_MODEL_CONFIGS.get(model_type, None)) is None:

--- a/mlx_lm/quant/dwq.py
+++ b/mlx_lm/quant/dwq.py
@@ -20,9 +20,9 @@ from mlx_lm.tuner.utils import print_trainable_parameters
 from mlx_lm.utils import (
     load,
     load_tokenizer,
-    pipeline_load,
     quantize_model,
     save,
+    sharded_load,
 )
 
 
@@ -300,6 +300,11 @@ def main():
         action="store_true",
         help="Use pipeline parallel instead of data parallel.",
     )
+    parser.add_argument(
+        "--trust-remote-code",
+        action="store_true",
+        help="Enable trusting remote code for tokenizer/model loading.",
+    )
 
     args = parser.parse_args()
 
@@ -332,9 +337,20 @@ def main():
     # Load the base model if we need it
     if not has_targets or args.quantized_model is None:
         if args.pipeline and group.size() > 1:
-            model, _, config = pipeline_load(args.model, return_config=True)
+            model, _, config = sharded_load(
+                args.model,
+                pipeline_group=mx.distributed.init(),
+                tensor_group=None,
+                return_config=True,
+                trust_remote_code=args.trust_remote_code,
+            )
         else:
-            model, _, config = load(args.model, return_config=True, lazy=True)
+            model, _, config = load(
+                args.model,
+                return_config=True,
+                lazy=True,
+                trust_remote_code=args.trust_remote_code,
+            )
     else:
         model = None
 
@@ -370,6 +386,7 @@ def main():
             args.quantized_model,
             lazy=True,
             return_config=True,
+            trust_remote_code=args.trust_remote_code,
         )
         if "quantization" not in config:
             raise ValueError("Quantized model must already be quantized.")

--- a/mlx_lm/quant/dynamic_quant.py
+++ b/mlx_lm/quant/dynamic_quant.py
@@ -182,10 +182,19 @@ def main():
         choices=["float32", "bfloat16"],
         help="What type to use to accumulate the gradients for the sensitivities",
     )
+    parser.add_argument(
+        "--trust-remote-code",
+        action="store_true",
+        help="Enable trusting remote code for tokenizer/model loading.",
+    )
     args = parser.parse_args()
 
     group = mx.distributed.init()
-    model, tokenizer, config = load(args.model, return_config=True)
+    model, tokenizer, config = load(
+        args.model,
+        return_config=True,
+        trust_remote_code=args.trust_remote_code,
+    )
 
     if args.sensitivities is None:
         mx.random.seed(args.seed)

--- a/mlx_lm/quant/gptq.py
+++ b/mlx_lm/quant/gptq.py
@@ -197,11 +197,21 @@ def main():
         help="Sequence length for the calibration data.",
     )
     parser.add_argument("--seed", type=int, default=123)
+    parser.add_argument(
+        "--trust-remote-code",
+        action="store_true",
+        help="Enable trusting remote code for tokenizer/model loading.",
+    )
     args = parser.parse_args()
 
     mx.random.seed(args.seed)
 
-    model, tokenizer, config = load(args.model, lazy=True, return_config=True)
+    model, tokenizer, config = load(
+        args.model,
+        lazy=True,
+        return_config=True,
+        trust_remote_code=args.trust_remote_code,
+    )
     calibration_data = load_data(tokenizer, args.num_samples, args.sequence_length)
 
     model, config["quantization"] = gptq_quantize(

--- a/mlx_lm/server.py
+++ b/mlx_lm/server.py
@@ -317,9 +317,7 @@ class ModelProvider:
         self._draft_model_map["default_model"] = self.cli_args.draft_model
 
         # Build the tokenizer config for later use in load
-        self._tokenizer_config = {
-            "trust_remote_code": True if cli_args.trust_remote_code else None
-        }
+        self._tokenizer_config = {"trust_remote_code": cli_args.trust_remote_code}
         if cli_args.chat_template:
             self._tokenizer_config["chat_template"] = cli_args.chat_template
 

--- a/mlx_lm/server.py
+++ b/mlx_lm/server.py
@@ -344,12 +344,14 @@ class ModelProvider:
                 pipeline_group=self.pipeline_group,
                 tensor_group=self.tensor_group,
                 tokenizer_config=self._tokenizer_config,
+                trust_remote_code=self.cli_args.trust_remote_code,
             )
         else:
             model, tokenizer = load(
                 model_path,
                 adapter_path=adapter_path,
                 tokenizer_config=self._tokenizer_config,
+                trust_remote_code=self.cli_args.trust_remote_code,
             )
 
         # Use the default chat template if needed

--- a/mlx_lm/utils.py
+++ b/mlx_lm/utils.py
@@ -58,17 +58,6 @@ MODEL_REMAPPING = {
 MAX_FILE_SIZE_GB = 5
 
 
-def _trust_remote_code(trust_remote_code: bool) -> bool:
-    """Check if remote code execution is enabled via flag or environment variable."""
-    if trust_remote_code:
-        return True
-    return os.environ.get("MLX_LM_TRUST_REMOTE_CODE", "").lower() in (
-        "1",
-        "true",
-        "yes",
-    )
-
-
 def _parse_size(x):
     sizes = {"M": 1e6, "G": 1e9, "MB": 1e6, "GB": 1e9, "": 1}
     split = 0
@@ -316,8 +305,7 @@ def load_model(
             Defaults to the ``_get_classes`` function.
         trust_remote_code (bool): If ``True``, allow executing a custom model
             architecture file specified by the config's ``model_file`` key.
-            Can also be enabled by setting the ``MLX_LM_TRUST_REMOTE_CODE``
-            environment variable to ``1``/``true``/``yes``. Default: ``False``.
+            Default: ``False``.
 
     Returns:
         Tuple[nn.Module, dict[str, Any]]: The loaded and initialized model and config.
@@ -342,12 +330,12 @@ def load_model(
         weights.update(mx.load(wf))
 
     if (model_file := config.get("model_file")) is not None:
-        if not _trust_remote_code(trust_remote_code):
+        if not trust_remote_code:
             raise ValueError(
                 f"The model at {model_path} requires importing and running a "
                 f"custom module ({model_file!r}) to build its architecture. This "
-                "is disabled by default. Pass trust_remote_code=True (or set the "
-                "env var MLX_LM_TRUST_REMOTE_CODE=1) if you trust this model."
+                "is disabled by default. Pass trust_remote_code=True if you "
+                "trust this model."
             )
         spec = importlib.util.spec_from_file_location(
             "custom_model",
@@ -506,9 +494,8 @@ def load(
         return_config (bool: If ``True`` return the model config as the last item..
         revision (str, optional): A revision id which can be a branch name, a tag, or a commit hash.
         trust_remote_code (bool): If ``True``, allow loading models that require
-            executing a custom Python file specified in their config. Can also
-            be enabled with the ``MLX_LM_TRUST_REMOTE_CODE`` environment
-            variable. Default: ``False``.
+            executing a custom Python file specified in their config.
+            Default: ``False``.
     Returns:
         Union[Tuple[nn.Module, TokenizerWrapper], Tuple[nn.Module, TokenizerWrapper, Dict[str, Any]]]:
             A tuple containing the loaded model, tokenizer and, if requested, the model config.

--- a/mlx_lm/utils.py
+++ b/mlx_lm/utils.py
@@ -58,6 +58,17 @@ MODEL_REMAPPING = {
 MAX_FILE_SIZE_GB = 5
 
 
+def _trust_remote_code(trust_remote_code: bool) -> bool:
+    """Check if remote code execution is enabled via flag or environment variable."""
+    if trust_remote_code:
+        return True
+    return os.environ.get("MLX_LM_TRUST_REMOTE_CODE", "").lower() in (
+        "1",
+        "true",
+        "yes",
+    )
+
+
 def _parse_size(x):
     sizes = {"M": 1e6, "G": 1e9, "MB": 1e6, "GB": 1e9, "": 1}
     split = 0
@@ -286,6 +297,7 @@ def load_model(
     strict: bool = True,
     model_config: Optional[Dict[str, Any]] = None,
     get_model_classes: Callable[[dict], Tuple[Type[nn.Module], Type]] = _get_classes,
+    trust_remote_code: bool = False,
 ) -> Tuple[nn.Module, dict]:
     """
     Load and initialize the model from a given path.
@@ -302,13 +314,19 @@ def load_model(
         get_model_classes (Callable[[dict], Tuple[Type[nn.Module], Type]], optional):
             A function that returns the model class and model args class given a config.
             Defaults to the ``_get_classes`` function.
+        trust_remote_code (bool): If ``True``, allow executing a custom model
+            architecture file specified by the config's ``model_file`` key.
+            Can also be enabled by setting the ``MLX_LM_TRUST_REMOTE_CODE``
+            environment variable to ``1``/``true``/``yes``. Default: ``False``.
 
     Returns:
         Tuple[nn.Module, dict[str, Any]]: The loaded and initialized model and config.
 
     Raises:
         FileNotFoundError: If the weight files (.safetensors) are not found.
-        ValueError: If the model class or args class are not found or cannot be instantiated.
+        ValueError: If the model class or args class are not found or cannot be
+            instantiated, or if the config requests a custom ``model_file`` and
+            ``trust_remote_code`` is not enabled.
     """
     config = load_config(model_path)
     if model_config is not None:
@@ -324,6 +342,13 @@ def load_model(
         weights.update(mx.load(wf))
 
     if (model_file := config.get("model_file")) is not None:
+        if not _trust_remote_code(trust_remote_code):
+            raise ValueError(
+                f"The model at {model_path} requires importing and running a "
+                f"custom module ({model_file!r}) to build its architecture. This "
+                "is disabled by default. Pass trust_remote_code=True (or set the "
+                "env var MLX_LM_TRUST_REMOTE_CODE=1) if you trust this model."
+            )
         spec = importlib.util.spec_from_file_location(
             "custom_model",
             model_path / model_file,
@@ -459,6 +484,7 @@ def load(
     lazy: bool = False,
     return_config: bool = False,
     revision: Optional[str] = None,
+    trust_remote_code: bool = False,
 ) -> Union[
     Tuple[nn.Module, TokenizerWrapper],
     Tuple[nn.Module, TokenizerWrapper, Dict[str, Any]],
@@ -479,6 +505,10 @@ def load(
             when needed. Default: ``False``
         return_config (bool: If ``True`` return the model config as the last item..
         revision (str, optional): A revision id which can be a branch name, a tag, or a commit hash.
+        trust_remote_code (bool): If ``True``, allow loading models that require
+            executing a custom Python file specified in their config. Can also
+            be enabled with the ``MLX_LM_TRUST_REMOTE_CODE`` environment
+            variable. Default: ``False``.
     Returns:
         Union[Tuple[nn.Module, TokenizerWrapper], Tuple[nn.Module, TokenizerWrapper, Dict[str, Any]]]:
             A tuple containing the loaded model, tokenizer and, if requested, the model config.
@@ -489,7 +519,12 @@ def load(
     """
     model_path = _download(path_or_hf_repo, revision=revision)
 
-    model, config = load_model(model_path, lazy, model_config=model_config)
+    model, config = load_model(
+        model_path,
+        lazy,
+        model_config=model_config,
+        trust_remote_code=trust_remote_code,
+    )
     if adapter_path is not None:
         model = load_adapters(model, adapter_path)
         model.eval()
@@ -510,6 +545,7 @@ def sharded_load(
     return_config: bool = False,
     *,
     tokenizer_config: Optional[Dict[str, Any]] = None,
+    trust_remote_code: bool = False,
 ):
     # Get model path with everything but weight safetensors
     model_path = _download(
@@ -528,7 +564,9 @@ def sharded_load(
 
     # Lazy load model to figure out what type of sharding we can do and which
     # weights we need to download.
-    model, config = load_model(model_path, lazy=True, strict=False)
+    model, config = load_model(
+        model_path, lazy=True, strict=False, trust_remote_code=trust_remote_code
+    )
 
     has_pipelining = hasattr(model, "model") and hasattr(model.model, "pipeline")
     has_tensor_parallel = hasattr(model, "shard")
@@ -577,7 +615,9 @@ def sharded_load(
         tokenizer_config or {"trust_remote_code": True},
         eos_token_ids=config.get("eos_token_id", None),
     )
-    model, _ = load_model(model_path, lazy=True, strict=False)
+    model, _ = load_model(
+        model_path, lazy=True, strict=False, trust_remote_code=trust_remote_code
+    )
     if tensor_group is not None:
         model.shard(tensor_group)
     if pipeline_group is not None:

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,9 +1,11 @@
 # Copyright © 2024 Apple Inc.
 
+import json
 import os
 import tempfile
 import unittest
 from pathlib import Path
+from unittest import mock
 
 import mlx.core as mx
 import mlx.nn as nn
@@ -15,7 +17,6 @@ HF_MODEL_PATH = "mlx-community/Qwen1.5-0.5B-Chat-4bit"
 
 
 class TestUtils(unittest.TestCase):
-
     @classmethod
     def setUpClass(cls):
         cls.test_dir_fid = tempfile.TemporaryDirectory()
@@ -182,6 +183,99 @@ class TestUtils(unittest.TestCase):
             logits = loaded(mx.array([[1, 2, 3]], dtype=mx.int32))
             mx.eval(logits)
             self.assertEqual(logits.shape, (1, 3, args.vocab_size))
+
+
+CUSTOM_MODEL_FILE = """\
+from pathlib import Path
+
+import mlx.nn as nn
+
+(Path(__file__).parent / "side_effect.txt").write_text("executed")
+
+
+class ModelArgs:
+    @classmethod
+    def from_dict(cls, params):
+        return cls()
+
+
+class Model(nn.Module):
+    def __init__(self, args):
+        super().__init__()
+        self.linear = nn.Linear(8, 8)
+
+    def __call__(self, x):
+        return self.linear(x)
+"""
+
+
+class TestTrustRemoteCode(unittest.TestCase):
+    def setUp(self):
+        self.model_dir_fid = tempfile.TemporaryDirectory()
+        self.model_path = Path(self.model_dir_fid.name)
+        self.env_patcher = mock.patch.dict(os.environ)
+        self.env_patcher.start()
+        os.environ.pop("MLX_LM_TRUST_REMOTE_CODE", None)
+
+    def tearDown(self):
+        self.env_patcher.stop()
+        self.model_dir_fid.cleanup()
+
+    @property
+    def _side_effect_file(self) -> Path:
+        return self.model_path / "side_effect.txt"
+
+    def _write_custom_model_dir(self):
+        config = {"model_type": "custom", "model_file": "arch.py"}
+        with open(self.model_path / "config.json", "w") as f:
+            json.dump(config, f)
+        (self.model_path / "arch.py").write_text(CUSTOM_MODEL_FILE)
+        mx.save_safetensors(
+            str(self.model_path / "model.safetensors"),
+            {"linear.weight": mx.zeros((8, 8)), "linear.bias": mx.zeros((8,))},
+        )
+
+    def test_model_file_blocked_by_default(self):
+        """load_model must refuse to execute a custom model_file by default."""
+        self._write_custom_model_dir()
+        with self.assertRaises(ValueError) as cm:
+            utils.load_model(self.model_path)
+        self.assertIn("trust_remote_code", str(cm.exception))
+        self.assertFalse(self._side_effect_file.exists())
+
+    def test_model_file_loads_with_trust_remote_code(self):
+        """Passing trust_remote_code=True opts in to executing model_file."""
+        self._write_custom_model_dir()
+        model, config = utils.load_model(self.model_path, trust_remote_code=True)
+        self.assertIsInstance(model, nn.Module)
+        self.assertEqual(config["model_file"], "arch.py")
+        self.assertTrue(self._side_effect_file.exists())
+
+    def test_model_file_enabled_via_env_var(self):
+        """MLX_LM_TRUST_REMOTE_CODE=1 enables model_file execution."""
+        self._write_custom_model_dir()
+        os.environ["MLX_LM_TRUST_REMOTE_CODE"] = "1"
+        model, _ = utils.load_model(self.model_path)
+        self.assertIsInstance(model, nn.Module)
+        self.assertTrue(self._side_effect_file.exists())
+
+    def test_normal_model_unaffected_by_default(self):
+        """Models without model_file load fine with default arguments."""
+        config = {
+            "model_type": "llama",
+            "hidden_size": 32,
+            "num_hidden_layers": 1,
+            "intermediate_size": 64,
+            "num_attention_heads": 4,
+            "num_key_value_heads": 4,
+            "rms_norm_eps": 1e-5,
+            "vocab_size": 64,
+        }
+        with open(self.model_path / "config.json", "w") as f:
+            json.dump(config, f)
+        model, loaded_config = utils.load_model(self.model_path, strict=False)
+        self.assertIsInstance(model, nn.Module)
+        self.assertEqual(loaded_config["model_type"], "llama")
 
 
 if __name__ == "__main__":

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -5,7 +5,6 @@ import os
 import tempfile
 import unittest
 from pathlib import Path
-from unittest import mock
 
 import mlx.core as mx
 import mlx.nn as nn
@@ -213,12 +212,8 @@ class TestTrustRemoteCode(unittest.TestCase):
     def setUp(self):
         self.model_dir_fid = tempfile.TemporaryDirectory()
         self.model_path = Path(self.model_dir_fid.name)
-        self.env_patcher = mock.patch.dict(os.environ)
-        self.env_patcher.start()
-        os.environ.pop("MLX_LM_TRUST_REMOTE_CODE", None)
 
     def tearDown(self):
-        self.env_patcher.stop()
         self.model_dir_fid.cleanup()
 
     @property
@@ -249,14 +244,6 @@ class TestTrustRemoteCode(unittest.TestCase):
         model, config = utils.load_model(self.model_path, trust_remote_code=True)
         self.assertIsInstance(model, nn.Module)
         self.assertEqual(config["model_file"], "arch.py")
-        self.assertTrue(self._side_effect_file.exists())
-
-    def test_model_file_enabled_via_env_var(self):
-        """MLX_LM_TRUST_REMOTE_CODE=1 enables model_file execution."""
-        self._write_custom_model_dir()
-        os.environ["MLX_LM_TRUST_REMOTE_CODE"] = "1"
-        model, _ = utils.load_model(self.model_path)
-        self.assertIsInstance(model, nn.Module)
         self.assertTrue(self._side_effect_file.exists())
 
     def test_normal_model_unaffected_by_default(self):


### PR DESCRIPTION
If a model's config.json has a `model_file` key, `load_model` imports and runs
  that Python file straight from the model directory (added in #830). It happens
  on a plain `load()` with no way to turn it off, so loading a model can execute
  arbitrary code. This is CVE-2026-5843 / GHSA-9m9w-53g9-47c4: it was reported
  against Docker Model Runner, which embeds mlx-lm, but the root cause is here in
  the library and main is still unguarded. The tokenizer path already puts custom
  code behind `trust_remote_code`, so this does the same for `model_file`.

  `load_model` now takes `trust_remote_code` (default False) and raises with a
  clear message if a config wants a `model_file` without it. Setting
  `MLX_LM_TRUST_REMOTE_CODE=1` works too for the CLI tools. The flag is threaded
  through `load()` and `sharded_load()`, and models without a `model_file` are
  unchanged.

  Tests cover the four cases: blocked by default with the custom file never
  executed, enabled by the argument, enabled by the env var, and a normal model
  still loading.ed