### PR TITLE
Add gemma4_unified model alias for Gemma 4 12B support

### DIFF
--- a/mlx_lm/models/gemma4_unified.py
+++ b/mlx_lm/models/gemma4_unified.py
@@ -1,0 +1,1 @@
+from .gemma4 import Model, ModelArgs


### PR DESCRIPTION
Gemma 4 12B uses model_type `gemma4_unified` in its config.json, which 
causes mlx-lm to throw:

  ValueError: Model type gemma4_unified not supported

This adds a simple alias file that maps gemma4_unified to the existing 
gemma4 implementation, which resolves the error.

Tested on M1 Pro 16GB with mlx-community/gemma-4-12b-it-4bit.