### PR TITLE
Add chunk-parallel gated delta ops for training

### DIFF
--- a/mlx_lm/models/gated_delta.py
+++ b/mlx_lm/models/gated_delta.py
@@ -301,18 +301,27 @@ def _solve_strict_lower(A: mx.array, b: mx.array, sb: int = SUB_BLOCK) -> mx.arr
 
 
 def _gated_delta_chunk(
-    state: mx.array,  # [B, H, Dk, Dv]
-    q: mx.array,  # [B, H, C, Dk]
-    k: mx.array,  # [B, H, C, Dk]
-    v: mx.array,  # [B, H, C, Dv]
-    g: mx.array,  # [B, H, C], gating in (0, 1)
-    beta: mx.array,  # [B, H, C]
+    state: mx.array,  # [B, Hv, Dk, Dv]
+    q: mx.array,  # [B, Hk, C, Dk]
+    k: mx.array,  # [B, Hk, C, Dk]
+    v: mx.array,  # [B, Hv, C, Dv]
+    g: mx.array,  # [B, Hv, C], gating in (0, 1)
+    beta: mx.array,  # [B, Hv, C]
+    repeat_factor: int = 1,
 ) -> Tuple[mx.array, mx.array]:
     """Run C timesteps as one triangular solve (gated UT/WY transform).
 
     Exact reformulation of the sequential recurrence; runs in fp32.
+
+    Under grouped-query attention (repeat_factor > 1) the C x C key Gram
+    and q . k^T products depend only on the Hk query/key heads, so they
+    are formed before the GQA broadcast to Hv; the per-Hv gating is
+    applied afterwards. This avoids materializing the repeated q/k for the
+    whole sequence and shrinks those two matmuls by repeat_factor.
     """
     C = q.shape[2]
+    Hk = q.shape[1]
+    Hv = v.shape[1]
     orig_dtype = q.dtype
 
     q = q.astype(mx.float32)
@@ -332,21 +341,40 @@ def _gated_delta_chunk(
     L_diff = (g_cumlog[..., :, None] - g_cumlog[..., None, :]) * tril_ones
     L_mask = mx.exp(L_diff) * tril_ones
 
-    v_beta = v * beta[..., None]  # [B, H, C, Dv]
-    k_beta = k * beta[..., None]  # [B, H, C, Dk]
+    # GQA sharing: the C x C products only need the Hk heads. Form them
+    # first, then broadcast q/k and the products to Hv.
+    kkT = k @ mx.swapaxes(k, -1, -2)  # [B, Hk, C, C], kkT[i, j] = <k_i, k_j>
+    qkT = q @ mx.swapaxes(k, -1, -2)  # [B, Hk, C, C]
+    if repeat_factor > 1:
+        B = q.shape[0]
 
+        def _to_hv(x):  # [B, Hk, C, D] -> [B, Hv, C, D]
+            D = x.shape[-1]
+            return mx.broadcast_to(x[:, :, None], (B, Hk, repeat_factor, C, D)).reshape(
+                B, Hv, C, D
+            )
+
+        kkT = _to_hv(kkT)
+        qkT = _to_hv(qkT)
+        q = _to_hv(q)
+        k = _to_hv(k)
+
+    v_beta = v * beta[..., None]  # [B, Hv, C, Dv]
+    k_beta = k * beta[..., None]  # [B, Hv, C, Dk]
+
+    # (k_beta @ k^T)[i, j] = beta_i * <k_i, k_j> = beta_i * kkT[i, j]
     strict_lower = mx.tril(mx.ones((C, C), dtype=mx.float32), k=-1)
-    A = -(k_beta @ mx.swapaxes(k, -1, -2)) * L_mask * strict_lower
+    A = -(beta[..., :, None] * kkT) * L_mask * strict_lower
 
-    decay_exp = mx.exp(g_cumlog)[..., None]  # [B, H, C, 1]
+    decay_exp = mx.exp(g_cumlog)[..., None]  # [B, Hv, C, 1]
     rhs = mx.concatenate([v_beta, k_beta * decay_exp], axis=-1)
     sol = _solve_strict_lower(A, rhs)
     v_corrected, k_cumdecay = mx.split(sol, [v.shape[-1]], axis=-1)
 
-    v_new = v_corrected - k_cumdecay @ state  # [B, H, C, Dv]
-    y_inter = (q * decay_exp) @ state  # [B, H, C, Dv]
+    v_new = v_corrected - k_cumdecay @ state  # [B, Hv, C, Dv]
+    y_inter = (q * decay_exp) @ state  # [B, Hv, C, Dv]
 
-    attn = (q @ mx.swapaxes(k, -1, -2)) * L_mask
+    attn = qkT * L_mask
     y = y_inter + attn @ v_new
 
     state_decay = mx.exp(g_last)[..., None]
@@ -390,13 +418,13 @@ def gated_delta_ops_chunked(
     B, T, Hk, Dk = q.shape
     Hv, Dv = v.shape[-2:]
     C = chunk_size or CHUNK_SIZE
+    repeat_factor = Hv // Hk
 
     if state is None:
         state = mx.zeros((B, Hv, Dv, Dk), dtype=mx.float32)
 
-    if (repeat_factor := Hv // Hk) > 1:
-        q = mx.repeat(q, repeat_factor, -2)
-        k = mx.repeat(k, repeat_factor, -2)
+    # q/k stay on the Hk query/key heads; the chunk shares their C x C
+    # products across the GQA group and broadcasts to Hv internally.
 
     # Masked steps are identities on the state (g = 1, beta = 0).
     if mask is not None:
@@ -415,9 +443,9 @@ def gated_delta_ops_chunked(
 
     num_chunks = (T + pad_len) // C
 
-    # [B, T, H, D] -> [B, H, Nc, C, D]
-    q = mx.swapaxes(q, 1, 2).reshape(B, Hv, num_chunks, C, Dk)
-    k = mx.swapaxes(k, 1, 2).reshape(B, Hv, num_chunks, C, Dk)
+    # [B, T, H, D] -> [B, H, Nc, C, D]; q/k keep their Hk heads.
+    q = mx.swapaxes(q, 1, 2).reshape(B, Hk, num_chunks, C, Dk)
+    k = mx.swapaxes(k, 1, 2).reshape(B, Hk, num_chunks, C, Dk)
     v = mx.swapaxes(v, 1, 2).reshape(B, Hv, num_chunks, C, Dv)
     g = mx.swapaxes(g, 1, 2).reshape(B, Hv, num_chunks, C)
     beta = mx.swapaxes(beta, 1, 2).reshape(B, Hv, num_chunks, C)
@@ -434,6 +462,7 @@ def gated_delta_ops_chunked(
             v[:, :, ci],
             g[:, :, ci],
             beta[:, :, ci],
+            repeat_factor,
         )
         ys.append(y_c)
 

--- a/mlx_lm/models/gated_delta.py
+++ b/mlx_lm/models/gated_delta.py
@@ -259,6 +259,192 @@ def gated_delta_ops(
     return y, state
 
 
+CHUNK_SIZE = 64
+
+# Solve block size; bounds fp32 error growth when keys repeat in a chunk.
+SUB_BLOCK = 16
+
+
+def _solve_strict_lower(A: mx.array, b: mx.array, sb: int = SUB_BLOCK) -> mx.array:
+    """Solve (I - A) x = b for strictly lower-triangular (nilpotent) A.
+
+    Blocked forward substitution; a global Neumann expansion can
+    overflow fp32 when keys repeat within a chunk.
+    """
+    C = A.shape[-1]
+
+    def doubling(Aii, rhs, n):
+        x = rhs
+        if n <= 1:
+            return x
+        P = Aii
+        steps = (n - 1).bit_length()
+        for s in range(steps):
+            x = x + P @ x
+            if s != steps - 1:
+                P = P @ P
+        return x
+
+    if C <= sb:
+        return doubling(A, b, C)
+
+    nb = (C + sb - 1) // sb
+    blocks = []
+    for i in range(nb):
+        lo, hi = i * sb, min((i + 1) * sb, C)
+        rhs = b[..., lo:hi, :]
+        if i > 0:
+            prev = blocks[0] if i == 1 else mx.concatenate(blocks, axis=-2)
+            rhs = rhs + A[..., lo:hi, :lo] @ prev
+        blocks.append(doubling(A[..., lo:hi, lo:hi], rhs, hi - lo))
+    return mx.concatenate(blocks, axis=-2)
+
+
+def _gated_delta_chunk(
+    state: mx.array,  # [B, H, Dk, Dv]
+    q: mx.array,  # [B, H, C, Dk]
+    k: mx.array,  # [B, H, C, Dk]
+    v: mx.array,  # [B, H, C, Dv]
+    g: mx.array,  # [B, H, C], gating in (0, 1)
+    beta: mx.array,  # [B, H, C]
+) -> Tuple[mx.array, mx.array]:
+    """Run C timesteps as one triangular solve (gated UT/WY transform).
+
+    Exact reformulation of the sequential recurrence; runs in fp32.
+    """
+    C = q.shape[2]
+    orig_dtype = q.dtype
+
+    q = q.astype(mx.float32)
+    k = k.astype(mx.float32)
+    v = v.astype(mx.float32)
+    g = g.astype(mx.float32)
+    beta = beta.astype(mx.float32)
+    state = state.astype(mx.float32)
+
+    # Log-domain cumulative decay; the clamp keeps -inf out of the cumsum.
+    g_log = mx.log(mx.maximum(g, 1e-12))  # [B, H, C]
+    g_cumlog = mx.cumsum(g_log, axis=-1)
+    g_last = g_cumlog[..., -1:]
+
+    # Zero the upper triangle before exp: it overflows, and inf * 0 = NaN.
+    tril_ones = mx.tril(mx.ones((C, C), dtype=mx.float32))
+    L_diff = (g_cumlog[..., :, None] - g_cumlog[..., None, :]) * tril_ones
+    L_mask = mx.exp(L_diff) * tril_ones
+
+    v_beta = v * beta[..., None]  # [B, H, C, Dv]
+    k_beta = k * beta[..., None]  # [B, H, C, Dk]
+
+    strict_lower = mx.tril(mx.ones((C, C), dtype=mx.float32), k=-1)
+    A = -(k_beta @ mx.swapaxes(k, -1, -2)) * L_mask * strict_lower
+
+    decay_exp = mx.exp(g_cumlog)[..., None]  # [B, H, C, 1]
+    rhs = mx.concatenate([v_beta, k_beta * decay_exp], axis=-1)
+    sol = _solve_strict_lower(A, rhs)
+    v_corrected, k_cumdecay = mx.split(sol, [v.shape[-1]], axis=-1)
+
+    v_new = v_corrected - k_cumdecay @ state  # [B, H, C, Dv]
+    y_inter = (q * decay_exp) @ state  # [B, H, C, Dv]
+
+    attn = (q @ mx.swapaxes(k, -1, -2)) * L_mask
+    y = y_inter + attn @ v_new
+
+    state_decay = mx.exp(g_last)[..., None]
+    decay_to_end = mx.exp(g_last - g_cumlog)[..., None]
+    new_state = state * state_decay + mx.swapaxes(k * decay_to_end, -1, -2) @ v_new
+
+    # The state stays fp32 across chunks; casting at boundaries drifts.
+    return y.astype(orig_dtype), new_state
+
+
+_gated_delta_chunk_checkpointed = mx.checkpoint(_gated_delta_chunk)
+
+
+def gated_delta_ops_chunked(
+    q: mx.array,
+    k: mx.array,
+    v: mx.array,
+    g: mx.array,
+    beta: mx.array,
+    state: Optional[mx.array] = None,
+    mask: Optional[mx.array] = None,
+    chunk_size: Optional[int] = None,
+) -> Tuple[mx.array, mx.array]:
+    """
+    Chunk-parallel implementation of prompt prefill for scalar gating.
+
+    Equivalent to gated_delta_ops but processes chunk_size timesteps at a
+    time with dense matmuls, each chunk wrapped in mx.checkpoint, so the
+    autodiff graph is O(T / chunk_size) instead of O(T).
+
+    Shapes:
+      - q, k: [B, T, Hk, Dk]
+      - v: [B, T, Hv, Dv]
+      - g: [B, T, Hv] (scalar gating only, values in (0, 1))
+      - beta: [B, T, Hv]
+      - state: [B, Hv, Dv, Dk]
+    Returns:
+      - y: [B, T, Hv, Dv]
+      - state: [B, Hv, Dv, Dk]
+    """
+    B, T, Hk, Dk = q.shape
+    Hv, Dv = v.shape[-2:]
+    C = chunk_size or CHUNK_SIZE
+
+    if state is None:
+        state = mx.zeros((B, Hv, Dv, Dk), dtype=mx.float32)
+
+    if (repeat_factor := Hv // Hk) > 1:
+        q = mx.repeat(q, repeat_factor, -2)
+        k = mx.repeat(k, repeat_factor, -2)
+
+    # Masked steps are identities on the state (g = 1, beta = 0).
+    if mask is not None:
+        m = mask[..., None]
+        g = mx.where(m, g, mx.ones_like(g))
+        beta = beta * m
+
+    # Pad T to a multiple of C with identity steps (g = 1, beta = 0).
+    pad_len = (C - (T % C)) % C
+    if pad_len > 0:
+        q = mx.pad(q, [(0, 0), (0, pad_len), (0, 0), (0, 0)])
+        k = mx.pad(k, [(0, 0), (0, pad_len), (0, 0), (0, 0)])
+        v = mx.pad(v, [(0, 0), (0, pad_len), (0, 0), (0, 0)])
+        g = mx.concatenate([g, mx.ones((B, pad_len, Hv), dtype=g.dtype)], axis=1)
+        beta = mx.pad(beta, [(0, 0), (0, pad_len), (0, 0)])
+
+    num_chunks = (T + pad_len) // C
+
+    # [B, T, H, D] -> [B, H, Nc, C, D]
+    q = mx.swapaxes(q, 1, 2).reshape(B, Hv, num_chunks, C, Dk)
+    k = mx.swapaxes(k, 1, 2).reshape(B, Hv, num_chunks, C, Dk)
+    v = mx.swapaxes(v, 1, 2).reshape(B, Hv, num_chunks, C, Dv)
+    g = mx.swapaxes(g, 1, 2).reshape(B, Hv, num_chunks, C)
+    beta = mx.swapaxes(beta, 1, 2).reshape(B, Hv, num_chunks, C)
+
+    # [B, Hv, Dv, Dk] -> [B, Hv, Dk, Dv]
+    state = mx.swapaxes(state.astype(mx.float32), -1, -2)
+
+    ys = []
+    for ci in range(num_chunks):
+        y_c, state = _gated_delta_chunk_checkpointed(
+            state,
+            q[:, :, ci],
+            k[:, :, ci],
+            v[:, :, ci],
+            g[:, :, ci],
+            beta[:, :, ci],
+        )
+        ys.append(y_c)
+
+    y = mx.concatenate(ys, axis=2)
+    if pad_len > 0:
+        y = y[:, :, :T, :]
+    y = mx.swapaxes(y, 1, 2)
+
+    return y, mx.swapaxes(state, -1, -2)
+
+
 def gated_delta_update(
     q: mx.array,
     k: mx.array,
@@ -279,5 +465,8 @@ def gated_delta_update(
         state = mx.zeros((B, Hv, Dv, Dk), dtype=mx.float32)
 
     if not use_kernel or mx.default_device() != mx.gpu or not mx.metal.is_available():
-        return gated_delta_ops(q, k, v, g, beta, state, mask)
+        if g.ndim == 4 or q.shape[1] == 1:
+            # Vectorized gating and single-token steps use the sequential path.
+            return gated_delta_ops(q, k, v, g, beta, state, mask)
+        return gated_delta_ops_chunked(q, k, v, g, beta, state, mask)
     return gated_delta_kernel(q, k, v, g, beta, state, mask)

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -3225,18 +3225,19 @@ class TestModels(unittest.TestCase):
     def test_gated_delta_chunked(self):
         B, Hk, Hv, Dk, Dv = 1, 2, 4, 32, 32
 
-        # (T, chunk_size, repeat_keys, with_state, g_mode)
+        # (T, chunk_size, repeat_keys, with_state, g_mode, beta_high)
         cases = [
-            (96, 16, False, False, "random"),  # multi-chunk
-            (96, 16, True, False, "random"),  # repeated keys (adversarial)
-            (70, 16, False, False, "random"),  # T not a multiple of chunk_size
-            (128, 64, False, False, "random"),  # blocked solve (C > SUB_BLOCK)
-            (128, 64, True, False, "random"),  # blocked solve, repeated keys
-            (96, 16, False, True, "random"),  # carried-in state
-            (96, 16, False, False, "zero"),  # g -> 0 (log-domain hazard)
-            (96, 16, False, False, "one"),  # g -> 1 (no decay)
+            (96, 16, False, False, "random", False),  # multi-chunk
+            (96, 16, True, False, "random", False),  # repeated keys (adversarial)
+            (70, 16, False, False, "random", False),  # T not multiple of chunk_size
+            (128, 64, False, False, "random", False),  # blocked solve (C > SUB_BLOCK)
+            (128, 64, True, False, "random", False),  # blocked solve, repeated keys
+            (96, 16, False, True, "random", False),  # carried-in state
+            (96, 16, False, False, "zero", False),  # g -> 0 (log-domain hazard)
+            (96, 16, False, False, "one", False),  # g -> 1 (no decay)
+            (128, 64, True, False, "one", True),  # collinear, no decay, beta -> 1
         ]
-        for T, chunk_size, repeat_keys, with_state, g_mode in cases:
+        for T, chunk_size, repeat_keys, with_state, g_mode, beta_high in cases:
             mx.random.seed(0)
             q = mx.random.normal(shape=(B, T, Hk, Dk)) * 0.5
             k = mx.random.normal(shape=(B, T, Hk, Dk))
@@ -3250,7 +3251,10 @@ class TestModels(unittest.TestCase):
                 g = mx.full((B, T, Hv), 1.0 - 1e-7)
             else:
                 g = mx.sigmoid(mx.random.normal(shape=(B, T, Hv)))
-            beta = mx.sigmoid(mx.random.normal(shape=(B, T, Hv)) + 2.0)
+            if beta_high:
+                beta = mx.full((B, T, Hv), 0.999)
+            else:
+                beta = mx.sigmoid(mx.random.normal(shape=(B, T, Hv)) + 2.0)
             state = (
                 mx.random.normal(shape=(B, Hv, Dv, Dk)) * 0.3 if with_state else None
             )
@@ -3259,8 +3263,11 @@ class TestModels(unittest.TestCase):
             y, st = gated_delta_ops_chunked(
                 q, k, v, g, beta, state, chunk_size=chunk_size
             )
-            self.assertTrue(mx.allclose(y, y_ref, rtol=1e-3, atol=1e-4))
-            self.assertTrue(mx.allclose(st, st_ref, rtol=1e-3, atol=1e-4))
+            # The collinear beta -> 1 corner is a blow-up guard: the blocked
+            # solve degrades to ~1e-3 there instead of fp32 noise.
+            rtol, atol = (1e-2, 1e-2) if beta_high else (1e-3, 1e-4)
+            self.assertTrue(mx.allclose(y, y_ref, rtol=rtol, atol=atol))
+            self.assertTrue(mx.allclose(st, st_ref, rtol=rtol, atol=atol))
 
     def test_gated_delta_chunked_masked(self):
         B, T, Hk, Hv, Dk, Dv = 1, 8, 2, 4, 32, 32

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -11,8 +11,10 @@ from mlx_lm.models import rope_utils
 from mlx_lm.models.base import create_causal_mask, scaled_dot_product_attention
 from mlx_lm.models.cache import KVCache, RotatingKVCache, make_prompt_cache
 from mlx_lm.models.gated_delta import (
+    compute_g,
     gated_delta_kernel,
     gated_delta_ops,
+    gated_delta_ops_chunked,
     gated_delta_update,
 )
 from mlx_lm.models.ssm import ssm_attn, ssm_update
@@ -3219,6 +3221,133 @@ class TestModels(unittest.TestCase):
                 y = y[:, s:e]
                 self.assertTrue(mx.allclose(y, y_gt, rtol=1e-4, atol=1e-4))
                 self.assertTrue(mx.allclose(st, st_gt, rtol=1e-4, atol=1e-3))
+
+    def test_gated_delta_chunked(self):
+        B, Hk, Hv, Dk, Dv = 1, 2, 4, 32, 32
+
+        # (T, chunk_size, repeat_keys, with_state, g_mode)
+        cases = [
+            (96, 16, False, False, "random"),  # multi-chunk
+            (96, 16, True, False, "random"),  # repeated keys (adversarial)
+            (70, 16, False, False, "random"),  # T not a multiple of chunk_size
+            (128, 64, False, False, "random"),  # blocked solve (C > SUB_BLOCK)
+            (128, 64, True, False, "random"),  # blocked solve, repeated keys
+            (96, 16, False, True, "random"),  # carried-in state
+            (96, 16, False, False, "zero"),  # g -> 0 (log-domain hazard)
+            (96, 16, False, False, "one"),  # g -> 1 (no decay)
+        ]
+        for T, chunk_size, repeat_keys, with_state, g_mode in cases:
+            mx.random.seed(0)
+            q = mx.random.normal(shape=(B, T, Hk, Dk)) * 0.5
+            k = mx.random.normal(shape=(B, T, Hk, Dk))
+            k = k / mx.linalg.norm(k, axis=-1, keepdims=True)
+            if repeat_keys:
+                k = mx.broadcast_to(k[:, :1], k.shape) * 1.0
+            v = mx.random.normal(shape=(B, T, Hv, Dv)) * 0.5
+            if g_mode == "zero":
+                g = mx.full((B, T, Hv), 1e-30)
+            elif g_mode == "one":
+                g = mx.full((B, T, Hv), 1.0 - 1e-7)
+            else:
+                g = mx.sigmoid(mx.random.normal(shape=(B, T, Hv)))
+            beta = mx.sigmoid(mx.random.normal(shape=(B, T, Hv)) + 2.0)
+            state = (
+                mx.random.normal(shape=(B, Hv, Dv, Dk)) * 0.3 if with_state else None
+            )
+
+            y_ref, st_ref = gated_delta_ops(q, k, v, g, beta, state)
+            y, st = gated_delta_ops_chunked(
+                q, k, v, g, beta, state, chunk_size=chunk_size
+            )
+            self.assertTrue(mx.allclose(y, y_ref, rtol=1e-3, atol=1e-4))
+            self.assertTrue(mx.allclose(st, st_ref, rtol=1e-3, atol=1e-4))
+
+    def test_gated_delta_chunked_masked(self):
+        B, T, Hk, Hv, Dk, Dv = 1, 8, 2, 4, 32, 32
+
+        mx.random.seed(0)
+        q = mx.random.normal(shape=(B, T, Hk, Dk))
+        k = mx.random.normal(shape=(B, T, Hk, Dk))
+        v = mx.random.normal(shape=(B, T, Hv, Dv))
+        g = mx.sigmoid(mx.random.normal(shape=(B, T, Hv)))
+        beta = mx.sigmoid(mx.random.normal(shape=(B, T, Hv)))
+        state = mx.random.normal(shape=(B, Hv, Dv, Dk)) * 0.3
+
+        for s, e, mask in [
+            (3, 8, mx.array([[False] * 3 + [True] * 5])),
+            (0, 5, mx.array([[True] * 5 + [False] * 3])),
+        ]:
+            y_gt, st_gt = gated_delta_ops(
+                q[:, s:e],
+                k[:, s:e],
+                v[:, s:e],
+                g[:, s:e],
+                beta[:, s:e],
+                state,
+            )
+            y, st = gated_delta_ops_chunked(q, k, v, g, beta, state, mask, chunk_size=4)
+            self.assertTrue(mx.allclose(y[:, s:e], y_gt, rtol=1e-3, atol=1e-4))
+            self.assertTrue(mx.allclose(st, st_gt, rtol=1e-3, atol=1e-4))
+
+    def test_gated_delta_chunked_grads(self):
+        B, T, Hk, Hv, Dk, Dv = 1, 64, 2, 4, 32, 32
+
+        def loss_ref(q, k, v, g, beta):
+            y, s = gated_delta_ops(q, k, v, g, beta)
+            return (y**2).sum() + (s**2).sum()
+
+        def loss_chunked(q, k, v, g, beta):
+            y, s = gated_delta_ops_chunked(q, k, v, g, beta, chunk_size=16)
+            return (y**2).sum() + (s**2).sum()
+
+        for repeat_keys in [False, True]:
+            mx.random.seed(0)
+            q = mx.random.normal(shape=(B, T, Hk, Dk)) * 0.5
+            k = mx.random.normal(shape=(B, T, Hk, Dk))
+            k = k / mx.linalg.norm(k, axis=-1, keepdims=True)
+            if repeat_keys:
+                k = mx.broadcast_to(k[:, :1], k.shape) * 1.0
+            v = mx.random.normal(shape=(B, T, Hv, Dv)) * 0.5
+            g = mx.sigmoid(mx.random.normal(shape=(B, T, Hv)))
+            beta = mx.sigmoid(mx.random.normal(shape=(B, T, Hv)) + 2.0)
+
+            grads_ref = mx.grad(loss_ref, argnums=(0, 1, 2, 3, 4))(q, k, v, g, beta)
+            grads = mx.grad(loss_chunked, argnums=(0, 1, 2, 3, 4))(q, k, v, g, beta)
+            for g_ref, g_chunked in zip(grads_ref, grads):
+                self.assertTrue(mx.allclose(g_chunked, g_ref, rtol=5e-3, atol=5e-3))
+
+    def test_gated_delta_chunked_update(self):
+        B, T, Hk, Hv, Dk, Dv = 1, 40, 2, 4, 32, 32
+
+        mx.random.seed(0)
+        q = mx.random.normal(shape=(B, T, Hk, Dk)) * 0.1
+        k = mx.random.normal(shape=(B, T, Hk, Dk)) * 0.1
+        v = mx.random.normal(shape=(B, T, Hv, Dv)) * 0.1
+        a = -5.0 + mx.random.normal(shape=(B, T, Hv)) * 0.1
+        b = mx.random.normal(shape=(B, T, Hv))
+        A_log = mx.zeros((Hv,))
+        dt_bias = mx.ones((Hv,))
+
+        # use_kernel=False routes multi-token calls through the chunked path.
+        y, st = gated_delta_update(q, k, v, a, b, A_log, dt_bias, use_kernel=False)
+        g = compute_g(A_log, a, dt_bias)
+        beta = mx.sigmoid(b)
+        y_ref, st_ref = gated_delta_ops(q, k, v, g, beta)
+        self.assertTrue(mx.allclose(y, y_ref, rtol=1e-3, atol=1e-4))
+        self.assertTrue(mx.allclose(st, st_ref, rtol=1e-3, atol=1e-4))
+
+        # bf16 training inputs must produce finite gradients.
+        qb, kb, vb, ab, bb = (t.astype(mx.bfloat16) for t in (q, k, v, a, b))
+
+        def loss(q_, k_, v_, a_, b_):
+            y, s = gated_delta_update(
+                q_, k_, v_, a_, b_, A_log, dt_bias, use_kernel=False
+            )
+            return (y.astype(mx.float32) ** 2).sum() + (s**2).sum()
+
+        grads = mx.grad(loss, argnums=(0, 1, 2, 3, 4))(qb, kb, vb, ab, bb)
+        for grad in grads:
+            self.assertTrue(bool(mx.isfinite(grad).all()))
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Problem

In training mode (`use_kernel=False`), `gated_delta_update` falls back to a sequential per-timestep loop. Autodiff keeps all `T` intermediate states alive, so Qwen3.5 / Qwen3-Next fine-tuning aborts with a Metal command-buffer OOM on the first backward pass (#1206, earlier #482). #997 noted the impact on finetuning.

## What this does

Replaces that fallback with the standard chunked formulation of the gated delta rule, the same algorithm the CUDA implementations use ([flash-linear-attention](https://github.com/fla-org/flash-linear-attention); [Yang et al.](https://arxiv.org/abs/2406.06484); [Yang & Kautz](https://arxiv.org/abs/2412.06464)):

- Each 64-step chunk becomes one unit-lower-triangular solve computed with dense matmuls.
- Each chunk is wrapped in `mx.checkpoint`, shrinking the autodiff graph from `O(T)` to `O(T / 64)` nodes.
- `gated_delta_update`'s signature, all call sites, and the inference kernel are unchanged. Vectorized gating (Kimi Linear) and single-token steps keep the sequential path.

## Why this approach

- Up to ~60x faster than the current fallback and ~3-20x lower peak memory (see below) — memory is the binding constraint on the 16-36 GB machines reporting #1206.
- ~200 lines of pure MLX ops: small to review, no custom kernel to maintain, and not Metal-specific (works on CPU and MLX's CUDA backend).
- No constraints: padding masks, any head dims, GQA, carried state.
- Independent of, and composable with, #1217 (a Metal backward kernel for the same path). Measured on the same machine, that kernel is ~1.2-2x faster where its constraints hold (GPU, no mask, `Dk % 32 == 0`) at ~2.8x higher peak memory; its own routing falls back to a sequential path everywhere else, and this PR is a strictly better fallback beneath it if it lands. This PR fixes the default path on its own either way.

## Correctness

- The chunked form is exact, not an approximation: the per-chunk system matrix is nilpotent, so the solve is algebraically identical to the recurrence.
- The solve runs in fp32 with blocked forward substitution; a global Neumann expansion overflows fp32 on repeated keys. Adversarial tests cover this, including a collinear `beta -> 1` case that guards the solve block size (independent verification in the #1217 thread showed `SUB_BLOCK=32` blows up while 16 degrades gracefully).
- New tests compare outputs, final state, and gradients against `gated_delta_ops` across multi-chunk, padding, GQA, carried-in state, masks, decay extremes, and repeated keys. Final-state max diff vs the fp32 sequential reference is ~1e-6 at T=256.
- Known benign deviation: below the `1e-12` decay clamp, the gradient w.r.t. `g` is zeroed where the sequential reference returns a nonzero value. Harmless in practice (the model's parameterization scales this gradient by `g` itself); flagged during independent verification in the #1217 thread by @SudarkinV.

## Performance

Single linear-attention layer, fwd+bwd at T=2048, bf16 inputs / fp32 state, median of 10, M3 Ultra:

| Shape | ops (main) | this PR |
|---|---|---|
| Qwen3.5-9B class (Hk16 Hv64 Dk192 Dv128) | 7.043 s / 64.0 GB | 0.117 s / 3.0 GB |
| Qwen3.5-35B-A3B (Hk16 Hv32 Dk128 Dv128) | 1.149 s / 24.6 GB | 0.071 s / 1.2 GB |

End-to-end, a 512-step DWQ distillation of Qwen3.5-35B-A3B (seq 2048, 30 GDN layers) ran at 12.6 s/step on a workload where `main` hits the OOM from #1206.

## Limitations

- Vectorized (per-channel) gating still uses the sequential loop; the chunked math extends to it but is left as a follow-up.
- Decode (`T == 1`) and the inference Metal kernel are untouched.