### PR TITLE
fix(server): honor prompt cache byte limit

### DIFF
--- a/mlx_lm/server.py
+++ b/mlx_lm/server.py
@@ -1740,12 +1740,19 @@ def run(
     handler_class=APIHandler,
 ):
     group = mx.distributed.init()
-    prompt_cache = LRUPromptCache(model_provider.cli_args.prompt_cache_size)
+    prompt_cache = make_lru_prompt_cache(model_provider.cli_args)
     response_generator = ResponseGenerator(model_provider, prompt_cache)
     if group.rank() == 0:
         _run_http_server(host, port, response_generator)
     else:
         response_generator.join()
+
+
+def make_lru_prompt_cache(args):
+    max_bytes = getattr(args, "prompt_cache_bytes", None)
+    if max_bytes is None:
+        max_bytes = 1 << 63
+    return LRUPromptCache(args.prompt_cache_size, max_bytes=max_bytes)
 
 
 def main():

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -17,6 +17,7 @@ from mlx_lm.server import (
     Response,
     ResponseGenerator,
     _process_control_tokens,
+    make_lru_prompt_cache,
 )
 from mlx_lm.utils import load
 
@@ -518,6 +519,19 @@ class TestKeepalive(unittest.TestCase):
 
 
 class TestLRUPromptCache(unittest.TestCase):
+    def test_server_prompt_cache_uses_byte_limit(self):
+        args = types.SimpleNamespace(prompt_cache_size=100, prompt_cache_bytes=10)
+        cache = make_lru_prompt_cache(args)
+        model = ("test", None, None)
+
+        cache.insert_cache(model, [1, 2], [MockCache("aaa")])
+        cache.insert_cache(model, [3, 4], [MockCache("bbb")])
+        cache.insert_cache(model, [4, 5], [MockCache("ccc")])
+        cache.insert_cache(model, [6, 7], [MockCache("ddd")])
+
+        self.assertEqual(len(cache), 3)
+        self.assertEqual(cache.nbytes, 9)
+
     def test_caching(self):
         cache = LRUPromptCache(max_size=10)
 


### PR DESCRIPTION
## Summary

`mlx_lm.server` parsed `--prompt-cache-bytes`, but the server-created `LRUPromptCache` was only initialized with `prompt_cache_size`. That left the LRU cache itself with its default effectively-unbounded byte limit, so sequential serving could retain prompt cache entries beyond the configured byte budget.

This wires `prompt_cache_bytes` into `LRUPromptCache(max_bytes=...)` when the server constructs the prompt cache, keeping byte-limit enforcement centralized for all cache insertion paths.

## Changes

- Add `make_lru_prompt_cache()` to construct the server prompt cache with both sequence and byte limits.
- Use the helper from `run()` so `--prompt-cache-bytes` is honored by the LRU cache itself.
- Add a regression test showing a server-created prompt cache evicts entries according to the configured byte budget.

## Alternatives considered

- Adding another trim call only in the sequential serve path. This was rejected because passing the byte limit into `LRUPromptCache` keeps enforcement centralized and applies consistently to every insertion path.

## Notes

- Fixes the server prompt-cache byte-limit enforcement gap related to #883.
- Related to #854 and #1015, which track broader Metal OOM recovery behavior. This PR reduces one server-side OOM trigger but does not attempt to make arbitrary Metal OOMs recoverable.
- Overlaps with #1118.

## Testing

- `python3 -m unittest tests.test_server.TestLRUPromptCache`
- `black --check mlx_lm/server.py tests/test_server.py`
- `isort --profile=black --check-only mlx_lm/server.py tests/test_server.py`
