### PR TITLE
fix(mistral): parse JSON-list tool calls

### DIFF
--- a/mlx_lm/tool_parsers/mistral.py
+++ b/mlx_lm/tool_parsers/mistral.py
@@ -11,10 +11,48 @@ tool_call_start = "[TOOL_CALLS]"
 tool_call_end = ""
 
 
+def _parse_json_list(text: str):
+    try:
+        tool_calls = json.loads(text)
+    except json.JSONDecodeError as e:
+        raise ValueError(f"Could not parse tool call from: {text}") from e
+
+    if not isinstance(tool_calls, list):
+        raise ValueError(f"Could not parse tool call from: {text}")
+
+    parsed = []
+    for tool_call in tool_calls:
+        if not isinstance(tool_call, dict):
+            raise ValueError(f"Could not parse tool call from: {text}")
+
+        name = tool_call.get("name")
+        arguments = tool_call.get("arguments", {})
+        if not isinstance(name, str):
+            raise ValueError(f"Could not parse tool call from: {text}")
+
+        if isinstance(arguments, str):
+            try:
+                arguments = json.loads(arguments)
+            except json.JSONDecodeError as e:
+                raise ValueError(f"Could not parse tool call from: {text}") from e
+
+        if not isinstance(arguments, dict):
+            raise ValueError(f"Could not parse tool call from: {text}")
+
+        result = {"name": name, "arguments": arguments}
+        if "id" in tool_call:
+            if not isinstance(tool_call["id"], str):
+                raise ValueError(f"Could not parse tool call from: {text}")
+            result["id"] = tool_call["id"]
+        parsed.append(result)
+
+    return parsed
+
+
 def parse_tool_call(text: str, tools: Any | None = None):
     match = _tool_call_regex.search(text)
     if match is None:
-        raise ValueError(f"Could not parse tool call from: {text}")
+        return _parse_json_list(text)
     func_name = match.group(1)
     func_args = json.loads(match.group(2))
     return dict(name=func_name, arguments=func_args)

--- a/tests/test_tool_parsing.py
+++ b/tests/test_tool_parsing.py
@@ -313,6 +313,33 @@ class TestToolParsing(unittest.TestCase):
         ]
         self.assertEqual(tool_calls, expected)
 
+    def test_mistral_json_list_tool_call(self):
+        test_case = '[{"name": "calculator", "arguments": {"expression": "2+3"}}]'
+        tool_calls = mistral.parse_tool_call(test_case, None)
+        expected = [
+            {
+                "name": "calculator",
+                "arguments": {"expression": "2+3"},
+            }
+        ]
+        self.assertEqual(tool_calls, expected)
+
+    def test_mistral_json_list_tool_call_with_string_arguments(self):
+        test_case = (
+            '[{"name": "calculator", '
+            '"arguments": "{\\"expression\\": \\"2+3\\"}", '
+            '"id": "abcdefghi"}]'
+        )
+        tool_calls = mistral.parse_tool_call(test_case, None)
+        expected = [
+            {
+                "id": "abcdefghi",
+                "name": "calculator",
+                "arguments": {"expression": "2+3"},
+            }
+        ]
+        self.assertEqual(tool_calls, expected)
+
     def test_minimax_m2(self):
         test_case = (
             '<invoke name="search">\n'


### PR DESCRIPTION
## Summary

Fixes #1374.

Adds support for Mistral-family tool call payloads emitted as JSON lists after `[TOOL_CALLS]`, while preserving the existing `name[ARGS]{...}` parser path.

## Changes

- Parse JSON-list Mistral tool call payloads.
- Decode `arguments` when templates render it as a JSON string.
- Preserve optional string `id` fields from parsed tool calls.
- Add regression tests for object and string argument forms.

## Alternatives considered

- Changing server-side tool call handling was broader than necessary because the failure is isolated to the Mistral parser.
- Replacing the existing regex path was rejected to preserve support for Devstral-style `name[ARGS]{...}` output.

## Notes

Verified the affected Mistral-family chat templates render assistant tool calls as JSON lists after `[TOOL_CALLS]`, including Ministral, Mistral-7B-Instruct-v0.3, Mistral-Nemo, and Mixtral-8x22B-Instruct-v0.1.

## Screenshots

Not applicable; no UI changes.

## Testing

- `python3 -m unittest tests.test_tool_parsing`
- `python3 -m unittest discover tests/`
- `pre-commit run --files mlx_lm/tool_parsers/mistral.py tests/test_tool_parsing.py`
