### PR TITLE
Fix Gemma 3n shared-KV layers with batched caches

### DIFF
--- a/mlx_lm/models/gemma3n.py
+++ b/mlx_lm/models/gemma3n.py
@@ -126,16 +126,20 @@ class Gemma3nAttention(nn.Module):
         queries = self.q_proj(x)
         queries = queries.reshape(B, L, -1, self.head_dim)
         queries = self.q_norm(queries)
+        queries = queries.transpose(0, 2, 1, 3)
 
-        offset = 0
         if self.is_kv_shared_layer and cache is not None:
-            # For shared layers, retrieve KV from the designated cache layer
-            keys, values = cache.state
-            offset = cache.offset
-
+            # For shared layers, retrieve KV from the designated cache layer.
+            # That cache was already updated earlier in this forward pass, so
+            # its offset is ahead of the current tokens by L.
+            keys, values = cache.state[:2]
+            queries = self.rope(queries, offset=cache.offset - L)
         else:
-            if cache is not None:
-                offset = cache.offset
+            offset = cache.offset if cache is not None else 0
+            # Apply RoPE before updating the cache since batched caches
+            # advance their (array) offset in-place in update_and_fetch
+            queries = self.rope(queries, offset=offset)
+
             keys = self.k_proj(x).reshape(B, L, -1, self.head_dim)
             keys = self.k_norm(keys)
             keys = keys.transpose(0, 2, 1, 3)
@@ -147,9 +151,6 @@ class Gemma3nAttention(nn.Module):
 
             if cache is not None:
                 keys, values = cache.update_and_fetch(keys, values)
-
-        queries = queries.transpose(0, 2, 1, 3)
-        queries = self.rope(queries, offset=offset)
 
         output = scaled_dot_product_attention(
             queries, keys, values, cache=cache, scale=self.scale, mask=mask

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -504,6 +504,108 @@ class TestModels(unittest.TestCase):
             model, args.model_type, args.vocab_size, args.num_hidden_layers
         )
 
+    def test_gemma3n_shared_kv_layers(self):
+        from mlx_lm.models import gemma3n
+        from mlx_lm.models.cache import BatchKVCache, BatchRotatingKVCache
+
+        config = {
+            "model_type": "gemma3n",
+            "text_config": {
+                "model_type": "gemma3n",
+                "hidden_size": 128,
+                "num_hidden_layers": 4,
+                "intermediate_size": 128,
+                "num_attention_heads": 4,
+                "head_dim": 32,
+                "rms_norm_eps": 1e-5,
+                "vocab_size": 1000,
+                "num_key_value_heads": 2,
+                "num_kv_shared_layers": 2,
+                "vocab_size_per_layer_input": 1000,
+                "sliding_window": 8,
+                "max_position_embeddings": 1000,
+                "rope_local_base_freq": 1.0,
+                "rope_theta": 1000.0,
+                "final_logit_softcapping": 1.0,
+                "layer_types": [
+                    "sliding_attention",
+                    "full_attention",
+                    "sliding_attention",
+                    "full_attention",
+                ],
+                "activation_sparsity_pattern": [0.5, 0.5, 0.5, 0.5],
+                "hidden_size_per_layer_input": 256,
+                "altup_num_inputs": 4,
+                "altup_coef_clip": 1.0,
+                "altup_correct_scale": True,
+                "altup_active_idx": 0,
+                "laurel_rank": 8,
+            },
+        }
+        model = gemma3n.Model(gemma3n.ModelArgs.from_dict(config))
+        mx.eval(model.parameters())
+
+        T = 12
+        tokens = mx.random.randint(0, 999, (1, T))
+
+        # The shared KV layers should rotate the queries with the right
+        # positions: prefill in one shot matches token-by-token decoding
+        cache = model.make_cache()
+        expected = model(tokens, cache=cache)
+        cache = model.make_cache()
+        out = mx.concatenate(
+            [model(tokens[:, t : t + 1], cache=cache) for t in range(T)], axis=1
+        )
+        self.assertTrue(mx.allclose(expected, out, rtol=1e-4, atol=1e-4))
+
+        def make_batch_cache(left_padding):
+            return [
+                (
+                    BatchKVCache(left_padding)
+                    if type(c) is KVCache
+                    else BatchRotatingKVCache(c.max_size, left_padding)
+                )
+                for c in model.make_cache()
+            ]
+
+        # Batched caches (used by batch_generate and the server) with B=1
+        # match the non-batched result
+        cache = make_batch_cache([0])
+        out = model(tokens, cache=cache)
+        self.assertTrue(mx.allclose(expected, out, rtol=1e-4, atol=1e-4))
+
+        # A left-padded batch matches individual runs, with enough decode
+        # steps to rotate the sliding window caches
+        n_decode = 8
+        seq_a = mx.random.randint(0, 999, (1, T + n_decode))
+        seq_b = mx.random.randint(0, 999, (1, T - 5 + n_decode))
+
+        expected = []
+        for seq, plen in ((seq_a, T), (seq_b, T - 5)):
+            cache = model.make_cache()
+            logits = [model(seq[:, :plen], cache=cache)[:, -1:]]
+            for t in range(plen, seq.shape[1]):
+                logits.append(model(seq[:, t : t + 1], cache=cache))
+            expected.append(mx.concatenate(logits, axis=1))
+
+        cache = make_batch_cache([0, 5])
+        batch_prompt = mx.concatenate(
+            [
+                seq_a[:, :T],
+                mx.concatenate(
+                    [mx.zeros((1, 5), seq_b.dtype), seq_b[:, : T - 5]], axis=1
+                ),
+            ],
+            axis=0,
+        )
+        logits = [model(batch_prompt, cache=cache)[:, -1:]]
+        for i in range(n_decode):
+            step = mx.concatenate([seq_a[:, T + i], seq_b[:, T - 5 + i]])[:, None]
+            logits.append(model(step, cache=cache))
+        out = mx.concatenate(logits, axis=1)
+        for b in range(2):
+            self.assertTrue(mx.allclose(expected[b][0], out[b], rtol=1e-4, atol=1e-4))
+
     def test_mixtral(self):
         from mlx_lm.models import mixtral
 


### PR DESCRIPTION
Fixes #1384.

The garbage output (symptom 2 there) turns out to be query RoPE positions rather than KV alignment, wrong in two independent ways:

- The shared-KV layers read `cache.offset` after the designated concrete layer has already advanced it in the same forward pass, so queries are roped `L` positions too far. This part isn't batch-specific: on main, one-shot prefill and stepwise decoding disagree even with the regular cache (max logit diff ~1.5 on a tiny random model; ~4e-6 with this fix).
- The non-shared layers rope queries after `update_and_fetch` using an `offset` captured beforehand — but the batch caches store `offset` as an `mx.array` and advance it in place, so the captured value aliases the post-update offset and queries again land at `position + L`. The int offsets of the non-batched caches are immune, which is why `mlx_lm.generate` stayed coherent.

Fix: `cache.state[:2]` and `cache.offset - L` in the shared branch; rope queries before updating the cache in the non-shared branch (the order other models use).

The regression test (tiny random gemma3n, no downloads) checks prefill == stepwise, batched B=1 == non-batched, and left-padded B=2 == per-row runs across sliding-window rotation. Re-ran the issue's repro with `mlx-community/gemma-3n-E2B-it-lm-4bit`: `batch_generate` now matches `mlx_lm.generate`.
