### PR TITLE
fix: shorten generated tool-call ids to 9 alphanumeric chars (fixes #1375)

### DIFF
--- a/mlx_lm/server.py
+++ b/mlx_lm/server.py
@@ -59,7 +59,7 @@ class ToolCallFormatter:
         self._streaming = streaming
 
     def _format(self, tc):
-        tc_id = tc.pop("id", None) or str(uuid.uuid4())
+        tc_id = tc.pop("id", None) or uuid.uuid4().hex[:9]
         tc["arguments"] = json.dumps(tc["arguments"], ensure_ascii=False)
         out = {
             "function": tc,


### PR DESCRIPTION
## Summary

- `ToolCallFormatter._format` in `server.py` falls back to `str(uuid.uuid4())` when a tool call has no `id` field
- `str(uuid.uuid4())` is 36 characters with hyphens; Mistral v3 chat templates enforce a 9-character alphanumeric constraint and raise `TemplateError` when this is violated
- This causes `apply_chat_template` to raise on the second turn of any multi-turn tool exchange with affected models, which the server surfaces as HTTP 404

## Change

```python
# before
tc_id = tc.pop("id", None) or str(uuid.uuid4())
# after
tc_id = tc.pop("id", None) or uuid.uuid4().hex[:9]
```

`uuid.uuid4().hex[:9]` yields 9 lowercase hex characters (e.g. `0819261ae`) — valid under the Mistral v3 constraint and accepted by all other templates tested.

## Affected models

`mlx-community/Ministral-8B-Instruct-2410-4bit`, `Mistral-7B-Instruct-v0.3`, `Mixtral`, `Mistral-Nemo` (any checkpoint sharing the v3 template family). `Devstral-Small-2-...-2512` is unaffected as its template has no id-length constraint.

Closes #1375