### PR TITLE
fix(server): flush tool call when generation ends in "tool" state (Mistral/Devstral)

### DIFF
--- a/mlx_lm/server.py
+++ b/mlx_lm/server.py
@@ -1497,7 +1497,13 @@ class APIHandler(BaseHTTPRequestHandler):
 
                 prev_state = gen.state
 
-            if prev_state == "tool" and tool_text:
+            # Flush any tool call still pending at end of generation. ``tool_text``
+            # is only non-empty when generation finished while in the "tool"
+            # state (e.g. Mistral/Devstral, whose ``tool_call_end`` is empty so
+            # the state machine never transitions back to "normal"). Guarding on
+            # ``prev_state == "tool"`` dropped these because the terminal event
+            # resets ``prev_state``.
+            if tool_text:
                 tool_calls.append(tool_text)
                 made_tool_call = True
 

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -13,11 +13,13 @@ import requests
 from mlx_lm.models.cache import KVCache
 from mlx_lm.server import (
     APIHandler,
+    GenerationContext,
     LRUPromptCache,
     Response,
     ResponseGenerator,
     _process_control_tokens,
 )
+from mlx_lm.tool_parsers import mistral
 from mlx_lm.utils import load
 
 
@@ -684,6 +686,96 @@ class TestLRUPromptCache(unittest.TestCase):
         c, t = cache.fetch_nearest_cache(model, [3, 4])
         self.assertEqual(c, None)
         self.assertEqual(t, [3, 4])
+
+
+class TestMistralToolStateFlush(unittest.TestCase):
+    """A tool call that ends while still in the "tool" state must be flushed.
+
+    Mistral / Devstral emit ``[TOOL_CALLS]<name>[ARGS]{json}`` and their
+    ``tool_call_end`` is empty, so the state machine never transitions back to
+    "normal" — generation finishes inside the "tool" state. The terminal
+    generation event resets ``prev_state``, so the old
+    ``if prev_state == "tool"`` flush guard dropped the call and the response
+    came back with an empty assistant message.
+    """
+
+    class _FakeGenerator:
+        cli_args = types.SimpleNamespace(
+            allowed_origins=["*"],
+            num_draft_tokens=3,
+            max_tokens=512,
+            temp=0.0,
+            top_p=1.0,
+            top_k=0,
+            min_p=0.0,
+            model=None,
+        )
+
+        def __init__(self, stream):
+            self._stream = stream
+
+        def generate(self, request, generation_args, progress_callback=None):
+            ctx = GenerationContext(
+                has_tool_calling=True,
+                has_thinking=False,
+                tool_parser=mistral.parse_tool_call,
+                sequences={(0,): "[TOOL_CALLS]"},
+                prompt=[1, 2, 3],
+                prompt_cache_count=0,
+            )
+            return ctx, iter(self._stream)
+
+        def stop_and_join(self):
+            pass
+
+    def _post(self, stream, stream_response=False):
+        gen = self._FakeGenerator(stream)
+        httpd = http.server.HTTPServer(
+            ("localhost", 0),
+            lambda *args, **kwargs: APIHandler(gen, *args, **kwargs),
+        )
+        port = httpd.server_port
+        thread = threading.Thread(target=httpd.serve_forever, daemon=True)
+        thread.start()
+        try:
+            return requests.post(
+                f"http://localhost:{port}/v1/chat/completions",
+                json={
+                    "model": "default_model",
+                    "messages": [{"role": "user", "content": "read the file"}],
+                    "stream": stream_response,
+                },
+            ).text
+        finally:
+            httpd.shutdown()
+            httpd.server_close()
+            thread.join()
+
+    def test_tool_call_flushed_when_generation_ends_in_tool_state(self):
+        # Last event carries the stop and a reset state (None), as the real
+        # generator does — this is what defeated the old prev_state guard.
+        stream = [
+            Response(
+                'read[ARGS]{"file_path": "/tmp/foo.txt"}',
+                10,
+                "tool",
+                None,
+                0.0,
+                None,
+                (),
+            ),
+            Response("", 2, None, None, 0.0, "stop", ()),
+        ]
+        body = json.loads(self._post(stream))
+        choice = body["choices"][0]
+        self.assertEqual(choice["finish_reason"], "tool_calls")
+        tool_calls = choice["message"]["tool_calls"]
+        self.assertEqual(len(tool_calls), 1)
+        self.assertEqual(tool_calls[0]["function"]["name"], "read")
+        self.assertEqual(
+            json.loads(tool_calls[0]["function"]["arguments"]),
+            {"file_path": "/tmp/foo.txt"},
+        )
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

The OpenAI server drops tool calls for models whose `tool_call_end` is empty — notably **Mistral / Devstral**, which emit `[TOOL_CALLS]<name>[ARGS]{json}`. The response comes back as an empty assistant message (no `content`, no `tool_calls`) even though the model generated a perfectly valid tool call.

## Root cause

For these models the state machine never transitions back to `"normal"` (there is no closing tool token), so generation finishes while still in the `"tool"` state. In `APIHandler.handle_completion` the end-of-generation flush is guarded on `prev_state == "tool"`:

```python
if prev_state == "tool" and tool_text:
    tool_calls.append(tool_text)
    made_tool_call = True
```

But the terminal generation event resets `prev_state` (it is `None` by the time the loop exits), so the accumulated `tool_text` is never appended to `tool_calls`. The `ToolCallFormatter` then receives an empty list and emits nothing.

I confirmed this with a debug print inside the flush:
```
prev_state=None  tool_text='read[ARGS]{"file_path": "/tmp/foo.txt"}'  tool_calls=[]
```
`tool_text` is collected correctly (with `[ARGS]` intact) — the only problem is the guard.

## Fix

Flush whenever `tool_text` is non-empty. `tool_text` is only ever populated while in the `"tool"` state and is reset to `""` on the `tool -> normal` transition, so this is also correct for models that *do* close their tool calls (no double flush):

```python
if tool_text:
    tool_calls.append(tool_text)
    made_tool_call = True
```

## Verification

End-to-end against a real `mlx_lm.server` serving `mlx-community/Devstral-Small-2-24B-Instruct-2512-4bit`:

- **Before:** `finish_reason: "stop"`, empty message, `tool_calls` absent (both streaming and non-streaming).
- **After:** `finish_reason: "tool_calls"` with the structured call — non-streaming `{"name":"read","arguments":"{\"file_path\": \"/tmp/foo.txt\"}"}`, and the streaming deltas assemble to the same.

Added `tests/test_server.py::TestMistralToolStateFlush`, which drives the request handler with a generation stream ending in the `"tool"` state (the terminal event carries `state=None`, reproducing the reset). It fails on `main` and passes with the fix.

```
python -m unittest tests.test_server tests.test_tool_parsing   # 26 tests, OK
black mlx_lm/server.py tests/test_server.py                     # clean
```

## AI assistance disclosure

Diagnosed and implemented with AI assistance (Claude). I reproduced the bug against a live Devstral server, traced the root cause with an instrumented build, and verified the fix end-to-end (streaming + non-streaming) and via the new regression test before submitting. Happy to adjust the test harness to your preferred style.
