### PR TITLE
fix(server): build xtc_special_tokens as a flat list

### DIFF
--- a/mlx_lm/server.py
+++ b/mlx_lm/server.py
@@ -386,10 +386,7 @@ def _make_sampler(args, tokenizer):
         min_p=args.sampling.min_p,
         xtc_probability=args.sampling.xtc_probability,
         xtc_threshold=args.sampling.xtc_threshold,
-        xtc_special_tokens=[
-            tokenizer.eos_token_id,
-            tokenizer.encode("\n"),
-        ],
+        xtc_special_tokens=tokenizer.encode("\n") + list(tokenizer.eos_token_ids),
     )
 
 

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -4,6 +4,7 @@ import http
 import io
 import json
 import threading
+import types
 import unittest
 
 import mlx.core as mx
@@ -11,7 +12,13 @@ import requests
 
 from mlx_lm.generate import TextStateMachine
 from mlx_lm.models.cache import KVCache
-from mlx_lm.server import APIHandler, LRUPromptCache, Response, ResponseGenerator
+from mlx_lm.server import (
+    APIHandler,
+    LRUPromptCache,
+    Response,
+    ResponseGenerator,
+    _make_sampler,
+)
 from mlx_lm.utils import load
 
 
@@ -189,6 +196,35 @@ class TestTextStateMachine(unittest.TestCase):
         self.assertEqual(text, "f[ARGS]{}")
         state, s = sm.discard(state)
         self.assertEqual(s, "tool")
+
+
+class TestMakeSampler(unittest.TestCase):
+    def test_xtc_special_tokens_are_flat(self):
+        # Regression: _make_sampler built xtc_special_tokens as a nested list
+        # ([eos_token_id, encode("\n")]), so apply_xtc raised
+        # "Initialization encountered extra dimension." for any request with
+        # temperature > 0 and xtc_probability > 0.
+        # The real TokenizerWrapper exposes both eos_token_id and eos_token_ids.
+        tokenizer = types.SimpleNamespace(
+            encode=lambda s: [3],
+            eos_token_id=0,
+            eos_token_ids=[0],
+        )
+        args = types.SimpleNamespace(
+            sampling=types.SimpleNamespace(
+                temperature=0.6,
+                top_p=1.0,
+                top_k=0,
+                min_p=0.0,
+                xtc_probability=1.0,
+                xtc_threshold=0.1,
+            )
+        )
+        sampler = _make_sampler(args, tokenizer)
+        logits = mx.log(mx.array([[0.4, 0.3, 0.15, 0.15]]))
+        token = sampler(logits)
+        mx.eval(token)
+        self.assertEqual(token.shape, (1,))
 
 
 class TestServer(unittest.TestCase):


### PR DESCRIPTION
### Bug

`_make_sampler` in `mlx_lm/server.py` builds `xtc_special_tokens` as a nested list:

```python
xtc_special_tokens=[
    tokenizer.eos_token_id,   # int
    tokenizer.encode("\n"),   # list, e.g. [198]
],
```

That produces `[int, [int]]` (e.g. `[50256, [198]]`). `apply_xtc` expects a flat `List[int]` — it does `mask[..., xtc_special_tokens] = False`. With the nested list it raises:

```
ValueError: Initialization encountered extra dimension.
```

So any server request with `temperature > 0` and `xtc_probability > 0` fails (at `temperature == 0` `make_sampler` short-circuits to argmax and never applies XTC, which is why it isn't always hit).

`generate.py` and `chat.py` already build this correctly:

```python
xtc_special_tokens=tokenizer.encode("\n") + list(tokenizer.eos_token_ids)
```

### Fix

Build the list the same flat way in `server.py`.

### Verification

Real tokenizer (gpt2) reproduces the exact construction and failure:

```
tokenizer.encode("\n")  -> [198]   (list)
tokenizer.eos_token_id  -> 50256   (int)
server builds           -> [50256, [198]]
apply_xtc(..., [50256, [198]])  -> ValueError: Initialization encountered extra dimension.
apply_xtc(..., [198, 50256])    -> OK
```

Added a network-free regression test (`tests/test_server.py::TestMakeSampler`) that calls `_make_sampler` with `temperature=0.6, xtc_probability=1.0` and runs the returned sampler. It fails on the current code with the `ValueError` above and passes with the fix. `tests/test_sample_utils.py` still passes (7); black + isort clean.
