### PR TITLE
fix(server): reduce prompt cache memory pressure

### DIFF
--- a/mlx_lm/models/cache.py
+++ b/mlx_lm/models/cache.py
@@ -1671,25 +1671,48 @@ class LRUPromptCache:
     def nbytes(self):
         return self._n_bytes
 
-    def fetch_nearest_cache(self, model: Any, tokens: List[int]):
+    def _pop_entry(self, model: Any, tokens: List[int]):
+        entry = self._trie.pop(model, tokens)
+        self._lru.remove(model, tokens)
+        self._n_bytes -= entry.nbytes
+        self._n_bytes_by_type[entry.cache_type] -= entry.nbytes
+        return entry
+
+    def _get_entry(self, model: Any, tokens: List[int], consume: bool):
+        if consume:
+            return self._pop_entry(model, tokens)
+        return self._trie.get(model, tokens)
+
+    def _return_cache(self, prompt_cache: List[Any], consume: bool):
+        if consume:
+            return prompt_cache
+        return copy.deepcopy(prompt_cache)
+
+    def fetch_nearest_cache(
+        self, model: Any, tokens: List[int], *, consume: bool = False
+    ):
         result = self._trie.search(model, tokens)
         if result.exact is not None:
-            cache_entry = self._trie.get(result.model, result.exact)
-            return copy.deepcopy(cache_entry.prompt_cache), []
+            cache_entry = self._get_entry(result.model, result.exact, consume)
+            return self._return_cache(cache_entry.prompt_cache, consume), []
 
         short_length = len(result.shorter) if result.shorter is not None else 0
         if result.longer is not None and result.common_prefix > short_length:
             cache_entry = self._trie.get(result.model, result.longer)
             if can_trim_prompt_cache(cache_entry.prompt_cache):
-                cache = copy.deepcopy(cache_entry.prompt_cache)
+                cache_entry = self._get_entry(result.model, result.longer, consume)
+                cache = self._return_cache(cache_entry.prompt_cache, consume)
                 prefix = min(len(tokens) - 1, result.common_prefix)
                 num_to_trim = len(result.longer) - prefix
                 trim_prompt_cache(cache, num_to_trim)
                 return cache, tokens[prefix:]
 
         if short_length > 0:
-            cache_entry = self._trie.get(result.model, result.shorter)
-            return copy.deepcopy(cache_entry.prompt_cache), tokens[short_length:]
+            cache_entry = self._get_entry(result.model, result.shorter, consume)
+            return (
+                self._return_cache(cache_entry.prompt_cache, consume),
+                tokens[short_length:],
+            )
 
         return None, tokens
 

--- a/mlx_lm/models/cache.py
+++ b/mlx_lm/models/cache.py
@@ -1649,25 +1649,48 @@ class LRUPromptCache:
     def nbytes(self):
         return self._n_bytes
 
-    def fetch_nearest_cache(self, model: Any, tokens: List[int]):
+    def _pop_entry(self, model: Any, tokens: List[int]):
+        entry = self._trie.pop(model, tokens)
+        self._lru.remove(model, tokens)
+        self._n_bytes -= entry.nbytes
+        self._n_bytes_by_type[entry.cache_type] -= entry.nbytes
+        return entry
+
+    def _get_entry(self, model: Any, tokens: List[int], consume: bool):
+        if consume:
+            return self._pop_entry(model, tokens)
+        return self._trie.get(model, tokens)
+
+    def _return_cache(self, prompt_cache: List[Any], consume: bool):
+        if consume:
+            return prompt_cache
+        return copy.deepcopy(prompt_cache)
+
+    def fetch_nearest_cache(
+        self, model: Any, tokens: List[int], *, consume: bool = False
+    ):
         result = self._trie.search(model, tokens)
         if result.exact is not None:
-            cache_entry = self._trie.get(result.model, result.exact)
-            return copy.deepcopy(cache_entry.prompt_cache), []
+            cache_entry = self._get_entry(result.model, result.exact, consume)
+            return self._return_cache(cache_entry.prompt_cache, consume), []
 
         short_length = len(result.shorter) if result.shorter is not None else 0
         if result.longer is not None and result.common_prefix > short_length:
             cache_entry = self._trie.get(result.model, result.longer)
             if can_trim_prompt_cache(cache_entry.prompt_cache):
-                cache = copy.deepcopy(cache_entry.prompt_cache)
+                cache_entry = self._get_entry(result.model, result.longer, consume)
+                cache = self._return_cache(cache_entry.prompt_cache, consume)
                 prefix = min(len(tokens) - 1, result.common_prefix)
                 num_to_trim = len(result.longer) - prefix
                 trim_prompt_cache(cache, num_to_trim)
                 return cache, tokens[prefix:]
 
         if short_length > 0:
-            cache_entry = self._trie.get(result.model, result.shorter)
-            return copy.deepcopy(cache_entry.prompt_cache), tokens[short_length:]
+            cache_entry = self._get_entry(result.model, result.shorter, consume)
+            return (
+                self._return_cache(cache_entry.prompt_cache, consume),
+                tokens[short_length:],
+            )
 
         return None, tokens
 

--- a/mlx_lm/server.py
+++ b/mlx_lm/server.py
@@ -963,7 +963,7 @@ class ResponseGenerator:
             # Load the KV cache
             self._log_cache_stats()
             cache, rest = self.prompt_cache.fetch_nearest_cache(
-                self.model_provider.model_key, prompt
+                self.model_provider.model_key, prompt, consume=True
             )
             ctx.prompt_cache_count = len(prompt) - len(rest)
             cache_key = prompt[:]
@@ -1732,6 +1732,16 @@ def _run_http_server(
         response_generator.stop_and_join()
 
 
+def make_lru_prompt_cache(model_provider: ModelProvider):
+    max_bytes = model_provider.cli_args.prompt_cache_bytes
+    if max_bytes is None:
+        return LRUPromptCache(model_provider.cli_args.prompt_cache_size)
+    return LRUPromptCache(
+        model_provider.cli_args.prompt_cache_size,
+        max_bytes=max_bytes,
+    )
+
+
 def run(
     host: str,
     port: int,
@@ -1740,7 +1750,7 @@ def run(
     handler_class=APIHandler,
 ):
     group = mx.distributed.init()
-    prompt_cache = LRUPromptCache(model_provider.cli_args.prompt_cache_size)
+    prompt_cache = make_lru_prompt_cache(model_provider)
     response_generator = ResponseGenerator(model_provider, prompt_cache)
     if group.rank() == 0:
         _run_http_server(host, port, response_generator)

--- a/mlx_lm/server.py
+++ b/mlx_lm/server.py
@@ -943,7 +943,7 @@ class ResponseGenerator:
             # Load the KV cache
             self._log_cache_stats()
             cache, rest = self.prompt_cache.fetch_nearest_cache(
-                self.model_provider.model_key, prompt
+                self.model_provider.model_key, prompt, consume=True
             )
             ctx.prompt_cache_count = len(prompt) - len(rest)
             cache_key = prompt[:]
@@ -1754,6 +1754,16 @@ def _run_http_server(
         response_generator.stop_and_join()
 
 
+def make_lru_prompt_cache(model_provider: ModelProvider):
+    max_bytes = model_provider.cli_args.prompt_cache_bytes
+    if max_bytes is None:
+        return LRUPromptCache(model_provider.cli_args.prompt_cache_size)
+    return LRUPromptCache(
+        model_provider.cli_args.prompt_cache_size,
+        max_bytes=max_bytes,
+    )
+
+
 def run(
     host: str,
     port: int,
@@ -1762,7 +1772,7 @@ def run(
     handler_class=APIHandler,
 ):
     group = mx.distributed.init()
-    prompt_cache = LRUPromptCache(model_provider.cli_args.prompt_cache_size)
+    prompt_cache = make_lru_prompt_cache(model_provider)
     response_generator = ResponseGenerator(model_provider, prompt_cache)
     if group.rank() == 0:
         _run_http_server(host, port, response_generator)

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -17,6 +17,7 @@ from mlx_lm.server import (
     Response,
     ResponseGenerator,
     _process_control_tokens,
+    make_lru_prompt_cache,
 )
 from mlx_lm.utils import load
 
@@ -568,6 +569,63 @@ class TestLRUPromptCache(unittest.TestCase):
         cache.insert_cache(model, tokens, c)
         self.assertEqual(len(cache), 2)
 
+    def test_fetch_deep_copies_by_default(self):
+        cache = LRUPromptCache(max_size=10)
+        model = ("test", None, None)
+        prompt_cache = [MockCache("test1")]
+
+        cache.insert_cache(model, [1, 2], prompt_cache)
+        fetched, rest = cache.fetch_nearest_cache(model, [1, 2])
+
+        self.assertEqual(fetched, prompt_cache)
+        self.assertIsNot(fetched, prompt_cache)
+        self.assertIsNot(fetched[0], prompt_cache[0])
+        self.assertEqual(rest, [])
+        self.assertEqual(len(cache), 1)
+        self.assertEqual(cache.nbytes, 5)
+
+    def test_fetch_can_consume_exact_match(self):
+        cache = LRUPromptCache(max_size=10)
+        model = ("test", None, None)
+        prompt_cache = [MockCache("test1")]
+
+        cache.insert_cache(model, [1, 2], prompt_cache)
+        fetched, rest = cache.fetch_nearest_cache(model, [1, 2], consume=True)
+
+        self.assertIs(fetched, prompt_cache)
+        self.assertEqual(rest, [])
+        self.assertEqual(len(cache), 0)
+        self.assertEqual(cache.nbytes, 0)
+
+    def test_fetch_can_consume_shorter_match(self):
+        cache = LRUPromptCache(max_size=10)
+        model = ("test", None, None)
+        prompt_cache = [MockCache("test1")]
+
+        cache.insert_cache(model, [1, 2], prompt_cache)
+        fetched, rest = cache.fetch_nearest_cache(model, [1, 2, 3], consume=True)
+
+        self.assertIs(fetched, prompt_cache)
+        self.assertEqual(rest, [3])
+        self.assertEqual(len(cache), 0)
+        self.assertEqual(cache.nbytes, 0)
+
+    def test_fetch_can_consume_trimmed_longer_match(self):
+        cache = LRUPromptCache(max_size=10)
+        model = ("test", None, None)
+        prompt_cache = [KVCache()]
+        keys = mx.arange(3).reshape(1, 1, 3, 1)
+        prompt_cache[0].update_and_fetch(keys, keys)
+
+        cache.insert_cache(model, [1, 2, 3], prompt_cache)
+        fetched, rest = cache.fetch_nearest_cache(model, [1, 2, 4], consume=True)
+
+        self.assertIs(fetched, prompt_cache)
+        self.assertEqual(fetched[0].offset, 2)
+        self.assertEqual(rest, [4])
+        self.assertEqual(len(cache), 0)
+        self.assertEqual(cache.nbytes, 0)
+
     def test_lru(self):
         cache = LRUPromptCache(max_size=2)
         model = ("test", None, None)
@@ -684,6 +742,28 @@ class TestLRUPromptCache(unittest.TestCase):
         c, t = cache.fetch_nearest_cache(model, [3, 4])
         self.assertEqual(c, None)
         self.assertEqual(t, [3, 4])
+
+    def test_server_prompt_cache_honors_byte_limit(self):
+        model_provider = types.SimpleNamespace(
+            cli_args=types.SimpleNamespace(
+                prompt_cache_size=100,
+                prompt_cache_bytes=10,
+            )
+        )
+        cache = make_lru_prompt_cache(model_provider)
+        model = ("test", None, None)
+
+        cache.insert_cache(model, [1, 2], [MockCache("aaa")])
+        cache.insert_cache(model, [3, 4], [MockCache("bbb")])
+        cache.insert_cache(model, [4, 5], [MockCache("ccc")])
+        cache.insert_cache(model, [6, 7], [MockCache("ddd")])
+
+        self.assertEqual(len(cache), 3)
+        self.assertEqual(cache.nbytes, 9)
+
+        c, t = cache.fetch_nearest_cache(model, [1, 2])
+        self.assertEqual(c, None)
+        self.assertEqual(t, [1, 2])
 
 
 if __name__ == "__main__":

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -5,6 +5,7 @@ import io
 import json
 import threading
 import time
+import types
 import unittest
 from queue import Queue
 from unittest import mock
@@ -20,6 +21,7 @@ from mlx_lm.server import (
     ResponseGenerator,
     SamplingArguments,
     _make_sampler,
+    make_lru_prompt_cache,
 )
 from mlx_lm.utils import load
 
@@ -708,6 +710,63 @@ class TestLRUPromptCache(unittest.TestCase):
         cache.insert_cache(model, tokens, c)
         self.assertEqual(len(cache), 2)
 
+    def test_fetch_deep_copies_by_default(self):
+        cache = LRUPromptCache(max_size=10)
+        model = ("test", None, None)
+        prompt_cache = [MockCache("test1")]
+
+        cache.insert_cache(model, [1, 2], prompt_cache)
+        fetched, rest = cache.fetch_nearest_cache(model, [1, 2])
+
+        self.assertEqual(fetched, prompt_cache)
+        self.assertIsNot(fetched, prompt_cache)
+        self.assertIsNot(fetched[0], prompt_cache[0])
+        self.assertEqual(rest, [])
+        self.assertEqual(len(cache), 1)
+        self.assertEqual(cache.nbytes, 5)
+
+    def test_fetch_can_consume_exact_match(self):
+        cache = LRUPromptCache(max_size=10)
+        model = ("test", None, None)
+        prompt_cache = [MockCache("test1")]
+
+        cache.insert_cache(model, [1, 2], prompt_cache)
+        fetched, rest = cache.fetch_nearest_cache(model, [1, 2], consume=True)
+
+        self.assertIs(fetched, prompt_cache)
+        self.assertEqual(rest, [])
+        self.assertEqual(len(cache), 0)
+        self.assertEqual(cache.nbytes, 0)
+
+    def test_fetch_can_consume_shorter_match(self):
+        cache = LRUPromptCache(max_size=10)
+        model = ("test", None, None)
+        prompt_cache = [MockCache("test1")]
+
+        cache.insert_cache(model, [1, 2], prompt_cache)
+        fetched, rest = cache.fetch_nearest_cache(model, [1, 2, 3], consume=True)
+
+        self.assertIs(fetched, prompt_cache)
+        self.assertEqual(rest, [3])
+        self.assertEqual(len(cache), 0)
+        self.assertEqual(cache.nbytes, 0)
+
+    def test_fetch_can_consume_trimmed_longer_match(self):
+        cache = LRUPromptCache(max_size=10)
+        model = ("test", None, None)
+        prompt_cache = [KVCache()]
+        keys = mx.arange(3).reshape(1, 1, 3, 1)
+        prompt_cache[0].update_and_fetch(keys, keys)
+
+        cache.insert_cache(model, [1, 2, 3], prompt_cache)
+        fetched, rest = cache.fetch_nearest_cache(model, [1, 2, 4], consume=True)
+
+        self.assertIs(fetched, prompt_cache)
+        self.assertEqual(fetched[0].offset, 2)
+        self.assertEqual(rest, [4])
+        self.assertEqual(len(cache), 0)
+        self.assertEqual(cache.nbytes, 0)
+
     def test_lru(self):
         cache = LRUPromptCache(max_size=2)
         model = ("test", None, None)
@@ -824,6 +883,28 @@ class TestLRUPromptCache(unittest.TestCase):
         c, t = cache.fetch_nearest_cache(model, [3, 4])
         self.assertEqual(c, None)
         self.assertEqual(t, [3, 4])
+
+    def test_server_prompt_cache_honors_byte_limit(self):
+        model_provider = types.SimpleNamespace(
+            cli_args=types.SimpleNamespace(
+                prompt_cache_size=100,
+                prompt_cache_bytes=10,
+            )
+        )
+        cache = make_lru_prompt_cache(model_provider)
+        model = ("test", None, None)
+
+        cache.insert_cache(model, [1, 2], [MockCache("aaa")])
+        cache.insert_cache(model, [3, 4], [MockCache("bbb")])
+        cache.insert_cache(model, [4, 5], [MockCache("ccc")])
+        cache.insert_cache(model, [6, 7], [MockCache("ddd")])
+
+        self.assertEqual(len(cache), 3)
+        self.assertEqual(cache.nbytes, 9)
+
+        c, t = cache.fetch_nearest_cache(model, [1, 2])
+        self.assertEqual(c, None)
+        self.assertEqual(t, [1, 2])
 
 
 class TestMakeSampler(unittest.TestCase):


### PR DESCRIPTION
## Summary

- avoid deep-copying LRU prompt cache entries on the sequential server path by adding a consume mode to `fetch_nearest_cache`
- keep the existing deep-copy behavior as the default for other callers
- honor `--prompt-cache-bytes` when constructing the server prompt cache
- add tests for default copy semantics, consumed cache hits, trimmed longer hits, and server byte-limit wiring

Fixes #1395.
Addresses the byte-limit path discussed in #1390.

## Testing

- `.venv/bin/pre-commit run --files mlx_lm/models/cache.py mlx_lm/server.py tests/test_server.py`
- `.venv/bin/python -m unittest tests.test_server tests.test_prompt_cache`
- manual server run with `mlx-community/Qwen3.5-4B-MLX-8bit`, `--prompt-cache-bytes 1G`, and repeated long requests; prompt cache stayed bounded at 2 sequences / 0.71 GB without OOM