### PR TITLE
fix: merge config.json eos_token_id with tokenizer-derived value instead of replacing it

### DIFF
--- a/mlx_lm/tokenizer_utils.py
+++ b/mlx_lm/tokenizer_utils.py
@@ -300,11 +300,14 @@ class TokenizerWrapper:
     ):
         self._tokenizer = tokenizer
         self._detokenizer_class = detokenizer_class
-        self._eos_token_ids = (
-            set(eos_token_ids)
-            if eos_token_ids is not None
-            else {tokenizer.eos_token_id}
-        )
+        if eos_token_ids is not None:
+            self._eos_token_ids = set(
+                [eos_token_ids] if isinstance(eos_token_ids, int) else eos_token_ids
+            )
+        else:
+            self._eos_token_ids = set()
+        if tokenizer.eos_token_id is not None:
+            self._eos_token_ids.add(tokenizer.eos_token_id)
         (
             self._think_start,
             self._think_end,

--- a/mlx_lm/tokenizer_utils.py
+++ b/mlx_lm/tokenizer_utils.py
@@ -345,12 +345,7 @@ class TokenizerWrapper:
     ):
         self._tokenizer = tokenizer
         self._detokenizer_class = detokenizer_class
-        if eos_token_ids is not None:
-            self._eos_token_ids = set(
-                [eos_token_ids] if isinstance(eos_token_ids, int) else eos_token_ids
-            )
-        else:
-            self._eos_token_ids = set()
+        self._eos_token_ids = set(eos_token_ids or [])
         if tokenizer.eos_token_id is not None:
             self._eos_token_ids.add(tokenizer.eos_token_id)
         (


### PR DESCRIPTION
## Summary
`TokenizerWrapper.__init__` treats `eos_token_ids` passed in from `config.json`
as a hard replacement for whatever the tokenizer itself correctly derives.
When `config.json` has a stale value (common in third-party MLX-quantized repos),
the correct stop token is silently discarded, causing generation to never stop
at the right boundary. The real stop token (e.g. `<|im_end|>`) leaks into output
as plain text and the model keeps generating until max tokens.

## Root Cause
In `utils.py`, both `load()` and `sharded_load()` do:
```python
tokenizer = load_tokenizer(
    model_path, tokenizer_config, eos_token_ids=config.get("eos_token_id", None)
)
```
And `TokenizerWrapper.__init__` treats this as a strict replacement:
```python
self._eos_token_ids = (
    set(eos_token_ids)
    if eos_token_ids is not None
    else {tokenizer.eos_token_id}
)
```
So if `config.json` has a stale value, the tokenizer's own correct derivation
is silently thrown away with no warning.

## Fix
```python
if eos_token_ids is not None:
    self._eos_token_ids = set(
        [eos_token_ids] if isinstance(eos_token_ids, int) else eos_token_ids
    )
else:
    self._eos_token_ids = set()
if tokenizer.eos_token_id is not None:
    self._eos_token_ids.add(tokenizer.eos_token_id)
```

## Verified
Model: `mlx-community/Qwen2.5-Coder-7B-Instruct-4bit`, 16GB M1 Mac.
`config.json` has `eos_token_id: 151643` (`<|endoftext|>`, stale pretraining EOS).
Tokenizer correctly derives `151645` (`<|im_end|>`).
```python
# Before fix
Via load(): {151643}          # correct value silently replaced, generation never stops

# After fix
Via load(): {151643, 151645}  # both present, generation stops correctly
```
Real-world symptom: `<|im_end|>` no longer leaks into output when using
`mlx_lm.server` with this model. Generation speed returns to normal since
the model stops at the correct boundary instead of running to max tokens.

## Tests
203 tests pass. Black formatting check passed.