### PR TITLE
Add MiniMax-M3 tool-call parser

### DIFF
--- a/mlx_lm/tool_parsers/minimax_m3.py
+++ b/mlx_lm/tool_parsers/minimax_m3.py
@@ -21,9 +21,12 @@ payload, and walks each ``<invoke>`` block with ElementTree, mapping
 """
 
 import json
+import logging
 import re
 import xml.etree.ElementTree as ET
 from typing import Any
+
+logger = logging.getLogger(__name__)
 
 NAMESPACE_TOKEN: str = "]<]minimax[>["
 
@@ -101,10 +104,45 @@ def parse_tool_call(text: str, tools: list | None = None):
         try:
             root = ET.fromstring(f"<args>{body}</args>")
             args = _element_to_python(root)
-        except ET.ParseError:
-            args = {}
+        except ET.ParseError as e:
+            # Do NOT silently fall back to {} — that reaches the client as
+            # arguments: "{}", fails tool validation with no hint of why, and
+            # lets any narration the model emitted alongside the call stand
+            # as a phantom success. Surface an explicit error payload instead:
+            # the client's validation error echoes it back to the model,
+            # which can then retry with fixed args. Also log it so the server
+            # has primary evidence of M3 emitting malformed argument XML.
+            logger.warning(
+                "minimax_m3: malformed argument XML for invoke %r (%s); "
+                "raw body[:300]=%r", name, e, body[:300],
+            )
+            args = {
+                "__parse_error__": (
+                    f"MiniMax-M3 emitted malformed argument XML for tool "
+                    f"'{name}' ({e}). Re-issue this tool call with each "
+                    f"argument as a simple <key>value</key> tag. "
+                    f"Raw snippet: {body[:200]!r}"
+                )
+            }
         if not isinstance(args, dict):
-            args = {}
+            if args == "":
+                # Legitimate no-argument call, e.g. <invoke name="x"></invoke>
+                # (empty body parses to an empty scalar, not a dict).
+                args = {}
+            else:
+                logger.warning(
+                    "minimax_m3: arguments for invoke %r parsed to %s, not "
+                    "an object; body[:300]=%r",
+                    name, type(args).__name__, body[:300],
+                )
+                args = {
+                    "__parse_error__": (
+                        f"Arguments for tool '{name}' parsed to "
+                        f"{type(args).__name__} instead of an object. "
+                        f"Re-issue the call with named <key>value</key> "
+                        f"argument tags."
+                    )
+                }
         calls.append({"name": name, "arguments": args})
 
     if not calls:

--- a/mlx_lm/tool_parsers/minimax_m3.py
+++ b/mlx_lm/tool_parsers/minimax_m3.py
@@ -1,0 +1,114 @@
+"""Tool-call parser for MiniMax-M3.
+
+M3's chat template emits tool calls wrapped in a namespaced XML dialect:
+
+    ]<]minimax[>[<tool_call>
+    ]<]minimax[>[<invoke name="get_weather">
+    ]<]minimax[>[<location>Paris]<]minimax[>[</location>
+    ]<]minimax[>[<days>3]<]minimax[>[</days>
+    ]<]minimax[>[</invoke>
+    ]<]minimax[>[</tool_call>
+
+The ``]<]minimax[>[`` namespace token is prepended to every tag start/end.
+Arguments are rendered by the template's ``to_xml`` macro:
+  - mappings -> ``<key>value</key>`` children
+  - iterables -> ``<item>value</item>`` children
+  - primitives -> raw text (json-serialised for booleans)
+
+This module strips the namespace tokens, isolates the ``<tool_call>``
+payload, and walks each ``<invoke>`` block with ElementTree, mapping
+``<item>...</item>`` children to lists and everything else to dicts.
+"""
+
+import json
+import re
+import xml.etree.ElementTree as ET
+from typing import Any
+
+NAMESPACE_TOKEN: str = "]<]minimax[>["
+
+# What omlx searches for in the model output to detect "tool call starts here".
+# Must be exactly what the model emits, including the namespace token.
+tool_call_start: str = NAMESPACE_TOKEN + "<tool_call>"
+tool_call_end: str = NAMESPACE_TOKEN + "</tool_call>"
+
+_invoke_pattern = re.compile(
+    r'<invoke\s+name=(?:"([^"]+)"|\'([^\']+)\')\s*>(.*?)</invoke>',
+    re.DOTALL,
+)
+
+
+def _strip_namespace(text: str) -> str:
+    """Remove all M3 namespace prefix tokens, leaving clean XML."""
+    return text.replace(NAMESPACE_TOKEN, "")
+
+
+def _coerce_scalar(text: str) -> Any:
+    """Try JSON parse for primitives, fall back to the raw string."""
+    if text is None:
+        return ""
+    s = text.strip()
+    if not s:
+        return ""
+    try:
+        return json.loads(s)
+    except (ValueError, TypeError):
+        return s
+
+
+def _element_to_python(elem: ET.Element) -> Any:
+    """Recursively convert an XML element into a Python value.
+
+    Mirrors the M3 chat template's ``to_xml`` macro:
+      - all <item> children -> list
+      - other named children -> dict
+      - leaf -> scalar (json-coerced if possible)
+    """
+    children = list(elem)
+    if not children:
+        return _coerce_scalar(elem.text)
+
+    if all(c.tag == "item" for c in children):
+        return [_element_to_python(c) for c in children]
+
+    out: dict[str, Any] = {}
+    for c in children:
+        out[c.tag] = _element_to_python(c)
+    return out
+
+
+def parse_tool_call(text: str, tools: list | None = None):
+    """Parse M3's tool-call XML format into structured tool_calls.
+
+    Returns ``{"name": ..., "arguments": {...}}`` for a single call,
+    or a list of such dicts for multiple. Raises ``ValueError`` if no
+    ``<invoke>`` block is found (this signals omlx that the model
+    didn't actually emit a tool call here).
+    """
+    cleaned = _strip_namespace(text)
+
+    # If the <tool_call>...</tool_call> wrapper is present, narrow to it.
+    if "<tool_call>" in cleaned and "</tool_call>" in cleaned:
+        start = cleaned.find("<tool_call>") + len("<tool_call>")
+        end = cleaned.find("</tool_call>", start)
+        if end > start:
+            cleaned = cleaned[start:end]
+
+    calls = []
+    for m in _invoke_pattern.finditer(cleaned):
+        name = m.group(1) or m.group(2)
+        body = m.group(3) or ""
+        try:
+            root = ET.fromstring(f"<args>{body}</args>")
+            args = _element_to_python(root)
+        except ET.ParseError:
+            args = {}
+        if not isinstance(args, dict):
+            args = {}
+        calls.append({"name": name, "arguments": args})
+
+    if not calls:
+        raise ValueError("No tool call found")
+    if len(calls) == 1:
+        return calls[0]
+    return calls

--- a/tests/test_tool_parsing.py
+++ b/tests/test_tool_parsing.py
@@ -9,6 +9,7 @@ from mlx_lm.tool_parsers import (
     kimi_k2,
     longcat,
     minimax_m2,
+    minimax_m3,
     mistral,
     pythonic,
     qwen3_coder,
@@ -36,6 +37,15 @@ class TestToolParsing(unittest.TestCase):
             (
                 '<invoke name="multiply">\n<parameter name="a">12234585</parameter>\n<parameter name="b">48838483920</parameter>\n</invoke>',
                 minimax_m2,
+            ),
+            (
+                ']<]minimax[>[<tool_call>'
+                ']<]minimax[>[<invoke name="multiply">'
+                ']<]minimax[>[<a>12234585]<]minimax[>[</a>'
+                ']<]minimax[>[<b>48838483920]<]minimax[>[</b>'
+                ']<]minimax[>[</invoke>'
+                ']<]minimax[>[</tool_call>',
+                minimax_m3,
             ),
             (
                 "<function=multiply>\n<parameter=a>\n12234585\n</parameter>\n<parameter=b>\n48838483920\n</parameter>\n</function>",
@@ -106,6 +116,14 @@ class TestToolParsing(unittest.TestCase):
             (
                 '<invoke name="get_current_temperature">\n<parameter name="location">London</parameter>\n</invoke>',
                 minimax_m2,
+            ),
+            (
+                ']<]minimax[>[<tool_call>'
+                ']<]minimax[>[<invoke name="get_current_temperature">'
+                ']<]minimax[>[<location>London]<]minimax[>[</location>'
+                ']<]minimax[>[</invoke>'
+                ']<]minimax[>[</tool_call>',
+                minimax_m3,
             ),
             (
                 "<function=get_current_temperature>\n<parameter=location>\nLondon\n</parameter>\n</function>",
@@ -328,6 +346,73 @@ class TestToolParsing(unittest.TestCase):
         ]
         tool_calls = minimax_m2.parse_tool_call(test_case, None)
         self.assertEqual(expected, tool_calls)
+
+    def test_minimax_m3(self):
+        # Multiple tool calls in a single <tool_call> block (M3 wraps all
+        # invokes in one wrapper per its chat template instructions).
+        test_case = (
+            ']<]minimax[>[<tool_call>'
+            ']<]minimax[>[<invoke name="search">'
+            ']<]minimax[>[<query>weather]<]minimax[>[</query>'
+            ']<]minimax[>[</invoke>'
+            ']<]minimax[>[<invoke name="read_file">'
+            ']<]minimax[>[<path>/tmp/test.txt]<]minimax[>[</path>'
+            ']<]minimax[>[</invoke>'
+            ']<]minimax[>[</tool_call>'
+        )
+        expected = [
+            {"name": "search", "arguments": {"query": "weather"}},
+            {"name": "read_file", "arguments": {"path": "/tmp/test.txt"}},
+        ]
+        tool_calls = minimax_m3.parse_tool_call(test_case, None)
+        self.assertEqual(expected, tool_calls)
+
+        # Nested array of objects (mapping renders <key>val</key>;
+        # iterable renders <item>...</item> per M3's to_xml macro).
+        test_case = (
+            ']<]minimax[>[<tool_call>'
+            ']<]minimax[>[<invoke name="filter">'
+            ']<]minimax[>[<rules>'
+            ']<]minimax[>[<item>'
+            ']<]minimax[>[<field>city]<]minimax[>[</field>'
+            ']<]minimax[>[<value>Paris]<]minimax[>[</value>'
+            ']<]minimax[>[</item>'
+            ']<]minimax[>[<item>'
+            ']<]minimax[>[<field>year]<]minimax[>[</field>'
+            ']<]minimax[>[<value>2026]<]minimax[>[</value>'
+            ']<]minimax[>[</item>'
+            ']<]minimax[>[</rules>'
+            ']<]minimax[>[</invoke>'
+            ']<]minimax[>[</tool_call>'
+        )
+        expected = {
+            "name": "filter",
+            "arguments": {
+                "rules": [
+                    {"field": "city", "value": "Paris"},
+                    {"field": "year", "value": 2026},
+                ]
+            },
+        }
+        tool_call = minimax_m3.parse_tool_call(test_case, None)
+        self.assertEqual(expected, tool_call)
+
+        # Conversational prefix before the tool call (model often emits a
+        # short "I'll do X..." sentence before the <tool_call> wrapper).
+        test_case = (
+            "I'll look up the current time for you."
+            ']<]minimax[>[<tool_call>'
+            ']<]minimax[>[<invoke name="get_time">'
+            ']<]minimax[>[</invoke>'
+            ']<]minimax[>[</tool_call>'
+        )
+        expected = {"name": "get_time", "arguments": {}}
+        tool_call = minimax_m3.parse_tool_call(test_case, None)
+        self.assertEqual(expected, tool_call)
+
+        # No tool call in the text should raise ValueError.
+        with self.assertRaises(ValueError):
+            minimax_m3.parse_tool_call("just plain text, no tool call", None)
 
 
 if __name__ == "__main__":

--- a/tests/test_tool_parsing.py
+++ b/tests/test_tool_parsing.py
@@ -414,6 +414,35 @@ class TestToolParsing(unittest.TestCase):
         with self.assertRaises(ValueError):
             minimax_m3.parse_tool_call("just plain text, no tool call", None)
 
+        # Malformed argument XML must NOT silently become {} — that reaches
+        # OpenAI-compat clients as arguments: "{}", fails tool validation
+        # with no reason, and any narration the model emitted alongside the
+        # call stands as a phantom success. The parser surfaces an explicit
+        # __parse_error__ payload instead so the calling harness/model can
+        # see why and retry (observed in production agent loops).
+        test_case = (
+            ']<]minimax[>[<tool_call>'
+            ']<]minimax[>[<invoke name="exec">'
+            ']<]minimax[>[<command>ls & rm <oops'
+            ']<]minimax[>[</invoke>'
+            ']<]minimax[>[</tool_call>'
+        )
+        tool_call = minimax_m3.parse_tool_call(test_case, None)
+        self.assertEqual("exec", tool_call["name"])
+        self.assertIn("__parse_error__", tool_call["arguments"])
+
+        # Top-level non-object arguments (bare <item> list) also surface
+        # __parse_error__ — OpenAI arguments must be an object.
+        test_case = (
+            ']<]minimax[>[<tool_call>'
+            ']<]minimax[>[<invoke name="exec">'
+            ']<]minimax[>[<item>a]<]minimax[>[</item>'
+            ']<]minimax[>[</invoke>'
+            ']<]minimax[>[</tool_call>'
+        )
+        tool_call = minimax_m3.parse_tool_call(test_case, None)
+        self.assertIn("__parse_error__", tool_call["arguments"])
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary

Adds `mlx_lm/tool_parsers/minimax_m3.py`, a tool-call parser for **MiniMax-M3**.

M3 emits tool calls in a namespaced XML dialect: the token `]<]minimax[>[` is prepended to every tag start/end inside a `<tool_call>...</tool_call>` wrapper. Arguments are rendered by the chat template's `to_xml` macro:

- **mappings** → `<key>value</key>` children
- **iterables** → `<item>value</item>` children
- **primitives** → raw text (json-serialised booleans)

A representative output the model emits:

```
I'll check the time.]<]minimax[>[<tool_call>
]<]minimax[>[<invoke name="get_weather">
]<]minimax[>[<location>Paris]<]minimax[>[</location>
]<]minimax[>[<days>3]<]minimax[>[</days>
]<]minimax[>[</invoke>
]<]minimax[>[</tool_call>
```

Without a matching parser, omlx / `mlx_lm.server` currently returns this raw XML inside the `content` field with `tool_calls: null` and `finish_reason: "stop"` (the existing tokenizer_config's `tool_parser_type: "json_tools"` doesn't apply — M3 isn't JSON-formatted).

## Implementation

The parser:

1. Strips all `]<]minimax[>[` namespace tokens, leaving clean XML
2. Narrows to the `<tool_call>...</tool_call>` payload if the wrapper is present
3. Regex-matches each `<invoke name="…">…</invoke>` block
4. Wraps each invoke's body and parses it with `xml.etree.ElementTree`
5. Recursively converts elements: `<item>...</item>` children → list, other named children → dict, leaf → JSON-coerced scalar

Stdlib only (`json`, `re`, `xml.etree.ElementTree`), no `regex` dependency needed. ~115 lines.

## Companion to #1401

This PR pairs with #1401 (Add MiniMax-M3 text backbone). With both merged, omlx / `mlx_lm.server` will load M3 *and* return structured `tool_calls` instead of leaking the XML through `content`. The two PRs are otherwise independent — this parser can land first or last.

The MLX-community M3 quants (e.g. `mlx-community/MiniMax-M3-4bit`, `pipenetwork/MiniMax-M3-MLX-{4,5,6,8}bit`) ship a `tokenizer_config.json` that declares `tool_parser_type: "json_tools"` — that's incorrect for the model's actual format. We've verified locally by editing those configs to `tool_parser_type: "minimax_m3"` and confirming structured tool calls flow end-to-end. A follow-up issue/PR to MLX-community to fix the metadata may also be appropriate.

## Tests

Adds entries to `tests/test_tool_parsing.py`:

- M3 case added to both `test_parsers` lists (standard `multiply(a, b)` and `get_current_temperature(location)`)
- New `test_minimax_m3` method covering M3-specific behaviors:
  - Multiple invokes in a single `<tool_call>` wrapper (per M3's chat template instructions)
  - Nested array-of-objects arguments (`<rules>[<item><field>...</field><value>...</value></item>, ...]</rules>`)
  - Conversational prefix before the wrapper (the model often emits a short "I'll do X…" sentence before the tool call)
  - No-tool-call input correctly raises `ValueError`

All six checks verified locally against a live M3 6-bit deployment.

## Test plan

- [x] Standard parser test (`test_parsers`) includes M3 entries for multiply + get_current_temperature
- [x] Dedicated `test_minimax_m3` for multi-invoke, nested args, prefix text, and the no-call ValueError path
- [x] End-to-end validation against `pipenetwork/MiniMax-M3-MLX-6bit` running under omlx — confirmed `tool_calls` field populated with correct `name` + `arguments`, `content: null`, `finish_reason: "tool_calls"`