### PR TITLE
Fix: qwen3_coder drops tool calls with float-formatted integer args

### DIFF
--- a/mlx_lm/tool_parsers/qwen3_coder.py
+++ b/mlx_lm/tool_parsers/qwen3_coder.py
@@ -54,7 +54,7 @@ def _convert_param_value(param_value: str, param_name: str, param_config: dict) 
         or param_type.startswith("short")
         or param_type.startswith("unsigned")
     ):
-        return int(param_value)
+        return int(float(param_value))
     elif param_type.startswith("num") or param_type.startswith("float"):
         float_param_value = float(param_value)
         int_param_value = int(float_param_value)

--- a/mlx_lm/tool_parsers/qwen3_coder.py
+++ b/mlx_lm/tool_parsers/qwen3_coder.py
@@ -54,7 +54,11 @@ def _convert_param_value(param_value: str, param_name: str, param_config: dict) 
         or param_type.startswith("short")
         or param_type.startswith("unsigned")
     ):
-        return int(float(param_value))
+        float_param_value = float(param_value)
+        int_param_value = int(float_param_value)
+        if float_param_value - int_param_value != 0:
+            raise ValueError(f"Invalid integer literal {param_value!r}")
+        return int_param_value
     elif param_type.startswith("num") or param_type.startswith("float"):
         float_param_value = float(param_value)
         int_param_value = int(float_param_value)


### PR DESCRIPTION
`mlx_lm/tool_parsers/qwen3_coder.py` `_convert_param_value` coerces integer-typed tool arguments with bare `int(param_value)`. Models frequently emit integer arguments float-formatted (e.g. `offset="230.0"`), so `int("230.0")` raises `ValueError: invalid literal for int() with base 10: '230.0'`.

`server.py`'s `ToolCallFormatter.__call__` catches that ValueError and `continue`s, **silently dropping the otherwise-valid tool call** and logging a misleading "tool text was likely truncated mid-generation" warning. The result is a response with `finish_reason="tool_calls"` and an empty `tool_calls` array, which stalls tool-using agents. This is hard to diagnose because the warning points at the wrong cause and the model output is actually complete and correct.