### PR TITLE
feat: add batch_generate_same_prompt for SSM/hybrid models

### DIFF
--- a/mlx_lm/__init__.py
+++ b/mlx_lm/__init__.py
@@ -7,13 +7,14 @@ from ._version import __version__
 os.environ["TRANSFORMERS_NO_ADVISORY_WARNINGS"] = "1"
 
 from .convert import convert
-from .generate import batch_generate, generate, stream_generate
+from .generate import batch_generate, batch_generate_same_prompt, generate, stream_generate
 from .utils import load
 
 __all__ = [
     "__version__",
     "convert",
     "batch_generate",
+    "batch_generate_same_prompt",
     "generate",
     "stream_generate",
     "load",

--- a/mlx_lm/generate.py
+++ b/mlx_lm/generate.py
@@ -1984,6 +1984,153 @@ def batch_generate(
     return BatchResponse(texts, stats, caches, token_ids, logprobs)
 
 
+def batch_generate_same_prompt(
+    model: nn.Module,
+    tokenizer: Union[PreTrainedTokenizer, TokenizerWrapper],
+    prompt: Union[str, List[int]],
+    num_completions: int = 4,
+    max_tokens: int = 256,
+    sampler: Optional[Callable[[mx.array], mx.array]] = None,
+    verbose: bool = False,
+) -> BatchResponse:
+    """
+    Generate multiple completions from the same prompt in a single batched
+    forward pass.
+
+    Unlike :func:`batch_generate` which uses continuous batching (optimal for
+    transformers with heterogeneous prompts), this function exploits the fact
+    that all sequences share the same prompt. It prefills once with batch
+    dimension K, then decodes K tokens per step in one ``model()`` call.
+
+    This is particularly effective for SSM/hybrid models (Mamba, Nemotron-H,
+    Jamba) where continuous batching adds overhead, and for RL workloads (GRPO,
+    RLOO, PPO) that generate K rollouts from the same prompt.
+
+    Args:
+        model (nn.Module): The language model.
+        tokenizer: The tokenizer.
+        prompt (Union[str, List[int]]): The input prompt string or token IDs.
+        num_completions (int): Number of completions to generate (K).
+            Default: ``4``.
+        max_tokens (int): Maximum tokens per completion. Default: ``256``.
+        sampler (Callable, optional): Sampling function that takes log
+            probabilities and returns a token. If None, uses greedy (argmax).
+            Default: ``None``.
+        verbose (bool): Print timing stats. Default: ``False``.
+
+    Returns:
+        BatchResponse: Contains ``texts``, ``token_ids``, ``logprobs``, and
+            ``stats``. Each list has length ``num_completions``.
+    """
+    if not isinstance(tokenizer, TokenizerWrapper):
+        tokenizer = TokenizerWrapper(tokenizer)
+
+    if isinstance(prompt, str):
+        add_special_tokens = tokenizer.bos_token is None or not prompt.startswith(
+            tokenizer.bos_token
+        )
+        prompt = tokenizer.encode(prompt, add_special_tokens=add_special_tokens)
+
+    K = num_completions
+    eos_ids = set(tokenizer.eos_token_ids)
+    sampler = sampler or (lambda x: mx.argmax(x, axis=-1))
+
+    # Duplicate prompt K times for batched prefill
+    prompt_arr = mx.array([prompt] * K)  # [K, prompt_len]
+
+    tic = time.perf_counter()
+
+    # Prefill — process entire prompt for all K sequences at once
+    prompt_cache = cache.make_prompt_cache(model)
+    with mx.stream(generation_stream):
+        logits = model(prompt_arr, cache=prompt_cache)
+        logits = logits[:, -1, :]  # [K, V]
+
+    mx.eval([c.state for c in prompt_cache])
+    prompt_time = time.perf_counter() - tic
+    tic = time.perf_counter()
+
+    # Decode — generate K tokens per step in one forward pass
+    active = [True] * K
+    generated = [[] for _ in range(K)]
+    all_logprobs = [[] for _ in range(K)]
+
+    for step in range(max_tokens):
+        with mx.stream(generation_stream):
+            # Log-probabilities
+            log_probs = logits - mx.logsumexp(logits, axis=-1, keepdims=True)
+
+            # Sample — apply sampler per sequence
+            tokens = mx.concatenate(
+                [sampler(log_probs[i : i + 1]) for i in range(K)]
+            )  # [K]
+        mx.eval(tokens, log_probs)
+
+        tok_list = tokens.tolist()
+        any_active = False
+
+        for i in range(K):
+            if not active[i]:
+                continue
+            token_id = tok_list[i]
+            token_logp = log_probs[i, token_id].item()
+
+            if token_id in eos_ids:
+                active[i] = False
+                continue
+
+            generated[i].append(token_id)
+            all_logprobs[i].append(token_logp)
+            any_active = True
+
+        if not any_active:
+            break
+
+        # Next step — feed all K tokens through model at once
+        with mx.stream(generation_stream):
+            logits = model(tokens.reshape(K, 1), cache=prompt_cache)
+            logits = logits[:, -1, :]
+        mx.eval(logits)
+
+        if step % 256 == 0:
+            mx.clear_cache()
+
+    gen_time = time.perf_counter() - tic
+    total_tokens = sum(len(g) for g in generated)
+
+    # Decode texts
+    texts = [tokenizer.decode(g) for g in generated]
+
+    stats = BatchStats(
+        prompt_tokens=len(prompt) * K,
+        prompt_tps=(len(prompt) * K) / prompt_time if prompt_time > 0 else 0,
+        prompt_time=prompt_time,
+        generation_tokens=total_tokens,
+        generation_tps=total_tokens / gen_time if gen_time > 0 else 0,
+        generation_time=gen_time,
+        peak_memory=mx.get_peak_memory() / 1e9,
+    )
+
+    if verbose:
+        print(
+            f"[batch_generate_same_prompt] Prompt: {len(prompt)} tokens, "
+            f"{stats.prompt_tps:.0f} tok/s"
+        )
+        print(
+            f"[batch_generate_same_prompt] Decode: {total_tokens} tokens "
+            f"({K} seqs), {stats.generation_tps:.0f} tok/s"
+        )
+        print(f"[batch_generate_same_prompt] Peak memory: {stats.peak_memory:.3f} GB")
+
+    return BatchResponse(
+        texts=texts,
+        stats=stats,
+        caches=None,
+        token_ids=generated,
+        logprobs=all_logprobs,
+    )
+
+
 def main():
     parser = setup_arg_parser()
     args = parser.parse_args()

--- a/tests/test_generate.py
+++ b/tests/test_generate.py
@@ -847,6 +847,74 @@ class TestGenerate(unittest.TestCase):
         self.assertIsNone(response.logprobs)
         self.assertIsNone(response.token_ids)
 
+    def test_batch_same_prompt_basic(self):
+        """Test that batch_generate_same_prompt returns K completions."""
+        from mlx_lm.generate import batch_generate_same_prompt
+
+        prompt = self.tokenizer.apply_chat_template(
+            [{"role": "user", "content": "Hi"}],
+            tokenize=True,
+            add_generation_prompt=True,
+        )
+        response = batch_generate_same_prompt(
+            self.model,
+            self.tokenizer,
+            prompt=prompt,
+            num_completions=4,
+            max_tokens=5,
+        )
+        self.assertEqual(len(response.texts), 4)
+        self.assertIsNotNone(response.token_ids)
+        self.assertEqual(len(response.token_ids), 4)
+        for tids in response.token_ids:
+            self.assertGreater(len(tids), 0)
+            self.assertLessEqual(len(tids), 5)
+
+    def test_batch_same_prompt_logprobs(self):
+        """Test that logprobs are returned and valid."""
+        from mlx_lm.generate import batch_generate_same_prompt
+
+        prompt = self.tokenizer.apply_chat_template(
+            [{"role": "user", "content": "Count to 3"}],
+            tokenize=True,
+            add_generation_prompt=True,
+        )
+        response = batch_generate_same_prompt(
+            self.model,
+            self.tokenizer,
+            prompt=prompt,
+            num_completions=2,
+            max_tokens=5,
+        )
+        self.assertIsNotNone(response.logprobs)
+        self.assertEqual(len(response.logprobs), 2)
+        for lps, tids in zip(response.logprobs, response.token_ids):
+            self.assertEqual(len(lps), len(tids))
+            for lp in lps:
+                self.assertLessEqual(lp, 0.0)
+
+    def test_batch_same_prompt_deterministic_with_temp_zero(self):
+        """With temp=0, all K completions should be identical."""
+        from mlx_lm.generate import batch_generate_same_prompt
+        from mlx_lm.sample_utils import make_sampler
+
+        prompt = self.tokenizer.apply_chat_template(
+            [{"role": "user", "content": "Hello"}],
+            tokenize=True,
+            add_generation_prompt=True,
+        )
+        response = batch_generate_same_prompt(
+            self.model,
+            self.tokenizer,
+            prompt=prompt,
+            num_completions=3,
+            max_tokens=5,
+            sampler=make_sampler(temp=0.0),
+        )
+        # All completions should be the same with greedy decoding
+        self.assertEqual(response.texts[0], response.texts[1])
+        self.assertEqual(response.texts[1], response.texts[2])
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary

Add `batch_generate_same_prompt()` — generates K completions from one prompt in a single batched forward pass. Reads model weights once per decode step instead of K times.

## Motivation

For RL training (GRPO, RLOO, PPO) each step generates K=8-16 rollouts from the same prompt. Generation is the dominant cost (~91% of step time, profiled with mlx-tracer).

`batch_generate()` uses continuous batching which adds overhead for SSM/hybrid models (cache extract/merge per finished sequence). This function exploits the shared-prompt structure instead.

## Benchmark (M4 Max 64GB, Nemotron-H 30B 4-bit)

| Method | K=8, 512 tokens | Speedup |
|--------|-----------------|---------|
| Sequential (`generate()` × K) | 72s | 1× |
| `batch_generate()` (continuous batching) | slower | 0.4× ❌ |
| **`batch_generate_same_prompt()`** | **24s** | **3×** ✅ |

## API

```python
from mlx_lm.generate import batch_generate_same_prompt
from mlx_lm.sample_utils import make_sampler

response = batch_generate_same_prompt(
    model, tokenizer,
    prompt=token_ids,
    num_completions=8,
    max_tokens=1024,
    sampler=make_sampler(temp=1.0),
)
# response.texts, response.token_ids, response.logprobs
```

## Changes

- `mlx_lm/generate.py`: +147 lines (new function)
- `mlx_lm/__init__.py`: export
- `tests/test_generate.py`: 3 tests (basic, logprobs, deterministic)

Closes #1403