### PR TITLE
fix: memory leak in cache fetching (#1395)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -137,3 +137,6 @@ dmypy.json
 
 # .DS_Store files
 .DS_Store
+
+# Claude workspace
+.claude/

--- a/mlx_lm/models/cache.py
+++ b/mlx_lm/models/cache.py
@@ -1671,25 +1671,36 @@ class LRUPromptCache:
     def nbytes(self):
         return self._n_bytes
 
-    def fetch_nearest_cache(self, model: Any, tokens: List[int]):
+    def fetch_nearest_cache(
+        self, model: Any, tokens: List[int], pop: bool = False
+    ):
         result = self._trie.search(model, tokens)
+
+        def _fetch(key_tokens: List[int], cached_entry=None) -> List[Any]:
+            if pop:
+                entry = self._trie.pop(result.model, key_tokens)
+                self._n_bytes -= entry.nbytes
+                self._n_bytes_by_type[entry.cache_type] -= entry.nbytes
+                self._lru.remove(result.model, key_tokens)
+                return entry.prompt_cache
+            e = cached_entry or self._trie.get(result.model, key_tokens)
+            return copy.deepcopy(e.prompt_cache)
+
         if result.exact is not None:
-            cache_entry = self._trie.get(result.model, result.exact)
-            return copy.deepcopy(cache_entry.prompt_cache), []
+            return _fetch(result.exact), []
 
         short_length = len(result.shorter) if result.shorter is not None else 0
         if result.longer is not None and result.common_prefix > short_length:
             cache_entry = self._trie.get(result.model, result.longer)
             if can_trim_prompt_cache(cache_entry.prompt_cache):
-                cache = copy.deepcopy(cache_entry.prompt_cache)
+                cache = _fetch(result.longer, cache_entry)
                 prefix = min(len(tokens) - 1, result.common_prefix)
                 num_to_trim = len(result.longer) - prefix
                 trim_prompt_cache(cache, num_to_trim)
                 return cache, tokens[prefix:]
 
         if short_length > 0:
-            cache_entry = self._trie.get(result.model, result.shorter)
-            return copy.deepcopy(cache_entry.prompt_cache), tokens[short_length:]
+            return _fetch(result.shorter), tokens[short_length:]
 
         return None, tokens
 

--- a/mlx_lm/server.py
+++ b/mlx_lm/server.py
@@ -751,7 +751,7 @@ class ResponseGenerator:
 
                     self._log_cache_stats()
                     cache, rest = self.prompt_cache.fetch_nearest_cache(
-                        current_model_key, prompt
+                        current_model_key, prompt, pop=True
                     )
                     prompt_cache_count = len(prompt) - len(rest)
                     N = prompt_cache_count
@@ -926,6 +926,9 @@ class ResponseGenerator:
         def progress(tokens_processed, tokens_total):
             rqueue.put((tokens_processed, tokens_total))
 
+        cache = None
+        cache_key = None
+        cache_was_popped = False
         try:
             # Load the model and tokenizer
             model = self.model_provider.model
@@ -963,8 +966,9 @@ class ResponseGenerator:
             # Load the KV cache
             self._log_cache_stats()
             cache, rest = self.prompt_cache.fetch_nearest_cache(
-                self.model_provider.model_key, prompt
+                self.model_provider.model_key, prompt, pop=True
             )
+            cache_was_popped = cache is not None
             ctx.prompt_cache_count = len(prompt) - len(rest)
             cache_key = prompt[:]
             if cache is None:
@@ -1022,6 +1026,10 @@ class ResponseGenerator:
 
         except Exception as e:
             rqueue.put(e)
+            if cache_was_popped:
+                self.prompt_cache.insert_cache(
+                    self.model_provider.model_key, cache_key, cache
+                )
 
     def generate(
         self,

--- a/mlx_lm/utils.py
+++ b/mlx_lm/utils.py
@@ -15,10 +15,12 @@ from typing import (
     Callable,
     Dict,
     List,
+    Literal,
     Optional,
     Tuple,
     Type,
     Union,
+    overload,
 )
 
 import mlx.core as mx
@@ -462,6 +464,48 @@ def load_tokenizer(model_path, tokenizer_config_extra=None, eos_token_ids=None):
         tokenizer_config_extra,
         eos_token_ids=eos_token_ids,
     )
+
+
+@overload
+def load(
+    path_or_hf_repo: str,
+    tokenizer_config: Optional[Dict[str, Any]] = None,
+    model_config: Optional[Dict[str, Any]] = None,
+    adapter_path: Optional[str] = None,
+    lazy: bool = False,
+    return_config: Literal[False] = False,
+    revision: Optional[str] = None,
+    trust_remote_code: bool = False,
+) -> Tuple[nn.Module, TokenizerWrapper]: ...
+
+
+@overload
+def load(
+    path_or_hf_repo: str,
+    tokenizer_config: Optional[Dict[str, Any]] = None,
+    model_config: Optional[Dict[str, Any]] = None,
+    adapter_path: Optional[str] = None,
+    lazy: bool = False,
+    return_config: Literal[True] = ...,
+    revision: Optional[str] = None,
+    trust_remote_code: bool = False,
+) -> Tuple[nn.Module, TokenizerWrapper, Dict[str, Any]]: ...
+
+
+@overload
+def load(
+    path_or_hf_repo: str,
+    tokenizer_config: Optional[Dict[str, Any]] = None,
+    model_config: Optional[Dict[str, Any]] = None,
+    adapter_path: Optional[str] = None,
+    lazy: bool = False,
+    return_config: bool = False,
+    revision: Optional[str] = None,
+    trust_remote_code: bool = False,
+) -> Union[
+    Tuple[nn.Module, TokenizerWrapper],
+    Tuple[nn.Module, TokenizerWrapper, Dict[str, Any]],
+]: ...
 
 
 def load(

--- a/tests/test_prompt_cache.py
+++ b/tests/test_prompt_cache.py
@@ -768,6 +768,45 @@ class TestPromptCache(unittest.TestCase):
         expected = create_causal_mask(1, offset=32, window_size=4)
         self.assertTrue(mx.array_equal(mask, expected))
 
+    def test_lru_prompt_cache_pop(self):
+        from mlx_lm.models.cache import LRUPromptCache, KVCache
+
+        lru = LRUPromptCache()
+        model_key = "test_model"
+
+        # 1. Test exact match with pop
+        tokens = [1, 2, 3]
+        c1 = KVCache()
+        c1.update_and_fetch(mx.zeros((1, 1, 3, 4)), mx.zeros((1, 1, 3, 4)))
+        lru.insert_cache(model_key, tokens, [c1])
+        self.assertEqual(len(lru), 1)
+
+        # Fetch without pop
+        cache, rest = lru.fetch_nearest_cache(model_key, tokens)
+        self.assertIsNotNone(cache)
+        self.assertEqual(len(lru), 1)
+
+        # Fetch with pop
+        cache, rest = lru.fetch_nearest_cache(model_key, tokens, pop=True)
+        self.assertIsNotNone(cache)
+        self.assertEqual(len(lru), 0)  # LRU is emptied
+        self.assertEqual(lru.nbytes, 0) # Memory bytes removed
+
+        # 2. Test longer prefix with pop (trimming)
+        tokens_longer = [1, 2, 3, 4, 5]
+        c2 = KVCache()
+        c2.update_and_fetch(mx.zeros((1, 1, 5, 4)), mx.zeros((1, 1, 5, 4)))
+        lru.insert_cache(model_key, tokens_longer, [c2])
+        self.assertEqual(len(lru), 1)
+
+        # Fetch shorter prompt from longer cache
+        cache, rest = lru.fetch_nearest_cache(model_key, [1, 2, 3], pop=True)
+        self.assertIsNotNone(cache)
+        self.assertEqual(rest, [3])
+        self.assertEqual(cache[0].offset, 2) # Verify cache was trimmed to prefix len 2
+        self.assertEqual(len(lru), 0) # LRU is emptied
+        self.assertEqual(lru.nbytes, 0) # Memory bytes removed
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
Resolves memory spike issue #1395 by adding `pop=True` to `fetch_nearest_cache`, enabling move semantics to prevent copy-on-write overhead during generation. Includes test coverage for cache popping.