### PR TITLE
Fix speculative decode with full rotating caches

### DIFF
--- a/mlx_lm/generate.py
+++ b/mlx_lm/generate.py
@@ -595,11 +595,11 @@ def speculative_generate_step(
             if not c.is_trimmable():
                 return 0
 
-            max_size = getattr(c, "max_size", None)
-            offset = getattr(c, "offset", None)
-            if max_size is None or offset is None:
+            if not isinstance(c, (RotatingKVCache, BatchRotatingKVCache)):
                 continue
 
+            max_size = c.max_size
+            offset = c._offset if isinstance(c, BatchRotatingKVCache) else c.offset
             if hasattr(offset, "item"):
                 offset = offset.item()
             # Rotating caches stop being trimmable once the window fills, so

--- a/mlx_lm/generate.py
+++ b/mlx_lm/generate.py
@@ -590,6 +590,25 @@ def speculative_generate_step(
         cache.trim_prompt_cache(model_cache, num_draft - num_accept)
         cache.trim_prompt_cache(draft_cache, max(num_draft - num_accept - 1, 0))
 
+    def _limit_draft_tokens(prompt_cache, num_draft, extra_target_tokens):
+        for c in prompt_cache:
+            if not c.is_trimmable():
+                return 0
+
+            max_size = getattr(c, "max_size", None)
+            offset = getattr(c, "offset", None)
+            if max_size is None or offset is None:
+                continue
+
+            if hasattr(offset, "item"):
+                offset = offset.item()
+            # Rotating caches stop being trimmable once the window fills, so
+            # only draft while a verifier rejection can still be rewound.
+            rollback_safe = max_size - int(offset) - extra_target_tokens - 1
+            num_draft = min(num_draft, rollback_safe)
+
+        return max(num_draft, 0)
+
     def _draft_generate(y, num_draft):
         if num_draft == 0:
             return mx.array([], mx.uint32)
@@ -611,6 +630,8 @@ def speculative_generate_step(
     try:
         while True:
             num_draft = min(max_tokens - ntoks, num_draft_tokens)
+            num_draft = _limit_draft_tokens(model_cache, num_draft, 1)
+            num_draft = _limit_draft_tokens(draft_cache, num_draft, 0)
             draft_tokens = _draft_generate(draft_y, num_draft)
             if prev_tokens is not None:
                 prev_tokens = prev_tokens[: prev_tokens.size - y.size - num_draft + 1]

--- a/tests/test_generate.py
+++ b/tests/test_generate.py
@@ -13,11 +13,85 @@ from mlx_lm.generate import (
     batch_generate,
     generate,
     generate_step,
+    speculative_generate_step,
     stream_generate,
 )
 from mlx_lm.models.cache import KVCache, RotatingKVCache
 from mlx_lm.sample_utils import make_logits_processors, make_sampler
 from mlx_lm.utils import load
+
+
+class _OffsetTokenModel:
+    def __init__(self, bias=0, max_cache_size=3, vocab_size=16):
+        self.bias = bias
+        self.max_cache_size = max_cache_size
+        self.vocab_size = vocab_size
+        self.layers = [object()]
+
+    def make_cache(self):
+        return [RotatingKVCache(max_size=self.max_cache_size)]
+
+    def __call__(self, tokens, cache):
+        cache_entry = cache[0]
+        offset = int(cache_entry.offset)
+        batch_size, seq_len = tokens.shape
+
+        logits = []
+        for _ in range(batch_size):
+            batch_logits = []
+            for i in range(seq_len):
+                token = (offset + i + self.bias) % self.vocab_size
+                row = [-1000.0] * self.vocab_size
+                row[token] = 0.0
+                batch_logits.append(row)
+            logits.append(batch_logits)
+
+        state = mx.zeros((batch_size, 1, seq_len, 1), dtype=mx.float32)
+        cache_entry.update_and_fetch(state, state)
+        return mx.array(logits, dtype=mx.float32)
+
+
+class TestSpeculativeGenerateStep(unittest.TestCase):
+    def test_draft_tokens_are_used_when_rotating_cache_can_rollback(self):
+        results = list(
+            speculative_generate_step(
+                mx.array([1, 2], dtype=mx.uint32),
+                _OffsetTokenModel(max_cache_size=10),
+                _OffsetTokenModel(max_cache_size=10),
+                num_draft_tokens=2,
+                max_tokens=5,
+            )
+        )
+
+        self.assertEqual(
+            [from_draft for _, _, from_draft in results],
+            [True, True, False, True, True],
+        )
+
+    def test_rotating_cache_falls_back_when_rollback_is_not_safe(self):
+        prompt = mx.array([1, 2], dtype=mx.uint32)
+
+        expected = [
+            token
+            for token, _ in generate_step(
+                prompt,
+                _OffsetTokenModel(max_cache_size=3),
+                max_tokens=4,
+            )
+        ]
+
+        results = list(
+            speculative_generate_step(
+                prompt,
+                _OffsetTokenModel(max_cache_size=3),
+                _OffsetTokenModel(bias=1, max_cache_size=3),
+                num_draft_tokens=2,
+                max_tokens=4,
+            )
+        )
+
+        self.assertEqual([token for token, _, _ in results], expected)
+        self.assertEqual([from_draft for _, _, from_draft in results], [False] * 4)
 
 
 class TestGenerate(unittest.TestCase):


### PR DESCRIPTION
## Summary

Speculative decoding can diverge from deterministic non-speculative generation when a `RotatingKVCache` reaches the point where it can no longer be trimmed. If a drafted token is rejected after that point, the existing rewind path cannot remove the speculative cache entries.

This limits draft length around full rotating caches and falls back to target-only generation when rollback is not safe. Other trimmable cache types keep their existing speculative path.

Fixes #1423.

## Tests

- `uv run --isolated --python 3.12 --with-editable . --with pytest python -m pytest tests/test_generate.py::TestSpeculativeGenerateStep tests/test_generate.py::TestGenerate::test_stream_generate_speculative -q`
- `python3 -m py_compile mlx_lm/generate.py tests/test_generate.py`
- `git diff --check HEAD~2..HEAD`
