### PR TITLE
server: add --lazy CLI flag for deferred model loading

### DIFF
--- a/mlx_lm/server.py
+++ b/mlx_lm/server.py
@@ -350,6 +350,7 @@ class ModelProvider:
                 adapter_path=adapter_path,
                 tokenizer_config=self._tokenizer_config,
                 trust_remote_code=self.cli_args.trust_remote_code,
+                lazy=getattr(self.cli_args, "lazy", False),
             )
 
         # Use the default chat template if needed
@@ -1748,7 +1749,7 @@ def run(
         response_generator.join()
 
 
-def main():
+def _build_arg_parser():
     parser = argparse.ArgumentParser(description="MLX Http Server.")
     parser.add_argument(
         "--model",
@@ -1794,6 +1795,11 @@ def main():
         "--trust-remote-code",
         action="store_true",
         help="Enable trusting remote code for tokenizer",
+    )
+    parser.add_argument(
+        "--lazy",
+        action="store_true",
+        help="Load model weights lazily instead of evaluating them on startup",
     )
     parser.add_argument(
         "--log-level",
@@ -1884,6 +1890,11 @@ def main():
         action="store_true",
         help="Use pipelining instead of tensor parallelism",
     )
+    return parser
+
+
+def main():
+    parser = _build_arg_parser()
     args = parser.parse_args()
     if mx.metal.is_available():
         wired_limit = mx.device_info()["max_recommended_working_set_size"]

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -6,6 +6,8 @@ import json
 import threading
 import types
 import unittest
+from argparse import Namespace
+from unittest.mock import patch
 
 import mlx.core as mx
 import requests
@@ -14,6 +16,7 @@ from mlx_lm.models.cache import KVCache
 from mlx_lm.server import (
     APIHandler,
     LRUPromptCache,
+    ModelProvider,
     Response,
     ResponseGenerator,
     _process_control_tokens,
@@ -154,6 +157,50 @@ class TestProcessControlTokens(unittest.TestCase):
         self.assertEqual(
             [t.state for t in out],
             ["tool", "tool", "tool", "normal", "normal"],
+        )
+
+
+class TestServerCli(unittest.TestCase):
+    def test_parser_exposes_lazy_flag(self):
+        from mlx_lm import server
+
+        parser = server._build_arg_parser()
+
+        self.assertFalse(parser.parse_args([]).lazy)
+        self.assertTrue(parser.parse_args(["--lazy"]).lazy)
+
+    def test_model_provider_passes_lazy_to_main_model_load(self):
+        args = Namespace(
+            model="mlx-community/test-model",
+            adapter_path=None,
+            draft_model=None,
+            trust_remote_code=False,
+            chat_template="",
+            use_default_chat_template=False,
+            pipeline=False,
+            lazy=True,
+        )
+        group = types.SimpleNamespace(size=lambda: 1)
+        tokenizer = types.SimpleNamespace(
+            chat_template=None,
+            default_chat_template="default",
+            vocab_size=1,
+        )
+
+        with patch("mlx_lm.server.mx.distributed.init", return_value=group):
+            with patch(
+                "mlx_lm.server.load", return_value=(object(), tokenizer)
+            ) as load:
+                with patch("mlx_lm.server.make_prompt_cache", return_value=[]):
+                    provider = ModelProvider(args)
+                    provider.load_default()
+
+        load.assert_called_once_with(
+            "mlx-community/test-model",
+            adapter_path=None,
+            tokenizer_config={"trust_remote_code": False},
+            trust_remote_code=False,
+            lazy=True,
         )
 
 


### PR DESCRIPTION
## Summary
- add a `--lazy` flag to the OpenAI-compatible server CLI
- pass the lazy-load option through when loading the main model
- cover the parser flag and load wiring in server tests

Fixes #1428.

## Verification
- `.venv/bin/python -m unittest tests.test_server -v`
- `git diff --check origin/main..HEAD`
- changed-file credential-pattern scan
