### PR TITLE
Fix deepseek indexer

### DIFF
--- a/mlx_lm/chat_templates/deepseek_v32.py
+++ b/mlx_lm/chat_templates/deepseek_v32.py
@@ -334,7 +334,9 @@ def apply_chat_template(
     messages, continue_final_message=False, add_generation_prompt=False, **kwargs
 ):
     if "enable_thinking" in kwargs:
-        kwargs["thinking_mode"] = "thinking" if kwargs.pop("enable_thinking") else "chat"
+        kwargs["thinking_mode"] = (
+            "thinking" if kwargs.pop("enable_thinking") else "chat"
+        )
     out = encode_messages(messages, **kwargs)
     if continue_final_message and add_generation_prompt:
         raise ValueError(

--- a/mlx_lm/chat_templates/deepseek_v32.py
+++ b/mlx_lm/chat_templates/deepseek_v32.py
@@ -333,6 +333,8 @@ def encode_messages(
 def apply_chat_template(
     messages, continue_final_message=False, add_generation_prompt=False, **kwargs
 ):
+    if "enable_thinking" in kwargs:
+        kwargs["thinking_mode"] = "thinking" if kwargs.pop("enable_thinking") else "chat"
     out = encode_messages(messages, **kwargs)
     if continue_final_message and add_generation_prompt:
         raise ValueError(

--- a/mlx_lm/models/deepseek_v32.py
+++ b/mlx_lm/models/deepseek_v32.py
@@ -50,6 +50,7 @@ class ModelArgs(BaseModelArgs):
     rope_theta: float = 10000.0
     rope_scaling: Dict = None
     attention_bias: bool = False
+    indexer_rope_interleave: bool = False
 
 
 class Indexer(nn.Module):
@@ -71,7 +72,7 @@ class Indexer(nn.Module):
         self.rope = initialize_rope(
             dims=args.qk_rope_head_dim,
             base=args.rope_theta,
-            traditional=True,
+            traditional=args.indexer_rope_interleave,
             max_position_embeddings=args.max_position_embeddings,
             scaling_config=args.rope_scaling,
         )

--- a/mlx_lm/models/glm_moe_dsa.py
+++ b/mlx_lm/models/glm_moe_dsa.py
@@ -42,6 +42,7 @@ class ModelArgs(BaseModelArgs):
     attention_bias: bool
     rope_scaling: Dict = None
     rope_theta: Optional[float] = None
+    indexer_rope_interleave: bool = True
 
     def __post_init__(self):
         self.rope_scaling = self.rope_parameters


### PR DESCRIPTION
_This description was written by a human_ 🙋‍♂️ 

Rope `traditional` was changed for the Indexer [here](https://github.com/ml-explore/mlx-lm/pull/867/changes/f921946dc630698a3f0cafd171f036c9661b9bde) as part of #867. This fixed a very obvious long-sequence generation error with GLM 5: the model started producing gibberish after a while.

I think that the indexer of Deepseek 3.2 requires `False`, but using `True` does not result in immediately observed garbage output. Outputs remain coherent, but quality silently degrades for long sequences.

I tested by generating 6 JavaScript implementations for different games using the prompts shown in the script below. We want generation to go beyond the 2048 sequence length where the indexer kicks in. In all 6 cases, the implementations from the current mlx-lm package are coherent, but the games are not playable. Using the patched version, all games are playable (with confusing visual imperfections in two of the games, but playable).

I found this issue while working on [GLM 5.2](https://github.com/ml-explore/mlx-lm/pull/1410). I think that silent degradation + superclass being used as the reference for other implementations is worth fixing as robustly as we can. Happy to run additional tests to confirm behavior!

<details><summary>Generation script</summary>

Covers 5 prompts, there's a sixth one I ran outside the script.

```bash
#!/bin/bash

declare -a prompts=(
  "Write a complete, polished, single-file HTML+JavaScript implementation of Tetris, with comments. Include the 7 tetromino shapes, rotation, line clearing, scoring, increasing speed by level, and a next-piece preview."
  "Write a complete, polished, single-file HTML+JavaScript 2048 game, with comments. Arrow-key controls, tile sliding and merging, score, win at 2048, and game-over detection."
  "Write a complete, polished, single-file HTML+JavaScript implementation of Snake, with comments. Grid movement, growth on eating food, self- and wall-collision death, score, and a restart."
  "Write a complete, polished, single-file HTML+JavaScript implementation of Breakout/Arkanoid, with comments. A paddle, a grid of destructible bricks, ball physics with wall/paddle/brick bounces, lives, score, and level-clear."
  "Write a complete, polished, single-file HTML+JavaScript implementation of Minesweeper, with comments. Random mine placement, left-click reveal with flood-fill on zero-adjacency cells, right-click flagging, number hints, and win/lose detection."
)

typeset -i id=1
for p in "${prompts[@]}"
do
  for version in "mlx-lm" "mlx-lm.patched"
  do
    uv pip install -e "./$version"
    echo "[$version] Generating prompt $p"
    mlx_lm.generate --model models/mlx-community/DeepSeek-V3.2-4bit --prompt "$p" -m 16384 --temp 0 | tee ${id}-${version}.txt
  done
  let id=$id+1
done
```
</details>

---

This PR is the counterpart of https://github.com/huggingface/transformers/pull/46842 (in transformers, GLM appears to be wrong but Deepseek is correct).
