### PR TITLE
fix: use FiscalNote/billsum HF dataset path in test_datsets

### DIFF
--- a/tests/test_datsets.py
+++ b/tests/test_datsets.py
@@ -113,7 +113,7 @@ class TestDatasets(unittest.TestCase):
 
     def test_hf(self):
         hf_args = {
-            "path": "billsum",
+            "path": "FiscalNote/billsum",
             "prompt_feature": "text",
             "completion_feature": "summary",
             "train_split": "train[:2%]",


### PR DESCRIPTION
## Problem

The `billsum` dataset path on HuggingFace Hub is no longer maintained. The canonical home for the BillSum dataset is now under the `FiscalNote` organization: https://huggingface.co/datasets/FiscalNote/billsum

This causes `test_hf` in `tests/test_datsets.py` to either fail or rely on a redirect that may break in the future.

## Fix

Update the test's HF dataset `path` from `"billsum"` to `"FiscalNote/billsum"` to point directly at the maintained copy.

## Testing

- `tests/test_datsets.py::TestDatasets::test_hf` will now load from the canonical FiscalNote/billsum path.
- Existing `prompt_feature`/`completion_feature`/`train_split` fields are unchanged — only the path string was updated.

## Notes

- This only touches a test file, so no production code paths are affected.
- Fork: https://github.com/ttxs69/mlx-lm (branch: fix/billsum-dataset-path)