### PR TITLE
Fix: pythonic tool parser not auto-detected for LFM2.5 models

### DIFF
--- a/mlx_lm/tokenizer_utils.py
+++ b/mlx_lm/tokenizer_utils.py
@@ -543,33 +543,44 @@ def _is_bpe_decoder(decoder):
     return isinstance(decoder, dict) and decoder.get("type", None) == "ByteLevel"
 
 
-def _infer_tool_parser(chat_template):
+def _infer_tool_parser(chat_template, tokenizer=None):
     """Attempt to auto-infer a tool parser from the chat template."""
-    if not isinstance(chat_template, str):
-        return None
-    elif "<minimax:tool_call>" in chat_template:
-        return "minimax_m2"
-    elif "<|tool_call>" in chat_template and "<tool_call|>" in chat_template:
-        return "gemma4"
-    elif "<start_function_call>" in chat_template:
-        return "function_gemma"
-    elif "<longcat_tool_call>" in chat_template:
-        return "longcat"
-    elif "<arg_key>" in chat_template:
-        return "glm47"
-    elif "<|tool_list_start|>" in chat_template:
-        return "pythonic"
-    elif (
-        "<tool_call>\\n<function=" in chat_template
-        or "<tool_call>\n<function=" in chat_template
-    ):
-        return "qwen3_coder"
-    elif "<|tool_calls_section_begin|>" in chat_template:
-        return "kimi_k2"
-    elif "[TOOL_CALLS]" in chat_template:
-        return "mistral"
-    elif "<tool_call>" in chat_template and "tool_call.name" in chat_template:
-        return "json_tools"
+    if isinstance(chat_template, str):
+        if "<minimax:tool_call>" in chat_template:
+            return "minimax_m2"
+        elif "<|tool_call>" in chat_template and "<tool_call|>" in chat_template:
+            return "gemma4"
+        elif "<start_function_call>" in chat_template:
+            return "function_gemma"
+        elif "<longcat_tool_call>" in chat_template:
+            return "longcat"
+        elif "<arg_key>" in chat_template:
+            return "glm47"
+        elif "<|tool_call_start|>" in chat_template:
+            return "pythonic"
+        elif (
+            "<tool_call>\\n<function=" in chat_template
+            or "<tool_call>\n<function=" in chat_template
+        ):
+            return "qwen3_coder"
+        elif "<|tool_calls_section_begin|>" in chat_template:
+            return "kimi_k2"
+        elif "[TOOL_CALLS]" in chat_template:
+            return "mistral"
+        elif "<tool_call>" in chat_template and "tool_call.name" in chat_template:
+            return "json_tools"
+    # Fallback: some models (e.g. LFM2.5) encode tool-call delimiters only in
+    # their vocabulary and generate them at inference time, without referencing
+    # them in the chat template. Detect this by checking whether the tokenizer
+    # knows <|tool_call_start|> as a real (non-UNK) token.
+    if tokenizer is not None:
+        try:
+            unk_id = tokenizer.unk_token_id
+            tcs_id = tokenizer.convert_tokens_to_ids("<|tool_call_start|>")
+            if tcs_id is not None and tcs_id != unk_id:
+                return "pythonic"
+        except Exception:
+            pass
     return None
 
 
@@ -621,7 +632,7 @@ def load(
         ).apply_chat_template
 
     tool_parser_type = tokenizer_config.get(
-        "tool_parser_type", _infer_tool_parser(tokenizer.chat_template)
+        "tool_parser_type", _infer_tool_parser(tokenizer.chat_template, tokenizer)
     )
 
     if tool_parser_type is not None:


### PR DESCRIPTION
[#864](https://github.com/ml-explore/mlx-lm/pull/864) added the `pythonic` tool parser for LFM2 models, with auto-detection triggered by the presence of `<|tool_list_start|>` in the chat template. This PR fixes two related bugs that prevent the parser from activating on LFM2.5 models.

**Bug 1 — Template trigger typo:** The detection string was `<|tool_list_start|>` but LFM2.5's actual delimiter token is `<|tool_call_start|>` (matching what the `pythonic` parser itself uses). The check would never match.

**Bug 2 — Template doesn't reference the delimiter at all:** LFM2.5 models encode `<|tool_call_start|>` and `<|tool_call_end|>` as vocabulary tokens and generate them at inference time. The Jinja chat template handles only the input format — it injects tool schemas into the system prompt as JSON and never mentions the output delimiters. So template scanning returns `None` regardless of which string is checked.

## Fix

1. Correct the template trigger (`tool_list_start` → `tool_call_start`) for models whose templates do reference the delimiter.

2. Add a vocabulary fallback to `_infer_tool_parser`: after template scanning produces nothing, check whether `<|tool_call_start|>` exists in the tokenizer vocabulary as a real (non-UNK) token. If so, return `"pythonic"`.

The call site in `load()` is updated to pass `tokenizer` as the second argument.

## Backward compatibility

- All existing template-based detection paths are unchanged.
- The vocab fallback only runs when template scanning returns nothing and a tokenizer is provided.
- Models without `<|tool_call_start|>` in their vocabulary resolve to UNK and fall through unaffected.

## Models fixed

- `mlx-community/LFM2.5-1.2B-Instruct-8bit` (and all LFM2.5 variants)