### PR TITLE
Make RotatingKVCache trimmable so prefix cache reuse works for sliding-window models

### DIFF
--- a/mlx_lm/models/cache.py
+++ b/mlx_lm/models/cache.py
@@ -108,7 +108,11 @@ def trim_prompt_cache(cache: List[Any], num_tokens: int) -> List[Any]:
     """
     if not can_trim_prompt_cache(cache) or len(cache) == 0:
         return 0
-    return [c.trim(num_tokens) for c in cache][0]
+    # Interleaved cache types (e.g. sliding-window models mixing RotatingKVCache
+    # and KVCache) may trim by different amounts. The number actually trimmed is
+    # the minimum across layers, since the cache is only consistent up to the
+    # least-trimmed layer.
+    return min(c.trim(num_tokens) for c in cache)
 
 
 def create_attention_mask(
@@ -414,7 +418,11 @@ class RotatingKVCache(_BaseCache):
         self.keep = keep
         self.keys = None
         self.values = None
+        # ``offset`` is the absolute chronological position (drives RoPE).
+        # ``_offset`` is the number of tokens physically resident in the ring
+        # buffer, capped at ``max_size``. The two diverge once the buffer wraps.
         self.offset = 0
+        self._offset = 0
         self.max_size = max_size
         self._idx = 0
 
@@ -434,7 +442,7 @@ class RotatingKVCache(_BaseCache):
         """
         if self._idx == v.shape[2]:
             return v
-        elif self._idx < self.offset:
+        elif self._idx < self._offset:
             return mx.concatenate(
                 [
                     v[..., : self.keep, :],
@@ -463,6 +471,7 @@ class RotatingKVCache(_BaseCache):
             self.keys = self._trim(trim_size, self.keys, keys)
             self.values = self._trim(trim_size, self.values, values)
         self.offset += keys.shape[2]
+        self._offset += keys.shape[2]
         self._idx = self.keys.shape[2]
         return self.keys, self.values
 
@@ -470,7 +479,7 @@ class RotatingKVCache(_BaseCache):
         # May not have hit the max size yet, so potentially
         # keep growing the cache
         B, n_kv_heads, S, k_head_dim = keys.shape
-        prev = self.offset
+        prev = self._offset
         if self.keys is None or (
             prev >= self.keys.shape[2] and self.keys.shape[2] < self.max_size
         ):
@@ -502,11 +511,15 @@ class RotatingKVCache(_BaseCache):
         self.keys[..., self._idx : self._idx + S, :] = keys
         self.values[..., self._idx : self._idx + S, :] = values
         self.offset += S
+        self._offset += S
         self._idx += S
 
         # If the buffer is not full, slice off the end
-        if self.offset < self.max_size:
-            return self.keys[..., : self.offset, :], self.values[..., : self.offset, :]
+        if self._offset < self.max_size:
+            return (
+                self.keys[..., : self._offset, :],
+                self.values[..., : self._offset, :],
+            )
         return self.keys, self.values
 
     def update_and_fetch(self, keys, values):
@@ -515,12 +528,15 @@ class RotatingKVCache(_BaseCache):
         return self._update_concat(keys, values)
 
     def size(self):
-        return min(self.offset, self.max_size)
+        return min(self._offset, self.max_size)
 
     @property
     def state(self):
-        if self.offset < self.keys.shape[2]:
-            return self.keys[..., : self.offset, :], self.values[..., : self.offset, :]
+        if self._offset < self.keys.shape[2]:
+            return (
+                self.keys[..., : self._offset, :],
+                self.values[..., : self._offset, :],
+            )
         else:
             return self.keys, self.values
 
@@ -530,22 +546,48 @@ class RotatingKVCache(_BaseCache):
 
     @property
     def meta_state(self):
-        return tuple(map(str, (self.keep, self.max_size, self.offset, self._idx)))
+        return tuple(
+            map(
+                str,
+                (self.keep, self.max_size, self.offset, self._idx, self._offset),
+            )
+        )
 
     @meta_state.setter
     def meta_state(self, v):
-        self.keep, self.max_size, self.offset, self._idx = map(
-            int,
-            v,
-        )
+        self.keep, self.max_size, self.offset, self._idx = map(int, v[:4])
+        # Backward compatibility: caches saved before the chronological/physical
+        # offset split only stored 4 values. Old code never trimmed, so the two
+        # offsets always coincided (``_offset == offset``).
+        self._offset = int(v[4]) if len(v) > 4 else self.offset
 
     def is_trimmable(self):
-        return self.offset < self.max_size
+        return True
 
     def trim(self, n):
-        n = min(self.offset, n)
+        if self.keys is None or n <= 0:
+            return 0
+        # Linearize the (possibly wrapped) ring buffer into temporal order. This
+        # also collapses any over-allocation so the tensor length equals the
+        # number of physically resident tokens, which bounds how far back the
+        # cache can be rolled (older tokens have been overwritten on wrap).
+        self.keys = self._temporal_order(self.keys)
+        self.values = self._temporal_order(self.values)
+        trimmable = self.keys.shape[2]
+        n = min(trimmable, n)
         self.offset -= n
-        self._idx -= n
+        new_size = trimmable - n
+        if new_size == 0:
+            self.keys = None
+            self.values = None
+            self._idx = 0
+            self._offset = 0
+        else:
+            # Drop the most recent ``n`` tokens.
+            self.keys = self.keys[..., :new_size, :]
+            self.values = self.values[..., :new_size, :]
+            self._idx = new_size
+            self._offset = new_size
         return n
 
     def to_quantized(self, group_size: int = 64, bits: int = 4) -> QuantizedKVCache:
@@ -556,7 +598,7 @@ class RotatingKVCache(_BaseCache):
     ):
         if N > 1:
             window_size = window_size or self.max_size
-            offset = min(self.max_size - 1, self.offset)
+            offset = min(self.max_size - 1, self._offset)
             if offset + N > window_size or return_array:
                 return create_causal_mask(N, offset, window_size=window_size)
             else:
@@ -565,12 +607,12 @@ class RotatingKVCache(_BaseCache):
             if window_size is None:
                 return None
             # May need a mask for when window_size < max_size
-            if self.offset >= window_size and self.max_size > window_size:
+            if self._offset >= window_size and self.max_size > window_size:
                 idx = self._idx
                 if idx >= self.max_size:
                     idx = 0
-                if self.offset < self.max_size:
-                    mask_size = self.offset + 1
+                if self._offset < self.max_size:
+                    mask_size = self._offset + 1
                 else:
                     mask_size = self.max_size
                 mask = mx.arange(mask_size) >= (mask_size - window_size)
@@ -1315,13 +1357,32 @@ class BatchRotatingKVCache(_BaseCache):
         self.rotated = bool(v[3])
 
     def is_trimmable(self):
-        return self._offset < self.max_size
+        return True
 
     def trim(self, n):
-        n = min(self._offset, n)
-        self._offset -= n
-        self._idx -= n
+        if self.keys is None or n <= 0:
+            return 0
+        # Linearize the (possibly wrapped) ring buffer into temporal order. This
+        # collapses any over-allocation so the tensor length equals the number
+        # of physically resident tokens, bounding how far back the cache can be
+        # rolled (older tokens have been overwritten on wrap).
+        self._temporal_order()
+        trimmable = self.keys.shape[2]
+        n = min(trimmable, n)
         self.offset -= n
+        new_size = trimmable - n
+        if new_size == 0:
+            self.keys = None
+            self.values = None
+            self._idx = 0
+            self._offset = 0
+            self.rotated = False
+        else:
+            # Drop the most recent ``n`` tokens.
+            self.keys = self.keys[..., :new_size, :]
+            self.values = self.values[..., :new_size, :]
+            self._idx = new_size
+            self._offset = new_size
         return n
 
     def to_quantized(self, group_size: int = 64, bits: int = 4) -> QuantizedKVCache:
@@ -1417,6 +1478,9 @@ class BatchRotatingKVCache(_BaseCache):
     def extract(self, idx):
         mx.eval(self.left_padding, self.offset)
         cache = RotatingKVCache(self.max_size)
+        if self.keys is None:
+            cache.offset = self.offset.tolist()[idx]
+            return cache
         padding = max(0, self.left_padding.tolist()[idx])
         offset = self.offset.tolist()[idx]
         cache.keys = self.keys[idx : idx + 1]
@@ -1430,6 +1494,7 @@ class BatchRotatingKVCache(_BaseCache):
         cache.values = mx.contiguous(cache.values[:, :, padding : cache._idx])
         cache.offset = offset
         cache._idx = cache.keys.shape[2]
+        cache._offset = cache.keys.shape[2]
         return cache
 
     @classmethod
@@ -1684,8 +1749,12 @@ class LRUPromptCache:
                 cache = copy.deepcopy(cache_entry.prompt_cache)
                 prefix = min(len(tokens) - 1, result.common_prefix)
                 num_to_trim = len(result.longer) - prefix
-                trim_prompt_cache(cache, num_to_trim)
-                return cache, tokens[prefix:]
+                trimmed = trim_prompt_cache(cache, num_to_trim)
+                # A rotating cache can only be trimmed back within its window.
+                # If the full trim did not succeed, the cache no longer matches
+                # the requested prefix, so fall back to the shorter-cache path.
+                if trimmed >= num_to_trim:
+                    return cache, tokens[prefix:]
 
         if short_length > 0:
             cache_entry = self._trie.get(result.model, result.shorter)
@@ -1716,13 +1785,21 @@ class LRUPromptCache:
             self._lru.remove(model, tokens)
         self._lru.push(model, tokens, cache_type)
 
-        # If it is a trimmable cache remove all prefixes cause they just take
-        # space
+        # If it is a trimmable cache remove the prefixes that this entry can be
+        # trimmed back to, since they just take space. A wrapped rotating cache
+        # can only be trimmed back within its window, so keep prefixes older than
+        # that as fallbacks for future reuse.
         if can_trim_prompt_cache(prompt_cache):
+            max_trimmable = min(c.size() for c in prompt_cache)
+            n = len(tokens)
             for prefix_len, entry in self._trie.pop_prefixes(model, tokens):
-                self._n_bytes -= entry.nbytes
-                self._n_bytes_by_type[entry.cache_type] -= entry.nbytes
-                self._lru.remove(model, tokens[:prefix_len])
+                if n - prefix_len <= max_trimmable:
+                    self._n_bytes -= entry.nbytes
+                    self._n_bytes_by_type[entry.cache_type] -= entry.nbytes
+                    self._lru.remove(model, tokens[:prefix_len])
+                else:
+                    # Re-attach this prefix; pop_prefixes already detached it.
+                    self._trie.add(model, tokens[:prefix_len], entry)
 
         # Ensure we match the constraints
         if len(self._lru) > self.max_size:

--- a/tests/test_prompt_cache.py
+++ b/tests/test_prompt_cache.py
@@ -95,8 +95,22 @@ class TestPromptCache(unittest.TestCase):
             k, v = c.update_and_fetch(x, x)
             lk, lv = lc.update_and_fetch(x, x)
             self.assertEqual(c.offset, lc.offset)
+            self.assertEqual(c._offset, lc._offset)
             self.assertTrue(mx.array_equal(k, lk))
             self.assertTrue(mx.array_equal(v, lv))
+
+        # The physical offset must survive a round-trip, and a post-load trim
+        # must behave identically to a trim on the original.
+        for c, lc in zip(cache, loaded_cache):
+            self.assertEqual(c.trim(3), lc.trim(3))
+            self.assertEqual(c.offset, lc.offset)
+            self.assertEqual(c._offset, lc._offset)
+
+        # Backward compatibility: an old 4-value meta_state (pre offset split)
+        # must load with _offset reconstructed as the chronological offset.
+        old = RotatingKVCache(max_size=8, keep=2)
+        old.meta_state = ("2", "8", "5", "5")
+        self.assertEqual(old._offset, 5)
 
     def test_save_load_mixed_cache(self):
         cache_file = os.path.join(self.test_dir, "prompt_cache.safetensors")
@@ -241,14 +255,25 @@ class TestPromptCache(unittest.TestCase):
         num_trimmed = trim_prompt_cache(cache, 4)
         self.assertEqual(num_trimmed, 4)
 
-        # Can't trim fixed-size KV cache after processing
-        # more than max_kv_size tokens
+        # A rotating cache can still be trimmed after it has wrapped, but only
+        # back within its window (older tokens have been overwritten).
         for c in cache:
             x = mx.random.uniform(shape=(1, 8, 10, 4))
             c.update_and_fetch(x, x)
 
         num_trimmed = trim_prompt_cache(cache, 4)
-        self.assertEqual(num_trimmed, 0)
+        self.assertEqual(num_trimmed, 4)
+
+        # Asking to trim past the retained window only trims as far as the
+        # window allows (max_size=6 tokens).
+        cache = [RotatingKVCache(max_size=6) for _ in range(2)]
+        for c in cache:
+            x = mx.random.uniform(shape=(1, 8, 20, 4))
+            c.update_and_fetch(x, x)
+            x = mx.random.uniform(shape=(1, 8, 1, 4))
+            c.update_and_fetch(x, x)
+        num_trimmed = trim_prompt_cache(cache, 100)
+        self.assertEqual(num_trimmed, 6)
 
         cache = [QuantizedKVCache() for _ in range(2)]
         for c in cache:
@@ -290,6 +315,88 @@ class TestPromptCache(unittest.TestCase):
         self.assertEqual(toks, second_toks)
         self.assertTrue(
             all(mx.allclose(l, l2) for l, l2 in zip(all_logits, second_all_logits))
+        )
+
+    def test_rotating_trim_matches_recompute(self):
+        # Feeding N tokens then trimming back to a prefix must leave the cache in
+        # the same logical state as building it from the prefix directly, even
+        # after the ring buffer has wrapped.
+        def build(seq, max_size, keep):
+            c = RotatingKVCache(max_size=max_size, keep=keep)
+            c.update_and_fetch(seq, seq)
+            return c
+
+        for keep in (0, 2):
+            mx.random.seed(0)
+            full_seq = mx.random.uniform(shape=(1, 8, 20, 4))
+            prefix_len = 15
+
+            c = build(full_seq, max_size=8, keep=keep)
+            trimmed = c.trim(20 - prefix_len)
+            self.assertEqual(trimmed, 5)
+            # Chronological position rolls back exactly.
+            self.assertEqual(c.offset, prefix_len)
+            # Physical buffer holds at most the window.
+            self.assertEqual(c.size(), 8)
+
+            # Reference: process only the retained prefix.
+            ref = build(full_seq[..., :prefix_len, :], max_size=8, keep=keep)
+            self.assertEqual(c.offset, ref.offset)
+            self.assertEqual(c.size(), ref.size())
+            self.assertTrue(mx.allclose(c.state[0], ref.state[0]))
+            self.assertTrue(mx.allclose(c.state[1], ref.state[1]))
+
+    def test_rotating_trim_can_trim(self):
+        from mlx_lm.models.cache import can_trim_prompt_cache
+
+        # Interleaved full + sliding-window layers, like Gemma 3 / GPT-OSS.
+        cache = [RotatingKVCache(max_size=8), KVCache()]
+        for c in cache:
+            x = mx.random.uniform(shape=(1, 8, 40, 4))
+            c.update_and_fetch(x, x)
+        # The whole cache must report trimmable even after the rotating layer
+        # has wrapped past its window.
+        self.assertTrue(can_trim_prompt_cache(cache))
+
+    def test_trim_rotating_cache_matches_fresh_through_model(self):
+        # This mirrors the server's prefix-reuse path for a sliding-window
+        # cache: prefill a long prompt, trim back to a common prefix, then
+        # process the divergent suffix. The result must match a cache that was
+        # freshly prefilled on the prefix, token-for-token, even though the
+        # prompt exceeds the rotating window.
+        model, tokenizer = self.model, self.tokenizer
+        tokens = tokenizer.encode(
+            "The quick brown fox jumps over the lazy dog near the river bank "
+            "while the sun sets behind the distant mountains."
+        )
+        tokens = mx.array(tokens)[None]
+        suffix_len = 5
+        prefix = tokens[:, :-suffix_len]
+        suffix = tokens[:, -suffix_len:]
+
+        # Reused path: prefill the full prompt, then trim back to the prefix.
+        reused = make_prompt_cache(model, max_kv_size=8)
+        model(tokens, cache=reused)
+        trimmed = trim_prompt_cache(reused, suffix_len)
+        self.assertEqual(trimmed, suffix_len)
+
+        # Fresh path: prefill only the prefix.
+        fresh = make_prompt_cache(model, max_kv_size=8)
+        model(prefix, cache=fresh)
+
+        # Caches must be in the same logical state.
+        for r, f in zip(reused, fresh):
+            self.assertEqual(r.offset, f.offset)
+
+        # Processing the same suffix through both must predict the same next
+        # tokens. (Greedy/token-for-token identity is the correctness gate; we
+        # don't compare raw logits because a 4-bit model's matmul reduction
+        # order depends on the prefill length, which perturbs logits within the
+        # quantization grid without changing the argmax.)
+        logits_reused = model(suffix, cache=reused)
+        logits_fresh = model(suffix, cache=fresh)
+        self.assertTrue(
+            mx.array_equal(logits_reused.argmax(-1), logits_fresh.argmax(-1))
         )
 
     def test_cache_copying(self):

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -87,6 +87,11 @@ class MockCache:
     def is_trimmable(self):
         return self._is_trimmable
 
+    def size(self):
+        # This mock models a fully (unboundedly) trimmable cache, so report a
+        # size large enough that the prefix-eviction guard never blocks.
+        return 1 << 30
+
     def trim(self, n):
         assert self._is_trimmable
         return n


### PR DESCRIPTION
## Summary

`mlx-lm`'s automatic prompt-cache prefix reuse works for full-attention models but **silently fails for sliding-window-attention models** (Gemma 2/3/3n, GPT-OSS) once the prompt exceeds the attention window — every request reprocesses the whole prompt.

Root cause: `RotatingKVCache.is_trimmable()` returned `False` once its ring buffer wrapped. Since sliding-window models interleave layer types (e.g. Gemma 3 mixes `RotatingKVCache` with a full `KVCache` every 6th layer), the all-or-nothing `can_trim_prompt_cache()` gate then returned `False` for the entire model, so the server discarded the prompt cache and recomputed from scratch.

## Fix

- Split `RotatingKVCache`'s overloaded `offset` into two fields: `offset` (absolute chronological position, drives RoPE) and `_offset` (physical tokens resident in the ring buffer, capped at `max_size`). They diverge only after a trim; pre-wrap behavior is byte-identical. This mirrors the design `BatchRotatingKVCache` already uses.
- Implement a correct `trim()` for the **wrapped** case by linearizing the ring buffer into temporal order, bounded by `max_size` (older tokens are physically overwritten on wrap, so reuse is bounded by the window).
- Make the server reuse/eviction paths window-aware: `fetch_nearest_cache` only reuses a trimmed entry if the trim fully succeeded; `insert_cache` keeps prefixes older than the window as fallbacks; `trim_prompt_cache` returns the min trimmed across layers.

Scope: `RotatingKVCache` + `BatchRotatingKVCache`. SSM/Mamba (`ArraysCache`) is out of scope — recurrent state can't be split at a token boundary.

## Results

`gemma-3-1b-it-4bit`, 2802-token prompt (`[long fixed prefix] + [short changing tail]`), sliding window W=512:

| | Before | After |
|---|---:|---:|
| Warm `cached_tokens` | **0** | **2788** |
| Cold latency | 1.24 s | 1.24 s |
| Warm latency (median) | ~0.84 s | **0.15 s** |
| Speedup | 1.1× (none) | **~8×** |

Greedy (temperature=0) warm output is identical to cold.

## Tests

- `RotatingKVCache` / `BatchRotatingKVCache` now report trimmable after wrap and trim correctly back within the window.
- Added unit tests that a wrapped trim matches a fresh prefix build (state-level and through-model argmax identity), plus `_offset` save/load round-trip and backward-compat loading of the old 4-value `meta_state`.

`python -m unittest tests.test_prompt_cache tests.test_server tests.test_generate` passes.

Refs #980.
