### PR TITLE
Fix qwen3.5-MoE garbage output: don't double-shift RMSNorm on MTP-retaining checkpoints

### DIFF
--- a/mlx_lm/models/qwen3_5.py
+++ b/mlx_lm/models/qwen3_5.py
@@ -346,11 +346,17 @@ class TextModel(nn.Module):
         return [ArraysCache(size=2) if l.is_linear else KVCache() for l in self.layers]
 
     def sanitize(self, weights):
-        has_mtp_weights = any("mtp." in k for k in weights)
         has_unsanitized_conv1d = any(
             "conv1d.weight" in k and v.shape[-1] != 1 for k, v in weights.items()
         )
-        should_shift_norm_weights = has_mtp_weights or has_unsanitized_conv1d
+        # The unsanitized conv1d weight shape is the authoritative signal that
+        # these are raw (pre-conversion) weights that still need the RMSNorm
+        # (1 + w) shift. The presence of MTP weights is NOT a reliable proxy:
+        # converted checkpoints that retain an MTP head (e.g. "*-mtp" quantized
+        # builds) already store final-form norm weights, and re-applying the
+        # +1.0 shift corrupts every RMSNorm -> garbage generations with no
+        # load-time warning.
+        should_shift_norm_weights = has_unsanitized_conv1d
         weights = {k: v for k, v in weights.items() if "mtp." not in k}
 
         if self.args.tie_word_embeddings:


### PR DESCRIPTION
## Summary

`Qwen3_5MoE` text models that **retain their MTP head** (e.g. `*-mtp` quantized
community builds) generate **pure garbage** — incoherent token salad, or empty
output under greedy decoding — even though the model loads cleanly with no
warning, `/v1/models` reports the right id, and prefill completes normally.

Root cause is in `TextModel.sanitize` (`mlx_lm/models/qwen3_5.py`). The RMSNorm
`(1 + w)` shift is gated on:

```python
should_shift_norm_weights = has_mtp_weights or has_unsanitized_conv1d
```

`has_mtp_weights` is used as a proxy for "this is a raw HF export that still
needs the norm shift." That proxy is **wrong for converted checkpoints that keep
the MTP head**: their norm weights are already in final form, so the extra
`+1.0` is applied a second time and corrupts **every** normalization layer. It
fails silently because tensor shapes never change.

The authoritative "raw export" signal is the **conv1d weight shape**
(`has_unsanitized_conv1d`) — which travels with the same provenance as the norm
convention. This PR drives the shift off that signal alone and drops the
unreliable MTP proxy.

## Evidence

`mlx-community/Qwen3.5-122B-A10B-oQ4-mtp` (retains MTP head; conv1d already
sanitized, shape `(..., 4, 1)`). RMSNorm weights read directly from the
safetensors — already centered near 1.0, i.e. final form:

| norm tensor (layer 0)             | stored mean | after the spurious `+1.0` |
|-----------------------------------|------------:|--------------------------:|
| `input_layernorm.weight`          |        0.99 |             1.99 (broken) |
| `post_attention_layernorm.weight` |        0.85 |             1.85 (broken) |
| `model.norm.weight`               |        2.29 |             3.29 (broken) |

**Before** (greedy, `temp=0`, prompt `"Reply with exactly: ready"`): empty /
non-rendering tokens. With sampling: `Update Oeste subs wych . c cymo v 3...`.

**After** this fix (same model, same prompt): `The capital of France is Paris.`
with a coherent reasoning trace — fully restored.

## Why it's safe

- For raw exports, `conv1d` is unsanitized (last dim != 1), so
  `has_unsanitized_conv1d` is `True` and the shift still fires exactly as before.
- For converted checkpoints (conv1d already `(..., k, 1)`), the shift no longer
  fires — correct, their norms are already final.
- The MTP weights are still stripped (`"mtp." not in k`) exactly as before; only
  the *norm-shift trigger* changes.
