### PR TITLE
Fix frozen PRNG in categorical_sampling under repeated sampling

### DIFF
--- a/mlx_lm/sample_utils.py
+++ b/mlx_lm/sample_utils.py
@@ -274,7 +274,6 @@ def apply_xtc(
     )
 
 
-@partial(mx.compile, inputs=mx.random.state, outputs=mx.random.state)
 def categorical_sampling(logits, temp):
     return mx.random.categorical(logits * (1 / temp))
 


### PR DESCRIPTION
## Problem

With `temperature > 0`, repeated requests to `mlx_lm.server` return identical text. The sampling stops being random after the first request.

## Root cause

`categorical_sampling` is decorated with `@partial(mx.compile, inputs=mx.random.state, outputs=mx.random.state)`. In the server's generation loop the RNG state stops advancing after the first request, so every sample reuses the same state. Calling `categorical_sampling` or `generate()` directly does not hit this (the state advances normally), so it only appears in the long-running compiled server path.

## Fix

Remove the decorator. The function is a single `mx.random.categorical` call, so the compile gives little benefit, and without it the function uses the live global RNG state on each call.

## Repro

1. Start the server:
mlx_lm.server --model mlx-community/Qwen2.5-0.5B-Instruct-4bit

2. Run the below curl cmd twice:
curl -s localhost:8080/v1/chat/completions -H "Content-Type: application/json" \
   -d '{"messages":[{"role":"user","content":"Tell me a one-sentence story."}],"temperature":1.0,"max_tokens":40}'

Before, two identical requests return byte-identical completions:
1. Once upon a time, in a neighboring village, a young woman named Rose found herself lost ...
2. Once upon a time, in a neighboring village, a young woman named Rose found herself lost ...

After, they differ:
 1. In a land of empires ... a hero named Robin ... a mighty rebellion against the Elite Nobility ...
 2. Ah, a sample story for you: When Eliza first arrived in New York, she felt immense pressure ...

`cached_tokens` is still 36 on the second call after the fix, so prompt cache reuse is unaffected; only the RNG state changed.

## Testing

`tests/test_sample_utils.py` passes. No unit test added: the freeze only reproduces in the compiled server loop, not a direct call, so a unit test would pass on the unfixed code too. Happy to add an integration test if preferred.

Note: `apply_top_k`, `apply_top_p`, and `apply_min_p` carry the same `random.state` decorator but do not use randomness. Left unchanged here.

Fixes #1439