### PR TITLE
Fix dropped tool calls for models with empty tool_call_end (Mistral/Devstral)

### DIFF
--- a/mlx_lm/server.py
+++ b/mlx_lm/server.py
@@ -1497,7 +1497,12 @@ class APIHandler(BaseHTTPRequestHandler):
 
                 prev_state = gen.state
 
-            if prev_state == "tool" and tool_text:
+            # Flush any tool call still buffered at the end of generation. For
+            # models with an empty tool_call_end (e.g. Mistral/Devstral), the
+            # final EOS transitions the state machine out of "tool" to None, so
+            # prev_state is no longer "tool" here; keying off tool_text captures
+            # the trailing call in that case.
+            if tool_text:
                 tool_calls.append(tool_text)
                 made_tool_call = True
 

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -157,6 +157,106 @@ class TestProcessControlTokens(unittest.TestCase):
         )
 
 
+class TestTrailingToolCallFlush(unittest.TestCase):
+    """Regression test for models with an empty ``tool_call_end``.
+
+    For Mistral/Devstral-style models the tool call has no explicit end marker,
+    so the final EOS moves the state machine out of the ``"tool"`` state
+    (``prev_state`` becomes ``None``). ``handle_completion`` must still surface
+    the buffered tool call rather than silently dropping it.
+    See https://github.com/ml-explore/mlx-lm/issues/1307.
+    """
+
+    def _make_handler(self, stream_responses, ctx):
+        handler = APIHandler.__new__(APIHandler)
+
+        # Minimal attributes read by handle_completion / generate_response.
+        defaults = dict(
+            requested_model="test-model",
+            requested_draft_model=None,
+            adapter=None,
+            temperature=0.0,
+            top_p=1.0,
+            top_k=0,
+            min_p=0.0,
+            xtc_probability=0.0,
+            xtc_threshold=0.0,
+            logit_bias=None,
+            repetition_penalty=None,
+            repetition_context_size=20,
+            presence_penalty=0.0,
+            presence_context_size=20,
+            frequency_penalty=0.0,
+            frequency_context_size=20,
+            max_tokens=64,
+            num_draft_tokens=0,
+            logprobs=False,
+            top_logprobs=0,
+            seed=None,
+            chat_template_kwargs={},
+            stream=False,
+            request_id="chatcmpl-test",
+            system_fingerprint="test",
+            object_type="chat.completion",
+            created=0,
+            wfile=io.BytesIO(),
+        )
+        for key, value in defaults.items():
+            setattr(handler, key, value)
+
+        # No-op the HTTP header machinery.
+        handler._set_completion_headers = lambda *a, **k: None
+        handler._set_stream_headers = lambda *a, **k: None
+        handler.send_header = lambda *a, **k: None
+        handler.end_headers = lambda *a, **k: None
+
+        # Mock generation: return the scripted (ctx, stream).
+        handler.response_generator = types.SimpleNamespace(
+            generate=lambda request, args, progress_callback=None: (
+                ctx,
+                iter(stream_responses),
+            )
+        )
+        return handler
+
+    def test_empty_tool_call_end_flushes_trailing_tool_call(self):
+        from mlx_lm.tool_parsers.mistral import parse_tool_call
+
+        # What _process_control_tokens yields for
+        # "[TOOL_CALLS]run_shell[ARGS]{...}<eos>": the marker is consumed as a
+        # state crossing, the body streams in the "tool" state, and the final
+        # EOS carries state=None because tool_call_end is empty.
+        stream = [
+            Response(
+                'run_shell[ARGS]{"command": "ls"}', 42, "tool", None, 0.0, None, ()
+            ),
+            Response("", 2, None, None, 0.0, "stop", ()),
+        ]
+        ctx = types.SimpleNamespace(
+            tool_parser=parse_tool_call,
+            prompt=[1, 2, 3],
+            prompt_cache_count=0,
+            stop=lambda: None,
+        )
+        request = types.SimpleNamespace(
+            tools=[{"type": "function", "function": {"name": "run_shell"}}]
+        )
+
+        handler = self._make_handler(stream, ctx)
+        handler.handle_completion(request, stop_words=[])
+
+        resp = json.loads(handler.wfile.getvalue().decode())
+        choice = resp["choices"][0]
+        self.assertEqual(choice["finish_reason"], "tool_calls")
+
+        tool_calls = choice["message"].get("tool_calls")
+        self.assertIsNotNone(tool_calls, "trailing tool call was dropped")
+        self.assertEqual(tool_calls[0]["function"]["name"], "run_shell")
+        self.assertEqual(
+            json.loads(tool_calls[0]["function"]["arguments"]), {"command": "ls"}
+        )
+
+
 class TestServer(unittest.TestCase):
     @classmethod
     def setUpClass(cls):


### PR DESCRIPTION
## Summary

Fixes #1307.

Models that use Mistral's native tool-call format (e.g. `Devstral-Small-2-24B`, `Ministral`, `Mistral-Small`) emit tool calls with **no explicit end marker** — their `tool_call_end` is `""`. As a result, the server's `SequenceStateMachine` has no `tool -> normal` transition, and the **final EOS** transitions the state out of `"tool"` to `None`.

At the end of `handle_completion`, the trailing flush is guarded by:

```python
if prev_state == "tool" and tool_text:
    tool_calls.append(tool_text)
    made_tool_call = True
```

Because the last token (EOS) already moved the state to `None`, `prev_state` is `None`, the guard never fires, and the buffered `tool_text` is silently discarded. The server returns an empty `message: {"role": "assistant"}` — neither `content` nor `tool_calls` — even though the model produced a valid `[TOOL_CALLS]name[ARGS]{json}` call.

## Fix

Key the end-of-generation flush off the buffered `tool_text` instead of `prev_state`. `tool_text` is only ever populated while in the `"tool"` state and is reset to `""` when a `tool -> normal` transition flushes it during the loop, so any leftover `tool_text` at the end is by definition an unflushed tool call. This is general and also covers models whose `tool_call_end` **is** defined (in that case `tool_text` is already empty here, so behavior is unchanged).

## Reproduction (before fix)

```bash
mlx_lm.server --model mlx-community/Devstral-Small-2-24B-Instruct-2512-8bit --port 8080
curl -s localhost:8080/v1/chat/completions -H 'Content-Type: application/json' -d '{
  "model":"mlx-community/Devstral-Small-2-24B-Instruct-2512-8bit",
  "messages":[{"role":"user","content":"List files using the tool."}],
  "tools":[{"type":"function","function":{"name":"run_shell","parameters":{"type":"object","properties":{"command":{"type":"string"}},"required":["command"]}}}]
}'
```

- **Before:** `message: {"role": "assistant"}` (call dropped), `finish_reason: "stop"`.
- **After:** `finish_reason: "tool_calls"`, `tool_calls: [{function: {name: "run_shell", arguments: "{\"command\": \"ls\"}"}}]`.

## Tests

Adds `TestTrailingToolCallFlush` in `tests/test_server.py`, which drives `handle_completion` with a scripted generation stream that ends in EOS while in the `"tool"` state (empty `tool_call_end`) and asserts the tool call is surfaced. Verified the test fails on `main` and passes with this change. Existing tool/state-machine tests still pass; `black` clean.
