### PR TITLE
Fix Mistral tool parser dropping parallel/multiple tool calls

### DIFF
--- a/mlx_lm/tool_parsers/mistral.py
+++ b/mlx_lm/tool_parsers/mistral.py
@@ -5,16 +5,39 @@ from typing import Any
 
 import regex as re
 
-_tool_call_regex = re.compile(r"\s*(\w+)\[ARGS\]\s*(\{.*\})", re.DOTALL)
+# Matches a single tool-call header of the form "name[ARGS]" and any trailing
+# whitespace, positioned right before the JSON arguments object.
+_tool_call_header_regex = re.compile(r"(\w+)\s*\[ARGS\]\s*", re.DOTALL)
 
 tool_call_start = "[TOOL_CALLS]"
 tool_call_end = ""
 
 
 def parse_tool_call(text: str, tools: Any | None = None):
-    match = _tool_call_regex.search(text)
-    if match is None:
+    # Mistral has no explicit tool-call end token, so the server accumulates the
+    # whole tail of the generation into a single string. That string may contain
+    # multiple concatenated calls (parallel tool calls, optionally separated by
+    # "[TOOL_CALLS]") and/or trailing natural-language text. Parse each call by
+    # locating a "name[ARGS]" header and decoding exactly one JSON object with
+    # raw_decode, which correctly respects string/brace boundaries and ignores
+    # any trailing data. Continue scanning after each decoded object.
+    decoder = json.JSONDecoder()
+    calls = []
+    pos = 0
+    while (match := _tool_call_header_regex.search(text, pos)) is not None:
+        name = match.group(1)
+        start = match.end()
+        if start >= len(text) or text[start] != "{":
+            pos = match.end()
+            continue
+        try:
+            arguments, end = decoder.raw_decode(text, start)
+        except json.JSONDecodeError:
+            pos = match.end()
+            continue
+        calls.append(dict(name=name, arguments=arguments))
+        pos = end
+
+    if not calls:
         raise ValueError(f"Could not parse tool call from: {text}")
-    func_name = match.group(1)
-    func_args = json.loads(match.group(2))
-    return dict(name=func_name, arguments=func_args)
+    return calls[0] if len(calls) == 1 else calls

--- a/mlx_lm/tool_parsers/mistral.py
+++ b/mlx_lm/tool_parsers/mistral.py
@@ -5,38 +5,26 @@ from typing import Any
 
 import regex as re
 
-# Matches a single tool-call header of the form "name[ARGS]" and any trailing
-# whitespace, positioned right before the JSON arguments object.
-_tool_call_header_regex = re.compile(r"(\w+)\s*\[ARGS\]\s*", re.DOTALL)
+# Matches a "name[ARGS]" header, ending where the JSON arguments start.
+_tool_call_header_regex = re.compile(r"([\w-]+)\s*\[ARGS\]\s*")
 
 tool_call_start = "[TOOL_CALLS]"
 tool_call_end = ""
 
 
 def parse_tool_call(text: str, tools: Any | None = None):
-    # Mistral has no explicit tool-call end token, so the server accumulates the
-    # whole tail of the generation into a single string. That string may contain
-    # multiple concatenated calls (parallel tool calls, optionally separated by
-    # "[TOOL_CALLS]") and/or trailing natural-language text. Parse each call by
-    # locating a "name[ARGS]" header and decoding exactly one JSON object with
-    # raw_decode, which correctly respects string/brace boundaries and ignores
-    # any trailing data. Continue scanning after each decoded object.
+    # Mistral has no tool-call end token, so the text can hold several calls.
+    # raw_decode reads exactly one JSON value and reports where it ended.
     decoder = json.JSONDecoder()
     calls = []
     pos = 0
     while (match := _tool_call_header_regex.search(text, pos)) is not None:
-        name = match.group(1)
-        start = match.end()
-        if start >= len(text) or text[start] != "{":
-            pos = match.end()
-            continue
+        pos = match.end()
         try:
-            arguments, end = decoder.raw_decode(text, start)
+            arguments, pos = decoder.raw_decode(text, pos)
         except json.JSONDecodeError:
-            pos = match.end()
             continue
-        calls.append(dict(name=name, arguments=arguments))
-        pos = end
+        calls.append(dict(name=match.group(1), arguments=arguments))
 
     if not calls:
         raise ValueError(f"Could not parse tool call from: {text}")

--- a/tests/test_tool_parsing.py
+++ b/tests/test_tool_parsing.py
@@ -275,6 +275,60 @@ class TestToolParsing(unittest.TestCase):
         self.assertEqual(tool_call["arguments"]["action"], "create")
         self.assertIn("{", tool_call["arguments"]["content"])
 
+    def test_mistral(self):
+        # Single call with trailing natural-language text. Mistral has no
+        # tool_call_end token, so trailing tokens land in the same segment and
+        # must be ignored rather than fed to json.loads (which raises
+        # "Extra data").
+        test_case = 'get_weather[ARGS]{"city": "Paris"}\n\nLet me check that.'
+        tool_call = mistral.parse_tool_call(test_case, None)
+        self.assertEqual(
+            tool_call, {"name": "get_weather", "arguments": {"city": "Paris"}}
+        )
+
+        # Multiple (parallel) tool calls concatenated into one segment,
+        # separated by the "[TOOL_CALLS]" marker. These must all be returned as
+        # a list rather than dropped.
+        test_case = (
+            'get_weather[ARGS]{"city": "Paris"}'
+            '[TOOL_CALLS]get_weather[ARGS]{"city": "Tokyo"}'
+        )
+        tool_calls = mistral.parse_tool_call(test_case, None)
+        self.assertIsInstance(tool_calls, list)
+        self.assertEqual(len(tool_calls), 2)
+        self.assertEqual(
+            tool_calls[0], {"name": "get_weather", "arguments": {"city": "Paris"}}
+        )
+        self.assertEqual(
+            tool_calls[1], {"name": "get_weather", "arguments": {"city": "Tokyo"}}
+        )
+
+        # Multiple calls with no separator between them.
+        test_case = 'a[ARGS]{"x": 1}b[ARGS]{"y": 2}'
+        tool_calls = mistral.parse_tool_call(test_case, None)
+        self.assertEqual(
+            tool_calls,
+            [
+                {"name": "a", "arguments": {"x": 1}},
+                {"name": "b", "arguments": {"y": 2}},
+            ],
+        )
+
+        # Nested JSON and literal braces / "[ARGS]" inside a string must not
+        # confuse the parser.
+        test_case = (
+            'run[ARGS]{"cmd": "echo {x} [ARGS] }", '
+            '"opts": {"deep": [1, 2, {"k": "v"}]}}'
+        )
+        tool_call = mistral.parse_tool_call(test_case, None)
+        self.assertEqual(tool_call["name"], "run")
+        self.assertEqual(tool_call["arguments"]["cmd"], "echo {x} [ARGS] }")
+        self.assertEqual(tool_call["arguments"]["opts"], {"deep": [1, 2, {"k": "v"}]})
+
+        # Text with no tool call still raises.
+        with self.assertRaises(ValueError):
+            mistral.parse_tool_call("just some prose, no call here", None)
+
     def test_kimi_k2(self):
         # Single tool call
         test_case = (

--- a/tests/test_tool_parsing.py
+++ b/tests/test_tool_parsing.py
@@ -291,10 +291,7 @@ class TestToolParsing(unittest.TestCase):
         self.assertIn("{", tool_call["arguments"]["content"])
 
     def test_mistral(self):
-        # Single call with trailing natural-language text. Mistral has no
-        # tool_call_end token, so trailing tokens land in the same segment and
-        # must be ignored rather than fed to json.loads (which raises
-        # "Extra data").
+        # Single call with trailing natural-language text.
         test_case = 'get_weather[ARGS]{"city": "Paris"}\n\nLet me check that.'
         tool_call = mistral.parse_tool_call(test_case, None)
         self.assertEqual(
@@ -303,16 +300,16 @@ class TestToolParsing(unittest.TestCase):
 
         # Multiple (parallel) tool calls concatenated into one segment,
         # separated by the "[TOOL_CALLS]" marker. These must all be returned as
-        # a list rather than dropped.
+        # a list rather than dropped. Hyphens are legal in tool names.
         test_case = (
-            'get_weather[ARGS]{"city": "Paris"}'
+            'get-weather[ARGS]{"city": "Paris"}'
             '[TOOL_CALLS]get_weather[ARGS]{"city": "Tokyo"}'
         )
         tool_calls = mistral.parse_tool_call(test_case, None)
         self.assertIsInstance(tool_calls, list)
         self.assertEqual(len(tool_calls), 2)
         self.assertEqual(
-            tool_calls[0], {"name": "get_weather", "arguments": {"city": "Paris"}}
+            tool_calls[0], {"name": "get-weather", "arguments": {"city": "Paris"}}
         )
         self.assertEqual(
             tool_calls[1], {"name": "get_weather", "arguments": {"city": "Tokyo"}}


### PR DESCRIPTION
## What

Fix the Mistral tool-call parser (`mlx_lm/tool_parsers/mistral.py`) dropping tool calls when a generation contains **multiple (parallel) tool calls** or a **single call followed by trailing text**.

## Why

Mistral/Devstral have an empty `tool_call_end`, so the server's state machine never leaves the `"tool"` state until EOS and accumulates the entire tail of the generation into a single string. That string can look like:

```
get_weather[ARGS]{"city": "Paris"}[TOOL_CALLS]get_weather[ARGS]{"city": "Tokyo"}
```

or a single call with trailing prose:

```
grep[ARGS]{"pattern": "TODO"}

Let me search for that.
```

The old parser used a greedy regex `(\{.*\})` and `json.loads` on the whole capture, which raises `json.JSONDecodeError: Extra data ...` in both cases. `ToolCallFormatter` catches that error and `continue`s, so **the call is silently dropped and the client receives an empty message** — an agent driving the server (e.g. via the OpenAI-compatible endpoint) then stalls with no tool call and no content.

## How

Locate each `name[ARGS]` header and decode **exactly one** JSON object with `json.JSONDecoder().raw_decode()`, which respects string/brace boundaries and ignores any trailing data. Scanning resumes after each decoded object, so all calls are collected. Returns a single dict for one call and a list for multiple — matching the existing `gemma4` and `kimi_k2` parsers, and `ToolCallFormatter` already normalizes both shapes.

## Tests

Adds `test_mistral` to `tests/test_tool_parsing.py` covering:
- single call followed by natural-language text,
- parallel calls with the `[TOOL_CALLS]` separator,
- multiple calls with no separator,
- nested JSON and literal braces / `[ARGS]` inside a string,
- the no-call `ValueError` path.

```
$ python -m unittest tests.test_tool_parsing -v
... test_mistral ... ok
Ran 6 tests OK
```

## Related

Complements #1447, which fixes the server-side flush so the trailing buffered call reaches the parser in the first place. This PR fixes the parser itself so multi/trailing calls are parsed rather than dropped. Together they address the empty-response behavior with Mistral/Devstral tool calling (see also #1307).
