### PR TITLE
Fix DSA indexer LoRA-training crash: stop gradients through sparse-attention top-k indices

### DIFF
--- a/mlx_lm/models/deepseek_v32.py
+++ b/mlx_lm/models/deepseek_v32.py
@@ -109,9 +109,16 @@ class Indexer(nn.Module):
         scores = scores.sum(axis=1, keepdims=True)
         if mask is not None:
             scores = mx.where(mask, scores, -float("inf"))
-        return mx.argpartition(scores, kth=-self.index_topk, axis=-1)[
-            ..., -self.index_topk :
-        ]
+        # The top-k indices are an integer selection and carry no gradient.
+        # Stop gradients here so that when training (e.g. LoRA) with
+        # sequences longer than index_topk, autograd does not request an
+        # indices VJP from the scatter/gather ops that consume them
+        # ("Cannot calculate VJP with respect to indices").
+        return mx.stop_gradient(
+            mx.argpartition(scores, kth=-self.index_topk, axis=-1)[
+                ..., -self.index_topk :
+            ]
+        )
 
 
 class DeepseekV32Attention(nn.Module):
@@ -206,6 +213,11 @@ class DeepseekV32Attention(nn.Module):
 
         topk_indices = self.indexer(x, qr, mask, cache=cache[1])
         if topk_indices is not None:
+            # Also stop gradients at the point of use: if the indices ever
+            # arrive through a traced boundary (e.g. as a checkpointed
+            # function input with grad_checkpoint), the producer-side
+            # stop_gradient is not visible to the re-traced graph.
+            topk_indices = mx.stop_gradient(topk_indices)
             if L == 1:
                 idx = topk_indices[:, :, 0, :, None]
                 kv_latent = mx.take_along_axis(

--- a/mlx_lm/models/deepseek_v32.py
+++ b/mlx_lm/models/deepseek_v32.py
@@ -111,16 +111,8 @@ class Indexer(nn.Module):
         scores = scores.sum(axis=1, keepdims=True)
         if mask is not None:
             scores = mx.where(mask, scores, -float("inf"))
-        # The top-k indices are an integer selection and carry no gradient.
-        # Stop gradients here so that when training (e.g. LoRA) with
-        # sequences longer than index_topk, autograd does not request an
-        # indices VJP from the scatter/gather ops that consume them
-        # ("Cannot calculate VJP with respect to indices").
-        return mx.stop_gradient(
-            mx.argpartition(scores, kth=-self.index_topk, axis=-1)[
-                ..., -self.index_topk :
-            ]
-        )
+        indices = mx.argpartition(scores, kth=-self.index_topk, axis=-1)
+        return mx.stop_gradient(indices[..., -self.index_topk :])
 
 
 class DeepseekV32Attention(nn.Module):
@@ -215,10 +207,6 @@ class DeepseekV32Attention(nn.Module):
 
         topk_indices = self.indexer(x, qr, mask, cache=cache[1])
         if topk_indices is not None:
-            # Also stop gradients at the point of use: if the indices ever
-            # arrive through a traced boundary (e.g. as a checkpointed
-            # function input with grad_checkpoint), the producer-side
-            # stop_gradient is not visible to the re-traced graph.
             topk_indices = mx.stop_gradient(topk_indices)
             if L == 1:
                 idx = topk_indices[:, :, 0, :, None]


### PR DESCRIPTION
## What

LoRA fine-tuning of DSA sparse-attention models (`deepseek_v32`, and `glm_moe_dsa` which subclasses it) crashes deterministically in the backward pass:

```
ValueError: [scatter_axis] Cannot calculate VJP with respect to indices.
```

Fixes #1449. Companion core issue: ml-explore/mlx#3787.

## Root cause

The DSA `Indexer` only activates when the key length exceeds `index_topk` (2048); below that it returns `None` and training works fine. Once a batch crosses that width, the indexer computes `topk_indices` via `mx.argpartition` over scores that derive from trainable projections (`wq_b`, `wk`, `weights_proj`, and the shared `q_a_proj` — all typical LoRA targets). Those integer indices then feed `mx.put_along_axis` (training/prefill path) and `mx.take_along_axis` (decode path) in the attention. Because the indices lie on the autodiff path, autograd requests a VJP with respect to the scatter's index argument, and `ScatterAxis::vjp` throws instead of returning a zero cotangent (ml-explore/mlx#3787).

This explains the reproduction in #1449 exactly: the crash lands on the first batch whose sequence width crosses 2048 — the same step every run under a fixed seed — and is unaffected by which LoRA keys are trained, the learning rate, or excluding `switch_mlp`. (My original report blamed the MoE routing scatter; that was wrong — the MoE gate's scatter is already protected by `mx.stop_gradient` on `group_idx`. The unprotected site is the indexer.)

## Fix

`mx.stop_gradient` on the top-k indices at two sites:

1. **Producer** — wrap the `Indexer.__call__` return. Integer top-k indices are a non-differentiable selection, so this is semantically exact: the forward pass is bit-identical, and inference never differentiates so serving is unaffected.
2. **Consumer** — re-assert the barrier where `topk_indices` is consumed in `DeepseekV32Attention.__call__`. This is defensive: if the indices ever reach the attention through a traced boundary (e.g. as a checkpointed function input under `grad_checkpoint` in a variant that passes indices between layers), a producer-side barrier is not visible to the re-traced graph and the crash returns. It is a no-op when the indices come straight from the producer, as here.

A zero-cotangent fix in core MLX (ml-explore/mlx#3787) would also resolve the throw, but the model-side barrier is exact regardless, avoids computing gradients that are discarded, and unblocks training today.

## Validation

- Applied the same two barriers to an mlx-lm 0.31.3 install and ran `mlx_lm.lora` on GLM-5.2 (4-bit, `glm_moe_dsa`) with `grad_checkpoint: true`, `max_seq_length: 4096` on real data: previously crashed at the first >2048-token batch, now trains cleanly (30-iteration smoke run, healthy loss descent).
- `python -m py_compile` and `black --check` pass on the changed file.
