### PR TITLE
fix(mlx_lm.server): fail fast when --draft-model set with non-trimmable cache

### DIFF
--- a/mlx_lm/server.py
+++ b/mlx_lm/server.py
@@ -40,10 +40,20 @@ from .generate import (
 )
 from .models.cache import (
     LRUPromptCache,
+    can_trim_prompt_cache,
     make_prompt_cache,
 )
 from .sample_utils import make_logits_processors, make_sampler
 from .utils import _parse_size, load, sharded_load
+
+
+def _ensure_speculation_supported(prompt_cache, model_path):
+    if not can_trim_prompt_cache(prompt_cache):
+        non_trimmable = {type(c).__name__ for c in prompt_cache if not c.is_trimmable()}
+        raise ValueError(
+            f"--draft-model was set, but speculative decoding requires a trimmable "
+            f"prompt cache; '{model_path}' uses non-trimmable cache(s): {non_trimmable}"
+        )
 
 
 def get_system_fingerprint():
@@ -357,6 +367,11 @@ class ModelProvider:
             if tokenizer.chat_template is None:
                 tokenizer.chat_template = tokenizer.default_chat_template
 
+        # Speculative decoding needs a trimmable target cache, fail fast if not
+        prompt_cache = make_prompt_cache(model)
+        if draft_model_path is not None:
+            _ensure_speculation_supported(prompt_cache, model_path)
+
         # Load the draft model for speculative decoding
         draft_model = None
         if draft_model_path is not None:
@@ -369,9 +384,7 @@ class ModelProvider:
 
         # Compute batchability
         is_batchable = draft_model is None
-        is_batchable = is_batchable and all(
-            hasattr(c, "merge") for c in make_prompt_cache(model)
-        )
+        is_batchable = is_batchable and all(hasattr(c, "merge") for c in prompt_cache)
 
         # Update the member variables
         self.model_key = (model_path, adapter_path, draft_model_path)

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -16,6 +16,7 @@ from mlx_lm.server import (
     LRUPromptCache,
     Response,
     ResponseGenerator,
+    _ensure_speculation_supported,
     _process_control_tokens,
 )
 from mlx_lm.utils import load
@@ -155,6 +156,26 @@ class TestProcessControlTokens(unittest.TestCase):
             [t.state for t in out],
             ["tool", "tool", "tool", "normal", "normal"],
         )
+
+
+class TestSpeculationValidation(unittest.TestCase):
+    def test_rejects_non_trimmable_cache(self):
+        with self.assertRaises(ValueError):
+            _ensure_speculation_supported(
+                [MockCache("aaa", is_trimmable=False)], "test/model"
+            )
+
+    def test_allows_trimmable_cache(self):
+        # Should not raise
+        _ensure_speculation_supported(
+            [MockCache("aaa", is_trimmable=True)], "test/model"
+        )
+
+    def test_error_message_names_bad_cache_type(self):
+        with self.assertRaisesRegex(ValueError, "MockCache"):
+            _ensure_speculation_supported(
+                [MockCache("aaa", is_trimmable=False)], "test/model"
+            )
 
 
 class TestServer(unittest.TestCase):


### PR DESCRIPTION
### Summary
Fixes https://github.com/ml-explore/mlx-lm/issues/1446. 

mlx_lm.server with --draft-model accepts startup and /v1/models, then crashes during the first completion with 
>"ValueError: Speculative decoding requires a trimmable prompt cache". 

This issue would affect hybrid-attention models such as `qwen3_5_moe` which use `ArraysCache` on their linear-attention layers, which cannot be trimmed. Speculative decoding needs trimming to roll back rejected draft tokens.

Since the user provides `--draft-model` explicitly, opting to fail fast here makes more sense (as opposed to say, silently disabling speculation). There are two other options named in the issue which don't strike me as particularly feasible at this time:
- `use/select a trimmable cache for this path`: The model's linear attention layer requires recurrent state https://sebastianraschka.com/llm-architecture-gallery/hybrid-attention/ which cannot be simply replaced by a trimmable cache structure.
- `support trimming the cache type used by these Qwen hybrid-attention models`: Similar to above, a cache for linear attention models cannot be easily trimmed (it would probably require checkpointing of the recurrent state, resulting in memory blowup).

### Implementation

Built the check into a small helper `_ensure_speculation_supported(prompt_cache, model_path)` with related unit tests using a mock cache (optionally, could inline the check but this seemed more testable).

### Tests

Added 3 unit tests (ensure check rejects non-trimmable caches, allows trimmable, and that the error message names the cache type in question). No model download.
Happy path cases remain covered by existing `TestServer` and `TestServerWithDraftModel` test classes.

### Verified Locally

With this fix, the server now fails at startup, before serving any request, instead of crashing mid-generation.

```
❯ python -m mlx_lm.server \
    --model mlx-community/mamba-130m-hf-bf16 \
    --draft-model mlx-community/Qwen2.5-0.5B-Instruct-4bit \
    --port 18087 --log-level ERROR

Exception in thread Thread-1 (_generate):
Traceback (most recent call last):
  File "/opt/miniconda3/lib/python3.13/threading.py", line 1043, in _bootstrap_inner
    self.run()
    ~~~~~~~~^^
  File "/opt/miniconda3/lib/python3.13/threading.py", line 994, in run
    self._target(*self._args, **self._kwargs)
    ~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/tejaskasturi/Documents/mlx-lm/mlx_lm/server.py", line 708, in _generate
    self.model_provider.load_default()
    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^^
  File "/Users/tejaskasturi/Documents/mlx-lm/mlx_lm/server.py", line 398, in load_default
    self.load("default_model", None, "default_model")
    ~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/tejaskasturi/Documents/mlx-lm/mlx_lm/server.py", line 407, in load
    self._load(*model_key)
    ~~~~~~~~~~^^^^^^^^^^^^
  File "/Users/tejaskasturi/Documents/mlx-lm/mlx_lm/server.py", line 373, in _load
    _ensure_speculation_supported(prompt_cache, model_path)
    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/tejaskasturi/Documents/mlx-lm/mlx_lm/server.py", line 53, in _ensure_speculation_supported
    raise ValueError(
    ...<2 lines>...
    )
ValueError: --draft-model was set, but speculative decoding requires a trimmable prompt cache; 'mlx-community/mamba-130m-hf-bf16' uses non-trimmable cache(s): {'ArraysCache'}
```