### PR TITLE
Fix NewlineTokenizer registration for transformers >= 5.13

### DIFF
--- a/mlx_lm/tokenizer_utils.py
+++ b/mlx_lm/tokenizer_utils.py
@@ -500,7 +500,7 @@ class NewlineTokenizer(PreTrainedTokenizerFast):
         return [self._postprocess_text(d) for d in decoded]
 
 
-AutoTokenizer.register("NewlineTokenizer", fast_tokenizer_class=NewlineTokenizer)
+AutoTokenizer.register(NewlineTokenizer, fast_tokenizer_class=NewlineTokenizer)
 
 
 def _match(a, b):


### PR DESCRIPTION
Fixes #1458

transformers 5.13.0 added an unguarded `key.__module__.startswith("transformers.")` check in `_LazyAutoMapping.register`, so registering a tokenizer with a string key now raises `AttributeError: 'str' object has no attribute '__module__'` at import time. mlx-lm registered `NewlineTokenizer` under the string `"NewlineTokenizer"`, which older transformers versions tolerated because the key was never dereferenced.

This PR passes the class itself as the registration key instead. Classes have `__module__`, so registration succeeds on 5.13, and nothing else changes: name-based lookup (`tokenizer_class_from_name`) resolves `"NewlineTokenizer"` through `REGISTERED_TOKENIZER_CLASSES`, which is keyed by the tokenizer's `__name__` regardless of the mapping key — so model repos with `"tokenizer_class": "NewlineTokenizer"` in their `tokenizer_config.json` load exactly as before.

Tested with transformers 5.13.0 and 5.7.0 (the minimum pinned version): `import mlx_lm` succeeds on both, and `tokenizer_class_from_name("NewlineTokenizer")` returns the class.

If you'd prefer registering with a `PreTrainedConfig` subclass per the documented signature, happy to update — this version just keeps the diff to one line.