### PR TITLE
Add quant2 / quant2_128 mixed-bit quant recipes

### DIFF
--- a/mlx_lm/convert.py
+++ b/mlx_lm/convert.py
@@ -77,7 +77,43 @@ def mixed_quant_predicate_builder(
     return mixed_quant_predicate
 
 
-QUANT_RECIPES = ["mixed_2_6", "mixed_3_4", "mixed_3_6", "mixed_4_6"]
+def quant2_predicate_builder(
+    recipe: str, model: nn.Module, group_size: int = 64
+) -> Callable[[str, nn.Module, dict], Union[bool, dict]]:
+    mode = "affine"
+    down_keys = [k for k, _ in model.named_modules() if "down_proj" in k]
+    if len(down_keys) == 0:
+        raise ValueError("Model does not have expected keys for quant2.")
+    for layer_location, k in enumerate(down_keys[0].split(".")):
+        if k.isdigit():
+            break
+    num_layers = len(model.layers)
+    # quant2_128 uses a wider group size (128) for a better quality/speed
+    # balance; quant2 uses the caller-supplied group_size.
+    gs = 128 if recipe == "quant2_128" else group_size
+
+    def quant2_predicate(path: str, module: nn.Module) -> Union[bool, dict]:
+        index = (
+            int(path.split(".")[layer_location])
+            if len(path.split(".")) > layer_location
+            else 0
+        )
+        # Keep embedding and output projection at 4-bit to preserve token
+        # resolution; keep the first and last decoder layers at 3-bit and
+        # quantize the bulk of the body at 2-bit for maximum decode speedup.
+        if "embed_tokens" in path or "lm_head" in path:
+            return {"group_size": group_size, "bits": 4, "mode": mode}
+        if index == 0 or index == num_layers - 1:
+            return {"group_size": gs, "bits": 3, "mode": mode}
+        return {"group_size": gs, "bits": 2, "mode": mode}
+
+    return quant2_predicate
+
+
+QUANT_RECIPES = [
+    "mixed_2_6", "mixed_3_4", "mixed_3_6", "mixed_4_6",
+    "quant2", "quant2_128",
+]
 
 MODEL_CONVERSION_DTYPES = ["float16", "bfloat16", "float32"]
 
@@ -121,11 +157,16 @@ def convert(
     if isinstance(quant_predicate, str):
         if q_mode != "affine":
             raise ValueError(f"Quant predicates only support 'affine' quantization.")
-        quant_predicate = mixed_quant_predicate_builder(
-            quant_predicate,
-            model,
-            q_group_size,
-        )
+        if quant_predicate in ("quant2", "quant2_128"):
+            quant_predicate = quant2_predicate_builder(
+                quant_predicate, model, q_group_size,
+            )
+        else:
+            quant_predicate = mixed_quant_predicate_builder(
+                quant_predicate,
+                model,
+                q_group_size,
+            )
 
     if dtype is None:
         dtype = config.get("torch_dtype", None)
@@ -220,7 +261,7 @@ def configure_parser() -> argparse.ArgumentParser:
     )
     parser.add_argument(
         "--quant-predicate",
-        help=f"Mixed-bit quantization recipe.",
+        help="Mixed-bit quantization recipe. The quant2 family (quant2, quant2_128) uses 2-bit for the decoder body and 4-bit for embed/lm_head for maximum decode speedup.",
         choices=QUANT_RECIPES,
         type=str,
         required=False,

--- a/tests/test_quant_recipes.py
+++ b/tests/test_quant_recipes.py
@@ -1,0 +1,86 @@
+# Copyright © 2024 Apple Inc.
+
+import unittest
+
+import mlx.core as mx
+import mlx.nn as nn
+
+from mlx_lm import utils
+from mlx_lm.convert import quant2_predicate_builder
+from mlx_lm.models import llama
+
+
+def _build_model(num_layers=4):
+    args = llama.ModelArgs(
+        model_type="llama",
+        hidden_size=256,
+        num_hidden_layers=num_layers,
+        intermediate_size=512,
+        num_attention_heads=4,
+        rms_norm_eps=1e-5,
+        vocab_size=1000,
+        tie_word_embeddings=False,
+    )
+    return llama.Model(args)
+
+
+class TestQuant2Recipes(unittest.TestCase):
+    def test_quant2_bit_allocation(self):
+        model = _build_model(num_layers=4)
+        pred = quant2_predicate_builder("quant2", model, 64)
+        model, _ = utils.quantize_model(model, {}, 64, 4, quant_predicate=pred)
+
+        # First and last decoder layers are kept at 3-bit.
+        self.assertEqual(model.layers[0].mlp.down_proj.bits, 3)
+        self.assertEqual(model.layers[-1].mlp.down_proj.bits, 3)
+        # Middle layers are quantized to 2-bit.
+        self.assertEqual(model.layers[1].mlp.down_proj.bits, 2)
+        self.assertEqual(model.layers[2].mlp.down_proj.bits, 2)
+        self.assertEqual(model.layers[1].mlp.down_proj.group_size, 64)
+        # Non-sensitive middle projection also at 2-bit.
+        self.assertEqual(model.layers[1].self_attn.q_proj.bits, 2)
+
+    def test_quant2_preserves_head(self):
+        model = _build_model(num_layers=4)
+        pred = quant2_predicate_builder("quant2", model, 64)
+        model, _ = utils.quantize_model(model, {}, 64, 4, quant_predicate=pred)
+        # lm_head is kept at 4-bit to preserve token resolution.
+        self.assertEqual(model.lm_head.bits, 4)
+        self.assertEqual(model.lm_head.group_size, 64)
+
+    def test_quant2_128_group_size(self):
+        model = _build_model(num_layers=4)
+        pred = quant2_predicate_builder("quant2_128", model, 64)
+        model, _ = utils.quantize_model(model, {}, 64, 4, quant_predicate=pred)
+        # Same bit allocation as quant2 ...
+        self.assertEqual(model.layers[0].mlp.down_proj.bits, 3)
+        self.assertEqual(model.layers[1].mlp.down_proj.bits, 2)
+        self.assertEqual(model.lm_head.bits, 4)
+        # ... but the 2/3-bit decoder body uses group_size=128.
+        self.assertEqual(model.layers[1].mlp.down_proj.group_size, 128)
+        self.assertEqual(model.layers[0].mlp.down_proj.group_size, 128)
+        # lm_head still uses the caller-supplied group_size.
+        self.assertEqual(model.lm_head.group_size, 64)
+
+    def test_quant2_first_and_last_layer_index(self):
+        # With 6 layers, indices 0 and 5 are the sensitive 3-bit positions.
+        model = _build_model(num_layers=6)
+        pred = quant2_predicate_builder("quant2", model, 64)
+        model, _ = utils.quantize_model(model, {}, 64, 4, quant_predicate=pred)
+        self.assertEqual(model.layers[0].mlp.down_proj.bits, 3)
+        self.assertEqual(model.layers[5].mlp.down_proj.bits, 3)
+        for i in range(1, 5):
+            self.assertEqual(model.layers[i].mlp.down_proj.bits, 2)
+
+    def test_quant2_runs_inference(self):
+        # The quantized model must still produce coherent output shapes.
+        model = _build_model(num_layers=4)
+        pred = quant2_predicate_builder("quant2", model, 64)
+        model, _ = utils.quantize_model(model, {}, 64, 4, quant_predicate=pred)
+        tokens = mx.array([[1, 2, 3]])
+        logits = model(tokens)
+        self.assertEqual(logits.shape, (1, 3, 1000))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Add `quant2` / `quant2_128` mixed-bit recipes

Adds two opt-in mixed-bit quantization recipes to `--quant-predicate`:

- **`quant2`** — 2-bit decoder body, 3-bit first/last layer, 4-bit `embed_tokens`/`lm_head`, group_size=64.
- **`quant2_128`** — same layer allocation, group_size=128 for a better quality/speed balance.

### Rationale

Refs #1450. That issue explored aggressive 2-bit quantization and benchmarked a pure 2-bit body on a 27B model at **+162% decode speedup** vs mxfp8 with coherent output. The downside of pure 2-bit is degraded token resolution at the embedding/output and the boundary layers. This recipe keeps those at 3–4-bit while quantizing the bulk of the decoder body at 2-bit, preserving coherence where it matters most while retaining the decode speedup.

### Layer allocation

| Layer                         | bits | group_size        |
|-------------------------------|------|-------------------|
| `embed_tokens`, `lm_head`     | 4    | caller-supplied   |
| first / last decoder layer    | 3    | 64 (`quant2`) / 128 (`quant2_128`) |
| decoder body                  | 2    | 64 (`quant2`) / 128 (`quant2_128`) |

### Usage

```bash
mlx_lm.convert --model <hf-or-local> -q --quant-predicate quant2 --q-group-size 64 --mlx-path out-quant2
mlx_lm.convert --model <hf-or-local> -q --quant-predicate quant2_128 --q-group-size 128 --mlx-path out-quant2-128
```

### Tests

`tests/test_quant_recipes.py` — 5 tests covering bit allocation per layer, head/embed preservation, group_size selection, first/last layer index detection, and end-to-end inference. All pass.

### Benchmark (Qwen2.5-7B-Instruct, Apple M5 Max, 60-token decode)

| recipe      | decode tok/s | vs mxfp8 speed | size (GiB) | vs mxfp8 size | bpw   |
|-------------|--------------|----------------|------------|---------------|-------|
| mxfp8       | 29.1         | 1.00x          | 7.31       | 1.00x         | 8.250 |
| quant2      | 97.7         | 3.36x (+236%)  | 2.53       | 0.35x         | 2.848 |
| quant2_128  | 139.1        | 4.78x (+378%)  | 2.30       | 0.31x         | 2.598 |

The recipe converts cleanly, runs end-to-end, and delivers a large decode speedup with a ~3x memory reduction. `quant2_128` is both faster and smaller than `quant2` thanks to the wider group.

### Quality note (important)

2-bit quantization has a coherence threshold tied to model scale. At 7B the recipe runs correctly and the speedup holds, but the 2-bit body degrades output coherence (English-shaped but nonsensical text); at 0.5B output is fully degraded. Coherent 2-bit output requires the larger model regime — #1450 reports coherent output at 27B with +162% speedup. The recipe is intended for that ≥27B scale where 2-bit is viable; on smaller models users should prefer `mixed_3_4` / `mixed_4_6` or uniform 4-bit.

Refs #1450.
