### PR TITLE
Fix broadcast crash in quantized SDPA with GQA + batched padding mask (batch >= 2)

### DIFF
--- a/mlx_lm/models/base.py
+++ b/mlx_lm/models/base.py
@@ -90,11 +90,7 @@ def quantized_scaled_dot_product_attention(
             q_indices = mx.arange(kL - qL, kL)
             k_indices = mx.arange(kL)
             mask = q_indices[:, None] >= k_indices[None]
-        if n_repeats > 1 and mask.ndim >= 3:
-            # GQA reshaped the scores to 5D (B, n_kv_heads, n_repeats, L, L); a
-            # mask carrying leading batch/head dims (e.g. a (B, 1, L, L) padding
-            # mask) must gain the n_repeats axis so it broadcasts over the repeat
-            # groups instead of colliding B against n_kv_heads at batch >= 2.
+        if n_repeats > 1 and mask.ndim > 3:
             mask = mx.expand_dims(mask, -3)
         if mask.dtype == mx.bool_:
             scores = mx.where(mask, scores, mx.finfo(scores.dtype).min)

--- a/mlx_lm/models/base.py
+++ b/mlx_lm/models/base.py
@@ -90,6 +90,12 @@ def quantized_scaled_dot_product_attention(
             q_indices = mx.arange(kL - qL, kL)
             k_indices = mx.arange(kL)
             mask = q_indices[:, None] >= k_indices[None]
+        if n_repeats > 1 and mask.ndim >= 3:
+            # GQA reshaped the scores to 5D (B, n_kv_heads, n_repeats, L, L); a
+            # mask carrying leading batch/head dims (e.g. a (B, 1, L, L) padding
+            # mask) must gain the n_repeats axis so it broadcasts over the repeat
+            # groups instead of colliding B against n_kv_heads at batch >= 2.
+            mask = mx.expand_dims(mask, -3)
         if mask.dtype == mx.bool_:
             scores = mx.where(mask, scores, mx.finfo(scores.dtype).min)
         else:

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -339,6 +339,37 @@ class TestModels(unittest.TestCase):
         )
         self.assertTrue(mx.allclose(out, qout, rtol=1e-2, atol=1e-2))
 
+    def test_quantized_sdpa_gqa_batched_mask(self):
+        # Regression test: quantized SDPA with grouped-query attention and a
+        # batched (B >= 2) padding mask used to crash with a broadcast error
+        # because the mask lacked the n_repeats axis introduced by the GQA
+        # reshape of the scores.
+        B, n_q_heads, n_kv_heads, L, D = 2, 8, 2, 16, 32
+
+        cache = KVCache()
+        k = 1e-1 * mx.random.normal(shape=(B, n_kv_heads, L, D))
+        v = 1e-1 * mx.random.normal(shape=(B, n_kv_heads, L, D))
+        k_up, v_up = cache.update_and_fetch(k, v)
+        quant_cache = cache.to_quantized(group_size=32, bits=8)
+        qk_up, qv_up = quant_cache.state
+
+        q = 1e-1 * mx.random.normal(shape=(B, n_q_heads, L, D))
+
+        # Batched padding mask, shape (B, 1, L, L), as produced by BatchKVCache.
+        mask = mx.ones((B, 1, L, L), dtype=mx.bool_)
+        mask[1, :, :, L // 2 :] = False
+
+        out = scaled_dot_product_attention(
+            q, k_up, v_up, cache=cache, mask=mask, scale=1.0
+        )
+        qout = scaled_dot_product_attention(
+            q, qk_up, qv_up, cache=quant_cache, mask=mask, scale=1.0
+        )
+        mx.eval(out, qout)
+        self.assertEqual(qout.shape, (B, n_q_heads, L, D))
+        self.assertTrue(mx.all(mx.isfinite(qout)).item())
+        self.assertTrue(mx.allclose(out, qout, rtol=1e-2, atol=1e-2))
+
     def model_test_runner(self, model, model_type, vocab_size, num_layers):
         self.assertEqual(len(model.layers), num_layers)
         self.assertEqual(model.model_type, model_type)


### PR DESCRIPTION
## Summary
`quantized_scaled_dot_product_attention` crashes with `[broadcast_shapes] … cannot be broadcast` for any grouped-query-attention model using a quantized KV cache once the batch size is ≥ 2. This makes `kv-bits` unusable with batched decoding on GQA models (e.g. Qwen3, Qwen3.5/3.6). Tested on `main` @ `2ed22318`.

## Root cause
For GQA (`n_repeats = n_q_heads // n_kv_heads > 1`) the function reshapes queries to 5D `(B, n_kv_heads, n_repeats, L, D)`, so `scores` become 5D `(B, n_kv_heads, n_repeats, L, L)` — but the mask is passed through unchanged. A batched padding mask is 4D `(B, 1, L, L)`. Right-aligned broadcasting lines the mask's `B` axis up against `n_kv_heads`: harmless at `B == 1` (`1`-vs-`n_kv_heads`), but at `B ≥ 2` it becomes `B`-vs-`n_kv_heads` (e.g. `2` vs `8`) with neither equal to 1 → broadcast failure.

## Minimal repro
Direct call to `quantized_scaled_dot_product_attention` with GQA dims (`n_q_heads=40, n_kv_heads=8` → `n_repeats=5`), 8-bit quantized KV, batch=2, a `(2,1,L,L)` bool mask:

```
queries (2, 40, 16, 128)  q_keys[0] (2, 8, 16, 32)  mask (2, 1, 16, 16)  n_repeats=5
ValueError: [broadcast_shapes] Shapes (2,1,16,16) and (2,8,5,16,16) cannot be broadcast.
  at mlx_lm/models/base.py:94  scores = mx.where(mask, scores, mx.finfo(scores.dtype).min)
```

## Fix
```diff
             mask = q_indices[:, None] >= k_indices[None]
+        if n_repeats > 1 and mask.ndim >= 3:
+            mask = mx.expand_dims(mask, -3)
         if mask.dtype == mx.bool_:
             scores = mx.where(mask, scores, mx.finfo(scores.dtype).min)
         else:
             scores += mask
```
Inserts a singleton `n_repeats` axis so `(B,1,L,L)` → `(B,1,1,L,L)` and broadcasts across the repeat groups. Guarded on `mask.ndim >= 3` so the 2D causal-string path and the MHA (`n_repeats == 1`) path are untouched.

## Verification
Patched, same B=2 GQA quantized-KV inputs:
```
OK: out.shape=(2, 40, 16, 128) finite=True
row1 padded-column attention-weight sum=0.000e+00   # mask applied correctly, not just made to broadcast
```
Also verified end-to-end: Qwen3.6-35B-A3B with `--kv-bits 8` and 8-way in-flight — which crashed on every batch ≥ 2 before — now serves concurrent generations cleanly (0 broadcast errors, coherent output).
