### PR TITLE
Fix MTPHead: correct hidden-state/embedding concat order and use pre-norm hidden

### DIFF
--- a/mlx_lm/generate.py
+++ b/mlx_lm/generate.py
@@ -517,11 +517,23 @@ def speculative_generate_step(
         model_cache = prompt_cache[: len(model.layers)]
         draft_cache = prompt_cache[len(model.layers) :]
 
-    if not cache.can_trim_prompt_cache(model_cache):
-        types = {type(c).__name__ for c in model_cache if not c.is_trimmable()}
+    if not cache.can_rewind_prompt_cache(model_cache):
+        types = {
+            type(c).__name__
+            for c in model_cache
+            if not (c.is_trimmable() or c.is_checkpointable())
+        }
         raise ValueError(
-            f"Speculative decoding requires a trimmable prompt cache " f"(got {types})."
+            "Speculative decoding requires a trimmable or checkpointable "
+            f"prompt cache (got {types})."
         )
+    # Some hybrid linear-attention models mix trimmable KV layers with
+    # fixed-size recurrent state that can only be checkpointed/restored, not
+    # trimmed to an arbitrary position -- rejecting draft tokens on those
+    # models means rewinding the whole round and replaying the accepted
+    # prefix (see _rewind_cache below), not just an O(1) trim.
+    needs_checkpoint = not cache.can_trim_prompt_cache(model_cache)
+    model_checkpoint = None
 
     sampler = sampler or (lambda x: mx.argmax(x, axis=-1))
 
@@ -577,8 +589,29 @@ def speculative_generate_step(
             mx.clear_cache()
         return y
 
-    def _rewind_cache(num_draft, num_accept):
-        cache.trim_prompt_cache(model_cache, num_draft - num_accept)
+    def _rewind_cache(num_draft, num_accept, batch_y):
+        if needs_checkpoint:
+            # model_checkpoint is None if this round never got far enough
+            # to take one (e.g. an exception during draft generation, which
+            # only touches the draft cache) -- nothing to rewind in that
+            # case, model_cache is still exactly where the last round left it.
+            if num_accept < num_draft and model_checkpoint is not None:
+                # A fixed-size recurrent state can't be trimmed back to the
+                # accepted position the way a KV cache can -- undo the
+                # whole round (trimmable layers roll back for free, the
+                # checkpointed ones are restored) and replay exactly the
+                # tokens that turned out to be correct so every layer ends
+                # up in sync again.
+                cache.rewind_prompt_cache(model_cache, model_checkpoint, num_draft + 1)
+                accepted = batch_y[: num_accept + 1]
+                with mx.stream(generation_stream):
+                    model(accepted[None], cache=model_cache)
+                    quantize_cache_fn(model_cache)
+                    mx.eval([c.state for c in model_cache])
+            # else: every draft token was accepted, so model_cache already
+            # reflects the true trajectory -- nothing to rewind.
+        else:
+            cache.trim_prompt_cache(model_cache, num_draft - num_accept)
         cache.trim_prompt_cache(draft_cache, max(num_draft - num_accept - 1, 0))
 
     def _draft_generate(y, num_draft):
@@ -599,6 +632,7 @@ def speculative_generate_step(
     # Set these so the finally block doesn't raise
     num_draft = 0
     n = 0
+    batch_y = y
     try:
         while True:
             num_draft = min(max_tokens - ntoks, num_draft_tokens)
@@ -606,6 +640,9 @@ def speculative_generate_step(
             if prev_tokens is not None:
                 prev_tokens = prev_tokens[: prev_tokens.size - y.size - num_draft + 1]
             y = mx.concatenate([y, draft_tokens])
+            batch_y = y
+            if needs_checkpoint:
+                model_checkpoint = cache.checkpoint_prompt_cache(model_cache)
             tokens, logprobs = _step(model, model_cache, y, num_draft + 1)
             mx.eval(tokens, draft_tokens)
             draft_tokens = draft_tokens.tolist()
@@ -640,9 +677,9 @@ def speculative_generate_step(
 
             if prev_tokens is not None:
                 prev_tokens = prev_tokens[: -max(num_draft - n, 1)]
-            _rewind_cache(num_draft, n)
+            _rewind_cache(num_draft, n, batch_y)
     finally:
-        _rewind_cache(num_draft, n)
+        _rewind_cache(num_draft, n, batch_y)
 
 
 def mtp_speculative_generate_step(
@@ -701,11 +738,21 @@ def mtp_speculative_generate_step(
         model_cache = prompt_cache
     mtp_cache = model.make_mtp_cache()
 
-    if not cache.can_trim_prompt_cache(model_cache):
-        types = {type(c).__name__ for c in model_cache if not c.is_trimmable()}
+    if not cache.can_rewind_prompt_cache(model_cache):
+        types = {
+            type(c).__name__
+            for c in model_cache
+            if not (c.is_trimmable() or c.is_checkpointable())
+        }
         raise ValueError(
-            f"Speculative decoding requires a trimmable prompt cache " f"(got {types})."
+            "Speculative decoding requires a trimmable or checkpointable "
+            f"prompt cache (got {types})."
         )
+    # See the comment in speculative_generate_step -- hybrid linear-attention
+    # models need checkpoint/restore + replay for the recurrent layers
+    # instead of an O(1) trim when draft tokens are rejected.
+    needs_checkpoint = not cache.can_trim_prompt_cache(model_cache)
+    model_checkpoint = None
 
     sampler = sampler or (lambda x: mx.argmax(x, axis=-1))
 
@@ -747,8 +794,20 @@ def mtp_speculative_generate_step(
             mx.clear_cache()
         return y, hidden
 
-    def _rewind_cache(num_draft, num_accept):
-        cache.trim_prompt_cache(model_cache, num_draft - num_accept)
+    def _rewind_cache(num_draft, num_accept, batch_y):
+        if needs_checkpoint:
+            if num_accept < num_draft and model_checkpoint is not None:
+                # See the comment in speculative_generate_step's
+                # _rewind_cache -- recurrent state can't be trimmed, so
+                # undo the round and replay the accepted prefix.
+                cache.rewind_prompt_cache(model_cache, model_checkpoint, num_draft + 1)
+                accepted = batch_y[: num_accept + 1]
+                with mx.stream(generation_stream):
+                    model(accepted[None], cache=model_cache)
+                    quantize_cache_fn(model_cache)
+                    mx.eval([c.state for c in model_cache])
+        else:
+            cache.trim_prompt_cache(model_cache, num_draft - num_accept)
         cache.trim_prompt_cache(mtp_cache, max(num_draft - num_accept - 1, 0))
 
     def _mtp_draft_generate(hidden_state, last_token, num_draft):
@@ -760,8 +819,17 @@ def mtp_speculative_generate_step(
         h, t = hidden_state, last_token
         for _ in range(num_draft):
             with mx.stream(generation_stream):
+                # t[None] turns the (1,)-shaped token id into (1, 1) so the
+                # embedding comes out (1, 1, D), matching h's (1, 1, D) --
+                # mx.concatenate inside MTPHead requires matching ranks.
                 logits, h = model.mtp_step(h, t[None], cache=mtp_cache)
                 t, _ = _process_and_sample(None, logits.squeeze(0)[-1])
+                # _process_and_sample's sampler (e.g. argmax) collapses a
+                # 1-D logits vector to a 0-d scalar; reshape back to (1,)
+                # so it chains into the next iteration the same way it
+                # came in, and so mx.concatenate(ys) below works at all
+                # (mx.concatenate rejects 0-d arrays).
+                t = t.reshape(1)
                 mx.async_eval(t)
             ys.append(t)
         return mx.concatenate(ys)
@@ -770,7 +838,10 @@ def mtp_speculative_generate_step(
         y, hidden = _prefill(y)
         logits, hidden = _target_forward(y, 1)
         tok, logprobs = _process_and_sample(None, logits.squeeze(0)[-1])
-        hidden = hidden[:, -1, :]
+        # Keep the sequence dim (shape (1, 1, D)) rather than collapsing to
+        # (1, D) -- _mtp_draft_generate needs a 3-D hidden state to
+        # concatenate against the 3-D token embedding.
+        hidden = hidden[:, -1:, :]
         mx.eval(tok, hidden)
 
     ntoks = 1
@@ -778,26 +849,34 @@ def mtp_speculative_generate_step(
     if ntoks == max_tokens:
         return
 
-    last_token = tok
+    # 0-d -> (1,), matching the shape last_token has on every later round
+    # (mx.array([...]) below) and what _mtp_draft_generate expects.
+    last_token = tok.reshape(1)
     num_draft = 0
     n = 0
+    batch_y = None
     try:
         while True:
             num_draft = min(max_tokens - ntoks, num_draft_tokens)
             draft_tokens = _mtp_draft_generate(hidden, last_token, num_draft)
             y = mx.concatenate([last_token, draft_tokens])
+            batch_y = y
             if prev_tokens is not None:
                 prev_tokens = prev_tokens[: prev_tokens.size - y.size - num_draft + 1]
 
+            if needs_checkpoint:
+                model_checkpoint = cache.checkpoint_prompt_cache(model_cache)
             with mx.stream(generation_stream):
                 verify_logits, verify_hidden = _target_forward(y, num_draft + 1)
                 verify_logits = verify_logits.squeeze(0)
-                verify_hidden = verify_hidden.squeeze(0)
                 verify_tokens = []
                 verify_logprobs = []
                 for i in range(num_draft + 1):
                     vt, vlp = _process_and_sample(None, verify_logits[i])
-                    verify_tokens.append(vt)
+                    # See the note in _mtp_draft_generate -- sampling a 1-D
+                    # logits vector gives a 0-d scalar, which
+                    # mx.concatenate below can't handle.
+                    verify_tokens.append(vt.reshape(1))
                     verify_logprobs.append(vlp)
                 verify_tokens = mx.concatenate(verify_tokens)
                 mx.eval(verify_tokens, draft_tokens)
@@ -823,13 +902,16 @@ def mtp_speculative_generate_step(
                 break
 
             last_token = mx.array([verify_list[n]], mx.uint32)
-            hidden = verify_hidden[n : n + 1]
+            # verify_hidden is (1, num_draft + 1, D) -- keep the sequence
+            # dim (shape (1, 1, D)) for the same reason as the initial
+            # `hidden` assignment above.
+            hidden = verify_hidden[:, n : n + 1, :]
 
             if prev_tokens is not None:
                 prev_tokens = prev_tokens[: -max(num_draft - n, 1)]
-            _rewind_cache(num_draft, n)
+            _rewind_cache(num_draft, n, batch_y)
     finally:
-        _rewind_cache(num_draft, n)
+        _rewind_cache(num_draft, n, batch_y)
 
 
 def stream_generate(

--- a/mlx_lm/generate.py
+++ b/mlx_lm/generate.py
@@ -645,6 +645,193 @@ def speculative_generate_step(
         _rewind_cache(num_draft, n)
 
 
+def mtp_speculative_generate_step(
+    prompt: mx.array,
+    model: nn.Module,
+    *,
+    num_draft_tokens: Optional[int] = None,
+    max_tokens: int = 256,
+    sampler: Optional[Callable[[mx.array], mx.array]] = None,
+    logits_processors: Optional[List[Callable[[mx.array, mx.array], mx.array]]] = None,
+    prompt_cache: Optional[Any] = None,
+    prefill_step_size: int = 512,
+    kv_bits: Optional[int] = None,
+    kv_group_size: int = 64,
+    quantized_kv_start: int = 0,
+) -> Generator[Tuple[mx.array, mx.array, bool], None, None]:
+    """
+    Speculative decoding for models with a built-in multi-token-prediction
+    (MTP) head (see ``models.qwen3_5.MTPHead``) rather than an independent
+    peer draft model. The head has no embedding table or output head of its
+    own — it's chained ``num_draft_tokens`` times, each step consuming the
+    target model's (or the previous MTP step's) hidden state plus the newly
+    proposed token's embedding, then every proposed token is verified
+    against the target model in a single batched forward pass, exactly like
+    :func:`speculative_generate_step`. The only difference from that
+    function is *how* draft tokens are produced; the verify/accept/reject
+    logic is the same, so this preserves the same lossless-relative-to-
+    greedy-decoding guarantee.
+
+    Args:
+        prompt (mx.array): The input prompt.
+        model (nn.Module): The target model. Must have ``has_mtp == True``.
+        num_draft_tokens (int, optional): Number of tokens to speculate per
+          round. Defaults to ``model.mtp_block_size``.
+        (all other args match :func:`speculative_generate_step`)
+
+    Yields:
+        Tuple[mx.array, mx.array, bool]: One token, a vector of log
+          probabilities, and a bool indicating if the token came from the
+          MTP head.
+    """
+    if not getattr(model, "has_mtp", False):
+        raise ValueError(
+            f"{type(model).__name__} has no attached MTP head — load one "
+            "first (see utils.load_mtp_head)."
+        )
+
+    num_draft_tokens = num_draft_tokens or getattr(model, "mtp_block_size", 1)
+
+    y = prompt.astype(mx.uint32)
+    prev_tokens = None
+
+    if prompt_cache is None:
+        model_cache = cache.make_prompt_cache(model)
+    else:
+        model_cache = prompt_cache
+    mtp_cache = model.make_mtp_cache()
+
+    if not cache.can_trim_prompt_cache(model_cache):
+        types = {type(c).__name__ for c in model_cache if not c.is_trimmable()}
+        raise ValueError(
+            f"Speculative decoding requires a trimmable prompt cache " f"(got {types})."
+        )
+
+    sampler = sampler or (lambda x: mx.argmax(x, axis=-1))
+
+    quantize_cache_fn = functools.partial(
+        maybe_quantize_kv_cache,
+        quantized_kv_start=quantized_kv_start,
+        kv_group_size=kv_group_size,
+        kv_bits=kv_bits,
+    )
+
+    def _process_and_sample(tokens, logits):
+        if logits_processors:
+            for processor in logits_processors:
+                logits = processor(tokens, logits)
+
+        logprobs = logits - mx.logsumexp(logits, axis=-1, keepdims=True)
+        y = sampler(logprobs)
+        return y, logprobs
+
+    def _target_forward(y, n_predict):
+        # Runs the *target* model, returning logits and hidden states for
+        # the last n_predict positions of y (the accepted/pending tokens
+        # plus this round's draft tokens).
+        logits, hidden = model(
+            y[None], cache=model_cache, output_hidden_states=True
+        )
+        return logits[:, -n_predict:, :], hidden[:, -n_predict:, :]
+
+    def _prefill(y):
+        hidden = None
+        while y.size > 1:
+            n_to_process = min(prefill_step_size, y.size - 1)
+            _, hidden = model(
+                y[:n_to_process][None], cache=model_cache, output_hidden_states=True
+            )
+            quantize_cache_fn(model_cache)
+            mx.eval([c.state for c in model_cache])
+            y = y[n_to_process:]
+            mx.clear_cache()
+        return y, hidden
+
+    def _rewind_cache(num_draft, num_accept):
+        cache.trim_prompt_cache(model_cache, num_draft - num_accept)
+        cache.trim_prompt_cache(mtp_cache, max(num_draft - num_accept - 1, 0))
+
+    def _mtp_draft_generate(hidden_state, last_token, num_draft):
+        # hidden_state/last_token describe the most recently *accepted*
+        # position — chain the MTP head forward from there.
+        if num_draft == 0:
+            return mx.array([], mx.uint32)
+        ys = []
+        h, t = hidden_state, last_token
+        for _ in range(num_draft):
+            with mx.stream(generation_stream):
+                logits, h = model.mtp_step(h, t[None], cache=mtp_cache)
+                t, _ = _process_and_sample(None, logits.squeeze(0)[-1])
+                mx.async_eval(t)
+            ys.append(t)
+        return mx.concatenate(ys)
+
+    with mx.stream(generation_stream):
+        y, hidden = _prefill(y)
+        logits, hidden = _target_forward(y, 1)
+        tok, logprobs = _process_and_sample(None, logits.squeeze(0)[-1])
+        hidden = hidden[:, -1, :]
+        mx.eval(tok, hidden)
+
+    ntoks = 1
+    yield tok.item(), logprobs, False
+    if ntoks == max_tokens:
+        return
+
+    last_token = tok
+    num_draft = 0
+    n = 0
+    try:
+        while True:
+            num_draft = min(max_tokens - ntoks, num_draft_tokens)
+            draft_tokens = _mtp_draft_generate(hidden, last_token, num_draft)
+            y = mx.concatenate([last_token, draft_tokens])
+            if prev_tokens is not None:
+                prev_tokens = prev_tokens[: prev_tokens.size - y.size - num_draft + 1]
+
+            with mx.stream(generation_stream):
+                verify_logits, verify_hidden = _target_forward(y, num_draft + 1)
+                verify_logits = verify_logits.squeeze(0)
+                verify_hidden = verify_hidden.squeeze(0)
+                verify_tokens = []
+                verify_logprobs = []
+                for i in range(num_draft + 1):
+                    vt, vlp = _process_and_sample(None, verify_logits[i])
+                    verify_tokens.append(vt)
+                    verify_logprobs.append(vlp)
+                verify_tokens = mx.concatenate(verify_tokens)
+                mx.eval(verify_tokens, draft_tokens)
+
+            draft_list = draft_tokens.tolist()
+            verify_list = verify_tokens.tolist()
+
+            n = 0
+            while n < num_draft:
+                tn, dtn, lpn = verify_list[n], draft_list[n], verify_logprobs[n]
+                if tn != dtn:
+                    break
+                n += 1
+                ntoks += 1
+                yield tn, lpn, True
+                if ntoks == max_tokens:
+                    break
+            if ntoks < max_tokens:
+                ntoks += 1
+                yield verify_list[n], verify_logprobs[n], False
+
+            if ntoks == max_tokens:
+                break
+
+            last_token = mx.array([verify_list[n]], mx.uint32)
+            hidden = verify_hidden[n : n + 1]
+
+            if prev_tokens is not None:
+                prev_tokens = prev_tokens[: -max(num_draft - n, 1)]
+            _rewind_cache(num_draft, n)
+    finally:
+        _rewind_cache(num_draft, n)
+
+
 def stream_generate(
     model: nn.Module,
     tokenizer: Union[PreTrainedTokenizer, TokenizerWrapper],
@@ -689,19 +876,26 @@ def stream_generate(
 
     kwargs["max_tokens"] = max_tokens
 
-    if draft_model is None:
+    if draft_model is None and not getattr(model, "has_mtp", False):
         kwargs.pop("num_draft_tokens", None)
         token_generator = generate_step(prompt, model, **kwargs)
         # from_draft always false for non-speculative generation
         token_generator = (
             (token, logprobs, False) for token, logprobs in token_generator
         )
-    else:
+    elif draft_model is not None:
         kwargs.pop("max_kv_size", None)
         kwargs.pop("prompt_progress_callback", None)
         token_generator = speculative_generate_step(
             prompt, model, draft_model, **kwargs
         )
+    else:
+        # No separate peer draft model, but the target model has a built-in
+        # MTP head attached (see utils.load_mtp_head) — speculate using that
+        # instead of an independent model.
+        kwargs.pop("max_kv_size", None)
+        kwargs.pop("prompt_progress_callback", None)
+        token_generator = mtp_speculative_generate_step(prompt, model, **kwargs)
     with wired_limit(model, [generation_stream]):
         tic = time.perf_counter()
         for n, (token, logprobs, from_draft) in enumerate(token_generator):

--- a/mlx_lm/models/cache.py
+++ b/mlx_lm/models/cache.py
@@ -111,6 +111,50 @@ def trim_prompt_cache(cache: List[Any], num_tokens: int) -> List[Any]:
     return [c.trim(num_tokens) for c in cache][0]
 
 
+def can_rewind_prompt_cache(cache: List[Any]) -> bool:
+    """
+    Check if a prompt cache can be rewound after a rejected speculative
+    decoding round -- either because every layer is exactly trimmable, or
+    because the non-trimmable layers (e.g. fixed-size recurrent state used
+    by hybrid linear-attention models) support checkpoint/restore.
+    """
+    return all(c.is_trimmable() or c.is_checkpointable() for c in cache)
+
+
+def checkpoint_prompt_cache(cache: List[Any]) -> List[Any]:
+    """
+    Snapshot the non-trimmable layers of a cache ahead of a speculative
+    decoding round, so they can be restored if the round is rejected.
+    Trimmable layers don't need a snapshot -- ``None`` is stored for them,
+    since they can just be trimmed back exactly.
+    """
+    return [None if c.is_trimmable() else c.checkpoint() for c in cache]
+
+
+def rewind_prompt_cache(
+    cache: List[Any], checkpoint: List[Any], num_tokens: int
+) -> None:
+    """
+    Roll ``cache`` all the way back to the state it was in when
+    ``checkpoint_prompt_cache`` produced ``checkpoint`` -- i.e. undo an
+    entire speculative decoding round (``num_tokens`` is the number of
+    tokens processed since then). Trimmable layers are trimmed exactly;
+    non-trimmable layers are restored from their snapshot.
+
+    Unlike ``trim_prompt_cache``, this cannot roll back to an arbitrary
+    partial position within the round for non-trimmable layers -- a fixed-
+    size recurrent state has no notion of "the state as of token k" other
+    than by recomputing it. The caller is responsible for replaying
+    whichever tokens turned out to be correct back through the model to
+    bring every layer (including the ones that were trimmed) back in sync.
+    """
+    for c, ckpt in zip(cache, checkpoint):
+        if ckpt is None:
+            c.trim(num_tokens)
+        else:
+            c.restore(ckpt)
+
+
 def create_attention_mask(
     N: int, offset: int, return_array: bool, window_size: Optional[int]
 ):
@@ -145,6 +189,25 @@ class _BaseCache:
 
     def is_trimmable(self):
         return False
+
+    def is_checkpointable(self):
+        """
+        Whether this cache supports checkpoint()/restore(), for caches whose
+        state can't be exactly trimmed to an arbitrary earlier position
+        (e.g. a fixed-size recurrent state, as opposed to an append-only
+        buffer like KVCache).
+        """
+        return False
+
+    def checkpoint(self):
+        raise NotImplementedError(
+            f"{type(self).__name__} does not support checkpoint/restore."
+        )
+
+    def restore(self, checkpoint):
+        raise NotImplementedError(
+            f"{type(self).__name__} does not support checkpoint/restore."
+        )
 
     def size(self):
         """
@@ -628,6 +691,19 @@ class ArraysCache(_BaseCache):
     @state.setter
     def state(self, v):
         self.cache = v
+
+    def is_checkpointable(self):
+        return True
+
+    def checkpoint(self):
+        # Every update replaces cache[i] wholesale (see e.g. mamba.py,
+        # qwen3_5.py) rather than mutating an array in place, so a shallow
+        # copy of the list is enough to freeze this snapshot -- the arrays
+        # it references are never written to after the fact.
+        return list(self.cache)
+
+    def restore(self, checkpoint):
+        self.cache = list(checkpoint)
 
     def filter(self, batch_indices):
         """

--- a/mlx_lm/models/qwen3_5.py
+++ b/mlx_lm/models/qwen3_5.py
@@ -283,7 +283,13 @@ class MTPHead(nn.Module):
     ) -> mx.array:
         h = self.pre_fc_norm_hidden(hidden_state)
         e = self.pre_fc_norm_embedding(embedding)
-        x = self.fc(mx.concatenate([h, e], axis=-1))
+        # Matches the published DeepSeek-V3-style MTP projection: the
+        # embedding half comes first, then the hidden-state half. Getting
+        # this backwards still produces a real (if scrambled) vocabulary
+        # projection rather than an error, which made it very hard to spot
+        # -- confirmed against ground truth by comparing draft vs. verify
+        # tokens with both orderings.
+        x = self.fc(mx.concatenate([e, h], axis=-1))
 
         if cache is None:
             cache = [None] * len(self.layers)
@@ -321,6 +327,7 @@ class Qwen3_5TextModel(PipelineMixin, nn.Module):
         inputs: mx.array,
         cache: Optional[Any] = None,
         input_embeddings: Optional[mx.array] = None,
+        output_hidden_states: bool = False,
     ) -> mx.array:
         if input_embeddings is not None:
             hidden_states = input_embeddings
@@ -365,7 +372,15 @@ class Qwen3_5TextModel(PipelineMixin, nn.Module):
                 : hidden_states.shape[0]
             ]
 
-        return self.norm(hidden_states)
+        out = self.norm(hidden_states)
+        if output_hidden_states:
+            # The MTP head (see MTPHead / mtp_step) needs the *pre-final-
+            # norm* residual stream, not the post-norm output used for the
+            # LM head -- that's what it was trained on (DeepSeek-V3-style
+            # MTP: final norm is paired with the output head, not meant to
+            # be fed back into an auxiliary module).
+            return out, hidden_states
+        return out
 
 
 class TextModel(nn.Module):
@@ -392,11 +407,16 @@ class TextModel(nn.Module):
         input_embeddings: Optional[mx.array] = None,
         output_hidden_states: bool = False,
     ):
-        hidden = self.model(inputs, cache, input_embeddings=input_embeddings)
-        out = self._to_logits(hidden)
         if output_hidden_states:
-            return out, hidden
-        return out
+            normed, hidden = self.model(
+                inputs,
+                cache,
+                input_embeddings=input_embeddings,
+                output_hidden_states=True,
+            )
+            return self._to_logits(normed), hidden
+        normed = self.model(inputs, cache, input_embeddings=input_embeddings)
+        return self._to_logits(normed)
 
     def _to_logits(self, hidden: mx.array) -> mx.array:
         if self.args.tie_word_embeddings:

--- a/mlx_lm/models/qwen3_5.py
+++ b/mlx_lm/models/qwen3_5.py
@@ -43,6 +43,11 @@ class TextModelArgs(BaseModelArgs):
     head_dim: Optional[int] = None
     full_attention_interval: int = 4
 
+    # Multi-token-prediction head (speculative decoding). 0 layers means the
+    # checkpoint has no MTP head — everything below is a no-op in that case.
+    mtp_num_hidden_layers: int = 0
+    mtp_use_dedicated_embeddings: bool = True
+
     # MoE fields (optional, for Qwen3_5MoeForConditionalGeneration)
     num_experts: int = 0
     num_experts_per_tok: int = 0
@@ -241,6 +246,53 @@ class DecoderLayer(nn.Module):
         return out
 
 
+class MTPHead(nn.Module):
+    """Multi-token-prediction head, following the published DeepSeek-V3 MTP
+    design that Qwen3.6's own checkpoints reuse: normalize the backbone's
+    hidden state and the (speculated) next token's embedding separately,
+    concatenate and project them back down to hidden_size, run through one
+    (or a few) ordinary transformer layer(s), and hand the result to the
+    *backbone's own* embedding/output-head weights — there is no separate
+    vocabulary projection here, `mtp_use_dedicated_embeddings=False` means
+    exactly that: this module borrows the target model's embed_tokens/lm_head
+    rather than carrying its own.
+
+    MTP layers always run as ordinary full attention regardless of the
+    backbone's linear/full attention interval, so `layer_idx` is fixed to a
+    value that makes `DecoderLayer.is_linear` resolve to False.
+    """
+
+    def __init__(self, args: TextModelArgs):
+        super().__init__()
+        self.pre_fc_norm_hidden = nn.RMSNorm(args.hidden_size, eps=args.rms_norm_eps)
+        self.pre_fc_norm_embedding = nn.RMSNorm(
+            args.hidden_size, eps=args.rms_norm_eps
+        )
+        self.fc = nn.Linear(2 * args.hidden_size, args.hidden_size, bias=False)
+        self.layers = [
+            DecoderLayer(args=args, layer_idx=args.full_attention_interval - 1)
+            for _ in range(args.mtp_num_hidden_layers)
+        ]
+        self.norm = nn.RMSNorm(args.hidden_size, eps=args.rms_norm_eps)
+
+    def __call__(
+        self,
+        hidden_state: mx.array,
+        embedding: mx.array,
+        cache: Optional[List[Any]] = None,
+    ) -> mx.array:
+        h = self.pre_fc_norm_hidden(hidden_state)
+        e = self.pre_fc_norm_embedding(embedding)
+        x = self.fc(mx.concatenate([h, e], axis=-1))
+
+        if cache is None:
+            cache = [None] * len(self.layers)
+        mask = create_attention_mask(x, cache[0] if cache else None)
+        for layer, c in zip(self.layers, cache):
+            x = layer(x, mask=mask, cache=c)
+        return self.norm(x)
+
+
 class Qwen3_5TextModel(PipelineMixin, nn.Module):
     def __init__(self, args: TextModelArgs):
         super().__init__()
@@ -324,19 +376,60 @@ class TextModel(nn.Module):
         self.model = Qwen3_5TextModel(args)
         if not args.tie_word_embeddings:
             self.lm_head = nn.Linear(args.hidden_size, args.vocab_size, bias=False)
+        # Built lazily in sanitize() — the config can declare
+        # mtp_num_hidden_layers > 0 purely as an architecture capability
+        # while the specific checkpoint file doesn't bundle the actual MTP
+        # tensors (they're commonly published as a separate drafter repo).
+        # Constructing this eagerly from config alone makes load_weights()
+        # fail with "missing parameters" on every checkpoint that doesn't
+        # carry the weights, which today is all of them.
+        self.mtp = None
 
     def __call__(
         self,
         inputs: mx.array,
         cache: Optional[Any] = None,
         input_embeddings: Optional[mx.array] = None,
-    ) -> mx.array:
-        out = self.model(inputs, cache, input_embeddings=input_embeddings)
-        if self.args.tie_word_embeddings:
-            out = self.model.embed_tokens.as_linear(out)
-        else:
-            out = self.lm_head(out)
+        output_hidden_states: bool = False,
+    ):
+        hidden = self.model(inputs, cache, input_embeddings=input_embeddings)
+        out = self._to_logits(hidden)
+        if output_hidden_states:
+            return out, hidden
         return out
+
+    def _to_logits(self, hidden: mx.array) -> mx.array:
+        if self.args.tie_word_embeddings:
+            return self.model.embed_tokens.as_linear(hidden)
+        return self.lm_head(hidden)
+
+    @property
+    def has_mtp(self) -> bool:
+        return self.mtp is not None
+
+    def mtp_step(
+        self,
+        hidden_state: mx.array,
+        token_ids: mx.array,
+        cache: Optional[List[Any]] = None,
+    ) -> mx.array:
+        """One MTP forward step: given the backbone's hidden state at some
+        position and the token that was (speculatively) placed there, predict
+        the logits for the *next* position. Chain calls, feeding each step's
+        returned hidden state back in as `hidden_state` alongside the newly
+        sampled token, to speculate more than one token ahead (up to
+        `ModelArgs.block_size`). Uses the backbone's own embedding table and
+        output head — the MTP head itself has neither."""
+        if self.mtp is None:
+            raise ValueError("This checkpoint has no attached MTP head.")
+        embedding = self.model.embed_tokens(token_ids)
+        hidden = self.mtp(hidden_state, embedding, cache=cache)
+        return self._to_logits(hidden), hidden
+
+    def make_mtp_cache(self):
+        if self.mtp is None:
+            return []
+        return [KVCache() for _ in self.mtp.layers]
 
     @property
     def layers(self):
@@ -346,10 +439,30 @@ class TextModel(nn.Module):
         return [ArraysCache(size=2) if l.is_linear else KVCache() for l in self.layers]
 
     def sanitize(self, weights):
+        # Substring match, not startswith: by the time weights reach here,
+        # the outer Model.sanitize() has already prefixed every key with
+        # "language_model.", so an MTP tensor never literally starts with
+        # "mtp." in practice — it's "language_model.mtp....".
+        has_mtp_weights = any("mtp." in k for k in weights)
         has_unsanitized_conv1d = any(
             "conv1d.weight" in k and v.shape[-1] != 1 for k, v in weights.items()
         )
-        weights = {k: v for k, v in weights.items() if "mtp." not in k}
+
+        if has_mtp_weights and self.args.mtp_num_hidden_layers > 0:
+            # The checkpoint actually bundles MTP tensors (prefixed
+            # "mtp.") and the config declares the architecture for them —
+            # build the submodule now so load_weights() has somewhere to
+            # put them, then keep the keys as-is.
+            if self.mtp is None:
+                self.mtp = MTPHead(self.args)
+            weights = dict(weights)
+        else:
+            # No bundled MTP weights in this specific file — this is the
+            # common case, including checkpoints whose config declares
+            # mtp_num_hidden_layers > 0 as an architecture capability while
+            # publishing the drafter separately. Same behavior as before
+            # this feature existed: drop any stray "mtp." keys.
+            weights = {k: v for k, v in weights.items() if "mtp." not in k}
 
         if self.args.tie_word_embeddings:
             weights.pop("lm_head.weight", None)
@@ -395,6 +508,9 @@ class TextModel(nn.Module):
 class ModelArgs(BaseModelArgs):
     model_type: str
     text_config: dict
+    # Number of extra tokens an attached MTP head can speculate per step
+    # (e.g. the community-published "qwen3_5_mtp" drafter checkpoints use 3).
+    block_size: int = 1
 
     @classmethod
     def from_dict(cls, params):
@@ -415,10 +531,28 @@ class Model(nn.Module):
         inputs: mx.array,
         cache=None,
         input_embeddings: Optional[mx.array] = None,
+        output_hidden_states: bool = False,
     ):
         return self.language_model(
-            inputs, cache=cache, input_embeddings=input_embeddings
+            inputs,
+            cache=cache,
+            input_embeddings=input_embeddings,
+            output_hidden_states=output_hidden_states,
         )
+
+    @property
+    def has_mtp(self) -> bool:
+        return self.language_model.has_mtp
+
+    def mtp_step(self, hidden_state, token_ids, cache=None):
+        return self.language_model.mtp_step(hidden_state, token_ids, cache=cache)
+
+    def make_mtp_cache(self):
+        return self.language_model.make_mtp_cache()
+
+    @property
+    def mtp_block_size(self) -> int:
+        return self.args.block_size
 
     @property
     def model(self):

--- a/mlx_lm/server.py
+++ b/mlx_lm/server.py
@@ -42,7 +42,15 @@ from .generate import (
 )
 from .models.cache import LRUPromptCache, make_prompt_cache
 from .sample_utils import make_logits_processors, make_sampler
-from .utils import _parse_size, load, sharded_load
+from .utils import (
+    _download,
+    _parse_size,
+    load,
+    load_config,
+    load_mtp_head,
+    is_mtp_head_checkpoint,
+    sharded_load,
+)
 
 
 def get_system_fingerprint():
@@ -339,18 +347,26 @@ class ModelProvider:
             if tokenizer.chat_template is None:
                 tokenizer.chat_template = tokenizer.default_chat_template
 
-        # Load the draft model for speculative decoding
+        # Load the draft model for speculative decoding — or, if the path
+        # points at a multi-token-prediction (MTP) head rather than a
+        # regular independently-runnable model, attach it directly to
+        # `model` instead (it has no embeddings/output head of its own and
+        # can't be loaded as a peer model; see utils.load_mtp_head).
         draft_model = None
         if draft_model_path is not None:
-            draft_model, draft_tokenizer = load(draft_model_path)
-            if draft_tokenizer.vocab_size != tokenizer.vocab_size:
-                logging.warning(
-                    "Draft model tokenizer does not match model tokenizer. "
-                    "Speculative decoding may not work as expected."
-                )
+            draft_config = load_config(_download(draft_model_path))
+            if is_mtp_head_checkpoint(draft_config):
+                load_mtp_head(model, draft_model_path)
+            else:
+                draft_model, draft_tokenizer = load(draft_model_path)
+                if draft_tokenizer.vocab_size != tokenizer.vocab_size:
+                    logging.warning(
+                        "Draft model tokenizer does not match model tokenizer. "
+                        "Speculative decoding may not work as expected."
+                    )
 
         # Compute batchability
-        is_batchable = draft_model is None
+        is_batchable = draft_model is None and not getattr(model, "has_mtp", False)
         is_batchable = is_batchable and all(
             hasattr(c, "merge") for c in make_prompt_cache(model)
         )

--- a/mlx_lm/utils.py
+++ b/mlx_lm/utils.py
@@ -450,6 +450,87 @@ def load_model(
     return model, config
 
 
+def is_mtp_head_checkpoint(config: dict) -> bool:
+    """True if a config describes a standalone multi-token-prediction (MTP)
+    drafter checkpoint (e.g. the community-published "*_mtp" repos split out
+    from a bundled release) rather than a regular, independently-runnable
+    model. These have no vocabulary/embedding of their own — they must be
+    attached to a matching target model with :func:`load_mtp_head` instead
+    of loaded with :func:`load`."""
+    text_config = config.get("text_config", config)
+    return (
+        str(config.get("model_type", "")).endswith("_mtp")
+        and text_config.get("mtp_num_hidden_layers", 0) > 0
+    )
+
+
+def load_mtp_head(model: nn.Module, mtp_path: str, lazy: bool = False) -> dict:
+    """
+    Load a separately-published MTP drafter checkpoint and attach it to an
+    already-loaded target ``model`` for use with
+    :func:`generate.mtp_speculative_generate_step`.
+
+    Unlike a normal ``--draft-model``, this is *not* an independent peer
+    model — the checkpoint has no embedding table or output head of its own
+    (see ``models.qwen3_5.MTPHead``), it borrows the target model's, and its
+    forward pass needs the target's hidden state as an input. That's
+    fundamentally incompatible with :func:`load`/:func:`load_model`, which
+    assume a self-contained model that can be called with just token ids.
+
+    Args:
+        model (nn.Module): An already-loaded target model. Must implement
+          ``mtp_step`` (currently: ``models.qwen3_5.Model``).
+        mtp_path (str): Local path or Hugging Face repo id of the MTP
+          checkpoint.
+        lazy (bool): If ``False``, eval the attached parameters immediately.
+
+    Returns:
+        dict: The MTP checkpoint's config (for callers that want e.g. its
+          ``block_size``).
+
+    Raises:
+        ValueError: If ``model`` has no ``mtp_step`` method, or the MTP
+          checkpoint's hidden size doesn't match the target model's.
+        FileNotFoundError: If no safetensors are found at ``mtp_path``.
+    """
+    if not hasattr(model, "mtp_step"):
+        raise ValueError(
+            f"{type(model).__name__} does not support attached MTP heads "
+            "(no mtp_step method)."
+        )
+
+    path = _download(mtp_path)
+    config = load_config(path)
+    text_config = config.get("text_config", config)
+
+    from .models.qwen3_5 import MTPHead, TextModelArgs
+
+    mtp_args = TextModelArgs.from_dict(text_config)
+    target_args = model.language_model.args
+    if mtp_args.hidden_size != target_args.hidden_size:
+        raise ValueError(
+            f"MTP checkpoint hidden_size ({mtp_args.hidden_size}) does not "
+            f"match the target model's ({target_args.hidden_size}) — is this "
+            "drafter published for a different model?"
+        )
+
+    weight_files = glob.glob(str(path / "model*.safetensors"))
+    if not weight_files:
+        raise FileNotFoundError(f"No safetensors found in {path}")
+    weights = {}
+    for wf in weight_files:
+        weights.update(mx.load(wf))
+
+    mtp = MTPHead(mtp_args)
+    mtp.load_weights(list(weights.items()), strict=True)
+    if not lazy:
+        mx.eval(mtp.parameters())
+
+    model.language_model.mtp = mtp
+    model.args.block_size = config.get("block_size", 1)
+    return config
+
+
 def load_adapters(model: nn.Module, adapter_path: str) -> nn.Module:
     from .tuner.utils import load_adapters as _load_adapters
 


### PR DESCRIPTION
**Stacked on #1468** — this branch is that PR's branch plus one more commit (`06d99ad`). Please review just the last commit / the `models/qwen3_5.py` diff; everything else duplicates #1468 and will resolve itself once that one merges (happy to rebase this down to just the new commit at that point, whatever's easiest for you).

## The bug

While verifying #1468 end to end, the attached MTP head's drafted tokens had ~0% agreement with the target model's actual output — not occasionally wrong, essentially unrelated (e.g. drafting `'ikum' 'i' 'lech'` where the target was actually generating `'s '\n' '\n'`). That pointed at a real bug rather than just a low-quality drafter, and turned out to be two of them in `MTPHead`:

1. **Wrong concat order.** `MTPHead.__call__` concatenated `[hidden, embedding]` before the `fc` projection; the correct (DeepSeek-V3-style) order is `[embedding, hidden]`. Confirmed empirically: ran both orderings against the same hidden state/token and compared the draft output to the target model's actual next tokens at that position — only the swapped order matched.

2. **Wrong hidden-state stage.** `Qwen3_5TextModel.__call__` only ever returned the **post-final-norm** hidden state via `output_hidden_states=True`, but the MTP head needs the **pre-final-norm** residual stream (the final norm is calibrated for the LM head, not meant to be fed into an auxiliary module). Now returns the pre-norm hidden state instead, threaded up through `TextModel.__call__`. This is safe to change: `output_hidden_states=True` has no other callers anywhere in the codebase (only `mtp_speculative_generate_step` uses it).

Both bugs silently produce a *structurally valid but semantically scrambled* vocabulary projection rather than an error, which is why they were easy to miss — garbage in, plausible-looking garbage out.

## Verified

Together these took MTP draft acceptance from 0% to ~66% on `unsloth/Qwen3.6-27B-UD-MLX-6bit` + `mlx-community/Qwen3.6-27B-MTP-bf16`, with temp=0 output still exactly matching plain generation (see #1468 for the correctness-test details). No regressions in the existing test suite.

This is a correctness bug in the MTP head itself, independent of the cache-rewind work in #1468 — worth landing even if that PR needs more discussion.

🤖 Generated with [Claude Code](https://claude.com/claude-code)