### PR TITLE
fix: pin transformers<5.13.0 to avoid AutoTokenizer.register breakage

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -26,7 +26,7 @@ setup(
     install_requires=[
         f"mlx>={MIN_MLX_VERSION}; platform_system == 'Darwin'",
         "numpy",
-        "transformers>=5.7.0",
+        "transformers>=5.7.0,<5.13.0",
         "sentencepiece",
         "protobuf",
         "pyyaml",


### PR DESCRIPTION
## Problem

transformers==5.13.0 introduced a breaking change in AutoTokenizer.register() that causes mlx-lm to fail at import time with Python 3.14 on macOS.

The error occurs in mlx_lm/tokenizer_utils.py at:
`python
AutoTokenizer.register("NewlineTokenizer", fast_tokenizer_class=NewlineTokenizer)
`

transformers 5.13.0 added a check in auto_factory.py that requires registered tokenizer classes to have __module__ starting with 'transformers.'. Since NewlineTokenizer is defined in mlx-lm, not in transformers, this check fails.

**Error:**
```
File "...transformers/models/auto/auto_factory.py", line 680, in register
    if key.__module__.startswith("transformers."):
```

**To reproduce:**
```bash
pip install mlx-lm transformers==5.13.0
python -c "import mlx_lm"  # fails
```

## Fix

Pin transformers<5.13.0 as a temporary fix while a proper solution (e.g. updating the AutoTokenizer.register call to be compatible with the new API) is investigated.