### PR TITLE
Fix NewlineTokenizer registration with Transformers v5

### DIFF
--- a/mlx_lm/tokenizer_utils.py
+++ b/mlx_lm/tokenizer_utils.py
@@ -500,7 +500,23 @@ class NewlineTokenizer(PreTrainedTokenizerFast):
         return [self._postprocess_text(d) for d in decoded]
 
 
-AutoTokenizer.register("NewlineTokenizer", fast_tokenizer_class=NewlineTokenizer)
+def _register_newline_tokenizer():
+    try:
+        from transformers.models.auto import tokenization_auto
+    except ImportError:
+        tokenization_auto = None
+
+    registered_tokenizer_classes = getattr(
+        tokenization_auto, "REGISTERED_TOKENIZER_CLASSES", None
+    )
+    if registered_tokenizer_classes is not None:
+        registered_tokenizer_classes[NewlineTokenizer.__name__] = NewlineTokenizer
+        return
+
+    AutoTokenizer.register("NewlineTokenizer", fast_tokenizer_class=NewlineTokenizer)
+
+
+_register_newline_tokenizer()
 
 
 def _match(a, b):

--- a/tests/test_tokenizers.py
+++ b/tests/test_tokenizers.py
@@ -4,10 +4,12 @@ import unittest
 from pathlib import Path
 
 from huggingface_hub import snapshot_download
+from transformers.models.auto.tokenization_auto import tokenizer_class_from_name
 
 from mlx_lm.tokenizer_utils import (
     BPEStreamingDetokenizer,
     NaiveStreamingDetokenizer,
+    NewlineTokenizer,
     SPMStreamingDetokenizer,
     TokenizerWrapper,
 )
@@ -122,6 +124,9 @@ class TestTokenizers(unittest.TestCase):
         prompt = [HI, THINK_START, THINK_END, THINK_START]
         self.assertEqual(find(prompt, [THINK_START], start=0), 1)
         self.assertEqual(find(prompt, [THINK_START], start=0, reverse=True), 3)
+
+    def test_newline_tokenizer_is_registered(self):
+        self.assertIs(tokenizer_class_from_name("NewlineTokenizer"), NewlineTokenizer)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- register NewlineTokenizer with Transformers v5 class-name lookup when available
- keep the existing AutoTokenizer.register fallback for older Transformers versions
- add a regression test for the NewlineTokenizer class-name registration

## Testing
- python -m unittest tests.test_tokenizers.TestTokenizers.test_newline_tokenizer_is_registered
- mlx_lm.server --help