### PR TITLE
Add KV cache quantization to mlx_lm.server (#1043)

### DIFF
--- a/mlx_lm/server.py
+++ b/mlx_lm/server.py
@@ -683,6 +683,11 @@ class ResponseGenerator:
         return sm, sequences
 
     def _is_batchable(self, args):
+        # Quantized KV caches are not mergeable, so they cannot participate in
+        # continuous batching. When --kv-bits is set, fall back to sequential
+        # generation (which applies the quantization) instead.
+        if self.cli_args.kv_bits is not None:
+            return False
         return self.model_provider.is_batchable and args.seed is None
 
     def _generate(self):
@@ -985,6 +990,9 @@ class ResponseGenerator:
                 num_draft_tokens=args.num_draft_tokens,
                 prompt_progress_callback=progress,
                 prefill_step_size=self.cli_args.prefill_step_size,
+                kv_bits=self.cli_args.kv_bits,
+                kv_group_size=self.cli_args.kv_group_size,
+                quantized_kv_start=self.cli_args.quantized_kv_start,
             ):
                 finish_reason = gen.finish_reason
                 sm_state, match_sequence, current_state = sm.match(sm_state, gen.token)
@@ -1878,6 +1886,25 @@ def main():
         "--prompt-cache-bytes",
         type=_parse_size,
         help="Maximum size in bytes of the KV caches",
+    )
+    parser.add_argument(
+        "--kv-bits",
+        type=int,
+        default=None,
+        help="Number of bits for KV cache quantization. Defaults to no quantization.",
+    )
+    parser.add_argument(
+        "--kv-group-size",
+        type=int,
+        default=64,
+        help="Group size for KV cache quantization.",
+    )
+    parser.add_argument(
+        "--quantized-kv-start",
+        type=int,
+        default=0,
+        help="When --kv-bits is set, start quantizing the KV cache "
+        "from this step onwards.",
     )
     parser.add_argument(
         "--pipeline",


### PR DESCRIPTION
# Add KV cache quantization to `mlx_lm.server` (closes #1043)

## Status: partly superseded by #1584 — rebasing on top of it

**Correction to an earlier version of this section, which said #1584 superseded the design outright.** It doesn't, and the difference decides what this PR still has to do.

#1584 makes quantized caches batchable **when `--max-kv-size` is set**: it implements `RotatingKVCache.to_quantized()` / `RotatingQuantizedKVCache` (on main today both `RotatingKVCache.to_quantized` and `BatchRotatingKVCache.to_quantized` raise `NotImplementedError("… Quantization NYI")`) and threads them into `BatchGenerator`. For that case the blanket `_is_batchable → False` opt-out described below is the wrong call, and this PR should defer to #1584's path.

It does **not** cover plain `--kv-bits` with no `--max-kv-size`, which is the default server shape. `QuantizedKVCache` on main implements neither `merge()` nor `to_quantized()`, and #1584 adds `merge()` only via `RotatingQuantizedKVCache` — as its author [confirmed while isolating it from his own diff](https://github.com/ml-explore/mlx-lm/pull/1584#issuecomment-5082799557), `kv_bits` without `max_kv_size` cannot do batching-with-history at all. So the sequential route stays necessary, and the rebase **narrows** the opt-out to that case rather than dropping it.

Split [agreed with @mabaeyens](https://github.com/ml-explore/mlx-lm/pull/1584#issuecomment-5035969478): #1584 lands the primitive and deliberately leaves `server.py` untouched; this PR is the server surface — the three CLI flags, plus routing `--quantized-kv-start > 0` to the sequential path, since the batch path rejects a nonzero start by design (per-job caches begin at offset 0, with no per-step re-check, so only immediate quantization is well-defined there). #1618 is the complementary fail-early validation and also deliberately adds no server flag.

I'm holding the rebase until #1584 merges, since it may still change in review (its author has asked whether to split it); it's a sub-hour change once it lands. Everything below this section describes the **current** commit, which still assumes the pre-#1584 world.

## What
Exposes the KV-cache quantization already supported by `generate`/`stream_generate`
as server CLI flags:

- `--kv-bits` (default `None` → off)
- `--kv-group-size` (default `64`)
- `--quantized-kv-start` (default `0`)

When set, they are threaded into the server's sequential `stream_generate` path.

## Why the batched path is handled by fallback, not plumbing
The server uses continuous batching (`BatchGenerator`) whenever a request
`_is_batchable` — which requires **mergeable** caches
(`all(hasattr(c, "merge") ...)`). `QuantizedKVCache` intentionally does **not**
implement `merge()`, so a quantized cache cannot participate in continuous
batching without new batch-membership support for quantized caches (a larger,
separate feature).

Rather than silently ignore `--kv-bits` in the default (batched) path, this PR
makes `_is_batchable` return `False` when `--kv-bits` is set, so those requests
use sequential generation, which applies the quantization. This keeps the
existing mergeable-cache invariant intact and makes the flag behave correctly.

Trade-off worth a maintainer call: with `--kv-bits`, requests no longer batch.
If you'd prefer, I can instead scope a follow-up that teaches the batched path
to carry quantized caches. Happy to go either way.

## Changes
- `mlx_lm/server.py`: 3 argparse flags; pass to `stream_generate`; `_is_batchable`
  returns `False` when `kv_bits` is set.

## Test plan
Verified on Apple Silicon (M3 Max, mlx 0.31.2, mlx-lm 0.31.3) with
`mlx-community/Qwen2.5-0.5B-Instruct-4bit`:

- [x] `--kv-bits` flags parse with correct defaults (`None` / `64` / `0`).
- [x] `stream_generate(..., kv_bits=4)` produces a `QuantizedKVCache` and coherent
      output; `kv_bits=None` stays a plain `KVCache` (regression check).

```
kv_bits=None: cache=KVCache          quantized=False coherent=True
kv_bits=4:    cache=QuantizedKVCache quantized=True  coherent=True
```

- [ ] End-to-end HTTP smoke against a running `mlx_lm.server --kv-bits 4` (recommended
      before merge; core generation path is exercised above).

## Notes
Mirrors the existing `generate.py` flag names/help text verbatim for consistency.
