### PR TITLE
Fix crash when batching requests with and without logits processors

### DIFF
--- a/mlx_lm/generate.py
+++ b/mlx_lm/generate.py
@@ -1343,7 +1343,7 @@ class GenerationBatch:
             processed_logits = []
             for e in range(len(self.uids)):
                 sample_logits = logits[e : e + 1]
-                for processor in self.logits_processors[e]:
+                for processor in self.logits_processors[e] or []:
                     sample_logits = processor(token_context[e], sample_logits)
                 processed_logits.append(sample_logits)
             logits = mx.concatenate(processed_logits, axis=0)

--- a/tests/test_generate.py
+++ b/tests/test_generate.py
@@ -438,6 +438,35 @@ class TestGenerate(unittest.TestCase):
         generated_token = self.tokenizer.encode(response.texts[0])[0]
         self.assertEqual(generated_token, 0)
 
+    def test_batch_generate_mixed_logits_processors(self):
+        """A request with logits processors joining a batch of requests
+        without them must not break generation (issue #1472)."""
+        tok = self.tokenizer.encode("hello")[-1]
+        batch_gen = BatchGenerator(self.model, max_tokens=5, prefill_step_size=8)
+
+        # Plain request long enough to need two prefill steps
+        (uid0,) = batch_gen.insert([[tok] * 17])
+        batch_gen.next()
+
+        # Request with a logits processor joins while the plain one is
+        # still prefilling
+        processors = make_logits_processors(logit_bias={0: 2000.0})
+        (uid1,) = batch_gen.insert([[tok] * 9], logits_processors=[processors])
+
+        first_logprobs = {}
+        finished = set()
+        while responses := batch_gen.next_generated():
+            for r in responses:
+                first_logprobs.setdefault(r.uid, r.logprobs)
+                if r.finish_reason is not None:
+                    finished.add(r.uid)
+
+        self.assertEqual(finished, {uid0, uid1})
+        # The processor was applied to the request that carries it
+        self.assertEqual(first_logprobs[uid1][0].item(), 0.0)
+        # ... and not to the one that doesn't
+        self.assertNotEqual(first_logprobs[uid0][0].item(), 0.0)
+
     def test_batch_generate_with_samplers(self):
         """Test that batch_generate with logits_processors produces correct results."""
         batch_gen = BatchGenerator(


### PR DESCRIPTION
Fixes #1472

The server dies when a request using `repetition_penalty` or `logit_bias` ends up in the same batch as one that doesn't use either: the generation thread crashes with `TypeError: 'NoneType' object is not iterable` but the HTTP server stays up, so it accepts connections forever without answering.

The cause is a mismatch between how the batch classes represent "no logits processors". `PromptProcessingBatch.extend()` normalizes an all-plain batch to `[None] * n`, but `GenerationBatch._step()` iterates each entry with no per-entry guard:

`    for processor in self.logits_processors[e]:   # entry can be None`

Timing matters, which is probably why this survived so long: the plain request has to still be mid-prefill when the processor carrying request is inserted. If it finishes prefill first, `filter()` rewrites the all-None list to `[[]]` and nothing goes wrong. When they overlap, the mixed list `[None, [proc]]` passes the batch-level `any()` check and the None reaches the loop.

The fix is a one-line guard at the consumption point, same as the samplers loop a few lines down already does (`self.samplers[e] or self.fallback_sampler`). This also covers `None` passed per-request through `insert()` directly.

The regression test replays the interleaving deterministically (17-token plain prompt with `prefill_step_size=8`, insert the processor request after one step). It fails on main with the traceback from #1472 and passes with this change. It also asserts the logit bias still applies to the request that carries it and not to the plain one, so the guard isn't just skipping processing.

One thing I deliberately left alone: `extend()` pads with `None` while `filter()` pads with `[]` for the same state. Normalizing that would also fix this, but it's a bigger change — happy to do it here or as a follow-up if you'd prefer.