### PR TITLE
Add draft-free prompt-lookup (n-gram) speculative decoding

### DIFF
--- a/mlx_lm/generate.py
+++ b/mlx_lm/generate.py
@@ -654,12 +654,263 @@ def speculative_generate_step(
         _rewind_cache(num_draft, n)
 
 
+def _pld_snapshot(caches):
+    """Pre-forward cache snapshot so a rejected multi-token proposal can be undone.
+
+    - KVCache: recorded by offset and undone with trim().
+    - RotatingKVCache: snapshotted by COPYING its (small, <=window) buffers even
+      when is_trimmable() is True at snapshot time. trim() only adjusts offset/_idx
+      (it does NOT shrink the key buffer), so if the upcoming multi-token forward
+      pushes the cache past the window, a later trim()-rewind desyncs the buffer
+      from the mask and crashes attention (mask K-len != cached K-len). Copying is
+      always correct.
+    - CacheList: recursed element-wise.
+    Any other cache type (e.g. ArraysCache for SSM/Mamba models) is unsupported;
+    prompt-lookup decoding raises rather than risk a silently-wrong rewind."""
+    def snap_one(c):
+        if isinstance(c, CacheList):
+            return ("list", [snap_one(sub) for sub in c.caches])
+        if isinstance(c, RotatingKVCache):
+            k = None if c.keys is None else mx.array(c.keys)
+            v = None if c.values is None else mx.array(c.values)
+            return ("restore", k, v, c.offset, getattr(c, "_idx", None))
+        if isinstance(c, KVCache):
+            return ("trim", c.offset)
+        raise NotImplementedError(
+            f"prompt-lookup decoding does not support cache type "
+            f"'{type(c).__name__}'. Supported: KVCache, RotatingKVCache (and "
+            "CacheList of those). Disable prompt_lookup for this model."
+        )
+    return [snap_one(c) for c in caches]
+
+
+def _pld_rewind(caches, snaps):
+    def rewind_one(c, s):
+        if s[0] == "list":
+            for sub, subsnap in zip(c.caches, s[1]):
+                rewind_one(sub, subsnap)
+        elif s[0] == "trim":
+            c.trim(c.offset - s[1])
+        else:
+            _, k, v, off, idx = s
+            c.keys, c.values, c.offset = k, v, off
+            if idx is not None:
+                c._idx = idx
+    for c, s in zip(caches, snaps):
+        rewind_one(c, s)
+
+
+def _pld_offset(c):
+    """Logical token offset of a possibly-nested cache leaf. A per-layer
+    ``CacheList`` has no offset of its own; its sub-caches advance together, so
+    descend to the first offset-bearing sub-cache."""
+    while isinstance(c, CacheList):
+        c = next((s for s in c.caches if hasattr(s, "offset")), c.caches[0])
+    return c.offset
+
+
+def prompt_lookup_generate_step(
+    prompt: mx.array,
+    model: nn.Module,
+    *,
+    max_tokens: int = 256,
+    sampler: Optional[Callable[[mx.array], mx.array]] = None,
+    prompt_cache: Optional[Any] = None,
+    prefill_step_size: int = 2048,
+    prompt_progress_callback: Optional[Callable[[int, int], None]] = None,
+    backend: Any = "ngram",
+    num_draft: int = 8,
+    ngram_max: int = 3,
+    ngram_min: int = 1,
+    prompt_only: bool = False,
+    adaptive: bool = False,
+    warmup: int = 48,
+    gate: float = 0.12,
+    stats: Optional[Any] = None,
+    **_ignored,
+) -> Generator[Tuple[int, mx.array, bool], None, None]:
+    """Draft-free (prompt-lookup) speculative decoding.
+
+    A pluggable proposer suggests a continuation of the running sequence and the
+    target verifies it in one batched forward. ``backend`` selects the proposer:
+    ``"ngram"`` (tail n-gram lookup) or ``"suffix_automaton"`` (longest repeated
+    suffix — stronger retrieval), or pass a proposer object with
+    ``observe(token)`` / ``propose(seq, max_span, prompt_len)``.
+
+    Lossless under the given ``sampler``: at each proposed position the target
+    distribution is sampled and the proposal is accepted iff it equals that
+    sample (speculative-sampling acceptance for a deterministic drafter), so the
+    output distribution matches the target's own (batched) greedy/sampled decode.
+    On a partial reject the cache is rewound (handling trimmable and rotating/
+    windowed caches). The prompt_cache is left representing exactly prompt+emitted
+    at every stop boundary.
+
+    ``adaptive`` enables a one-way never-lose latch: after ``warmup`` tokens, if
+    the accepted-proposal fraction is below ``gate`` (i.e. the work isn't
+    copy-heavy), it latches once to a plain ``generate_step`` tail — zero
+    regression on non-copy output; copy-heavy work never latches. ``stats``
+    (a HybridStats) is filled in place. Yields ``(token, logprobs, from_draft)``.
+    """
+    from .prompt_lookup import HybridStats, NgramProposer, make_proposer
+
+    if prompt_cache is None:
+        prompt_cache = cache.make_prompt_cache(model)
+    # Validate cache types up front so unsupported models (e.g. ArraysCache/SSM)
+    # fail loud immediately, and record the base offset so a non-empty (reused)
+    # cache's existing prefix is preserved by the end-of-run reconciliation.
+    _pld_snapshot(prompt_cache)
+    base_offset = _pld_offset(prompt_cache[0])
+    sampler = sampler or (lambda x: mx.argmax(x, axis=-1))
+    prompt_progress_callback = prompt_progress_callback or (lambda *_: None)
+    stats = stats if stats is not None else HybridStats()
+
+    seq = prompt.tolist() if isinstance(prompt, mx.array) else list(prompt)
+    prompt_len = len(seq)
+
+    if backend == "ngram":
+        proposer = NgramProposer(ngram_max, ngram_min, prompt_only)
+    else:
+        proposer = make_proposer(backend)  # empty; the observe loop below is the
+    for t in seq:                          # single seeding authority (avoids a
+        proposer.observe(t)                # double-seed that desyncs SAM coords)
+
+    # Prefill everything but the last token.
+    with mx.stream(generation_stream):
+        head = seq[:-1]
+        processed = 0
+        prompt_progress_callback(0, prompt_len)
+        while processed < len(head):
+            chunk = head[processed : processed + prefill_step_size]
+            model(mx.array(chunk)[None], cache=prompt_cache)
+            mx.eval([c.state for c in prompt_cache])
+            processed += len(chunk)
+            prompt_progress_callback(processed, prompt_len)
+            mx.clear_cache()
+        prompt_progress_callback(prompt_len, prompt_len)
+
+    pending = [seq[-1]]
+    generated = 0
+    retrieved = 0  # tokens emitted from accepted proposals
+    latched = False
+    prompt_len = len(seq)
+    last_snap = None  # snapshot before the most recent proposal forward
+    try:
+        while (max_tokens < 0 or generated < max_tokens) and not latched:
+            stats.cycles += 1
+            # Clamp the proposal to the remaining budget so a cycle never forwards
+            # (and commits) more tokens than it will yield -> the cache stays
+            # consistent with the yielded prefix at the max_tokens boundary.
+            span = num_draft
+            if max_tokens >= 0:
+                span = min(num_draft, max(max_tokens - generated - 1, 0))
+            prop = (
+                proposer.propose(seq, span, prompt_len)
+                if (span > 0 and len(pending) <= 2)
+                else []
+            )
+            x = pending + prop
+            snaps = _pld_snapshot(prompt_cache) if prop else None
+            if snaps is not None:
+                last_snap = snaps
+
+            with mx.stream(generation_stream):
+                logits = model(mx.array(x)[None], cache=prompt_cache)[0]
+                logprobs = logits - mx.logsumexp(logits, axis=-1, keepdims=True)
+                mx.eval(logprobs)
+
+            base = len(pending) - 1
+            emit = []  # (token, logprobs_row, from_draft)
+            for j in range(len(prop) + 1):
+                row = logprobs[base + j]
+                s = int(sampler(row[None])[0].item())
+                if j < len(prop) and prop[j] == s:
+                    emit.append((prop[j], row, True))
+                else:
+                    emit.append((s, row, False))
+                    break
+            n_acc = len(emit) - 1
+
+            if prop:
+                stats.retrieval_cycles += 1
+                stats.retrieval_proposed += len(prop)
+                stats.retrieval_accepted += n_acc
+                stats.bonus_tokens += 1
+            else:
+                stats.plain_cycles += 1
+                stats.plain_tokens += 1
+
+            if prop and n_acc < len(prop):
+                _pld_rewind(prompt_cache, snaps)
+                pending = pending + [t for t, _, _ in emit]
+            else:
+                pending = [emit[-1][0]]
+
+            for tok, row, from_draft in emit:
+                seq.append(tok)
+                proposer.observe(tok)
+                generated += 1
+                if from_draft:
+                    retrieved += 1
+                yield tok, row, from_draft
+                if max_tokens >= 0 and generated >= max_tokens:
+                    return
+
+            # One-way never-lose latch: once we have enough evidence the work
+            # isn't copy-heavy, switch to a plain generate_step tail (bit-exact,
+            # no per-cycle proposal overhead) for all remaining tokens.
+            if adaptive and generated >= warmup and retrieved / generated < gate:
+                latched = True
+
+        if latched and (max_tokens < 0 or generated < max_tokens):
+            stats.latched = True
+            remaining = -1 if max_tokens < 0 else (max_tokens - generated)
+            for tok, lp in generate_step(
+                mx.array(pending),
+                model,
+                max_tokens=remaining,
+                sampler=sampler,
+                prompt_cache=prompt_cache,
+                prefill_step_size=prefill_step_size,
+            ):
+                seq.append(int(tok))
+                generated += 1
+                stats.plain_tokens += 1
+                yield int(tok), lp, False
+    finally:
+        # Leave prompt_cache representing EXACTLY prompt + emitted tokens (like
+        # generate_step), even though PLD forwards in batches and may stop mid-batch
+        # (e.g. caller breaks on EOS). This keeps callers that persist/reuse the
+        # cache (e.g. an LRU prompt cache) correct.
+        #   behind -> forward the missing emitted tail.
+        #   ahead  -> the extra tokens came from the last proposal forward, so undo
+        #     it via that snapshot (a copy-restore that is safe for rotating caches,
+        #     unlike trim past the window) and forward the emitted tail instead.
+        # Offsets are absolute (include any reused-cache base); seq is local
+        # (prompt+emitted), so index the missing tail by (off - base_offset).
+        target = base_offset + prompt_len + generated
+        off = _pld_offset(prompt_cache[0])
+        if off > target and last_snap is not None:
+            _pld_rewind(prompt_cache, last_snap)
+            off = _pld_offset(prompt_cache[0])
+        if off < target:
+            miss = seq[off - base_offset : prompt_len + generated]
+            if miss:
+                with mx.stream(generation_stream):
+                    model(mx.array(miss)[None], cache=prompt_cache)
+                    mx.eval([c.state for c in prompt_cache])
+        elif off > target:
+            for c in prompt_cache:
+                if c.is_trimmable():
+                    c.trim(off - target)
+
+
 def stream_generate(
     model: nn.Module,
     tokenizer: Union[PreTrainedTokenizer, TokenizerWrapper],
     prompt: Union[str, mx.array, List[int]],
     max_tokens: int = 256,
     draft_model: Optional[nn.Module] = None,
+    prompt_lookup: Optional[dict] = None,
     **kwargs,
 ) -> Generator[GenerationResponse, None, None]:
     """
@@ -698,7 +949,39 @@ def stream_generate(
 
     kwargs["max_tokens"] = max_tokens
 
-    if draft_model is None:
+    # Prompt-lookup (draft-free) speculative decoding. Engages only when it is
+    # safe to do losslessly: no draft model, no logits processors, no KV-cache
+    # quantization, and no input embeddings / bounded KV (unsupported by the
+    # rewind path). Otherwise fall through to the standard generators.
+    pld_safe = (
+        prompt_lookup
+        and draft_model is None
+        and not kwargs.get("logits_processors")
+        and kwargs.get("kv_bits") is None
+        and kwargs.get("input_embeddings") is None
+        and kwargs.get("max_kv_size") is None
+    )
+    if pld_safe:
+        for k in (
+            "num_draft_tokens", "relaxed_topk", "relaxed_delta", "speculative_stats",
+            "logits_processors", "kv_bits", "kv_group_size", "quantized_kv_start",
+            "input_embeddings", "max_kv_size",
+        ):
+            kwargs.pop(k, None)
+        token_generator = prompt_lookup_generate_step(
+            prompt,
+            model,
+            backend=prompt_lookup.get("backend", "ngram"),
+            num_draft=prompt_lookup.get("num_draft", 8),
+            ngram_max=prompt_lookup.get("ngram_max", 3),
+            ngram_min=prompt_lookup.get("ngram_min", 1),
+            prompt_only=prompt_lookup.get("prompt_only", False),
+            adaptive=prompt_lookup.get("adaptive", False),
+            warmup=prompt_lookup.get("warmup", 48),
+            gate=prompt_lookup.get("gate", 0.12),
+            **kwargs,
+        )
+    elif draft_model is None:
         kwargs.pop("num_draft_tokens", None)
         token_generator = generate_step(prompt, model, **kwargs)
         # from_draft always false for non-speculative generation

--- a/mlx_lm/prompt_lookup.py
+++ b/mlx_lm/prompt_lookup.py
@@ -1,0 +1,185 @@
+"""Proposal backends for draft-free (prompt-lookup) speculative decoding.
+
+Two interchangeable proposers feed the shared verify/accept/cache core in
+``generate.prompt_lookup_generate_step``:
+
+- ``NgramProposer`` — tail n-gram lookup against the running sequence. Simple,
+  stateless, zero dependencies. Good default.
+- ``SuffixAutomatonProposer`` — an online suffix automaton that returns the
+  longest repeated suffix's continuation. Strictly stronger retrieval (finds
+  longer/earlier matches than a fixed n-gram) at ~microseconds/token.
+
+Both expose the same interface:
+    observe(token: int)                      # feed each committed token
+    propose(seq, max_span, prompt_len) -> list[int]
+
+The ``SuffixAutomaton`` and ``HybridStats`` classes here come from the
+hybrid-speculative work in this project (SuffixAutomaton retrieval + per-source
+accounting); they are reused verbatim so the two efforts converge on one core.
+"""
+from dataclasses import dataclass
+from typing import List, Sequence, Tuple
+
+
+class SuffixAutomaton:
+    """Online suffix automaton over token ids.
+
+    Built incrementally (``extend`` per committed token), it answers, in
+    O(suffix-link chain) per call: what is the longest suffix of the current
+    sequence that also occurs ending at an earlier position, and where does that
+    earlier occurrence end? ``first_end`` is the end position of the FIRST
+    occurrence of a state's substrings, fixed at creation (clones inherit it).
+    """
+
+    __slots__ = ("seq", "_len", "_link", "_next", "_first_end", "_last")
+
+    def __init__(self, tokens: Sequence[int] = ()):
+        self.seq: List[int] = []
+        self._len = [0]
+        self._link = [-1]
+        self._next: List[dict] = [{}]
+        self._first_end = [-1]
+        self._last = 0
+        for t in tokens:
+            self.extend(t)
+
+    def __len__(self) -> int:
+        return len(self.seq)
+
+    def extend(self, token: int) -> None:
+        token = int(token)
+        pos = len(self.seq)
+        self.seq.append(token)
+        lens, link, nxt, first_end = self._len, self._link, self._next, self._first_end
+        cur = len(lens)
+        lens.append(lens[self._last] + 1)
+        link.append(-1)
+        nxt.append({})
+        first_end.append(pos)
+        p = self._last
+        while p != -1 and token not in nxt[p]:
+            nxt[p][token] = cur
+            p = link[p]
+        if p == -1:
+            link[cur] = 0
+        else:
+            q = nxt[p][token]
+            if lens[p] + 1 == lens[q]:
+                link[cur] = q
+            else:
+                clone = len(lens)
+                lens.append(lens[p] + 1)
+                link.append(link[q])
+                nxt.append(dict(nxt[q]))
+                first_end.append(first_end[q])
+                while p != -1 and nxt[p].get(token) == q:
+                    nxt[p][token] = clone
+                    p = link[p]
+                link[q] = clone
+                link[cur] = clone
+        self._last = cur
+
+    def longest_suffix_match(self, max_len: int = 16) -> Tuple[int, int]:
+        """Return (match_len, next_pos): the longest suffix (<= max_len) that
+        also occurs ending strictly before the current end, and the index right
+        after that earlier occurrence (``seq[next_pos:]`` is the continuation).
+        Returns (0, -1) when no suffix repeats."""
+        n = len(self.seq)
+        if n < 2:
+            return 0, -1
+        v = self._last
+        while v != 0 and self._first_end[v] >= n - 1:
+            v = self._link[v]
+        if v == 0:
+            return 0, -1
+        return min(self._len[v], max_len), self._first_end[v] + 1
+
+
+class NgramProposer:
+    """Tail n-gram lookup. Stateless: proposes the continuation of the rightmost
+    earlier occurrence of the tail n-gram (largest n first)."""
+
+    def __init__(self, ngram_max: int = 3, ngram_min: int = 1, prompt_only: bool = False):
+        self.ngram_max = ngram_max
+        self.ngram_min = ngram_min
+        self.prompt_only = prompt_only
+
+    def observe(self, token: int) -> None:  # stateless
+        pass
+
+    def propose(self, seq: List[int], max_span: int, prompt_len: int) -> List[int]:
+        search_len = prompt_len if self.prompt_only else None
+        n = len(seq)
+        limit = n if search_len is None else min(search_len, n)
+        for g in range(self.ngram_max, self.ngram_min - 1, -1):
+            if n < g + 1:
+                continue
+            key = seq[-g:]
+            start = (limit - g) if search_len is not None else (n - g - 1)
+            for i in range(min(start, n - g - 1), -1, -1):
+                if seq[i : i + g] == key:
+                    cont = seq[i + g : i + g + max_span]
+                    if cont:
+                        return cont
+        return []
+
+
+class SuffixAutomatonProposer:
+    """Suffix-automaton retrieval: continuation of the longest repeated suffix."""
+
+    def __init__(self, min_match: int = 3, max_lookback: int = 32,
+                 initial_tokens: Sequence[int] = ()):
+        self.min_match = min_match
+        self.max_lookback = max_lookback
+        self.sam = SuffixAutomaton(initial_tokens)
+
+    def observe(self, token: int) -> None:
+        self.sam.extend(token)
+
+    def propose(self, seq: List[int], max_span: int, prompt_len: int) -> List[int]:
+        mlen, nxt = self.sam.longest_suffix_match(self.max_lookback)
+        if mlen >= self.min_match and 0 <= nxt < len(seq):
+            return seq[nxt : nxt + max_span]
+        return []
+
+
+def make_proposer(spec):
+    """Build an EMPTY proposer from a `backend` string, or pass through a proposer
+    object. The caller seeds it (feeds the prompt via observe()) — do not seed here
+    too, or a stateful backend's coordinates desync from the caller's sequence.
+    spec: "ngram" | "suffix_automaton" | a proposer instance."""
+    if hasattr(spec, "propose"):
+        return spec
+    if spec in (None, "ngram"):
+        return NgramProposer()
+    if spec == "suffix_automaton":
+        return SuffixAutomatonProposer()
+    raise ValueError(f"unknown prompt-lookup backend {spec!r}")
+
+
+@dataclass
+class HybridStats:
+    """Per-source accounting for one prompt-lookup generation run."""
+
+    cycles: int = 0
+    retrieval_cycles: int = 0
+    plain_cycles: int = 0
+    retrieval_proposed: int = 0
+    retrieval_accepted: int = 0
+    bonus_tokens: int = 0
+    plain_tokens: int = 0
+    latched: bool = False
+
+    @property
+    def total_emitted(self) -> int:
+        return self.retrieval_accepted + self.bonus_tokens + self.plain_tokens
+
+    def summary(self) -> str:
+        tot = max(self.total_emitted, 1)
+        acc = self.retrieval_accepted / max(self.retrieval_proposed, 1)
+        return (
+            f"cycles {self.cycles} (retrieval {self.retrieval_cycles}, plain {self.plain_cycles}) | "
+            f"tokens {self.total_emitted}: retrieval {self.retrieval_accepted} "
+            f"({self.retrieval_accepted / tot:.0%}) + bonus {self.bonus_tokens} + plain {self.plain_tokens} | "
+            f"retrieval acceptance {acc:.0%} | latched={self.latched}"
+        )

--- a/mlx_lm/server.py
+++ b/mlx_lm/server.py
@@ -192,6 +192,8 @@ class GenerationArguments:
     top_logprobs: int
     seed: Optional[int]
     chat_template_kwargs: Optional[Dict[str, Any]]
+    prompt_lookup_ngram: int = 0
+    prompt_lookup_tokens: int = 8
 
 
 @dataclass
@@ -683,7 +685,14 @@ class ResponseGenerator:
         return sm, sequences
 
     def _is_batchable(self, args):
-        return self.model_provider.is_batchable and args.seed is None
+        if not self.model_provider.is_batchable:
+            return False
+        if args.seed is not None:
+            return False
+        # Prompt-lookup speculative decoding runs on the single-stream path.
+        if getattr(args, "prompt_lookup_ngram", 0):
+            return False
+        return True
 
     def _generate(self):
         # Local thread stream that we 'll pass to the BatchGenerator to make
@@ -983,6 +992,14 @@ class ResponseGenerator:
                 prompt_cache=cache,
                 draft_model=draft_model,
                 num_draft_tokens=args.num_draft_tokens,
+                prompt_lookup=(
+                    {
+                        "ngram_max": args.prompt_lookup_ngram,
+                        "num_draft": args.prompt_lookup_tokens,
+                    }
+                    if getattr(args, "prompt_lookup_ngram", 0)
+                    else None
+                ),
                 prompt_progress_callback=progress,
                 prefill_step_size=self.cli_args.prefill_step_size,
             ):
@@ -1164,6 +1181,12 @@ class APIHandler(BaseHTTPRequestHandler):
         self.requested_draft_model = self.body.get("draft_model", "default_model")
         self.num_draft_tokens = self.body.get(
             "num_draft_tokens", self.response_generator.cli_args.num_draft_tokens
+        )
+        self.prompt_lookup_ngram = self.body.get(
+            "prompt_lookup_ngram", self.response_generator.cli_args.prompt_lookup_ngram
+        )
+        self.prompt_lookup_tokens = self.body.get(
+            "prompt_lookup_tokens", self.response_generator.cli_args.prompt_lookup_tokens
         )
         self.adapter = self.body.get("adapters", None)
         self.max_tokens = self.body.get("max_completion_tokens", None)
@@ -1399,6 +1422,8 @@ class APIHandler(BaseHTTPRequestHandler):
             stop_words=stop_words,
             max_tokens=self.max_tokens,
             num_draft_tokens=self.num_draft_tokens,
+            prompt_lookup_ngram=self.prompt_lookup_ngram,
+            prompt_lookup_tokens=self.prompt_lookup_tokens,
             logprobs=self.logprobs,
             top_logprobs=self.top_logprobs,
             seed=self.seed,
@@ -1789,6 +1814,20 @@ def main():
         type=int,
         help="Number of tokens to draft when using speculative decoding.",
         default=3,
+    )
+    parser.add_argument(
+        "--prompt-lookup-ngram",
+        type=int,
+        default=0,
+        help="Enable draft-free prompt-lookup (n-gram) speculative decoding "
+        "with this max n-gram size (0 disables). Great for code editing / "
+        "long verbatim copies.",
+    )
+    parser.add_argument(
+        "--prompt-lookup-tokens",
+        type=int,
+        default=8,
+        help="Max tokens to propose per prompt-lookup step (default: 8).",
     )
     parser.add_argument(
         "--trust-remote-code",

--- a/tests/test_prompt_lookup.py
+++ b/tests/test_prompt_lookup.py
@@ -1,0 +1,204 @@
+# Copyright © 2024 Apple Inc.
+
+"""Tests for draft-free prompt-lookup (PLD) speculative decoding.
+
+Covers the proposer backends, the cache-lifecycle helpers, and end-to-end
+correctness — including the two cache-reconciliation regressions found in review:
+cache REUSE (a non-empty incoming prompt_cache must not be trimmed) and CacheList
+models (the reconcile must not assume a flat ``.offset``).
+"""
+import unittest
+
+import mlx.core as mx
+import mlx.nn as nn
+from mlx_lm import load
+from mlx_lm.generate import (
+    _pld_offset,
+    _pld_snapshot,
+    generate_step,
+    prompt_lookup_generate_step,
+)
+from mlx_lm.models.cache import ArraysCache, CacheList, KVCache, make_prompt_cache
+from mlx_lm.prompt_lookup import (
+    NgramProposer,
+    SuffixAutomaton,
+    SuffixAutomatonProposer,
+    make_proposer,
+)
+from mlx_lm.sample_utils import make_sampler
+
+GREEDY = make_sampler(temp=0.0)
+
+
+class TestProposers(unittest.TestCase):
+    def test_ngram_finds_earlier_continuation(self):
+        # "a b c ... a b" -> proposes the continuation after the earlier "a b".
+        seq = [1, 2, 3, 9, 9, 1, 2]
+        p = NgramProposer(ngram_max=2, ngram_min=1)
+        self.assertEqual(p.propose(seq, max_span=3, prompt_len=len(seq)), [3, 9, 9])
+
+    def test_ngram_no_match(self):
+        p = NgramProposer(ngram_max=3, ngram_min=2)
+        self.assertEqual(p.propose([1, 2, 3, 4], max_span=4, prompt_len=4), [])
+
+    def test_suffix_automaton_longest_repeat(self):
+        sam = SuffixAutomaton([5, 6, 7, 8, 5, 6])
+        mlen, nxt = sam.longest_suffix_match(max_len=16)
+        self.assertEqual(mlen, 2)          # "5 6" repeats
+        self.assertEqual([5, 6, 7, 8, 5, 6][nxt], 7)  # continuation is "7"
+
+    def test_make_proposer_returns_empty(self):
+        # The caller is the single seeding authority; make_proposer must not seed.
+        p = make_proposer("suffix_automaton")
+        self.assertIsInstance(p, SuffixAutomatonProposer)
+        self.assertEqual(len(p.sam), 0)
+        with self.assertRaises(ValueError):
+            make_proposer("nope")
+
+
+class TestCacheHelpers(unittest.TestCase):
+    def test_pld_offset_flat(self):
+        c = KVCache()
+        c.offset = 11
+        self.assertEqual(_pld_offset(c), 11)
+
+    def test_pld_offset_cachelist(self):
+        # CacheList has no .offset of its own; the helper must descend.
+        cl = CacheList(KVCache(), KVCache())
+        cl.caches[0].offset = 7
+        cl.caches[1].offset = 7
+        self.assertFalse(hasattr(cl, "offset"))
+        self.assertEqual(_pld_offset(cl), 7)
+
+    def test_snapshot_rejects_unsupported_cache(self):
+        # ArraysCache (SSM/Mamba/recurrent) is unsupported and must fail loud.
+        with self.assertRaises(NotImplementedError):
+            _pld_snapshot([ArraysCache(size=2)])
+
+
+class _TinyCacheListModel(nn.Module):
+    """Minimal model whose per-layer cache is ``CacheList(KVCache, KVCache)`` —
+    mirroring deepseek_v32 / longcat_flash, which put two KV caches per layer.
+    Lets the CacheList path (snapshot/rewind + the finally reconcile) be tested
+    without downloading a large real model."""
+
+    def __init__(self, vocab=48, dim=16):
+        super().__init__()
+        self.embed = nn.Embedding(vocab, dim)
+        self.q = nn.Linear(dim, dim, bias=False)
+        self.out = nn.Linear(dim, vocab, bias=False)
+
+    def make_cache(self):
+        return [CacheList(KVCache(), KVCache())]
+
+    def __call__(self, x, cache=None):
+        h = self.embed(x)
+        if cache is not None:
+            B, S, D = h.shape
+            kv = self.q(h).reshape(B, 1, S, D)  # [B, heads=1, S, D]
+            for sub in cache[0].caches:
+                sub.update_and_fetch(kv, kv)     # advance both sub-caches
+        return self.out(h)
+
+
+class TestCacheListModel(unittest.TestCase):
+    def test_pld_runs_on_cachelist_model(self):
+        # Regression for the finally-reconcile CacheList bug: prompt_cache[0] is a
+        # CacheList (no flat .offset). PLD must run and leave the cache exact.
+        mx.random.seed(0)
+        model = _TinyCacheListModel()
+        mx.eval(model.parameters())
+        prompt = mx.array([3, 7, 1, 3, 7])  # repeated suffix -> retrieval fires
+        cache = make_prompt_cache(model)
+        self.assertIsInstance(cache[0], CacheList)
+        out = [
+            int(t)
+            for t, _, _ in prompt_lookup_generate_step(
+                prompt, model, max_tokens=24, sampler=GREEDY,
+                prompt_cache=cache, backend="suffix_automaton",
+            )
+        ]
+        self.assertEqual(len(out), 24)
+        self.assertEqual(_pld_offset(cache[0]), prompt.size + len(out))
+
+
+class TestPromptLookupGenerate(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.model, cls.tokenizer = load("mlx-community/Qwen1.5-0.5B-Chat-4bit")
+
+    def _prompt(self, text):
+        return mx.array(self.tokenizer.encode(text))
+
+    def _run(self, prompt, cache, backend, max_tokens):
+        return [
+            int(t)
+            for t, _, _ in prompt_lookup_generate_step(
+                prompt, self.model, max_tokens=max_tokens,
+                sampler=GREEDY, prompt_cache=cache, backend=backend,
+            )
+        ]
+
+    def test_backends_run_and_cache_exact(self):
+        prompt = self._prompt("def add(a, b):\n    return a + b\n# repeat: def add")
+        for backend in ("ngram", "suffix_automaton"):
+            cache = make_prompt_cache(self.model)
+            out = self._run(prompt, cache, backend, max_tokens=48)
+            self.assertGreater(len(out), 0)
+            # Cache is left EXACTLY at prompt + emitted.
+            self.assertEqual(_pld_offset(cache[0]), prompt.size + len(out))
+
+    def test_matches_target_batched_greedy(self):
+        # PLD output must equal the target's own greedy over prompt+output, i.e.
+        # every emitted token is the batched argmax given its prefix. (This is the
+        # correct losslessness bar; bit-identity with sequential generate_step is
+        # NOT expected for any speculative decoder — batched verify != sequential.)
+        prompt = self._prompt("List: apple, banana, apple, banana, apple,")
+        cache = make_prompt_cache(self.model)
+        out = self._run(prompt, cache, "suffix_automaton", max_tokens=40)
+        full = mx.array(prompt.tolist() + out)[None]
+        logits = self.model(full)
+        L = prompt.size
+        for i, tok in enumerate(out):
+            self.assertEqual(int(mx.argmax(logits[0, L - 1 + i]).item()), tok)
+
+    def test_max_tokens_boundary_cache_exact(self):
+        prompt = self._prompt("Count: 1 2 3 1 2 3 1 2 3")
+        for mt in (1, 7, 20):
+            cache = make_prompt_cache(self.model)
+            out = self._run(prompt, cache, "ngram", max_tokens=mt)
+            self.assertEqual(len(out), mt)
+            self.assertEqual(_pld_offset(cache[0]), prompt.size + mt)
+
+    def test_cache_reuse_preserves_base(self):
+        # Regression: a reused (non-empty) cache's existing prefix must survive
+        # the end-of-run reconciliation.
+        cache = make_prompt_cache(self.model)
+        p1 = self._prompt("Write a haiku about the sea.")
+        g1 = self._run(p1, cache, "suffix_automaton", max_tokens=32)
+        base = _pld_offset(cache[0])
+        self.assertEqual(base, p1.size + len(g1))
+        # Second turn reuses the same cache.
+        p2 = self._prompt("\nNow one about the mountains.\n")
+        g2 = self._run(p2, cache, "suffix_automaton", max_tokens=32)
+        self.assertEqual(_pld_offset(cache[0]), base + p2.size + len(g2))
+
+    def test_adaptive_latch_runs(self):
+        prompt = self._prompt("Explain why the sky is blue in one paragraph.")
+        cache = make_prompt_cache(self.model)
+        from mlx_lm.prompt_lookup import HybridStats
+        stats = HybridStats()
+        out = [
+            int(t)
+            for t, _, _ in prompt_lookup_generate_step(
+                prompt, self.model, max_tokens=80, sampler=GREEDY,
+                prompt_cache=cache, backend="suffix_automaton",
+                adaptive=True, warmup=16, gate=0.5, stats=stats,
+            )
+        ]
+        self.assertEqual(len(out), 80)
+        self.assertEqual(_pld_offset(cache[0]), prompt.size + len(out))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Draft-free prompt-lookup (n-gram) speculative decoding

This adds **prompt-lookup decoding** to `mlx-lm`: a draft-free form of speculative decoding that proposes continuations by retrieving them from the prompt/context (n-gram or suffix-automaton lookup) and verifies them with the standard speculative-sampling accept. It needs **no draft model and no extra weights**, and is **lossless** with respect to the model's own sampling.

It shines whenever the output copies substantial spans from the input — code editing, diff/refactor, RAG, structured rewrites, agentic tool loops — where it can propose long verbatim runs the model would otherwise emit one token at a time. On code-editing workloads I've measured ~1.5–3× decode speedups; on pure fresh generation it correctly falls back to no overhead.

### API

```python
from mlx_lm import load, stream_generate

model, tok = load("mlx-community/Qwen2.5-Coder-7B-Instruct-4bit")
for r in stream_generate(model, tok, prompt, max_tokens=512,
                         prompt_lookup={"ngram_max": 3, "num_draft": 8}):
    print(r.text, end="", flush=True)
```

Server:

```
mlx_lm.server --model ... --prompt-lookup-ngram 3 --prompt-lookup-tokens 8
```

…or per-request via `"prompt_lookup_ngram"` / `"prompt_lookup_tokens"` in the JSON body.

### What's included

- **`mlx_lm/prompt_lookup.py`** — `NgramProposer` (tail n-gram lookup) and `SuffixAutomatonProposer` (online suffix automaton; longer/earlier matches at ~µs/token) behind a common `observe()`/`propose()` interface, plus `make_proposer()` and per-source `HybridStats`.
- **`mlx_lm/generate.py`** — `prompt_lookup_generate_step` (the verify/accept/cache core), cache snapshot/rewind helpers that correctly handle `KVCache`, `RotatingKVCache` (copy, not `trim()`, since a multi-token block feed can cross the sliding window), and `CacheList` (`_pld_snapshot` / `_pld_rewind` / `_pld_offset`), and a `stream_generate` dispatch via a new `prompt_lookup=` argument.
- **`mlx_lm/server.py`** — `--prompt-lookup-ngram` / `--prompt-lookup-tokens` flags, matching request fields, and single-stream gating in `_is_batchable`.
- **`tests/test_prompt_lookup.py`** — 13 tests.

### Safety / losslessness

Prompt-lookup **engages only when it can be lossless**: no draft model, no logits processors, no KV quantization, no input embeddings, no bounded KV cache. Otherwise `stream_generate` falls through to the existing generators unchanged (the new `prompt_lookup=` argument defaults to `None`, so behavior is identical when unused).

Losslessness bar: every emitted token equals the target's **batched-greedy** argmax at that position (the accept rule always commits the target's own sampled token), not bit-identity with sequential `generate_step` — batched vs. incremental decode differ by inherent FP noise at the same positions regardless of PLD. The test suite encodes exactly this bar and also verifies cache-offset exactness after each step.

### Testing

```
$ python -m unittest tests.test_prompt_lookup -v
Ran 13 tests in 4.1s
OK
```

Covers: proposer units; cache-helper units incl. `CacheList` and loud rejection of unsupported caches (e.g. SSM `ArraysCache`); losslessness vs batched-greedy; cache-exactness single-turn and at the `max_tokens` boundary; **cache reuse across turns** (a reused non-empty prompt cache's base is preserved through reconciliation); a **`CacheList` model** end-to-end; and the optional adaptive latch.

### Attribution

The cache-reconciliation hardening (base-offset handling for reused caches; `CacheList` support) and the test suite were developed and verified in a parallel work session; folded in here with attribution.
