### PR TITLE
Fix mixed-bit quantized load for sanitize()-derived MLA projections

### DIFF
--- a/mlx_lm/utils.py
+++ b/mlx_lm/utils.py
@@ -366,7 +366,25 @@ def load_model(
                 return config["quantization"][p]
             if not hasattr(m, "to_quantized"):
                 return False
-            return f"{p}.scales" in weights
+            if f"{p}.scales" not in weights:
+                return False
+            # This path has no entry in the per-tensor quantization map but
+            # the checkpoint already carries a quantized weight for it (e.g.
+            # a model's sanitize() can derive and re-quantize tensors, such
+            # as the absorbed MLA projections in deepseek_v3/deepseek_v32/
+            # glm4_moe_lite/kimi_linear/longcat_flash, from a source tensor
+            # that has its own per-tensor bits/group_size override). Infer
+            # the actual packing from the weight/scales shapes instead of
+            # assuming the top-level default, so the module nn.quantize
+            # allocates matches the weight that will be loaded into it.
+            in_dims = m.weight.shape[-1]
+            group_size = in_dims // weights[f"{p}.scales"].shape[-1]
+            bits = (weights[f"{p}.weight"].shape[-1] * 32) // in_dims
+            return {
+                "group_size": group_size,
+                "bits": bits,
+                "mode": quantization.get("mode", "affine"),
+            }
 
         nn.quantize(
             model,

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,5 +1,6 @@
 # Copyright © 2024 Apple Inc.
 
+import dataclasses
 import json
 import os
 import tempfile
@@ -178,6 +179,88 @@ class TestUtils(unittest.TestCase):
                 "language_model.model.per_layer_model_projection",
                 loaded_config["quantization"],
             )
+
+            logits = loaded(mx.array([[1, 2, 3]], dtype=mx.int32))
+            mx.eval(logits)
+            self.assertEqual(logits.shape, (1, 3, args.vocab_size))
+
+    def test_load_model_with_mixed_bit_derived_mla_projection(self):
+        # Regression test for a mismatch that only shows up with a
+        # non-uniform per-tensor quantization map: deepseek_v3's sanitize()
+        # derives embed_q/unembed_out from kv_b_proj and re-quantizes them
+        # at kv_b_proj's own bits, but those derived paths never appear in
+        # the per-tensor quantization map (the converter never saw them),
+        # so load_model must infer their true bits from the saved weight
+        # shapes rather than assume the global default.
+        from mlx_lm.models import deepseek_v3
+
+        args = deepseek_v3.ModelArgs(
+            model_type="deepseek_v3",
+            vocab_size=64,
+            hidden_size=32,
+            intermediate_size=64,
+            moe_intermediate_size=64,
+            num_hidden_layers=1,
+            num_attention_heads=2,
+            num_key_value_heads=2,
+            n_routed_experts=2,
+            n_group=1,
+            topk_group=1,
+            num_experts_per_tok=2,
+            n_shared_experts=1,
+            kv_lora_rank=32,
+            q_lora_rank=32,
+            qk_rope_head_dim=32,
+            v_head_dim=32,
+            qk_nope_head_dim=32,
+            rope_scaling={
+                "beta_fast": 32,
+                "beta_slow": 1,
+                "factor": 40,
+                "mscale": 1.0,
+                "mscale_all_dim": 1.0,
+                "original_max_position_embeddings": 4096,
+                "type": "yarn",
+            },
+        )
+        model = deepseek_v3.Model(args)
+        model, config = utils.quantize_model(
+            model, dataclasses.asdict(args), group_size=32, bits=4
+        )
+
+        # Simulate a checkpoint where kv_b_proj carried a per-tensor bits
+        # override: re-pack the already-derived embed_q/unembed_out at a
+        # different bit width than the model's global default, without
+        # adding their paths to config["quantization"].
+        attn = model.layers[0].self_attn
+        for proj in (attn.embed_q, attn.unembed_out):
+            w = mx.dequantize(
+                proj.weight,
+                proj.scales,
+                proj.biases,
+                group_size=proj.group_size,
+                bits=proj.bits,
+                mode=proj.mode,
+            )
+            proj.weight, proj.scales, proj.biases = mx.quantize(
+                w, group_size=32, bits=8, mode=proj.mode
+            )
+            proj.group_size, proj.bits = 32, 8
+
+        with tempfile.TemporaryDirectory(dir=self.test_dir) as mlx_path:
+            utils.save_model(mlx_path, model)
+            utils.save_config(config, os.path.join(mlx_path, "config.json"))
+            self.assertFalse(
+                any(
+                    "embed_q" in k or "unembed_out" in k for k in config["quantization"]
+                )
+            )
+
+            loaded, _ = utils.load_model(Path(mlx_path))
+
+            loaded_attn = loaded.layers[0].self_attn
+            self.assertEqual(loaded_attn.embed_q.bits, 8)
+            self.assertEqual(loaded_attn.unembed_out.bits, 8)
 
             logits = loaded(mx.array([[1, 2, 3]], dtype=mx.int32))
             mx.eval(logits)


### PR DESCRIPTION
## Summary

Loading a mixed-bit quantized checkpoint fails with a shape mismatch when the source tensor a model's `sanitize()` derives another tensor from carries a per-tensor quantization override.

Concretely: `deepseek_v3.py`, `deepseek_v32.py`, `glm4_moe_lite.py`, `kimi_linear.py`, and `longcat_flash.py` all derive the absorbed MLA projections `embed_q`/`unembed_out` from `kv_b_proj` inside `sanitize()`, dequantizing and re-quantizing them at whatever bits/group_size `kv_b_proj` itself used. But `embed_q`/`unembed_out` never appear in `config["quantization"]` — the converter never saw those paths, since they only come into existence inside `sanitize()`. So `load_model`'s `class_predicate` (`mlx_lm/utils.py`) falls through to `f"{p}.scales" in weights`, which is `True` (sanitize just created those scales), and `nn.quantize` allocates the module at the **global default** bits/group_size instead of the bits it was actually packed at. On any layer where the source tensor's override differs from the default, `load_weights` then raises a shape mismatch.

Repro (from #1451):
```python
from mlx_lm import load
load("kwonhan/GLM-4.7-Flash-mixed-4-6-g32-mlx")
# ValueError: Expected shape (20, 512, 24) but received shape (20, 512, 36)
# for parameter model.layers.0.self_attn.embed_q.weight
```

Fixes #1451.

## Fix

When a path is missing from `config["quantization"]` but its weight already carries `.scales`, infer the actual `group_size`/`bits` from the packed weight and scales shapes (`in_dims = m.weight.shape[-1]`, same formula every affected `sanitize()` already uses on the source tensor) instead of assuming the top-level default. This is generic — it isn't specific to any one model file — and a no-op for the common uniform-bit case, since the inferred bits equal the default that was used to produce the checkpoint in the first place.

## Testing

- Added `test_load_model_with_mixed_bit_derived_mla_projection` in `tests/test_utils.py`: builds a tiny `deepseek_v3` model, quantizes it uniformly, then re-packs `embed_q`/`unembed_out` at a different bit width (without adding their paths to the quantization map) to simulate a `kv_b_proj` override — confirms the old code raises the shape-mismatch error from #1451, and the fix loads cleanly with the modules correctly reporting the overridden bits.
- `python -m unittest tests.test_models` — 76 passed.
- `python -m unittest tests.test_utils tests.test_prompt_cache` — all pass except two pre-existing failures in `test_convert`/`test_load_model_with_custom_get_classes` caused by an incomplete local HF cache with network disabled, unrelated to this change.
- `pre-commit run --files mlx_lm/utils.py tests/test_utils.py` (black, isort) — clean.