### PR TITLE
Add opt-in checkout_cache/return_cache to avoid deep-copy on fetch (#1395)

### DIFF
--- a/mlx_lm/models/cache.py
+++ b/mlx_lm/models/cache.py
@@ -1,6 +1,7 @@
 # Copyright © 2023-2024 Apple Inc.
 
 import copy
+import threading
 from collections import deque
 from dataclasses import dataclass
 from typing import Any, Dict, List, Optional
@@ -1626,7 +1627,10 @@ class LRUPromptCache:
         prompt_cache: List[Any]
         nbytes: int
         cache_type: str
-        checked_out: bool = False
+        # Nonce identifying the currently active checkout, or None when the
+        # entry isn't checked out. Comparing identities in return_cache means
+        # only the checkout that set it can clear it.
+        checked_out: Optional[object] = None
 
     class CacheOrder:
         def __init__(self, ordering: List[str] = ["assistant", "user", "system"]):
@@ -1664,6 +1668,9 @@ class LRUPromptCache:
         self._lru = LRUPromptCache.CacheOrder()
         self._n_bytes = 0
         self._n_bytes_by_type = {k: 0 for k in self._lru._ordering}
+        # Serializes the checked_out check-then-set/clear so two concurrent
+        # checkout_cache calls can never both take the no-copy path.
+        self._checkout_lock = threading.Lock()
 
     def __len__(self):
         return len(self._lru)
@@ -1701,10 +1708,15 @@ class LRUPromptCache:
         # sharing that reference would corrupt the first's history. Only
         # hand out the shared reference (skipping the copy) when nothing
         # else currently holds it; otherwise fall back to the safe copy.
-        if cache_entry.checked_out:
-            return copy.deepcopy(cache_entry.prompt_cache), None
-        cache_entry.checked_out = True
-        return cache_entry.prompt_cache, (model, entry_tokens)
+        # The lock makes the check-then-set atomic, and the per-checkout
+        # nonce means a stale or doubled return_cache can't release a
+        # checkout it doesn't own. The deep copy happens outside the lock.
+        with self._checkout_lock:
+            if cache_entry.checked_out is None:
+                nonce = object()
+                cache_entry.checked_out = nonce
+                return cache_entry.prompt_cache, (model, entry_tokens, nonce)
+        return copy.deepcopy(cache_entry.prompt_cache), None
 
     def checkout_cache(self, model: Any, tokens: List[int]):
         """Like fetch_nearest_cache, but avoids deep-copying the returned KV
@@ -1721,7 +1733,10 @@ class LRUPromptCache:
         Returns (prompt_cache, rest_tokens, checkout_token). checkout_token
         is None whenever nothing was actually checked out (no match, or the
         deep-copy fallback was used) -- passing None to return_cache is
-        always a safe no-op.
+        always a safe no-op. Tokens are single-use and scoped to the
+        checkout that produced them; returning one twice is a no-op, not a
+        release of some later caller's checkout. Safe to call from multiple
+        threads.
         """
         result = self._trie.search(model, tokens)
         if result.exact is not None:
@@ -1750,17 +1765,23 @@ class LRUPromptCache:
         return None, tokens, None
 
     def return_cache(self, checkout_token):
-        """Release a checkout obtained from checkout_cache. Safe to call
-        with None (no-op) and safe to call if the entry was evicted while
-        checked out (no-op)."""
+        """Release a checkout obtained from checkout_cache.
+
+        Tokens are single-use and scoped to the specific checkout that
+        produced them: a token that has already been returned, or that
+        belongs to an entry evicted (and possibly reinserted under the same
+        tokens) since the checkout, is a safe no-op and cannot release a
+        checkout held by another caller. Passing None is also a no-op."""
         if checkout_token is None:
             return
-        model, entry_tokens = checkout_token
-        try:
-            entry = self._trie.get(model, entry_tokens)
-        except KeyError:
-            return
-        entry.checked_out = False
+        model, entry_tokens, nonce = checkout_token
+        with self._checkout_lock:
+            try:
+                entry = self._trie.get(model, entry_tokens)
+            except KeyError:
+                return
+            if entry.checked_out is nonce:
+                entry.checked_out = None
 
     def insert_cache(
         self,

--- a/mlx_lm/models/cache.py
+++ b/mlx_lm/models/cache.py
@@ -1626,6 +1626,7 @@ class LRUPromptCache:
         prompt_cache: List[Any]
         nbytes: int
         cache_type: str
+        checked_out: bool = False
 
     class CacheOrder:
         def __init__(self, ordering: List[str] = ["assistant", "user", "system"]):
@@ -1692,6 +1693,74 @@ class LRUPromptCache:
             return copy.deepcopy(cache_entry.prompt_cache), tokens[short_length:]
 
         return None, tokens
+
+    def _checkout_or_copy(self, model: Any, entry_tokens: List[int], cache_entry):
+        # Two concurrent owners must never share one mutable KV buffer --
+        # KVCache.update_and_fetch() writes new tokens into a slice of a
+        # pre-allocated buffer in place, so a second in-progress generation
+        # sharing that reference would corrupt the first's history. Only
+        # hand out the shared reference (skipping the copy) when nothing
+        # else currently holds it; otherwise fall back to the safe copy.
+        if cache_entry.checked_out:
+            return copy.deepcopy(cache_entry.prompt_cache), None
+        cache_entry.checked_out = True
+        return cache_entry.prompt_cache, (model, entry_tokens)
+
+    def checkout_cache(self, model: Any, tokens: List[int]):
+        """Like fetch_nearest_cache, but avoids deep-copying the returned KV
+        cache when the matched entry isn't already checked out by another
+        caller.
+
+        The caller MUST call return_cache with the returned checkout token
+        once done with the cache -- including on error paths (e.g. in a
+        try/finally) -- so the entry becomes eligible for the no-copy path
+        again for future callers. Forgetting to call return_cache doesn't
+        corrupt anything; it just means that specific entry permanently
+        falls back to the safe copy-based behavior from then on.
+
+        Returns (prompt_cache, rest_tokens, checkout_token). checkout_token
+        is None whenever nothing was actually checked out (no match, or the
+        deep-copy fallback was used) -- passing None to return_cache is
+        always a safe no-op.
+        """
+        result = self._trie.search(model, tokens)
+        if result.exact is not None:
+            cache_entry = self._trie.get(result.model, result.exact)
+            cache, token = self._checkout_or_copy(model, result.exact, cache_entry)
+            return cache, [], token
+
+        short_length = len(result.shorter) if result.shorter is not None else 0
+        if result.longer is not None and result.common_prefix > short_length:
+            cache_entry = self._trie.get(result.model, result.longer)
+            if can_trim_prompt_cache(cache_entry.prompt_cache):
+                # Trimming rewinds the offset and then continues generation
+                # into the region the untrimmed entry still needs -- always
+                # unsafe to share, regardless of checkout state.
+                cache = copy.deepcopy(cache_entry.prompt_cache)
+                prefix = min(len(tokens) - 1, result.common_prefix)
+                num_to_trim = len(result.longer) - prefix
+                trim_prompt_cache(cache, num_to_trim)
+                return cache, tokens[prefix:], None
+
+        if short_length > 0:
+            cache_entry = self._trie.get(result.model, result.shorter)
+            cache, token = self._checkout_or_copy(model, result.shorter, cache_entry)
+            return cache, tokens[short_length:], token
+
+        return None, tokens, None
+
+    def return_cache(self, checkout_token):
+        """Release a checkout obtained from checkout_cache. Safe to call
+        with None (no-op) and safe to call if the entry was evicted while
+        checked out (no-op)."""
+        if checkout_token is None:
+            return
+        model, entry_tokens = checkout_token
+        try:
+            entry = self._trie.get(model, entry_tokens)
+        except KeyError:
+            return
+        entry.checked_out = False
 
     def insert_cache(
         self,

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -803,6 +803,62 @@ class TestLRUPromptCache(unittest.TestCase):
         cache = LRUPromptCache(max_size=10)
         cache.return_cache(None)  # must not raise
 
+    def test_double_return_does_not_release_a_later_checkout(self):
+        cache = LRUPromptCache(max_size=10)
+        model = ("test", None, None)
+        entry = [MockCache("test1")]
+        cache.insert_cache(model, [1, 2], entry)
+
+        # A checks out and returns once -- normal lifecycle.
+        _, _, token_a = cache.checkout_cache(model, [1, 2])
+        cache.return_cache(token_a)
+
+        # B legitimately checks out the same entry.
+        c_b, _, token_b = cache.checkout_cache(model, [1, 2])
+        self.assertIs(c_b, entry)
+        self.assertIsNotNone(token_b)
+
+        # A's stale token gets returned a second time (e.g. a double-release
+        # bug in a finally block). It must NOT release B's checkout.
+        cache.return_cache(token_a)
+
+        # C must therefore get a copy, not the live reference B holds.
+        c_c, _, token_c = cache.checkout_cache(model, [1, 2])
+        self.assertIsNot(c_c, entry)
+        self.assertEqual(c_c, entry)
+        self.assertIsNone(token_c)
+
+        cache.return_cache(token_b)
+
+    def test_stale_token_after_evict_and_reinsert_is_noop(self):
+        cache = LRUPromptCache(max_size=1)
+        model = ("test", None, None)
+        entry = [MockCache("test1")]
+        cache.insert_cache(model, [1, 2], entry)
+
+        _, _, stale_token = cache.checkout_cache(model, [1, 2])
+
+        # Evict the checked-out entry, then reinsert the same tokens as a
+        # brand-new entry.
+        cache.insert_cache(model, [3, 4], [MockCache("test2")])
+        new_entry = [MockCache("test3")]
+        cache.insert_cache(model, [1, 2], new_entry)
+
+        # B checks out the new entry.
+        c_b, _, token_b = cache.checkout_cache(model, [1, 2])
+        self.assertIs(c_b, new_entry)
+        self.assertIsNotNone(token_b)
+
+        # The pre-eviction token must not release B's checkout on the new
+        # entry that happens to share the same key.
+        cache.return_cache(stale_token)
+
+        c_c, _, token_c = cache.checkout_cache(model, [1, 2])
+        self.assertIsNot(c_c, new_entry)
+        self.assertIsNone(token_c)
+
+        cache.return_cache(token_b)
+
     def test_fetch_nearest_cache_still_copies_without_checkout(self):
         cache = LRUPromptCache(max_size=10)
         model = ("test", None, None)

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -733,6 +733,76 @@ class TestLRUPromptCache(unittest.TestCase):
         self.assertEqual(c, None)
         self.assertEqual(t, [3, 4])
 
+    def test_checkout_cache_shares_reference_when_uncontested(self):
+        cache = LRUPromptCache(max_size=10)
+        model = ("test", None, None)
+        entry = [MockCache("test1")]
+        cache.insert_cache(model, [1, 2], entry)
+
+        c, t, token = cache.checkout_cache(model, [1, 2])
+        # No deep copy: the caller gets the exact same list/object the
+        # cache is storing, not an equal-but-distinct clone.
+        self.assertIs(c, entry)
+        self.assertEqual(t, [])
+        self.assertIsNotNone(token)
+
+        cache.return_cache(token)
+
+    def test_checkout_cache_falls_back_to_copy_when_contended(self):
+        cache = LRUPromptCache(max_size=10)
+        model = ("test", None, None)
+        entry = [MockCache("test1")]
+        cache.insert_cache(model, [1, 2], entry)
+
+        c1, _, token1 = cache.checkout_cache(model, [1, 2])
+        self.assertIs(c1, entry)
+        self.assertIsNotNone(token1)
+
+        # entry is already checked out -- must not hand out the same
+        # mutable reference to a second caller.
+        c2, _, token2 = cache.checkout_cache(model, [1, 2])
+        self.assertIsNot(c2, entry)
+        self.assertEqual(c2, entry)  # still correct content, just a copy
+        self.assertIsNone(token2)  # nothing to return for the copy path
+
+        cache.return_cache(token1)
+
+    def test_return_cache_allows_reuse_of_no_copy_path(self):
+        cache = LRUPromptCache(max_size=10)
+        model = ("test", None, None)
+        entry = [MockCache("test1")]
+        cache.insert_cache(model, [1, 2], entry)
+
+        _, _, token1 = cache.checkout_cache(model, [1, 2])
+        cache.return_cache(token1)
+
+        # Released -- the next checkout should get the shared reference
+        # again, not fall back to a copy.
+        c2, _, token2 = cache.checkout_cache(model, [1, 2])
+        self.assertIs(c2, entry)
+        self.assertIsNotNone(token2)
+        cache.return_cache(token2)
+
+    def test_return_cache_is_safe_after_eviction(self):
+        cache = LRUPromptCache(max_size=1)
+        model = ("test", None, None)
+        entry = [MockCache("test1")]
+        cache.insert_cache(model, [1, 2], entry)
+
+        _, _, token = cache.checkout_cache(model, [1, 2])
+
+        # Evict the checked-out entry by exceeding max_size.
+        cache.insert_cache(model, [3, 4], [MockCache("test2")])
+        self.assertEqual(len(cache), 1)
+
+        # Returning a checkout for an entry that no longer exists must not
+        # raise.
+        cache.return_cache(token)
+
+    def test_return_cache_noop_on_none(self):
+        cache = LRUPromptCache(max_size=10)
+        cache.return_cache(None)  # must not raise
+
 
 class TestMakeSampler(unittest.TestCase):
     def test_xtc_special_tokens(self):

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -803,6 +803,39 @@ class TestLRUPromptCache(unittest.TestCase):
         cache = LRUPromptCache(max_size=10)
         cache.return_cache(None)  # must not raise
 
+    def test_fetch_nearest_cache_still_copies_without_checkout(self):
+        cache = LRUPromptCache(max_size=10)
+        model = ("test", None, None)
+
+        def get_kv(n):
+            keys = mx.arange(n).reshape(1, 1, n, 1)
+            return keys, keys
+
+        entry = [KVCache()]
+        entry[0].update_and_fetch(*get_kv(8))
+        cache.insert_cache(model, [1, 2], entry)
+
+        # The default path must keep handing out a copy -- never the stored
+        # reference -- for callers that don't opt in to checkout_cache.
+        c, t = cache.fetch_nearest_cache(model, [1, 2])
+        self.assertEqual(t, [])
+        self.assertIsNot(c, entry)
+        self.assertIsNot(c[0], entry[0])
+
+        # Mutate the fetched copy's KV state in place -- the same
+        # update_and_fetch buffer write generation performs, which the
+        # default path's deep copy exists to isolate.
+        c[0].update_and_fetch(*get_kv(4))
+        self.assertEqual(c[0].offset, 12)
+
+        # The stored entry must not see the mutation.
+        c2, t2 = cache.fetch_nearest_cache(model, [1, 2])
+        self.assertEqual(t2, [])
+        self.assertEqual(c2[0].offset, 8)
+        k, v = c2[0].state
+        self.assertTrue((k == v).all().item())
+        self.assertTrue((k.flatten() == mx.arange(8)).all().item())
+
 
 class TestMakeSampler(unittest.TestCase):
     def test_xtc_special_tokens(self):


### PR DESCRIPTION
Fixes #1395.

## Problem

`LRUPromptCache.fetch_nearest_cache` deep-copies the matched entry's full KV cache on every fetch. For the duration of the fetch, the process holds two full copies of that conversation's KV -- on memory-constrained machines this can OOM-crash the server exactly when reusing the longest-running conversation (see #1395 for the full repro: ~6.3GB cached sequence dies instantly on fetch on a 16GB Mac).

## Why not just remove the deep copy

`KVCache.update_and_fetch` writes new tokens into a slice of a pre-allocated buffer **in place** (`self.keys[..., prev:offset, :] = keys`), not via functional/immutable concatenation. So two references sharing that buffer would corrupt each other the moment either one continues generation -- the deep copy is load-bearing, not incidental.

It's also not a safe drop-in change: the existing test suite (`test_lru`, `test_caching`) explicitly exercises repeated fetches of the same/overlapping-prefix entry with no re-insertion in between, and asserts the entry is still found each time. A naive pop-on-fetch would break that documented, tested contract, and the batched server path (`server.py`, `batch_generator`) can have multiple concurrent requests sharing a prefix, which a blind pop would also mishandle.

## This PR

Adds `checkout_cache` / `return_cache` as a new, **opt-in** API alongside the existing `fetch_nearest_cache` / `insert_cache`, which are completely unchanged:

- `checkout_cache(model, tokens)` returns the same object reference (no copy) when the matched entry isn't currently checked out by anyone else, or falls back to the existing safe deep-copy behavior if it's contended.
- `return_cache(checkout_token)` releases the checkout, making the no-copy path available again. Safe to call with `None`, and safe to call if the entry was evicted while checked out (both are no-ops).
- The trim-and-continue path (`can_trim_prompt_cache`) always uses the deep-copy behavior regardless of checkout state, since trimming's continuation writes into a region the untrimmed entry still needs.

Nothing about the default `fetch_nearest_cache`/`insert_cache` behavior changes, so this is zero-risk to existing callers. Wiring `checkout_cache`/`return_cache` into `server.py`'s actual request-handling call sites (with a `try`/`finally` around generation) is a natural follow-up once this primitive lands -- happy to send that as a second PR, or fold it into this one if preferred.

## Testing

- All existing `tests/test_server.py` cache tests pass unmodified (verified before and after).
- Added tests covering: no-copy on the uncontested path (verified via object identity, not just equality), fallback-to-copy when contended, reuse of the no-copy path after `return_cache`, and safe no-op behavior when returning a checkout for an entry that was evicted in the meantime.

- Added regression tests for two release-safety cases: a doubled `return_cache` of a stale token must not release a later caller's checkout, and a token from before an evict-and-reinsert of the same key must not release the new entry's checkout (both verified failing before the hardening commit that scoped tokens per checkout and added the lock).
