### PR TITLE
hy_v3: keep MTP layer + self-speculative decoding (stacked on #1211)

### DIFF
--- a/mlx_lm/generate.py
+++ b/mlx_lm/generate.py
@@ -654,6 +654,117 @@ def speculative_generate_step(
         _rewind_cache(num_draft, n)
 
 
+def mtp_generate_step(
+    prompt: mx.array,
+    model: nn.Module,
+    *,
+    max_tokens: int = 256,
+    sampler: Optional[Callable[[mx.array], mx.array]] = None,
+    logits_processors: Optional[List[Callable[[mx.array, mx.array], mx.array]]] = None,
+    max_kv_size: Optional[int] = None,
+    prompt_cache: Optional[Any] = None,
+    prefill_step_size: int = 2048,
+    kv_bits: Optional[int] = None,
+    kv_group_size: int = 64,
+    quantized_kv_start: int = 0,
+    prompt_progress_callback: Optional[Callable[[int, int], None]] = None,
+) -> Generator[Tuple[mx.array, mx.array], None, None]:
+    """Self-speculative decoding using a model's Multi-Token-Prediction head.
+
+    The model must expose ``num_nextn_predict_layers > 0`` and a
+    ``predict_next_tokens(hidden_state, token_ids, cache)`` method (see
+    ``mlx_lm.models.hy_v3``). Each step drafts one token with the MTP head and
+    verifies it with a single forward pass of the target model, yielding up to
+    two tokens per target pass. Verification is greedy (argmax), so this path
+    ignores ``sampler``/``logits_processors`` and matches temperature-0 output.
+    """
+    y = prompt.astype(mx.uint32)
+
+    if prompt_cache is None:
+        model_cache = cache.make_prompt_cache(model)
+        mtp_cache = KVCache()
+    else:
+        model_cache = prompt_cache[:-1]
+        mtp_cache = prompt_cache[-1]
+
+    # Prefill the prompt chunk by chunk, leaving the last token for the
+    # hidden-state pass below.
+    with mx.stream(generation_stream):
+        total = len(y)
+        processed = 0
+        while total - processed > 1:
+            n_to_process = min(prefill_step_size, (total - processed) - 1)
+            model(y[processed : processed + n_to_process][None], cache=model_cache)
+            mx.eval([c.state for c in model_cache])
+            processed += n_to_process
+            mx.clear_cache()
+
+        last_token = y[processed : processed + 1]
+        logits, h_N = model(
+            last_token[None], cache=model_cache, return_hidden_states=True
+        )
+        token_N1 = mx.argmax(logits[:, -1, :], axis=-1)
+        h_N_last = h_N[:, -1:]
+
+    y = token_N1
+    mx.eval(y, h_N_last, [c.state for c in model_cache])
+    yield y.item(), None
+
+    ntoks = 1
+    while max_tokens == -1 or ntoks < max_tokens:
+        with mx.stream(generation_stream):
+            # 1. Draft one token with the MTP head.
+            token_N1_arr = y[..., None]
+            logits_mtp = model.predict_next_tokens(
+                h_N_last, token_N1_arr, cache=mtp_cache
+            )
+            draft_token = mx.argmax(logits_mtp[:, -1, :], axis=-1)
+
+            # 2. Verify the current + drafted token in a single target pass.
+            target_input = mx.concatenate(
+                [token_N1_arr, draft_token[..., None]], axis=-1
+            )
+            logits_target, h_N_target = model(
+                target_input, cache=model_cache, return_hidden_states=True
+            )
+            pred_token_N2 = mx.argmax(logits_target[:, 0, :], axis=-1)
+            token_N3 = mx.argmax(logits_target[:, 1, :], axis=-1)
+            mx.async_eval(draft_token, pred_token_N2, token_N3, h_N_target)
+
+        mx.eval(draft_token, pred_token_N2, token_N3)
+
+        if draft_token.item() == pred_token_N2.item():
+            # Draft accepted: emit two tokens for one target pass.
+            lp = logits_target[:, 0, :] - mx.logsumexp(
+                logits_target[:, 0, :], keepdims=True
+            )
+            yield draft_token.item(), lp.squeeze(0)
+            ntoks += 1
+            if max_tokens != -1 and ntoks >= max_tokens:
+                break
+            lp = logits_target[:, 1, :] - mx.logsumexp(
+                logits_target[:, 1, :], keepdims=True
+            )
+            yield token_N3.item(), lp.squeeze(0)
+            ntoks += 1
+            y = token_N3
+            h_N_last = h_N_target[:, 1:]
+        else:
+            # Draft rejected: emit the verified token and roll back the caches.
+            lp = logits_target[:, 0, :] - mx.logsumexp(
+                logits_target[:, 0, :], keepdims=True
+            )
+            yield pred_token_N2.item(), lp.squeeze(0)
+            ntoks += 1
+            for c in model_cache:
+                c.trim(1)
+            mtp_cache.trim(1)
+            y = pred_token_N2
+            h_N_last = h_N_target[:, 0:1]
+
+        mx.eval(h_N_last, [c.state for c in model_cache], mtp_cache.state)
+
+
 def stream_generate(
     model: nn.Module,
     tokenizer: Union[PreTrainedTokenizer, TokenizerWrapper],
@@ -700,11 +811,18 @@ def stream_generate(
 
     if draft_model is None:
         kwargs.pop("num_draft_tokens", None)
-        token_generator = generate_step(prompt, model, **kwargs)
-        # from_draft always false for non-speculative generation
-        token_generator = (
-            (token, logprobs, False) for token, logprobs in token_generator
-        )
+        if getattr(model, "num_nextn_predict_layers", 0) > 0:
+            # Self-speculative decoding via the model's built-in MTP head.
+            token_generator = (
+                (token, logprobs, True)
+                for token, logprobs in mtp_generate_step(prompt, model, **kwargs)
+            )
+        else:
+            token_generator = generate_step(prompt, model, **kwargs)
+            # from_draft always false for non-speculative generation
+            token_generator = (
+                (token, logprobs, False) for token, logprobs in token_generator
+            )
     else:
         kwargs.pop("max_kv_size", None)
         kwargs.pop("prompt_progress_callback", None)

--- a/mlx_lm/generate.py
+++ b/mlx_lm/generate.py
@@ -675,9 +675,20 @@ def mtp_generate_step(
     ``predict_next_tokens(hidden_state, token_ids, cache)`` method (see
     ``mlx_lm.models.hy_v3``). Each step drafts one token with the MTP head and
     verifies it with a single forward pass of the target model, yielding up to
-    two tokens per target pass. Verification is greedy (argmax), so this path
-    ignores ``sampler``/``logits_processors`` and matches temperature-0 output.
+    two tokens per target pass.
+
+    Verification is distribution-preserving. The drafted token and the target's
+    own token are each drawn from their processed distributions (honoring
+    ``sampler`` and ``logits_processors``) and the draft is accepted only when it
+    matches the target's independent sample. Every emitted token is therefore a
+    sample from the target's processed distribution, so temperature / top-p /
+    top-k requests are respected exactly -- this is the same acceptance rule used
+    by :func:`speculative_generate_step`. With a temperature-0 sampler (argmax)
+    it reduces to greedy draft-equals-target matching.
     """
+    sampler = sampler or (lambda x: mx.argmax(x, axis=-1))
+    logits_processors = logits_processors or []
+
     y = prompt.astype(mx.uint32)
 
     if prompt_cache is None:
@@ -686,6 +697,18 @@ def mtp_generate_step(
     else:
         model_cache = prompt_cache[:-1]
         mtp_cache = prompt_cache[-1]
+
+    # Running token history, needed only when logits processors are present
+    # since they are functions of the whole sequence generated so far.
+    history = y if logits_processors else None
+
+    def _sample(logits):
+        # logits: [1, vocab] -> (token: [1] uint32, logprobs: [vocab])
+        if logits_processors:
+            for processor in logits_processors:
+                logits = processor(history, logits)
+        logprobs = logits - mx.logsumexp(logits, axis=-1, keepdims=True)
+        return sampler(logprobs).astype(mx.uint32), logprobs.squeeze(0)
 
     # Prefill the prompt chunk by chunk, leaving the last token for the
     # hidden-state pass below.
@@ -703,66 +726,66 @@ def mtp_generate_step(
         logits, h_N = model(
             last_token[None], cache=model_cache, return_hidden_states=True
         )
-        token_N1 = mx.argmax(logits[:, -1, :], axis=-1)
+        token, logprobs = _sample(logits[:, -1, :])
         h_N_last = h_N[:, -1:]
 
-    y = token_N1
-    mx.eval(y, h_N_last, [c.state for c in model_cache])
-    yield y.item(), None
+    y = token
+    mx.eval(y, logprobs, h_N_last, [c.state for c in model_cache])
+    yield y.item(), logprobs
+    if logits_processors:
+        history = mx.concatenate([history, y])
 
     ntoks = 1
     while max_tokens == -1 or ntoks < max_tokens:
         with mx.stream(generation_stream):
-            # 1. Draft one token with the MTP head.
-            token_N1_arr = y[..., None]
-            logits_mtp = model.predict_next_tokens(
-                h_N_last, token_N1_arr, cache=mtp_cache
-            )
-            draft_token = mx.argmax(logits_mtp[:, -1, :], axis=-1)
+            # 1. Draft one token with the MTP head, sampled from its processed
+            #    distribution.
+            y_arr = y[..., None]
+            logits_mtp = model.predict_next_tokens(h_N_last, y_arr, cache=mtp_cache)
+            draft_token, _ = _sample(logits_mtp[:, -1, :])
 
-            # 2. Verify the current + drafted token in a single target pass.
-            target_input = mx.concatenate(
-                [token_N1_arr, draft_token[..., None]], axis=-1
-            )
+            # 2. Verify the current + drafted token in a single target pass. The
+            #    target's own sample at the drafted position is what we emit, so
+            #    the target distribution is preserved regardless of the draft.
+            target_input = mx.concatenate([y_arr, draft_token[..., None]], axis=-1)
             logits_target, h_N_target = model(
                 target_input, cache=model_cache, return_hidden_states=True
             )
-            pred_token_N2 = mx.argmax(logits_target[:, 0, :], axis=-1)
-            token_N3 = mx.argmax(logits_target[:, 1, :], axis=-1)
-            mx.async_eval(draft_token, pred_token_N2, token_N3, h_N_target)
+            verify_token, verify_lp = _sample(logits_target[:, 0, :])
+            mx.async_eval(draft_token, verify_token, h_N_target)
 
-        mx.eval(draft_token, pred_token_N2, token_N3)
+        mx.eval(draft_token, verify_token)
 
-        if draft_token.item() == pred_token_N2.item():
-            # Draft accepted: emit two tokens for one target pass.
-            lp = logits_target[:, 0, :] - mx.logsumexp(
-                logits_target[:, 0, :], keepdims=True
-            )
-            yield draft_token.item(), lp.squeeze(0)
+        if draft_token.item() == verify_token.item():
+            # Accepted: the draft equals the target's own sample, so emit it and
+            # get a bonus token from the second verified position for free.
+            yield verify_token.item(), verify_lp
             ntoks += 1
+            if logits_processors:
+                history = mx.concatenate([history, verify_token])
             if max_tokens != -1 and ntoks >= max_tokens:
                 break
-            lp = logits_target[:, 1, :] - mx.logsumexp(
-                logits_target[:, 1, :], keepdims=True
-            )
-            yield token_N3.item(), lp.squeeze(0)
+            bonus_token, bonus_lp = _sample(logits_target[:, 1, :])
+            yield bonus_token.item(), bonus_lp
             ntoks += 1
-            y = token_N3
+            if logits_processors:
+                history = mx.concatenate([history, bonus_token])
+            y = bonus_token
             h_N_last = h_N_target[:, 1:]
         else:
-            # Draft rejected: emit the verified token and roll back the caches.
-            lp = logits_target[:, 0, :] - mx.logsumexp(
-                logits_target[:, 0, :], keepdims=True
-            )
-            yield pred_token_N2.item(), lp.squeeze(0)
+            # Rejected: emit the target's own sample and roll back the
+            # speculative position from both caches.
+            yield verify_token.item(), verify_lp
             ntoks += 1
+            if logits_processors:
+                history = mx.concatenate([history, verify_token])
             for c in model_cache:
                 c.trim(1)
             mtp_cache.trim(1)
-            y = pred_token_N2
+            y = verify_token
             h_N_last = h_N_target[:, 0:1]
 
-        mx.eval(h_N_last, [c.state for c in model_cache], mtp_cache.state)
+        mx.eval(y, h_N_last, [c.state for c in model_cache], mtp_cache.state)
 
 
 def stream_generate(

--- a/mlx_lm/generate.py
+++ b/mlx_lm/generate.py
@@ -38,7 +38,7 @@ from .models.cache import (
     TokenBuffer,
     load_prompt_cache,
 )
-from .sample_utils import make_sampler
+from .sample_utils import apply_min_p, apply_top_k, apply_top_p, make_sampler
 from .tokenizer_utils import TokenizerWrapper
 from .utils import does_model_support_input_embeddings, load
 
@@ -678,16 +678,52 @@ def mtp_generate_step(
     two tokens per target pass.
 
     Verification is distribution-preserving. The drafted token and the target's
-    own token are each drawn from their processed distributions (honoring
-    ``sampler`` and ``logits_processors``) and the draft is accepted only when it
-    matches the target's independent sample. Every emitted token is therefore a
-    sample from the target's processed distribution, so temperature / top-p /
-    top-k requests are respected exactly -- this is the same acceptance rule used
-    by :func:`speculative_generate_step`. With a temperature-0 sampler (argmax)
-    it reduces to greedy draft-equals-target matching.
+    own token are drawn from their processed distributions (honoring ``sampler``
+    and ``logits_processors``). By default the draft is accepted only when it
+    matches the target's independent sample -- the same acceptance rule as
+    :func:`speculative_generate_step`, which works with any sampler. When the
+    sampler exposes its parameters (any :func:`make_sampler` output) and no
+    logits processors are active, the higher-acceptance **residual (Leviathan)**
+    rule is used instead: the draft ``x ~ q`` is accepted with probability
+    ``min(1, p(x) / q(x))`` and, on rejection, a token is resampled from the
+    normalized residual ``relu(p - q)``. Both rules emit a token distributed
+    exactly as the target's processed distribution, so temperature / top-p /
+    top-k are respected; a temperature-0 sampler reduces to greedy matching.
     """
     sampler = sampler or (lambda x: mx.argmax(x, axis=-1))
     logits_processors = logits_processors or []
+
+    # The residual (Leviathan) acceptance rule accepts strictly more often than
+    # plain match sampling while preserving the target distribution, but it needs
+    # the processed draft/target distributions -- reconstructed here from the
+    # sampler's parameters. Fall back to match sampling for temp-0, custom
+    # samplers (no exposed params), XTC (non-deterministic mask), or any active
+    # logits processors.
+    s_temp = getattr(sampler, "temp", None)
+    s_top_p = getattr(sampler, "top_p", 0.0) or 0.0
+    s_top_k = getattr(sampler, "top_k", 0) or 0
+    s_min_p = getattr(sampler, "min_p", 0.0) or 0.0
+    s_min_keep = getattr(sampler, "min_tokens_to_keep", 1) or 1
+    s_xtc = getattr(sampler, "xtc_probability", 0.0) or 0.0
+    use_residual = (
+        s_temp is not None
+        and s_temp > 0.0
+        and s_xtc == 0.0
+        and not logits_processors
+    )
+
+    def _probs(logits):
+        # Reconstruct the categorical distribution make_sampler draws from: mask
+        # temp-1 log-probs (top-p, then min-p, then top-k, matching make_sampler's
+        # order) and apply temperature. Returns a probability row vector [1, V].
+        lp = logits - mx.logsumexp(logits, axis=-1, keepdims=True)
+        if 0.0 < s_top_p < 1.0:
+            lp = apply_top_p(lp, s_top_p)
+        if s_min_p > 0.0:
+            lp = apply_min_p(lp, s_min_p, s_min_keep)
+        if s_top_k > 0:
+            lp = apply_top_k(lp, s_top_k)
+        return mx.softmax(lp * (1.0 / s_temp), axis=-1)
 
     y = prompt.astype(mx.uint32)
 
@@ -739,30 +775,62 @@ def mtp_generate_step(
     while max_tokens == -1 or ntoks < max_tokens:
         with mx.stream(generation_stream):
             # 1. Draft one token with the MTP head, sampled from its processed
-            #    distribution.
+            #    distribution q.
             y_arr = y[..., None]
             logits_mtp = model.predict_next_tokens(h_N_last, y_arr, cache=mtp_cache)
-            draft_token, _ = _sample(logits_mtp[:, -1, :])
+            mtp_logits = logits_mtp[:, -1, :]
+            draft_token, _ = _sample(mtp_logits)
 
-            # 2. Verify the current + drafted token in a single target pass. The
-            #    target's own sample at the drafted position is what we emit, so
-            #    the target distribution is preserved regardless of the draft.
+            # 2. Verify the current + drafted token in a single target pass.
             target_input = mx.concatenate([y_arr, draft_token[..., None]], axis=-1)
             logits_target, h_N_target = model(
                 target_input, cache=model_cache, return_hidden_states=True
             )
-            verify_token, verify_lp = _sample(logits_target[:, 0, :])
-            mx.async_eval(draft_token, verify_token, h_N_target)
+            tgt_logits = logits_target[:, 0, :]
+            emit_lp = tgt_logits - mx.logsumexp(tgt_logits, axis=-1, keepdims=True)
+            if use_residual:
+                q = _probs(mtp_logits)
+                p = _probs(tgt_logits)
+                mx.async_eval(draft_token, q, p, h_N_target)
+            else:
+                verify_token, _ = _sample(tgt_logits)
+                mx.async_eval(draft_token, verify_token, h_N_target)
 
-        mx.eval(draft_token, verify_token)
+        if use_residual:
+            # Residual/Leviathan: accept x~q with prob min(1, p(x)/q(x)); on
+            # rejection resample the emitted token from relu(p - q). Either way
+            # the emitted token is distributed exactly as the target's p.
+            mx.eval(draft_token, q, p)
+            x = draft_token.item()
+            accepted = mx.random.uniform().item() < min(
+                1.0, (p[0, x] / q[0, x]).item()
+            )
+            if accepted:
+                emit_token = draft_token
+            else:
+                residual = mx.maximum(p - q, 0.0)
+                if residual.sum().item() > 0.0:
+                    emit_token = mx.random.categorical(
+                        mx.log(residual + 1e-20)
+                    ).astype(mx.uint32)
+                else:  # p already dominated by q everywhere (degenerate)
+                    emit_token, _ = _sample(tgt_logits)
+                mx.eval(emit_token)
+        else:
+            # Match: emit the target's own sample; accept when it equals the
+            # draft. Works with any sampler.
+            mx.eval(draft_token, verify_token)
+            accepted = draft_token.item() == verify_token.item()
+            emit_token = verify_token
 
-        if draft_token.item() == verify_token.item():
-            # Accepted: the draft equals the target's own sample, so emit it and
-            # get a bonus token from the second verified position for free.
-            yield verify_token.item(), verify_lp
-            ntoks += 1
-            if logits_processors:
-                history = mx.concatenate([history, verify_token])
+        emit_lp = emit_lp.squeeze(0)
+        yield emit_token.item(), emit_lp
+        ntoks += 1
+        if logits_processors:
+            history = mx.concatenate([history, emit_token])
+
+        if accepted:
+            # Bonus token from the second verified position, for free.
             if max_tokens != -1 and ntoks >= max_tokens:
                 break
             bonus_token, bonus_lp = _sample(logits_target[:, 1, :])
@@ -773,16 +841,11 @@ def mtp_generate_step(
             y = bonus_token
             h_N_last = h_N_target[:, 1:]
         else:
-            # Rejected: emit the target's own sample and roll back the
-            # speculative position from both caches.
-            yield verify_token.item(), verify_lp
-            ntoks += 1
-            if logits_processors:
-                history = mx.concatenate([history, verify_token])
+            # Roll back the speculative position from both caches.
             for c in model_cache:
                 c.trim(1)
             mtp_cache.trim(1)
-            y = verify_token
+            y = emit_token
             h_N_last = h_N_target[:, 0:1]
 
         mx.eval(y, h_N_last, [c.state for c in model_cache], mtp_cache.state)

--- a/mlx_lm/models/hy_v3.py
+++ b/mlx_lm/models/hy_v3.py
@@ -1,0 +1,382 @@
+# Copyright © 2026 Apple Inc.
+
+from dataclasses import dataclass
+from typing import Any, Dict, Optional
+
+import mlx.core as mx
+import mlx.nn as nn
+from mlx.nn.layers.distributed import shard_inplace, shard_linear, sum_gradients
+
+from .activations import swiglu
+from .base import BaseModelArgs, create_attention_mask, scaled_dot_product_attention
+from .pipeline import PipelineMixin
+from .rope_utils import initialize_rope
+from .switch_layers import SwitchGLU
+
+
+@dataclass
+class ModelArgs(BaseModelArgs):
+    model_type: str
+    vocab_size: int
+    hidden_size: int
+    intermediate_size: int
+    num_hidden_layers: int
+    num_attention_heads: int
+    num_key_value_heads: int
+    head_dim: int
+    num_experts: int
+    num_experts_per_tok: int
+    num_shared_experts: int
+    expert_hidden_dim: int
+    first_k_dense_replace: int
+    rms_norm_eps: float
+    rope_parameters: Dict[str, Any]
+    router_scaling_factor: float = 1.0
+    qk_norm: bool = True
+    route_norm: bool = True
+    moe_router_use_sigmoid: bool = True
+    moe_router_enable_expert_bias: bool = True
+    tie_word_embeddings: bool = False
+    num_nextn_predict_layers: int = 0
+    max_position_embeddings: int = 262144
+
+
+class Attention(nn.Module):
+    def __init__(self, args: ModelArgs):
+        super().__init__()
+
+        dim = args.hidden_size
+        self.n_heads = args.num_attention_heads
+        self.n_kv_heads = args.num_key_value_heads
+        self.head_dim = args.head_dim
+        self.scale = self.head_dim**-0.5
+
+        self.q_proj = nn.Linear(dim, self.n_heads * self.head_dim, bias=False)
+        self.k_proj = nn.Linear(dim, self.n_kv_heads * self.head_dim, bias=False)
+        self.v_proj = nn.Linear(dim, self.n_kv_heads * self.head_dim, bias=False)
+        self.o_proj = nn.Linear(self.n_heads * self.head_dim, dim, bias=False)
+
+        self.use_qk_norm = args.qk_norm
+        if self.use_qk_norm:
+            self.q_norm = nn.RMSNorm(self.head_dim, eps=args.rms_norm_eps)
+            self.k_norm = nn.RMSNorm(self.head_dim, eps=args.rms_norm_eps)
+
+        self.rope = initialize_rope(
+            dims=self.head_dim,
+            base=args.rope_parameters["rope_theta"],
+            traditional=False,
+            scaling_config=args.rope_parameters,
+            max_position_embeddings=args.max_position_embeddings,
+        )
+
+    def __call__(
+        self,
+        x: mx.array,
+        mask: Optional[mx.array] = None,
+        cache: Optional[Any] = None,
+    ) -> mx.array:
+        B, L, _ = x.shape
+
+        queries = self.q_proj(x).reshape(B, L, self.n_heads, self.head_dim)
+        keys = self.k_proj(x).reshape(B, L, self.n_kv_heads, self.head_dim)
+        values = self.v_proj(x).reshape(B, L, self.n_kv_heads, self.head_dim)
+
+        if self.use_qk_norm:
+            queries = self.q_norm(queries)
+            keys = self.k_norm(keys)
+
+        queries = queries.transpose(0, 2, 1, 3)
+        keys = keys.transpose(0, 2, 1, 3)
+        values = values.transpose(0, 2, 1, 3)
+
+        offset = cache.offset if cache is not None else 0
+        queries = self.rope(queries, offset=offset)
+        keys = self.rope(keys, offset=offset)
+        if cache is not None:
+            keys, values = cache.update_and_fetch(keys, values)
+
+        output = scaled_dot_product_attention(
+            queries, keys, values, cache=cache, scale=self.scale, mask=mask
+        )
+        output = output.transpose(0, 2, 1, 3).reshape(B, L, -1)
+        return self.o_proj(output)
+
+
+class MLP(nn.Module):
+    def __init__(self, hidden_size: int, intermediate_size: int):
+        super().__init__()
+        self.gate_proj = nn.Linear(hidden_size, intermediate_size, bias=False)
+        self.up_proj = nn.Linear(hidden_size, intermediate_size, bias=False)
+        self.down_proj = nn.Linear(intermediate_size, hidden_size, bias=False)
+
+    def __call__(self, x):
+        return self.down_proj(swiglu(self.gate_proj(x), self.up_proj(x)))
+
+
+@mx.compile
+def expert_select(
+    gates,
+    expert_bias,
+    top_k,
+    routed_scaling_factor,
+    norm_topk_prob,
+):
+    in_type = gates.dtype
+    scores = mx.sigmoid(gates.astype(mx.float32))
+    orig_scores = scores
+    scores = scores + expert_bias
+
+    inds = mx.argpartition(scores, kth=-top_k, axis=-1)[..., -top_k:]
+    scores = mx.take_along_axis(orig_scores, inds, axis=-1)
+    if top_k > 1 and norm_topk_prob:
+        scores = scores / scores.sum(axis=-1, keepdims=True)
+    scores = scores * routed_scaling_factor
+
+    return inds, scores.astype(in_type)
+
+
+class MoEGate(nn.Module):
+    def __init__(self, args: ModelArgs):
+        super().__init__()
+        self.top_k = args.num_experts_per_tok
+        self.norm_topk_prob = args.route_norm
+        self.routed_scaling_factor = args.router_scaling_factor
+        self.gate = nn.Linear(args.hidden_size, args.num_experts, bias=False)
+        self.expert_bias = mx.zeros((args.num_experts,))
+
+    def __call__(self, x):
+        return expert_select(
+            self.gate(x),
+            self.expert_bias,
+            self.top_k,
+            self.routed_scaling_factor,
+            self.norm_topk_prob,
+        )
+
+
+class MoE(nn.Module):
+    def __init__(self, args: ModelArgs):
+        super().__init__()
+        self.num_experts_per_tok = args.num_experts_per_tok
+        self.switch_mlp = SwitchGLU(
+            args.hidden_size,
+            args.expert_hidden_dim,
+            args.num_experts,
+        )
+        self.router = MoEGate(args)
+        if args.num_shared_experts > 0:
+            self.shared_mlp = MLP(
+                args.hidden_size,
+                args.expert_hidden_dim * args.num_shared_experts,
+            )
+        else:
+            self.shared_mlp = None
+
+        self.sharding_group = None
+
+    def __call__(self, x):
+        if self.sharding_group is not None:
+            x = sum_gradients(self.sharding_group)(x)
+
+        inds, scores = self.router(x)
+        y = self.switch_mlp(x, inds)
+        y = (y * scores[..., None]).sum(axis=-2)
+        if self.shared_mlp is not None:
+            y = y + self.shared_mlp(x)
+
+        if self.sharding_group is not None:
+            y = mx.distributed.all_sum(y, group=self.sharding_group)
+
+        return y
+
+
+class DecoderLayer(nn.Module):
+    def __init__(self, args: ModelArgs, layer_idx: int):
+        super().__init__()
+        self.self_attn = Attention(args)
+        if layer_idx < args.first_k_dense_replace:
+            self.mlp = MLP(args.hidden_size, args.intermediate_size)
+        else:
+            self.mlp = MoE(args)
+        self.input_layernorm = nn.RMSNorm(args.hidden_size, eps=args.rms_norm_eps)
+        self.post_attention_layernorm = nn.RMSNorm(
+            args.hidden_size, eps=args.rms_norm_eps
+        )
+
+    def __call__(
+        self,
+        x: mx.array,
+        mask: Optional[mx.array] = None,
+        cache: Optional[Any] = None,
+    ) -> mx.array:
+        r = self.self_attn(self.input_layernorm(x), mask, cache)
+        h = x + r
+        r = self.mlp(self.post_attention_layernorm(h))
+        return h + r
+
+
+class HYV3Model(PipelineMixin, nn.Module):
+    def __init__(self, args: ModelArgs):
+        super().__init__()
+        self.vocab_size = args.vocab_size
+        self.embed_tokens = nn.Embedding(args.vocab_size, args.hidden_size)
+        self.layers = [DecoderLayer(args, idx) for idx in range(args.num_hidden_layers)]
+        self.norm = nn.RMSNorm(args.hidden_size, eps=args.rms_norm_eps)
+
+    def __call__(
+        self,
+        x: mx.array,
+        cache: Optional[Any] = None,
+    ) -> mx.array:
+        h = self.embed_tokens(x)
+
+        pipeline_rank = self.pipeline_rank
+        pipeline_size = self.pipeline_size
+
+        if cache is None:
+            cache = [None] * len(self.pipeline_layers)
+        mask = create_attention_mask(h, cache[0])
+
+        if pipeline_rank < pipeline_size - 1:
+            h = mx.distributed.recv_like(h, (pipeline_rank + 1))
+
+        for layer, c in zip(self.pipeline_layers, cache):
+            h = layer(h, mask, cache=c)
+
+        if pipeline_rank != 0:
+            h = mx.distributed.send(h, (pipeline_rank - 1) % pipeline_size)
+            if cache[-1] is not None:
+                cache[-1].keys = mx.depends(cache[-1].keys, h)
+
+        if pipeline_size > 1:
+            h = mx.distributed.all_gather(h)[: h.shape[0]]
+
+        return self.norm(h)
+
+
+class Model(nn.Module):
+    def __init__(self, args: ModelArgs):
+        super().__init__()
+        self.args = args
+        self.model_type = args.model_type
+        self.model = HYV3Model(args)
+        if not args.tie_word_embeddings:
+            self.lm_head = nn.Linear(args.hidden_size, args.vocab_size, bias=False)
+
+    def __call__(
+        self,
+        inputs: mx.array,
+        cache: Optional[Any] = None,
+    ):
+        out = self.model(inputs, cache)
+        if self.args.tie_word_embeddings:
+            return self.model.embed_tokens.as_linear(out)
+        return self.lm_head(out)
+
+    def sanitize(self, weights):
+        n_layers = self.args.num_hidden_layers
+        n_mtp = self.args.num_nextn_predict_layers
+
+        if n_mtp > 0:
+            mtp_prefixes = tuple(f"model.layers.{n_layers + i}." for i in range(n_mtp))
+            weights = {
+                k: v for k, v in weights.items() if not k.startswith(mtp_prefixes)
+            }
+
+        for l in range(n_layers):
+            prefix = f"model.layers.{l}"
+
+            bias_key = f"{prefix}.mlp.expert_bias"
+            if bias_key in weights:
+                weights[f"{prefix}.mlp.router.expert_bias"] = weights.pop(bias_key)
+
+            for m in ("gate_proj", "down_proj", "up_proj"):
+                for k in ("weight", "scales", "biases"):
+                    if f"{prefix}.mlp.experts.0.{m}.{k}" in weights:
+                        to_join = [
+                            weights.pop(f"{prefix}.mlp.experts.{e}.{m}.{k}")
+                            for e in range(self.args.num_experts)
+                        ]
+                        weights[f"{prefix}.mlp.switch_mlp.{m}.{k}"] = mx.stack(to_join)
+
+        if self.args.tie_word_embeddings:
+            weights.pop("lm_head.weight", None)
+
+        return weights
+
+    def shard(self, group: Optional[mx.distributed.Group] = None):
+        group = group or mx.distributed.init()
+        N = group.size()
+        for layer in self.model.layers:
+            layer.self_attn.q_proj = shard_linear(
+                layer.self_attn.q_proj, "all-to-sharded", group=group
+            )
+            layer.self_attn.k_proj = shard_linear(
+                layer.self_attn.k_proj, "all-to-sharded", group=group
+            )
+            layer.self_attn.v_proj = shard_linear(
+                layer.self_attn.v_proj, "all-to-sharded", group=group
+            )
+            layer.self_attn.o_proj = shard_linear(
+                layer.self_attn.o_proj, "sharded-to-all", group=group
+            )
+            layer.self_attn.n_heads //= N
+            layer.self_attn.n_kv_heads = max(1, layer.self_attn.n_kv_heads // N)
+
+            if isinstance(layer.mlp, MLP):
+                layer.mlp.gate_proj = shard_linear(
+                    layer.mlp.gate_proj, "all-to-sharded", group=group
+                )
+                layer.mlp.down_proj = shard_linear(
+                    layer.mlp.down_proj, "sharded-to-all", group=group
+                )
+                layer.mlp.up_proj = shard_linear(
+                    layer.mlp.up_proj, "all-to-sharded", group=group
+                )
+            else:
+                layer.mlp.sharding_group = group
+                if layer.mlp.shared_mlp is not None:
+                    shard_inplace(
+                        layer.mlp.shared_mlp.gate_proj,
+                        "all-to-sharded",
+                        group=group,
+                    )
+                    shard_inplace(
+                        layer.mlp.shared_mlp.down_proj,
+                        "sharded-to-all",
+                        group=group,
+                    )
+                    shard_inplace(
+                        layer.mlp.shared_mlp.up_proj,
+                        "all-to-sharded",
+                        group=group,
+                    )
+                shard_inplace(
+                    layer.mlp.switch_mlp.gate_proj, "all-to-sharded", group=group
+                )
+                shard_inplace(
+                    layer.mlp.switch_mlp.down_proj, "sharded-to-all", group=group
+                )
+                shard_inplace(
+                    layer.mlp.switch_mlp.up_proj, "all-to-sharded", group=group
+                )
+
+    @property
+    def layers(self):
+        return self.model.pipeline_layers
+
+    @property
+    def quant_predicate(self):
+        def predicate(path, _):
+            if path.endswith("mlp.router.gate"):
+                return {"group_size": 64, "bits": 8}
+            return True
+
+        return predicate
+
+    @property
+    def cast_predicate(self):
+        def predicate(k):
+            return "expert_bias" not in k
+
+        return predicate

--- a/mlx_lm/models/hy_v3.py
+++ b/mlx_lm/models/hy_v3.py
@@ -39,6 +39,8 @@ class ModelArgs(BaseModelArgs):
     tie_word_embeddings: bool = False
     num_nextn_predict_layers: int = 0
     max_position_embeddings: int = 262144
+    enable_moe_fp32_combine: bool = False
+    enable_lm_head_fp32: bool = False
 
 
 class Attention(nn.Module):
@@ -121,7 +123,6 @@ def expert_select(
     routed_scaling_factor,
     norm_topk_prob,
 ):
-    in_type = gates.dtype
     scores = mx.sigmoid(gates.astype(mx.float32))
     orig_scores = scores
     scores = scores + expert_bias
@@ -129,10 +130,10 @@ def expert_select(
     inds = mx.argpartition(scores, kth=-top_k, axis=-1)[..., -top_k:]
     scores = mx.take_along_axis(orig_scores, inds, axis=-1)
     if top_k > 1 and norm_topk_prob:
-        scores = scores / scores.sum(axis=-1, keepdims=True)
+        scores = scores / (scores.sum(axis=-1, keepdims=True) + 1e-20)
     scores = scores * routed_scaling_factor
 
-    return inds, scores.astype(in_type)
+    return inds, scores
 
 
 class MoEGate(nn.Module):
@@ -172,6 +173,7 @@ class MoE(nn.Module):
         else:
             self.shared_mlp = None
 
+        self.fp32_combine = args.enable_moe_fp32_combine
         self.sharding_group = None
 
     def __call__(self, x):
@@ -179,6 +181,8 @@ class MoE(nn.Module):
             x = sum_gradients(self.sharding_group)(x)
 
         inds, scores = self.router(x)
+        if not self.fp32_combine:
+            scores = scores.astype(x.dtype)
         y = self.switch_mlp(x, inds)
         y = (y * scores[..., None]).sum(axis=-2)
         if self.shared_mlp is not None:
@@ -187,7 +191,7 @@ class MoE(nn.Module):
         if self.sharding_group is not None:
             y = mx.distributed.all_sum(y, group=self.sharding_group)
 
-        return y
+        return y.astype(x.dtype)
 
 
 class DecoderLayer(nn.Module):
@@ -269,6 +273,8 @@ class Model(nn.Module):
         cache: Optional[Any] = None,
     ):
         out = self.model(inputs, cache)
+        if self.args.enable_lm_head_fp32:
+            out = out.astype(mx.float32)
         if self.args.tie_word_embeddings:
             return self.model.embed_tokens.as_linear(out)
         return self.lm_head(out)

--- a/mlx_lm/models/hy_v3.py
+++ b/mlx_lm/models/hy_v3.py
@@ -1,4 +1,9 @@
 # Copyright © 2026 Apple Inc.
+#
+# Tencent Hunyuan 3 (hy_v3). Base model support follows the community work in
+# ml-explore/mlx-lm#1211 (kernelpool); this file additionally *keeps and uses*
+# the Multi-Token-Prediction (MTP) layer for self-speculative decoding instead
+# of stripping it.
 
 from dataclasses import dataclass
 from typing import Any, Dict, Optional
@@ -219,6 +224,35 @@ class DecoderLayer(nn.Module):
         return h + r
 
 
+class MTPBlock(nn.Module):
+    """Hy3 Multi-Token-Prediction block (the layer after the main stack).
+
+    Projects concat[norm(next-token embedding), norm(hidden state)] through
+    ``eh_proj`` and one full decoder layer to produce the hidden state for the
+    speculatively-drafted next token.
+    """
+
+    def __init__(self, args: ModelArgs):
+        super().__init__()
+        self.enorm = nn.RMSNorm(args.hidden_size, eps=args.rms_norm_eps)
+        self.hnorm = nn.RMSNorm(args.hidden_size, eps=args.rms_norm_eps)
+        self.eh_proj = nn.Linear(args.hidden_size * 2, args.hidden_size, bias=False)
+        self.layer = DecoderLayer(args, layer_idx=args.num_hidden_layers)
+        self.final_layernorm = nn.RMSNorm(args.hidden_size, eps=args.rms_norm_eps)
+
+    def __call__(
+        self,
+        h_N: mx.array,
+        e_N1: mx.array,
+        mask: Optional[mx.array] = None,
+        cache: Optional[Any] = None,
+    ) -> mx.array:
+        # Order matters: [normed embedding, normed hidden state].
+        x = mx.concatenate([self.enorm(e_N1), self.hnorm(h_N)], axis=-1)
+        y = self.layer(self.eh_proj(x), mask, cache)
+        return self.final_layernorm(y)
+
+
 class HYV3Model(PipelineMixin, nn.Module):
     def __init__(self, args: ModelArgs):
         super().__init__()
@@ -231,6 +265,7 @@ class HYV3Model(PipelineMixin, nn.Module):
         self,
         x: mx.array,
         cache: Optional[Any] = None,
+        return_hidden_states: bool = False,
     ) -> mx.array:
         h = self.embed_tokens(x)
 
@@ -255,7 +290,10 @@ class HYV3Model(PipelineMixin, nn.Module):
         if pipeline_size > 1:
             h = mx.distributed.all_gather(h)[: h.shape[0]]
 
-        return self.norm(h)
+        out = self.norm(h)
+        if return_hidden_states:
+            return out, h
+        return out
 
 
 class Model(nn.Module):
@@ -267,43 +305,82 @@ class Model(nn.Module):
         if not args.tie_word_embeddings:
             self.lm_head = nn.Linear(args.hidden_size, args.vocab_size, bias=False)
 
-    def __call__(
-        self,
-        inputs: mx.array,
-        cache: Optional[Any] = None,
-    ):
-        out = self.model(inputs, cache)
+        self.num_nextn_predict_layers = getattr(args, "num_nextn_predict_layers", 0)
+        if self.num_nextn_predict_layers > 0:
+            self.mtp = MTPBlock(args)
+
+    def _logits(self, out):
         if self.args.enable_lm_head_fp32:
             out = out.astype(mx.float32)
         if self.args.tie_word_embeddings:
             return self.model.embed_tokens.as_linear(out)
         return self.lm_head(out)
 
+    def __call__(
+        self,
+        inputs: mx.array,
+        cache: Optional[Any] = None,
+        return_hidden_states: bool = False,
+    ):
+        if return_hidden_states:
+            out, h = self.model(inputs, cache, return_hidden_states=True)
+            return self._logits(out), h
+        out = self.model(inputs, cache)
+        return self._logits(out)
+
+    def predict_next_tokens(self, h_N: mx.array, token_ids: mx.array, cache=None):
+        """Run the MTP head to draft the next token from a hidden state."""
+        if not hasattr(self, "mtp"):
+            raise ValueError("MTP is not enabled or its weights are not loaded.")
+        e_N1 = self.model.embed_tokens(token_ids)
+        mask = create_attention_mask(e_N1, cache)
+        h_mtp = self.mtp(h_N, e_N1, mask, cache)
+        return self._logits(h_mtp)
+
     def sanitize(self, weights):
         n_layers = self.args.num_hidden_layers
         n_mtp = self.args.num_nextn_predict_layers
 
+        # Keep the MTP layer (the base model drops it). If the checkpoint stores
+        # it under model.layers.{n_layers}.*, remap it onto the mtp.* submodule;
+        # if it is already stored under mtp.*, leave it as-is.
         if n_mtp > 0:
-            mtp_prefixes = tuple(f"model.layers.{n_layers + i}." for i in range(n_mtp))
-            weights = {
-                k: v for k, v in weights.items() if not k.startswith(mtp_prefixes)
-            }
+            mtp_src = f"model.layers.{n_layers}."
+            for k in list(weights.keys()):
+                if k.startswith(mtp_src):
+                    rest = k[len(mtp_src):]
+                    if any(
+                        t in rest
+                        for t in ("enorm", "hnorm", "eh_proj", "final_layernorm")
+                    ):
+                        weights["mtp." + rest] = weights.pop(k)
+                    else:
+                        weights["mtp.layer." + rest] = weights.pop(k)
 
-        for l in range(n_layers):
-            prefix = f"model.layers.{l}"
-
+        def fix_moe(prefix):
             bias_key = f"{prefix}.mlp.expert_bias"
             if bias_key in weights:
                 weights[f"{prefix}.mlp.router.expert_bias"] = weights.pop(bias_key)
-
             for m in ("gate_proj", "down_proj", "up_proj"):
                 for k in ("weight", "scales", "biases"):
-                    if f"{prefix}.mlp.experts.0.{m}.{k}" in weights:
+                    per_expert = f"{prefix}.mlp.experts.0.{m}.{k}"
+                    stacked = f"{prefix}.mlp.experts.{m}.{k}"
+                    if per_expert in weights:
                         to_join = [
                             weights.pop(f"{prefix}.mlp.experts.{e}.{m}.{k}")
                             for e in range(self.args.num_experts)
                         ]
                         weights[f"{prefix}.mlp.switch_mlp.{m}.{k}"] = mx.stack(to_join)
+                    elif stacked in weights:
+                        # Already stacked (MLX-converted checkpoint): just rename.
+                        weights[f"{prefix}.mlp.switch_mlp.{m}.{k}"] = weights.pop(
+                            stacked
+                        )
+
+        for l in range(n_layers):
+            fix_moe(f"model.layers.{l}")
+        if n_mtp > 0:
+            fix_moe("mtp.layer")
 
         if self.args.tie_word_embeddings:
             weights.pop("lm_head.weight", None)
@@ -343,19 +420,13 @@ class Model(nn.Module):
                 layer.mlp.sharding_group = group
                 if layer.mlp.shared_mlp is not None:
                     shard_inplace(
-                        layer.mlp.shared_mlp.gate_proj,
-                        "all-to-sharded",
-                        group=group,
+                        layer.mlp.shared_mlp.gate_proj, "all-to-sharded", group=group
                     )
                     shard_inplace(
-                        layer.mlp.shared_mlp.down_proj,
-                        "sharded-to-all",
-                        group=group,
+                        layer.mlp.shared_mlp.down_proj, "sharded-to-all", group=group
                     )
                     shard_inplace(
-                        layer.mlp.shared_mlp.up_proj,
-                        "all-to-sharded",
-                        group=group,
+                        layer.mlp.shared_mlp.up_proj, "all-to-sharded", group=group
                     )
                 shard_inplace(
                     layer.mlp.switch_mlp.gate_proj, "all-to-sharded", group=group

--- a/mlx_lm/sample_utils.py
+++ b/mlx_lm/sample_utils.py
@@ -43,8 +43,20 @@ def make_sampler(
         Callable[mx.array, mx.array]:
             A sampler which takes log-probabilities and returns tokens.
     """
+    def _tag(fn):
+        # Expose the sampling parameters on the returned callable so consumers
+        # that need the processed distribution itself (e.g. the residual
+        # speculative-sampling path in ``mtp_generate_step``) can reconstruct it.
+        fn.temp = temp
+        fn.top_p = top_p
+        fn.top_k = top_k
+        fn.min_p = min_p
+        fn.min_tokens_to_keep = min_tokens_to_keep
+        fn.xtc_probability = xtc_probability
+        return fn
+
     if temp == 0:
-        return lambda x: mx.argmax(x, axis=-1)
+        return _tag(lambda x: mx.argmax(x, axis=-1))
 
     # Create sampler chain
     sampling_methods = []
@@ -66,7 +78,7 @@ def make_sampler(
         # Return the sampled token
         return categorical_sampling(logprobs, temp)
 
-    return sampler
+    return _tag(sampler)
 
 
 def make_logits_processors(

--- a/mlx_lm/tokenizer_utils.py
+++ b/mlx_lm/tokenizer_utils.py
@@ -557,6 +557,8 @@ def _infer_tool_parser(chat_template):
         return "function_gemma"
     elif "<longcat_tool_call>" in chat_template:
         return "longcat"
+    elif "<tool_sep>" in chat_template and "<arg_key>" in chat_template:
+        return "hy_v3"
     elif "<arg_key>" in chat_template:
         return "glm47"
     elif "<|tool_list_start|>" in chat_template:

--- a/mlx_lm/tokenizer_utils.py
+++ b/mlx_lm/tokenizer_utils.py
@@ -257,6 +257,7 @@ def _infer_thinking(tokenizer):
     vocab = tokenizer.get_vocab()
     THINK_TOKENS = [
         ("<think>", "</think>"),
+        ("<think:opensource>", "</think:opensource>"),
         ("<longcat_think>", "</longcat_think>"),
     ]
 
@@ -557,8 +558,8 @@ def _infer_tool_parser(chat_template):
         return "function_gemma"
     elif "<longcat_tool_call>" in chat_template:
         return "longcat"
-    elif "<tool_sep>" in chat_template and "<arg_key>" in chat_template:
-        return "hy_v3"
+    elif "<tool_sep" in chat_template and "<arg_key" in chat_template:
+        return "hy_v3_opensource" if ":opensource" in chat_template else "hy_v3"
     elif "<arg_key>" in chat_template:
         return "glm47"
     elif "<|tool_list_start|>" in chat_template:

--- a/mlx_lm/tool_parsers/hy_v3.py
+++ b/mlx_lm/tool_parsers/hy_v3.py
@@ -1,0 +1,93 @@
+# Copyright © 2026 Apple Inc.
+
+"""
+Tool parser for Tencent Hy3-preview (HYV3).
+
+Reference:
+https://github.com/vllm-project/vllm/blob/main/vllm/tool_parsers/hy_v3_tool_parser.py
+
+Format:
+    <tool_calls>
+    <tool_call>function_name<tool_sep>
+    <arg_key>key1</arg_key>
+    <arg_value>value1</arg_value>
+    ...
+    </tool_call>
+    ...
+    </tool_calls>
+"""
+
+import ast
+import json
+from typing import Any
+
+import regex as re
+
+tool_call_start = "<tool_calls>"
+tool_call_end = "</tool_calls>"
+
+_tool_call_regex = re.compile(r"<tool_call>(.*?)<tool_sep>(.*?)</tool_call>", re.DOTALL)
+_arg_pair_regex = re.compile(
+    r"<arg_key>(.*?)</arg_key>(?:\\n|\s)*<arg_value>(.*?)</arg_value>",
+    re.DOTALL,
+)
+
+
+def _is_string_type(
+    tool_name: str,
+    arg_name: str,
+    tools: list[Any] | None,
+) -> bool:
+    if tools is None:
+        return False
+    for tool in tools:
+        func = tool.get("function", {})
+        if func.get("name") != tool_name:
+            continue
+        params = func.get("parameters") or {}
+        arg_type = params.get("properties", {}).get(arg_name, {}).get("type")
+        return arg_type == "string"
+    return False
+
+
+def _deserialize(value: str) -> Any:
+    try:
+        return json.loads(value)
+    except Exception:
+        pass
+    try:
+        return ast.literal_eval(value)
+    except Exception:
+        pass
+    return value
+
+
+def _parse_single_call(text: str, tools: list[Any] | None):
+    name_match = re.match(r"(.*?)<tool_sep>", text, re.DOTALL)
+    if name_match:
+        func_name = name_match.group(1).strip()
+        body = text[name_match.end() :]
+    else:
+        func_name = text.split("<arg_key>", 1)[0].strip()
+        body = text
+
+    arg_dct: dict[str, Any] = {}
+    for key, value in _arg_pair_regex.findall(body):
+        arg_key = key.strip()
+        arg_val = value.strip()
+        if not _is_string_type(func_name, arg_key, tools):
+            arg_val = _deserialize(arg_val)
+        arg_dct[arg_key] = arg_val
+    return dict(name=func_name, arguments=arg_dct)
+
+
+def parse_tool_call(text: str, tools: list[Any] | None = None):
+    matches = _tool_call_regex.findall(text)
+    if matches:
+        calls = [
+            _parse_single_call(f"{name}<tool_sep>{body}", tools)
+            for name, body in matches
+        ]
+        return calls[0] if len(calls) == 1 else calls
+
+    return _parse_single_call(text.strip(), tools)

--- a/mlx_lm/tool_parsers/hy_v3.py
+++ b/mlx_lm/tool_parsers/hy_v3.py
@@ -15,6 +15,10 @@ Format:
     </tool_call>
     ...
     </tool_calls>
+
+The full Hy3 release renames every token with a ":opensource" suffix
+(``<tool_call:opensource>`` etc.), which the regexes below also accept;
+see ``hy_v3_opensource`` for the suffixed start/end sentinels.
 """
 
 import ast
@@ -26,11 +30,22 @@ import regex as re
 tool_call_start = "<tool_calls>"
 tool_call_end = "</tool_calls>"
 
-_tool_call_regex = re.compile(r"<tool_call>(.*?)<tool_sep>(.*?)</tool_call>", re.DOTALL)
-_arg_pair_regex = re.compile(
-    r"<arg_key>(.*?)</arg_key>(?:\\n|\s)*<arg_value>(.*?)</arg_value>",
+_SUFFIX = r"(?::[\w-]+)?"
+
+_tool_call_regex = re.compile(
+    rf"<tool_call{_SUFFIX}>(.*?)<tool_sep{_SUFFIX}>(.*?)</tool_call{_SUFFIX}>",
     re.DOTALL,
 )
+_arg_pair_regex = re.compile(
+    rf"<arg_key{_SUFFIX}>(.*?)</arg_key{_SUFFIX}>"
+    rf"(?:\\n|\s)*"
+    rf"<arg_value{_SUFFIX}>(.*?)</arg_value{_SUFFIX}>",
+    re.DOTALL,
+)
+_tool_sep_regex = re.compile(
+    rf"(?:\s*<tool_call{_SUFFIX}>)?(.*?)<tool_sep{_SUFFIX}>", re.DOTALL
+)
+_arg_key_regex = re.compile(rf"<arg_key{_SUFFIX}>")
 
 
 def _is_string_type(
@@ -63,12 +78,12 @@ def _deserialize(value: str) -> Any:
 
 
 def _parse_single_call(text: str, tools: list[Any] | None):
-    name_match = re.match(r"(.*?)<tool_sep>", text, re.DOTALL)
+    name_match = _tool_sep_regex.match(text)
     if name_match:
         func_name = name_match.group(1).strip()
         body = text[name_match.end() :]
     else:
-        func_name = text.split("<arg_key>", 1)[0].strip()
+        func_name = _arg_key_regex.split(text, 1)[0].strip()
         body = text
 
     arg_dct: dict[str, Any] = {}

--- a/mlx_lm/tool_parsers/hy_v3_opensource.py
+++ b/mlx_lm/tool_parsers/hy_v3_opensource.py
@@ -1,0 +1,15 @@
+# Copyright © 2026 Apple Inc.
+
+"""
+Tool parser for Tencent Hy3 (HYV3).
+
+The full Hy3 release renames the Hy3-preview chat tokens with an
+":opensource" suffix at the same token ids (``<tool_calls>`` becomes
+``<tool_calls:opensource>``). Parsing is shared with ``hy_v3``; only the
+start and end sentinels differ.
+"""
+
+from .hy_v3 import parse_tool_call
+
+tool_call_start = "<tool_calls:opensource>"
+tool_call_end = "</tool_calls:opensource>"

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -1797,6 +1797,36 @@ class TestModels(unittest.TestCase):
             model, args.model_type, args.vocab_size, args.num_hidden_layers
         )
 
+    def test_hy_v3(self):
+        from mlx_lm.models import hy_v3
+
+        args = hy_v3.ModelArgs(
+            model_type="hy_v3",
+            vocab_size=1024,
+            hidden_size=128,
+            intermediate_size=256,
+            num_hidden_layers=4,
+            num_attention_heads=8,
+            num_key_value_heads=2,
+            head_dim=16,
+            num_experts=4,
+            num_experts_per_tok=2,
+            num_shared_experts=1,
+            expert_hidden_dim=128,
+            first_k_dense_replace=1,
+            rms_norm_eps=1e-5,
+            rope_parameters={"rope_theta": 10000.0, "rope_type": "default"},
+            router_scaling_factor=2.0,
+            qk_norm=True,
+            route_norm=True,
+            moe_router_use_sigmoid=True,
+            moe_router_enable_expert_bias=True,
+        )
+        model = hy_v3.Model(args)
+        self.model_test_runner(
+            model, args.model_type, args.vocab_size, args.num_hidden_layers
+        )
+
     def test_hunyuan_v1_dense(self):
         from mlx_lm.models import hunyuan_v1_dense
 

--- a/tests/test_tool_parsing.py
+++ b/tests/test_tool_parsing.py
@@ -5,6 +5,7 @@ from mlx_lm.tool_parsers import (
     function_gemma,
     gemma4,
     glm47,
+    hy_v3,
     json_tools,
     kimi_k2,
     longcat,
@@ -44,6 +45,10 @@ class TestToolParsing(unittest.TestCase):
             (
                 "multiply<longcat_arg_key>a</longcat_arg_key>\n<longcat_arg_value>12234585</longcat_arg_value>\n<longcat_arg_key>b</longcat_arg_key>\n<longcat_arg_value>48838483920</longcat_arg_value>",
                 longcat,
+            ),
+            (
+                "<tool_call>multiply<tool_sep>\n<arg_key>a</arg_key>\n<arg_value>12234585</arg_value>\n<arg_key>b</arg_key>\n<arg_value>48838483920</arg_value>\n</tool_call>",
+                hy_v3,
             ),
             (
                 '{"name": "multiply", "arguments": {"a": 12234585, "b": 48838483920}}',
@@ -114,6 +119,10 @@ class TestToolParsing(unittest.TestCase):
             (
                 "get_current_temperature<longcat_arg_key>location</longcat_arg_key>\n<longcat_arg_value>London</longcat_arg_value>",
                 longcat,
+            ),
+            (
+                "<tool_call>get_current_temperature<tool_sep>\n<arg_key>location</arg_key>\n<arg_value>London</arg_value>\n</tool_call>",
+                hy_v3,
             ),
             (
                 '{"name": "get_current_temperature", "arguments": {"location": "London"}}',
@@ -312,6 +321,73 @@ class TestToolParsing(unittest.TestCase):
             },
         ]
         self.assertEqual(tool_calls, expected)
+
+    def test_hy_v3(self):
+        # Single tool call
+        test_case = (
+            "<tool_call>search<tool_sep>\n"
+            "<arg_key>query</arg_key>\n"
+            "<arg_value>weather</arg_value>\n"
+            "</tool_call>"
+        )
+        tool_call = hy_v3.parse_tool_call(test_case, None)
+        self.assertEqual(
+            tool_call,
+            {"name": "search", "arguments": {"query": "weather"}},
+        )
+
+        # Multiple tool calls
+        test_case = (
+            "<tool_call>search<tool_sep>\n"
+            "<arg_key>query</arg_key>\n"
+            "<arg_value>weather</arg_value>\n"
+            "</tool_call>\n"
+            "<tool_call>read_file<tool_sep>\n"
+            "<arg_key>path</arg_key>\n"
+            "<arg_value>/tmp/test.txt</arg_value>\n"
+            "</tool_call>"
+        )
+        tool_calls = hy_v3.parse_tool_call(test_case, None)
+        self.assertEqual(
+            tool_calls,
+            [
+                {"name": "search", "arguments": {"query": "weather"}},
+                {"name": "read_file", "arguments": {"path": "/tmp/test.txt"}},
+            ],
+        )
+
+        # Type coercion via schema (string preserved, number coerced)
+        tools = [
+            {
+                "type": "function",
+                "function": {
+                    "name": "configure",
+                    "parameters": {
+                        "type": "object",
+                        "properties": {
+                            "name": {"type": "string"},
+                            "limit": {"type": "integer"},
+                            "enabled": {"type": "boolean"},
+                        },
+                    },
+                },
+            }
+        ]
+        test_case = (
+            "<tool_call>configure<tool_sep>\n"
+            "<arg_key>name</arg_key>\n"
+            "<arg_value>5</arg_value>\n"
+            "<arg_key>limit</arg_key>\n"
+            "<arg_value>5</arg_value>\n"
+            "<arg_key>enabled</arg_key>\n"
+            "<arg_value>true</arg_value>\n"
+            "</tool_call>"
+        )
+        tool_call = hy_v3.parse_tool_call(test_case, tools)
+        self.assertEqual(tool_call["name"], "configure")
+        self.assertEqual(tool_call["arguments"]["name"], "5")
+        self.assertEqual(tool_call["arguments"]["limit"], 5)
+        self.assertEqual(tool_call["arguments"]["enabled"], True)
 
     def test_minimax_m2(self):
         test_case = (

--- a/tests/test_tool_parsing.py
+++ b/tests/test_tool_parsing.py
@@ -6,6 +6,7 @@ from mlx_lm.tool_parsers import (
     gemma4,
     glm47,
     hy_v3,
+    hy_v3_opensource,
     json_tools,
     kimi_k2,
     longcat,
@@ -49,6 +50,10 @@ class TestToolParsing(unittest.TestCase):
             (
                 "<tool_call>multiply<tool_sep>\n<arg_key>a</arg_key>\n<arg_value>12234585</arg_value>\n<arg_key>b</arg_key>\n<arg_value>48838483920</arg_value>\n</tool_call>",
                 hy_v3,
+            ),
+            (
+                "<tool_call:opensource>multiply<tool_sep:opensource>\n<arg_key:opensource>a</arg_key:opensource>\n<arg_value:opensource>12234585</arg_value:opensource>\n<arg_key:opensource>b</arg_key:opensource>\n<arg_value:opensource>48838483920</arg_value:opensource>\n</tool_call:opensource>",
+                hy_v3_opensource,
             ),
             (
                 '{"name": "multiply", "arguments": {"a": 12234585, "b": 48838483920}}',
@@ -123,6 +128,10 @@ class TestToolParsing(unittest.TestCase):
             (
                 "<tool_call>get_current_temperature<tool_sep>\n<arg_key>location</arg_key>\n<arg_value>London</arg_value>\n</tool_call>",
                 hy_v3,
+            ),
+            (
+                "<tool_call:opensource>get_current_temperature<tool_sep:opensource>\n<arg_key:opensource>location</arg_key:opensource>\n<arg_value:opensource>London</arg_value:opensource>\n</tool_call:opensource>",
+                hy_v3_opensource,
             ),
             (
                 '{"name": "get_current_temperature", "arguments": {"location": "London"}}',
@@ -388,6 +397,55 @@ class TestToolParsing(unittest.TestCase):
         self.assertEqual(tool_call["arguments"]["name"], "5")
         self.assertEqual(tool_call["arguments"]["limit"], 5)
         self.assertEqual(tool_call["arguments"]["enabled"], True)
+
+    def test_hy_v3_opensource(self):
+        self.assertEqual(hy_v3_opensource.tool_call_start, "<tool_calls:opensource>")
+        self.assertEqual(hy_v3_opensource.tool_call_end, "</tool_calls:opensource>")
+
+        # Single tool call
+        test_case = (
+            "<tool_call:opensource>search<tool_sep:opensource>\n"
+            "<arg_key:opensource>query</arg_key:opensource>\n"
+            "<arg_value:opensource>weather</arg_value:opensource>\n"
+            "</tool_call:opensource>"
+        )
+        tool_call = hy_v3_opensource.parse_tool_call(test_case, None)
+        self.assertEqual(
+            tool_call,
+            {"name": "search", "arguments": {"query": "weather"}},
+        )
+
+        # Multiple tool calls
+        test_case = (
+            "<tool_call:opensource>search<tool_sep:opensource>\n"
+            "<arg_key:opensource>query</arg_key:opensource>\n"
+            "<arg_value:opensource>weather</arg_value:opensource>\n"
+            "</tool_call:opensource>\n"
+            "<tool_call:opensource>read_file<tool_sep:opensource>\n"
+            "<arg_key:opensource>path</arg_key:opensource>\n"
+            "<arg_value:opensource>/tmp/test.txt</arg_value:opensource>\n"
+            "</tool_call:opensource>"
+        )
+        tool_calls = hy_v3_opensource.parse_tool_call(test_case, None)
+        self.assertEqual(
+            tool_calls,
+            [
+                {"name": "search", "arguments": {"query": "weather"}},
+                {"name": "read_file", "arguments": {"path": "/tmp/test.txt"}},
+            ],
+        )
+
+        # Truncated call without the </tool_call:opensource> terminator
+        test_case = (
+            "<tool_call:opensource>search<tool_sep:opensource>\n"
+            "<arg_key:opensource>query</arg_key:opensource>\n"
+            "<arg_value:opensource>weather</arg_value:opensource>"
+        )
+        tool_call = hy_v3_opensource.parse_tool_call(test_case, None)
+        self.assertEqual(
+            tool_call,
+            {"name": "search", "arguments": {"query": "weather"}},
+        )
 
     def test_minimax_m2(self):
         test_case = (


### PR DESCRIPTION
## Summary

Adds **Multi-Token-Prediction (MTP) self-speculative decoding** for Tencent Hunyuan 3 (`hy_v3`).

**This is stacked on #1211 (kernelpool)**, which adds the base `hy_v3` model + tool parsers + tokenizer fixes. That PR intentionally **strips the MTP layer** at load. This branch keeps kernelpool's commits as-is and adds **three commits** on top that keep and use the MTP head:

- `models/hy_v3.py`: load the MTP block instead of dropping it in `sanitize()`; add `Model.predict_next_tokens(...)` and a `return_hidden_states` path. `sanitize()` also accepts already-stacked (MLX-converted) expert weights, not just the per-expert Tencent layout.
- `generate.py`: `mtp_generate_step(...)` + auto-routing in `stream_generate` when `num_nextn_predict_layers > 0` — no external draft model; up to two tokens per target pass. Verification is **distribution-preserving** and honors `sampler` / `logits_processors` / temperature / top-p / top-k exactly.
- Verification uses the **residual (Leviathan)** rule when possible (accept `x~q` with prob `min(1, p(x)/q(x))`, resample from `relu(p-q)` on reject) for strictly higher acceptance, falling back to sampler-agnostic **match** verification (emit the target's own sample) for temp-0, custom samplers, XTC, or active logits processors. `make_sampler` now tags its callable with its params so the MTP path can reconstruct the processed distributions.

**Only the last three commits are mine to review** (the rest is #1211). Happy to rebase to an MTP-only diff once #1211 merges.

Test checkpoint (2/3-bit experts + MTP, MLX): `ox-ox/Hy3-295B-Instruct-w2q3exp-AProjQ8-SExpQ8-OutQ8-MTP-mlx`.

## Testing

- `sanitize` remapping validated in isolation for both the MLX-converted (pre-stacked experts + `mtp.*`) and the original Tencent (per-expert + `model.layers.N`) layouts.
- End-to-end on the quantized MLX checkpoint (M3 Max): loads, generates coherent text, MTP acceptance ~35-40%.

## Notes

- Two distribution-preserving verification rules, both respecting `sampler` / `logits_processors` / temperature / top-p / top-k: **residual (Leviathan)** — accept `x~q` with prob `min(1, p(x)/q(x))`, resample from the normalized `relu(p-q)` on reject — used when the sampler exposes its params (any `make_sampler` output), temp>0, XTC off, no logits processors; and **match** (emit the target's own independent sample, accept when it equals the draft), the sampler-agnostic fallback used otherwise and for temp-0 (where it reduces to greedy). Residual accepts `Σ min(p,q) ≥ Σ p·q` (match), i.e. strictly more often, for the same output distribution. Validated by Monte-Carlo: the reconstructed distribution and the residual-emitted distribution match the sampler's to within sampling noise, and measured acceptance matches the `Σ min(p,q)` theory.
- Acceptance is checkpoint-bound here: the test checkpoint's MTP drafter runs 2–3-bit experts (same precision as the target), so it reflects quant precision more than the method's ceiling. Measured on M3 Max at temp=0.9: **residual ~25% vs match ~18%** accept on this 2–3-bit drafter; higher-precision drafters measure ~64–66% at greedy (see thread).
- No changes to `switch_layers.py` or the default (non-MTP) generation path.

