### PR TITLE
Exact speculative rollback for hybrid caches (model-agnostic cache API)

### DIFF
--- a/mlx_lm/generate.py
+++ b/mlx_lm/generate.py
@@ -517,7 +517,9 @@ def speculative_generate_step(
         model_cache = prompt_cache[: len(model.layers)]
         draft_cache = prompt_cache[len(model.layers) :]
 
-    if not cache.can_trim_prompt_cache(model_cache):
+    if not cache.can_trim_prompt_cache(model_cache) and not getattr(
+        model, "supports_speculative_rollback", False
+    ):
         types = {type(c).__name__ for c in model_cache if not c.is_trimmable()}
         raise ValueError(
             f"Speculative decoding requires a trimmable prompt cache " f"(got {types})."
@@ -595,6 +597,12 @@ def speculative_generate_step(
         draft_y = _prefill(draft_model, draft_cache, y)
         y = _prefill(model, model_cache, y)
 
+    # After prefill (recording a rollback for the whole prompt would hold on to
+    # prompt-sized tensors), let rollback-capable caches start recording so
+    # verify steps can be trimmed exactly (no-op for regular KV caches).
+    for c in model_cache:
+        c.start_speculation()
+
     ntoks = 0
     # Set these so the finally block doesn't raise
     num_draft = 0
@@ -643,6 +651,8 @@ def speculative_generate_step(
             _rewind_cache(num_draft, n)
     finally:
         _rewind_cache(num_draft, n)
+        for c in model_cache:
+            c.stop_speculation()
 
 
 def stream_generate(

--- a/mlx_lm/generate.py
+++ b/mlx_lm/generate.py
@@ -665,7 +665,10 @@ def speculative_generate_step(
             _rewind_cache(num_draft, n)
     finally:
         _rewind_cache(num_draft, n)
-        for c in model_cache:
+        # Symmetric with start_speculation above: draft caches must stop
+        # recording too, or a reused draft prompt cache keeps reporting
+        # is_trimmable() with stale rollback records.
+        for c in model_cache + draft_cache:
             c.stop_speculation()
 
 

--- a/mlx_lm/generate.py
+++ b/mlx_lm/generate.py
@@ -587,8 +587,18 @@ def speculative_generate_step(
         return y
 
     def _rewind_cache(num_draft, num_accept):
-        cache.trim_prompt_cache(model_cache, num_draft - num_accept)
-        cache.trim_prompt_cache(draft_cache, max(num_draft - num_accept - 1, 0))
+        # trim_prompt_cache is all-or-none: if any cache reports untrimmable
+        # (e.g. a layer that declared rollback support but never armed it),
+        # it trims nothing and returns 0. Continuing would leave ghost tokens
+        # in every layer, silently. Fail loudly instead.
+        for c, n in ((model_cache, num_draft - num_accept),
+                     (draft_cache, max(num_draft - num_accept - 1, 0))):
+            if n > 0 and cache.trim_prompt_cache(c, n) != n:
+                raise RuntimeError(
+                    "Speculative rewind failed: cache refused to trim "
+                    f"{n} tokens. A cache in the model reports untrimmable "
+                    "mid-speculation; its layer likely never recorded a rollback."
+                )
 
     def _draft_generate(y, num_draft):
         if num_draft == 0:

--- a/mlx_lm/generate.py
+++ b/mlx_lm/generate.py
@@ -517,10 +517,17 @@ def speculative_generate_step(
         model_cache = prompt_cache[: len(model.layers)]
         draft_cache = prompt_cache[len(model.layers) :]
 
-    if not cache.can_trim_prompt_cache(model_cache) and not getattr(
-        model, "supports_speculative_rollback", False
-    ):
-        types = {type(c).__name__ for c in model_cache if not c.is_trimmable()}
+    def _can_speculate(c):
+        # Trimmable directly, or able to record an exact rollback while
+        # speculating (see ArraysCache.record_rollback). The model must also
+        # declare support: recording is done by its recurrent layers.
+        return c.is_trimmable() or (
+            hasattr(c, "record_rollback")
+            and getattr(model, "supports_speculative_rollback", False)
+        )
+
+    if not all(_can_speculate(c) for c in model_cache):
+        types = {type(c).__name__ for c in model_cache if not _can_speculate(c)}
         raise ValueError(
             f"Speculative decoding requires a trimmable prompt cache " f"(got {types})."
         )
@@ -599,8 +606,10 @@ def speculative_generate_step(
 
     # After prefill (recording a rollback for the whole prompt would hold on to
     # prompt-sized tensors), let rollback-capable caches start recording so
-    # verify steps can be trimmed exactly (no-op for regular KV caches).
-    for c in model_cache:
+    # verify steps can be trimmed exactly (no-op for regular KV caches). The
+    # draft cache records too: hybrid draft models (e.g. a small Qwen3.5) need
+    # their recurrent state rewound just like the target's.
+    for c in model_cache + draft_cache:
         c.start_speculation()
 
     ntoks = 0
@@ -610,6 +619,11 @@ def speculative_generate_step(
     try:
         while True:
             num_draft = min(max_tokens - ntoks, num_draft_tokens)
+            # Until this round's verify step has advanced the caches there is
+            # nothing to rewind; keep n == num_draft so an exception here (or a
+            # generator close) makes the finally-block rewind a no-op instead
+            # of trimming with values from a previous round.
+            n = num_draft
             draft_tokens = _draft_generate(draft_y, num_draft)
             if prev_tokens is not None:
                 prev_tokens = prev_tokens[: prev_tokens.size - y.size - num_draft + 1]

--- a/mlx_lm/models/cache.py
+++ b/mlx_lm/models/cache.py
@@ -146,6 +146,19 @@ class _BaseCache:
     def is_trimmable(self):
         return False
 
+    def start_speculation(self):
+        """Called by speculative decoding before draft/verify steps begin.
+
+        Caches that cannot trim directly but support an exact rollback (e.g.
+        recurrent-state caches, see ``ArraysCache``) use this to start recording
+        the information needed to roll a verify step back. No-op by default.
+        """
+        pass
+
+    def stop_speculation(self):
+        """Called by speculative decoding when it finishes. No-op by default."""
+        pass
+
     def size(self):
         """
         Return the size (i.e. sequence length) of the cache.
@@ -596,12 +609,57 @@ class ArraysCache(_BaseCache):
         instance = super().__new__(cls)
         instance.left_padding = None
         instance.lengths = None
+        instance.speculating = False
+        instance._rollback = None
         return instance
 
     def __init__(self, size, left_padding: Optional[List[int]] = None):
         self.cache = [None] * size
         if left_padding:
             self.left_padding = mx.array(left_padding)
+
+    def start_speculation(self):
+        self.speculating = True
+        self._rollback = None
+
+    def stop_speculation(self):
+        self.speculating = False
+        self._rollback = None
+
+    def record_rollback(self, num_tokens, fn, snapshot):
+        """Recorded by the owning layer during a forward while ``speculating``.
+
+        Args:
+            num_tokens (int): Sequence length of the forward being recorded.
+            fn (callable): ``fn(m) -> list`` returning the cache entries as they
+                would be had only the first ``m`` of ``num_tokens`` tokens been
+                processed. Must be exact (e.g. replay the recurrence from the
+                pre-forward state over the stashed per-token inputs).
+            snapshot (list): The cache entries from before the forward (returned
+                for a full rollback, ``m == 0``).
+        """
+        self._rollback = (num_tokens, fn, snapshot)
+
+    def is_trimmable(self):
+        # While speculating, every forward records an exact rollback, so the
+        # cache is trimmable within the last forward's window.
+        return self.speculating
+
+    def trim(self, n):
+        if n <= 0:
+            return 0
+        if self._rollback is None:
+            raise RuntimeError(
+                "ArraysCache.trim requires a rollback recorded by the model's "
+                "recurrent layers; this model does not support speculative "
+                "rollback."
+            )
+        num_tokens, fn, snapshot = self._rollback
+        n = min(n, num_tokens)
+        m = num_tokens - n
+        self.cache = list(snapshot) if m == 0 else fn(m)
+        self._rollback = None
+        return n
 
     @property
     def batch_size(self):

--- a/mlx_lm/models/cache.py
+++ b/mlx_lm/models/cache.py
@@ -422,6 +422,17 @@ class KVCache(_BaseCache):
 
 class RotatingKVCache(_BaseCache):
     step = 256
+    # Tokens of exact-rollback history kept while speculating (mirrors
+    # ArraysCache; a speculative trim never exceeds the last verify window).
+    _ROLLBACK_WINDOW = 64
+
+    def __new__(cls, *args, **kwargs):
+        # Set on __new__ (not __init__) so caches reconstructed by
+        # load_prompt_cache (which bypasses __init__) still have them.
+        instance = super().__new__(cls)
+        instance.speculating = False
+        instance._rollbacks = deque()
+        return instance
 
     def __init__(self, max_size, keep=0):
         self.keep = keep
@@ -430,6 +441,32 @@ class RotatingKVCache(_BaseCache):
         self.offset = 0
         self.max_size = max_size
         self._idx = 0
+
+    def start_speculation(self):
+        self.speculating = True
+        self._rollbacks.clear()
+
+    def stop_speculation(self):
+        self.speculating = False
+        self._rollbacks.clear()
+
+    def record_rollback(self, num_tokens, snapshot, keys, values):
+        """Recorded by ``update_and_fetch`` during a forward while
+        ``speculating``. A sliding-window KV cache is not directly trimmable
+        once it has wrapped (``offset >= max_size``): the tokens a verify step
+        pushes out of the window are gone. So we stash the pre-forward window
+        (``snapshot``) plus this forward's new K/V; ``trim`` rebuilds the exact
+        window for any accepted prefix by restoring the snapshot and
+        re-appending the first ``m`` tokens. The verify path uses
+        ``_update_concat`` which reallocates (never mutates in place), so
+        holding references in ``snapshot`` is safe."""
+        self._rollbacks.append((num_tokens, snapshot, keys, values))
+        total = sum(r[0] for r in self._rollbacks)
+        while (
+            len(self._rollbacks) > 1
+            and total - self._rollbacks[0][0] >= self._ROLLBACK_WINDOW
+        ):
+            total -= self._rollbacks.popleft()[0]
 
     def _trim(self, trim_size, v, append=None):
         to_cat = []
@@ -523,6 +560,13 @@ class RotatingKVCache(_BaseCache):
         return self.keys, self.values
 
     def update_and_fetch(self, keys, values):
+        if self.speculating:
+            self.record_rollback(
+                keys.shape[2],
+                [self.keys, self.values, self._idx, self.offset],
+                keys,
+                values,
+            )
         if keys.shape[2] == 1:
             return self._update_in_place(keys, values)
         return self._update_concat(keys, values)
@@ -553,12 +597,43 @@ class RotatingKVCache(_BaseCache):
         )
 
     def is_trimmable(self):
-        return self.offset < self.max_size
+        # While speculating every forward records an exact rollback, so the
+        # cache is trimmable within the recorded window even after it wraps.
+        return self.speculating or self.offset < self.max_size
 
     def trim(self, n):
-        n = min(self.offset, n)
-        self.offset -= n
-        self._idx -= n
+        if not self.speculating:
+            n = min(self.offset, n)
+            self.offset -= n
+            self._idx -= n
+            return n
+        recorded = sum(r[0] for r in self._rollbacks)
+        if recorded < n:
+            raise RuntimeError(
+                f"Cannot trim {n} tokens from RotatingKVCache: only {recorded} "
+                "tokens of exact rollback are recorded (speculative window)."
+            )
+        trimmed = 0
+        while trimmed < n:
+            num_tokens, snap, keys, values = self._rollbacks.pop()
+            take = min(n - trimmed, num_tokens)
+            m = num_tokens - take
+            # Restore the pre-forward window, then re-append the first m tokens
+            # of this chunk to reconstruct the exact accepted-prefix window.
+            self.keys, self.values, self._idx, self.offset = (
+                snap[0],
+                snap[1],
+                snap[2],
+                snap[3],
+            )
+            if m > 0:
+                if m == 1:
+                    self._update_in_place(keys[..., :1, :], values[..., :1, :])
+                else:
+                    self._update_concat(keys[..., :m, :], values[..., :m, :])
+                # The record still describes its first m tokens; keep it.
+                self._rollbacks.append((m, snap, keys, values))
+            trimmed += take
         return n
 
     def to_quantized(self, group_size: int = 64, bits: int = 4) -> QuantizedKVCache:

--- a/mlx_lm/models/cache.py
+++ b/mlx_lm/models/cache.py
@@ -605,12 +605,18 @@ class RotatingKVCache(_BaseCache):
 
 
 class ArraysCache(_BaseCache):
+    # Tokens of exact-rollback history kept while speculating — records beyond
+    # this window are dropped (speculative trims never exceed the last verify
+    # window, so 64 tokens is far more than any round needs). Bounding by
+    # tokens keeps the retained per-token stashes small.
+    _ROLLBACK_WINDOW = 64
+
     def __new__(cls, *args, **kwargs):
         instance = super().__new__(cls)
         instance.left_padding = None
         instance.lengths = None
         instance.speculating = False
-        instance._rollback = None
+        instance._rollbacks = deque()
         return instance
 
     def __init__(self, size, left_padding: Optional[List[int]] = None):
@@ -620,11 +626,11 @@ class ArraysCache(_BaseCache):
 
     def start_speculation(self):
         self.speculating = True
-        self._rollback = None
+        self._rollbacks.clear()
 
     def stop_speculation(self):
         self.speculating = False
-        self._rollback = None
+        self._rollbacks.clear()
 
     def record_rollback(self, num_tokens, fn, snapshot):
         """Recorded by the owning layer during a forward while ``speculating``.
@@ -638,27 +644,40 @@ class ArraysCache(_BaseCache):
             snapshot (list): The cache entries from before the forward (returned
                 for a full rollback, ``m == 0``).
         """
-        self._rollback = (num_tokens, fn, snapshot)
+        self._rollbacks.append((num_tokens, fn, snapshot))
+        total = sum(r[0] for r in self._rollbacks)
+        while (
+            len(self._rollbacks) > 1
+            and total - self._rollbacks[0][0] >= self._ROLLBACK_WINDOW
+        ):
+            total -= self._rollbacks.popleft()[0]
 
     def is_trimmable(self):
         # While speculating, every forward records an exact rollback, so the
-        # cache is trimmable within the last forward's window.
+        # cache is trimmable within the recorded window.
         return self.speculating
 
     def trim(self, n):
         if n <= 0:
             return 0
-        if self._rollback is None:
+        if sum(r[0] for r in self._rollbacks) < n:
             raise RuntimeError(
-                "ArraysCache.trim requires a rollback recorded by the model's "
-                "recurrent layers; this model does not support speculative "
-                "rollback."
+                f"Cannot trim {n} tokens from ArraysCache: only "
+                f"{sum(r[0] for r in self._rollbacks)} tokens of exact rollback "
+                "are recorded. Recurrent state cannot be trimmed beyond the "
+                "speculative window."
             )
-        num_tokens, fn, snapshot = self._rollback
-        n = min(n, num_tokens)
-        m = num_tokens - n
-        self.cache = list(snapshot) if m == 0 else fn(m)
-        self._rollback = None
+        trimmed = 0
+        while trimmed < n:
+            num_tokens, fn, snapshot = self._rollbacks.pop()
+            take = min(n - trimmed, num_tokens)
+            m = num_tokens - take
+            self.cache = list(snapshot) if m == 0 else fn(m)
+            trimmed += take
+            if m > 0:
+                # The record still describes the first m tokens of its chunk
+                # (fn(m') is valid for any m' <= m), so keep it for further trims.
+                self._rollbacks.append((m, fn, snapshot))
         return n
 
     @property

--- a/mlx_lm/models/gpt_oss.py
+++ b/mlx_lm/models/gpt_oss.py
@@ -230,6 +230,11 @@ class GptOssMoeModel(nn.Module):
 
 
 class Model(nn.Module):
+    # Sliding-window (RotatingKVCache) layers record an exact rollback while
+    # speculating, so the cache is trimmable within the verify window (see
+    # RotatingKVCache.record_rollback) — enables --draft-model speculation.
+    supports_speculative_rollback = True
+
     def __init__(self, args: ModelArgs):
         super().__init__()
         self.args = args

--- a/mlx_lm/models/qwen3_5.py
+++ b/mlx_lm/models/qwen3_5.py
@@ -181,6 +181,40 @@ class GatedDeltaNet(nn.Module):
         q = (inv_scale**2) * mx.fast.rms_norm(q, None, 1e-6)
         k = inv_scale * mx.fast.rms_norm(k, None, 1e-6)
 
+        if (
+            cache is not None
+            and getattr(cache, "speculating", False)
+            and mask is None
+            and cache.lengths is None
+            and cache.left_padding is None
+        ):
+            # Record an exact rollback for speculative decoding: replaying the
+            # recurrence from the pre-forward state over the first m of the
+            # exact per-token inputs the kernel consumes reproduces the state
+            # after m tokens bit-for-bit; the conv state after m tokens is a
+            # slice of conv_input. See ArraysCache.record_rollback.
+            n_keep = self.conv_kernel_size - 1
+            use_kernel = not self.training
+
+            def _rollback(
+                m, q=q, k=k, v=v, a=a, b=b, S0=state, ci=conv_input, nk=n_keep
+            ):
+                _, s_m = gated_delta_update(
+                    q[:, :m],
+                    k[:, :m],
+                    v[:, :m],
+                    a[:, :m],
+                    b[:, :m],
+                    self.A_log,
+                    self.dt_bias,
+                    S0,
+                    None,
+                    use_kernel,
+                )
+                return [mx.contiguous(ci[:, m : m + nk, :]), s_m]
+
+            cache.record_rollback(S, _rollback, [conv_state, state])
+
         out, state = gated_delta_update(
             q,
             k,
@@ -406,6 +440,11 @@ class ModelArgs(BaseModelArgs):
 
 
 class Model(nn.Module):
+    # The GDN layers record exact rollbacks on their ArraysCache during
+    # speculative decoding, making the hybrid cache trimmable (see
+    # GatedDeltaNet.__call__ and ArraysCache.record_rollback).
+    supports_speculative_rollback = True
+
     def __init__(self, args: ModelArgs):
         super().__init__()
         self.args = args

--- a/mlx_lm/models/qwen3_next.py
+++ b/mlx_lm/models/qwen3_next.py
@@ -284,6 +284,40 @@ class Qwen3NextGatedDeltaNet(nn.Module):
         q = (inv_scale**2) * mx.fast.rms_norm(q, None, 1e-6)
         k = inv_scale * mx.fast.rms_norm(k, None, 1e-6)
 
+        if (
+            cache is not None
+            and getattr(cache, "speculating", False)
+            and mask is None
+            and cache.lengths is None
+            and cache.left_padding is None
+        ):
+            # Record an exact rollback for speculative decoding: replaying the
+            # recurrence from the pre-forward state over the first m of the
+            # exact per-token inputs the kernel consumes reproduces the state
+            # after m tokens bit-for-bit; the conv state after m tokens is a
+            # slice of conv_input. See ArraysCache.record_rollback.
+            n_keep = self.conv_kernel_size - 1
+            use_kernel = not self.training
+
+            def _rollback(
+                m, q=q, k=k, v=v, a=a, b=b, S0=state, ci=conv_input, nk=n_keep
+            ):
+                _, s_m = gated_delta_update(
+                    q[:, :m],
+                    k[:, :m],
+                    v[:, :m],
+                    a[:, :m],
+                    b[:, :m],
+                    self.A_log,
+                    self.dt_bias,
+                    S0,
+                    None,
+                    use_kernel,
+                )
+                return [mx.contiguous(ci[:, m : m + nk, :]), s_m]
+
+            cache.record_rollback(S, _rollback, [conv_state, state])
+
         out, state = gated_delta_update(
             q,
             k,
@@ -422,6 +456,11 @@ class Qwen3NextModel(nn.Module):
 
 
 class Model(nn.Module):
+    # The GDN layers record exact rollbacks on their ArraysCache during
+    # speculative decoding, making the hybrid cache trimmable (see
+    # Qwen3NextGatedDeltaNet.__call__ and ArraysCache.record_rollback).
+    supports_speculative_rollback = True
+
     def __init__(self, args: ModelArgs):
         super().__init__()
         self.args = args

--- a/tests/test_rotating_rollback.py
+++ b/tests/test_rotating_rollback.py
@@ -1,0 +1,118 @@
+# Copyright © 2026 Apple Inc.
+
+"""Exact speculative rollback for RotatingKVCache (sliding-window KV).
+
+The sibling of the ArraysCache (GDN) exact-replay rollback: once a rotating
+cache wraps (offset >= max_size) it is not directly trimmable, so speculative
+decoding needs an exact rollback. These tests pin the key property —
+bit-exact tail-independence: two verify chunks that share an m-token prefix
+but have different tails must leave IDENTICAL windows after rolling back to m
+(any off-by-one in the restore/re-append leaks the tail).
+"""
+import unittest
+
+import mlx.core as mx
+from mlx_lm.models.cache import RotatingKVCache
+
+W = 4  # tiny window so the cache wraps
+H, D = 2, 8
+
+
+def _kv(n, seed):
+    mx.random.seed(seed)
+    return (mx.random.normal((1, H, n, D)), mx.random.normal((1, H, n, D)))
+
+
+def _prefill(cache, n, seed=0):
+    k, v = _kv(n, seed)
+    cache.update_and_fetch(k, v)
+    return k, v
+
+
+def _window(cache):
+    return (
+        mx.contiguous(cache._temporal_order(cache.keys)),
+        mx.contiguous(cache._temporal_order(cache.values)),
+    )
+
+
+class TestRotatingRollback(unittest.TestCase):
+    def test_tail_independence(self):
+        # Reference: prefill P (wraps), then append only the shared prefix m.
+        P, m, tail = 6, 3, 3
+        pk, pv = _kv(m, seed=1)  # shared prefix K/V
+
+        ref = RotatingKVCache(max_size=W)
+        _prefill(ref, P, seed=9)
+        ref.update_and_fetch(pk, pv)
+        rk, rv = _window(ref)
+
+        for tail_seed in (2, 3):  # two DIFFERENT tails
+            tk, tv = _kv(tail, seed=tail_seed)
+            c = RotatingKVCache(max_size=W)
+            _prefill(c, P, seed=9)
+            c.start_speculation()
+            # one verify forward of [prefix ++ tail]
+            c.update_and_fetch(
+                mx.concatenate([pk, tk], axis=2),
+                mx.concatenate([pv, tv], axis=2),
+            )
+            c.trim(tail)  # roll back to the m-token prefix
+            wk, wv = _window(c)
+            self.assertTrue(mx.allclose(wk, rk, atol=1e-5).item(),
+                            f"keys leak tail (seed {tail_seed})")
+            self.assertTrue(mx.allclose(wv, rv, atol=1e-5).item(),
+                            f"values leak tail (seed {tail_seed})")
+            self.assertEqual(c.offset, ref.offset)
+
+    def test_trim_to_various_prefixes(self):
+        P, block = 5, 4
+        c = RotatingKVCache(max_size=W)
+        _prefill(c, P, seed=7)
+        bk, bv = _kv(block, seed=8)
+        for keep in range(block + 1):
+            ref = RotatingKVCache(max_size=W)
+            _prefill(ref, P, seed=7)
+            if keep > 0:
+                ref.update_and_fetch(bk[..., :keep, :], bv[..., :keep, :])
+            rk, rv = _window(ref)
+
+            t = RotatingKVCache(max_size=W)
+            _prefill(t, P, seed=7)
+            t.start_speculation()
+            t.update_and_fetch(bk, bv)
+            t.trim(block - keep)
+            wk, wv = _window(t)
+            self.assertTrue(mx.allclose(wk, rk, atol=1e-5).item(),
+                            f"keys mismatch at keep={keep}")
+            self.assertTrue(mx.allclose(wv, rv, atol=1e-5).item(),
+                            f"values mismatch at keep={keep}")
+            self.assertEqual(t.offset, ref.offset, f"offset at keep={keep}")
+
+    def test_stacked_draft_records(self):
+        # Mimic a draft: several single-token forwards, then roll them all back.
+        P = 5
+        c = RotatingKVCache(max_size=W)
+        _prefill(c, P, seed=4)
+        base_k, base_v = _window(c)
+        base_off = c.offset
+        c.start_speculation()
+        for i in range(3):
+            k, v = _kv(1, seed=100 + i)
+            c.update_and_fetch(k, v)
+        c.trim(3)  # rewind all three draft tokens
+        wk, wv = _window(c)
+        self.assertTrue(mx.allclose(wk, base_k, atol=1e-5).item())
+        self.assertTrue(mx.allclose(wv, base_v, atol=1e-5).item())
+        self.assertEqual(c.offset, base_off)
+
+    def test_not_speculating_uses_plain_trim(self):
+        c = RotatingKVCache(max_size=64)
+        _prefill(c, 10, seed=0)  # offset < max_size -> directly trimmable
+        self.assertTrue(c.is_trimmable())
+        c.trim(3)
+        self.assertEqual(c.offset, 7)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_speculative_rollback.py
+++ b/tests/test_speculative_rollback.py
@@ -1,0 +1,133 @@
+# Copyright © 2026 Apple Inc.
+
+import unittest
+
+import mlx.core as mx
+
+from mlx_lm.generate import generate_step, speculative_generate_step
+from mlx_lm.models import cache, llama, qwen3_next
+
+QWEN3_NEXT_ARGS = {
+    "model_type": "qwen3_next",
+    "hidden_size": 128,
+    "num_hidden_layers": 4,
+    "intermediate_size": 128,
+    "num_attention_heads": 8,
+    "num_key_value_heads": 4,
+    "vocab_size": 1000,
+    "linear_num_value_heads": 4,
+    "linear_num_key_heads": 4,
+    "linear_key_head_dim": 32,
+    "linear_value_head_dim": 32,
+    "linear_conv_kernel_dim": 3,
+    "num_experts": 4,
+    "num_experts_per_tok": 2,
+    "decoder_sparse_step": 1,
+    "shared_expert_intermediate_size": 128,
+    "mlp_only_layers": [0],
+    "moe_intermediate_size": 128,
+    "rms_norm_eps": 1e-5,
+    "head_dim": 64,
+    "rope_theta": 1000.0,
+    "partial_rotary_factor": 0.5,
+    "max_position_embeddings": 1000,
+}
+
+LLAMA_ARGS = {
+    "model_type": "llama",
+    "hidden_size": 64,
+    "num_hidden_layers": 2,
+    "intermediate_size": 128,
+    "num_attention_heads": 4,
+    "rms_norm_eps": 1e-5,
+    "vocab_size": 1000,
+}
+
+
+def make_hybrid(seed=0):
+    mx.random.seed(seed)
+    return qwen3_next.Model(qwen3_next.ModelArgs.from_dict(QWEN3_NEXT_ARGS))
+
+
+class TestSpeculativeRollback(unittest.TestCase):
+
+    def test_rollback_is_exact(self):
+        # Tail independence: feed two verify chunks sharing the first m tokens
+        # but with different tails, roll both back to m — every cache entry and
+        # the next-token logits must be IDENTICAL (no numeric tolerance: same
+        # starting state, same shapes, deterministic kernels). Any off-by-one
+        # in the recorded rollback leaks the divergent tail.
+        model = make_hybrid()
+        prompt = mx.random.randint(0, 1000, (32,), dtype=mx.uint32)
+        T = 8
+        xs = mx.random.randint(0, 1000, (T,), dtype=mx.uint32)
+        zs = mx.random.randint(0, 1000, (T,), dtype=mx.uint32)
+        probe = mx.array([7], mx.uint32)
+
+        def run(chunk, m):
+            c = model.make_cache()
+            model(prompt[None], cache=c)
+            mx.eval([x.state for x in c])
+            for x in c:
+                x.start_speculation()
+            model(chunk[None], cache=c)
+            self.assertEqual(cache.trim_prompt_cache(c, chunk.size - m),
+                             chunk.size - m)
+            logits = model(probe[None], cache=c)
+            mx.eval(logits, [x.state for x in c])
+            return c, logits
+
+        for m in (1, 3, T - 1):
+            cA, lA = run(xs, m)
+            chunk_b = mx.concatenate([xs[:m], zs[: T - m]])
+            cB, lB = run(chunk_b, m)
+            self.assertTrue(mx.array_equal(lA, lB))
+            for a, b in zip(cA, cB):
+                if isinstance(a, cache.ArraysCache):
+                    for ea, eb in zip(a.cache, b.cache):
+                        self.assertTrue(mx.array_equal(ea, eb))
+                else:
+                    self.assertEqual(a.offset, b.offset)
+                    self.assertTrue(
+                        mx.array_equal(a.keys[..., : a.offset, :],
+                                       b.keys[..., : b.offset, :]))
+                    self.assertTrue(
+                        mx.array_equal(a.values[..., : a.offset, :],
+                                       b.values[..., : b.offset, :]))
+
+    def test_speculative_matches_vanilla(self):
+        # With an unrelated (random) draft model the acceptance rate is ~0, so
+        # every round exercises the rollback path; greedy speculative decoding
+        # must still reproduce the vanilla greedy generation exactly.
+        model = make_hybrid()
+        mx.random.seed(1)
+        draft = llama.Model(llama.ModelArgs.from_dict(LLAMA_ARGS))
+        prompt = mx.random.randint(0, 1000, (16,), dtype=mx.uint32)
+        n = 24
+
+        vanilla = [
+            int(tok) for tok, _ in generate_step(prompt, model, max_tokens=n)
+        ]
+        spec = [
+            int(tok)
+            for tok, _, _ in speculative_generate_step(
+                prompt, model, draft, num_draft_tokens=3, max_tokens=n
+            )
+        ]
+        self.assertEqual(vanilla, spec)
+
+    def test_unsupported_hybrid_still_raises(self):
+        # An ArraysCache whose layers never record a rollback must not be
+        # silently trimmable outside of speculation.
+        c = cache.ArraysCache(size=2)
+        self.assertFalse(c.is_trimmable())
+        c.start_speculation()
+        self.assertTrue(c.is_trimmable())
+        with self.assertRaises(RuntimeError):
+            c.trim(1)
+        c.stop_speculation()
+        self.assertFalse(c.is_trimmable())
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_speculative_rollback.py
+++ b/tests/test_speculative_rollback.py
@@ -246,6 +246,34 @@ class TestSpeculativeRollback(unittest.TestCase):
                 pass
         self.assertIs(ctx.exception, boom)
 
+    def test_rewind_refusal_raises_not_silent(self):
+        # A cache can pass the support gate (record_rollback attr + the model
+        # declaring support) while never actually arming: its layer never calls
+        # record_rollback, so is_trimmable() stays False mid-speculation. Since
+        # trim_prompt_cache is all-or-none, that would silently rewind NOTHING
+        # in ANY layer and generation would continue over ghost tokens. The
+        # rewind must fail loudly instead.
+        class UnarmedArraysCache(cache.ArraysCache):
+            def start_speculation(self):  # gate passes, recording never arms
+                pass
+
+        model = make_hybrid(seed=0)
+        draft = make_hybrid(seed=7)
+        prompt = mx.random.randint(0, 1000, (16,), dtype=mx.uint32)
+        c = cache.make_prompt_cache(model) + cache.make_prompt_cache(draft)
+        for i, x in enumerate(c):
+            if isinstance(x, cache.ArraysCache):
+                bad = UnarmedArraysCache(len(x.cache) if hasattr(x, "cache") else 2)
+                bad.__dict__.update(x.__dict__)
+                c[i] = bad
+                break
+        with self.assertRaises(RuntimeError):
+            for _ in speculative_generate_step(
+                prompt, model, draft, num_draft_tokens=3, max_tokens=24,
+                prompt_cache=c,
+            ):
+                pass
+
     def test_trim_beyond_window_raises(self):
         # Trimming more than the recorded rollback window must fail loudly and
         # consistently rather than silently clamping (which would desync the

--- a/tests/test_speculative_rollback.py
+++ b/tests/test_speculative_rollback.py
@@ -71,8 +71,7 @@ class TestSpeculativeRollback(unittest.TestCase):
             for x in c:
                 x.start_speculation()
             model(chunk[None], cache=c)
-            self.assertEqual(cache.trim_prompt_cache(c, chunk.size - m),
-                             chunk.size - m)
+            self.assertEqual(cache.trim_prompt_cache(c, chunk.size - m), chunk.size - m)
             logits = model(probe[None], cache=c)
             mx.eval(logits, [x.state for x in c])
             return c, logits
@@ -89,11 +88,15 @@ class TestSpeculativeRollback(unittest.TestCase):
                 else:
                     self.assertEqual(a.offset, b.offset)
                     self.assertTrue(
-                        mx.array_equal(a.keys[..., : a.offset, :],
-                                       b.keys[..., : b.offset, :]))
+                        mx.array_equal(
+                            a.keys[..., : a.offset, :], b.keys[..., : b.offset, :]
+                        )
+                    )
                     self.assertTrue(
-                        mx.array_equal(a.values[..., : a.offset, :],
-                                       b.values[..., : b.offset, :]))
+                        mx.array_equal(
+                            a.values[..., : a.offset, :], b.values[..., : b.offset, :]
+                        )
+                    )
 
     def test_speculative_matches_vanilla(self):
         # With an unrelated (random) draft model the acceptance rate is ~0, so
@@ -105,9 +108,7 @@ class TestSpeculativeRollback(unittest.TestCase):
         prompt = mx.random.randint(0, 1000, (16,), dtype=mx.uint32)
         n = 24
 
-        vanilla = [
-            int(tok) for tok, _ in generate_step(prompt, model, max_tokens=n)
-        ]
+        vanilla = [int(tok) for tok, _ in generate_step(prompt, model, max_tokens=n)]
         spec = [
             int(tok)
             for tok, _, _ in speculative_generate_step(
@@ -115,6 +116,62 @@ class TestSpeculativeRollback(unittest.TestCase):
             )
         ]
         self.assertEqual(vanilla, spec)
+
+    def test_cache_reusable_after_speculation(self):
+        # A prompt cache used for speculative decoding must come back clean:
+        # not trimmable, no dangling rollback, and usable for plain decoding
+        # that matches a never-speculated run.
+        model = make_hybrid()
+        mx.random.seed(2)
+        draft = llama.Model(llama.ModelArgs.from_dict(LLAMA_ARGS))
+        prompt = mx.random.randint(0, 1000, (16,), dtype=mx.uint32)
+
+        c = cache.make_prompt_cache(model) + cache.make_prompt_cache(draft)
+        spec = [
+            int(tok)
+            for tok, _, _ in speculative_generate_step(
+                prompt, model, draft, num_draft_tokens=3, max_tokens=8, prompt_cache=c
+            )
+        ]
+        model_cache = c[: len(model.layers)]
+        self.assertFalse(cache.can_trim_prompt_cache(model_cache))
+        for x in model_cache:
+            if isinstance(x, cache.ArraysCache):
+                self.assertFalse(x.speculating)
+                self.assertIsNone(x._rollback)
+
+        # continue decoding on the same cache with plain steps
+        cont = [
+            int(tok)
+            for tok, _ in generate_step(
+                mx.array(spec[-1:], mx.uint32),
+                model,
+                max_tokens=8,
+                prompt_cache=model_cache,
+            )
+        ]
+
+        # reference: one uninterrupted vanilla run over the same tokens
+        ref = [
+            int(tok)
+            for tok, _ in generate_step(prompt, model, max_tokens=8 + len(spec))
+        ]
+        self.assertEqual(ref, spec + cont)
+
+    def test_early_generator_close(self):
+        # Closing the speculative generator mid-stream must roll the cache back
+        # cleanly (the finally path) without raising.
+        model = make_hybrid()
+        mx.random.seed(3)
+        draft = llama.Model(llama.ModelArgs.from_dict(LLAMA_ARGS))
+        prompt = mx.random.randint(0, 1000, (16,), dtype=mx.uint32)
+
+        gen = speculative_generate_step(
+            prompt, model, draft, num_draft_tokens=3, max_tokens=64
+        )
+        took = [next(gen) for _ in range(3)]
+        gen.close()  # must not raise (double-rewind / consumed-rollback bugs)
+        self.assertEqual(len(took), 3)
 
     def test_unsupported_hybrid_still_raises(self):
         # An ArraysCache whose layers never record a rollback must not be

--- a/tests/test_speculative_rollback.py
+++ b/tests/test_speculative_rollback.py
@@ -135,9 +135,13 @@ class TestSpeculativeRollback(unittest.TestCase):
         ]
         model_cache = c[: len(model.layers)]
         self.assertFalse(cache.can_trim_prompt_cache(model_cache))
-        for x in model_cache:
+        # The whole cache list must come back clean, draft caches included:
+        # they start speculating alongside the model cache and record during
+        # draft steps, so a dangling speculating flag would make a reused
+        # draft cache trim through stale rollback records.
+        for x in c:
+            self.assertFalse(getattr(x, "speculating", False))
             if isinstance(x, cache.ArraysCache):
-                self.assertFalse(x.speculating)
                 self.assertEqual(len(x._rollbacks), 0)
 
         # continue decoding on the same cache with plain steps
@@ -196,13 +200,21 @@ class TestSpeculativeRollback(unittest.TestCase):
         n = 24
 
         vanilla = [int(tok) for tok, _ in generate_step(prompt, model, max_tokens=n)]
+        c = cache.make_prompt_cache(model) + cache.make_prompt_cache(draft)
         spec = [
             int(tok)
             for tok, _, _ in speculative_generate_step(
-                prompt, model, draft, num_draft_tokens=3, max_tokens=n
+                prompt, model, draft, num_draft_tokens=3, max_tokens=n, prompt_cache=c
             )
         ]
         self.assertEqual(vanilla, spec)
+        # Draft caches record too (T=1 records per draft step), so they must
+        # be stopped alongside the model caches: a dangling speculating flag
+        # would make a reused draft cache trim through stale rollback records.
+        for x in c:
+            self.assertFalse(getattr(x, "speculating", False))
+            if isinstance(x, cache.ArraysCache):
+                self.assertEqual(len(x._rollbacks), 0)
 
     def test_draft_exception_not_masked(self):
         # An exception raised mid-round (e.g. inside the draft model) must

--- a/tests/test_speculative_rollback.py
+++ b/tests/test_speculative_rollback.py
@@ -138,7 +138,7 @@ class TestSpeculativeRollback(unittest.TestCase):
         for x in model_cache:
             if isinstance(x, cache.ArraysCache):
                 self.assertFalse(x.speculating)
-                self.assertIsNone(x._rollback)
+                self.assertEqual(len(x._rollbacks), 0)
 
         # continue decoding on the same cache with plain steps
         cont = [
@@ -184,6 +184,72 @@ class TestSpeculativeRollback(unittest.TestCase):
             c.trim(1)
         c.stop_speculation()
         self.assertFalse(c.is_trimmable())
+
+    def test_hybrid_draft_model(self):
+        # Target AND draft are hybrid GDN models (the setup reported in #1446:
+        # Qwen3.6 target + Qwen3.5 draft). The draft cache is rewound exactly
+        # too — its rollback spans several T=1 records per round — and the
+        # output must still equal vanilla greedy.
+        model = make_hybrid(seed=0)
+        draft = make_hybrid(seed=7)  # different weights, same arch
+        prompt = mx.random.randint(0, 1000, (16,), dtype=mx.uint32)
+        n = 24
+
+        vanilla = [int(tok) for tok, _ in generate_step(prompt, model, max_tokens=n)]
+        spec = [
+            int(tok)
+            for tok, _, _ in speculative_generate_step(
+                prompt, model, draft, num_draft_tokens=3, max_tokens=n
+            )
+        ]
+        self.assertEqual(vanilla, spec)
+
+    def test_draft_exception_not_masked(self):
+        # An exception raised mid-round (e.g. inside the draft model) must
+        # surface as itself: the finally-block cache rewind must not replace it
+        # with a rollback RuntimeError.
+        model = make_hybrid()
+        mx.random.seed(4)
+        draft = llama.Model(llama.ModelArgs.from_dict(LLAMA_ARGS))
+        prompt = mx.random.randint(0, 1000, (16,), dtype=mx.uint32)
+
+        boom = ValueError("draft exploded")
+        calls = {"n": 0}
+
+        class Flaky:
+            def __call__(self, *args, **kwargs):
+                calls["n"] += 1
+                if calls["n"] > 4:  # fail during the second round's draft steps
+                    raise boom
+                return draft(*args, **kwargs)
+
+            def __getattr__(self, name):
+                return getattr(draft, name)
+
+        gen = speculative_generate_step(
+            prompt, model, Flaky(), num_draft_tokens=3, max_tokens=32
+        )
+        with self.assertRaises(ValueError) as ctx:
+            for _ in gen:
+                pass
+        self.assertIs(ctx.exception, boom)
+
+    def test_trim_beyond_window_raises(self):
+        # Trimming more than the recorded rollback window must fail loudly and
+        # consistently rather than silently clamping (which would desync the
+        # ArraysCache layers from the KVCache layers).
+        model = make_hybrid()
+        prompt = mx.random.randint(0, 1000, (32,), dtype=mx.uint32)
+        c = model.make_cache()
+        model(prompt[None], cache=c)
+        mx.eval([x.state for x in c])
+        for x in c:
+            x.start_speculation()
+        chunk = mx.random.randint(0, 1000, (4,), dtype=mx.uint32)
+        model(chunk[None], cache=c)
+        arrays = next(x for x in c if isinstance(x, cache.ArraysCache))
+        with self.assertRaises(RuntimeError):
+            arrays.trim(10)  # only 4 tokens of rollback recorded
 
 
 if __name__ == "__main__":


### PR DESCRIPTION

Up front: I'm not a professional ML engineer and this was done with heavy AI
assistance — I've validated everything I could on-device (the matrix below is
all real measured runs), and I'd welcome expert scrutiny on anything I've missed.

Split of #1456 as @pierre427 proposed: this is the **rollback cache-API alone**
(the shared dependency), landed standalone. The qwen3.5 MTP-head loading follows
as a separate PR on top. Co-developed with @pierre427, who contributed the
`RotatingKVCache` support and reviews.

## What & why

Speculative decoding needs to rewind the KV/state cache when a draft is
rejected. mlx-lm's existing `--draft-model` path does this by `trim()`ing the
cache — but that **silently corrupts** any cache that isn't trimmable:
- **hybrid GDN/SSM models** (qwen3-next, qwen3.5): the GatedDeltaNet recurrent
  state (`ArraysCache`) has no valid `trim()` (#980, #1446) — a multi-token
  draft advances the recurrence and there is no way to undo it by truncation;
- **`RotatingKVCache`**: `trim()` only adjusts `offset`/`_idx`, it does **not**
  shrink the key buffer, so a multi-token block feed that crosses the sliding
  window leaves stale keys.

This PR adds an **exact** rollback protocol so speculative decoding is
lossless on these caches.

## The API (model-agnostic — proven on two cache families)

A small protocol on the cache objects: `start/stop_speculation()`,
`record_rollback(num_tokens, fn, snapshot)`, `is_trimmable()`, strict `trim()`.
Two independent implementations demonstrate the abstraction isn't cache-specific:

1. **GDN / ArraysCache** (lBroth): rollback by **exact state replay** — snapshot
   the pre-block `conv_state` + recurrent `S`, capture (via hooks) the exact
   tensors the GatedDeltaNet kernel consumed, and reconstruct `S_m` by re-running
   `gated_delta_update` on the committed prefix. Exact by construction (no
   approximation), because the recurrence can't be truncated.
2. **RotatingKVCache** (pierre427): rollback by **copying** the (≤ window) buffers
   at snapshot time, since `trim()` can't shrink them.

Same protocol, opposite mechanisms — that's the evidence the API is right.

## Correctness (the first thing you'll ask)

- Rollback is **exact**, not approximate. Contract tests assert token-for-token
  identity between speculative and non-speculative greedy decode.
- Losslessness bar: every emitted token equals the target's **batched-greedy
  argmax** at that position (the accept rule always commits the target's own
  token) — not bit-identity with sequential `generate_step`, which differs by
  inherent FP noise regardless of speculation.
- Tests: `tests/test_speculative_rollback.py` (8) + `tests/test_rotating_rollback.py`
  (4) — 12 total, all green. Cover cache-reuse across turns, early-close, and
  offset-exactness after each step.

## No overhead when unused, no regressions

- The path is inert unless speculation is active: `start_speculation()` is only
  called on the speculative branch; normal generation is byte-identical.
- Cross-hardware validation (fresh envs, python 3.13, mlx 0.31.2): M5 Pro 48GB /
  M2 Pro 16GB / M3 16GB / CPU(ops) — unit tests 15/15, cache regression 22/22
  (failure set ⊆ main's), real-weights e2e identical (80B Coder-Next + 0.8B
  draft, token-for-token vs non-speculative). No regressions found anywhere.

## Scope

Rollback cache-API + speculative wiring + GDN & RotatingKVCache support + tests.
**No** MTP head (separate follow-up). Diff is +639/-6 across 7 files.


