### PR TITLE
sample_utils: add make_reasoning_budget logits processor

### DIFF
--- a/mlx_lm/sample_utils.py
+++ b/mlx_lm/sample_utils.py
@@ -1,6 +1,7 @@
 # Copyright © 2023-2024 Apple Inc.
 
 import math
+from collections import Counter
 from functools import partial
 from typing import Callable, Dict, List, Optional
 
@@ -365,3 +366,132 @@ def make_frequency_penalty(penalty: float, context_size: int = 20):
         return logits
 
     return frequency_penalty_processor
+
+
+def _is_token_cycle(ids, max_cycle, min_span, window=800):
+    """True if the tail of ``ids`` is a period-``p`` cycle (1..max_cycle)
+    repeated back-to-back for at least ``min_span`` tokens. Decode-free and
+    not newline-aligned, so it catches loops in flowing prose that a
+    line-based check misses. ``min_span`` scales the required repeat count
+    with the cycle size (a 1-token cycle must repeat many times before it
+    counts, a longer phrase only a few)."""
+    t = ids[-window:]
+    n = len(t)
+    for p in range(1, min(max_cycle, n // 3) + 1):
+        block = t[-p:]
+        reps, i = 1, n - 2 * p
+        while i >= 0 and t[i : i + p] == block:
+            reps += 1
+            i -= p
+        if reps >= 3 and reps * p >= min_span:
+            return True
+    return False
+
+
+def _is_line_repetition(text, min_line=20, max_repeats=3):
+    """True if any substantive line (>= ``min_line`` chars) recurs at least
+    ``max_repeats`` times — the signature of a trace that found its point and
+    is now looping on it."""
+    counts = Counter(
+        ln.strip() for ln in (text or "").splitlines() if len(ln.strip()) >= min_line
+    )
+    return bool(counts) and counts.most_common(1)[0][1] >= max_repeats
+
+
+def make_reasoning_budget(
+    think_close: int,
+    max_think_tokens: int,
+    *,
+    think_open: Optional[int] = None,
+    tokenizer=None,
+    check_every: int = 16,
+    max_cycle: int = 80,
+    min_cycle_span: int = 30,
+):
+    """
+    Make a logits processor that bounds a runaway reasoning channel.
+
+    Reasoning models can enter a "thinking" channel and never leave it —
+    finding an answer, then looping or over-deliberating until the token cap,
+    yielding a long trace and no usable answer. Soft sampling pressure
+    (``repetition_penalty``) does not robustly bound this. This processor is a
+    hard, adaptive cap: it stays out of the way while the model reasons and
+    only intervenes — by forcing the ``think_close`` token, so generation
+    leaves the reasoning channel and produces an answer from what it has —
+    once the reasoning is provably running away.
+
+    A trip fires on any of:
+
+    * a hard budget of ``max_think_tokens`` spent inside the channel;
+    * a repeated token cycle in the tail of the channel (decode-free);
+    * a repeated substantive line (only if a ``tokenizer`` is given).
+
+    Args:
+        think_close (int): Token id that closes the reasoning channel; this is
+            what gets forced on a trip (e.g. the id of ``</think>``).
+        max_think_tokens (int): Hard ceiling on tokens spent inside the
+            channel before the close is forced.
+        think_open (int, optional): Token id that opens the channel. If
+            ``None``, generation is assumed to start inside the channel (as
+            with templates that open it for the model). Default: ``None``.
+        tokenizer (optional): If given, enables the decode-based line-repetition
+            detector. Only its ``decode`` method is used. Default: ``None``.
+        check_every (int): How often (in channel tokens) to run the loop
+            detectors. Default: ``16``.
+        max_cycle (int): Longest token-cycle period considered. Default: ``80``.
+        min_cycle_span (int): Minimum repeated span (in tokens) for a cycle to
+            count. Default: ``30``.
+
+    Returns:
+        Callable[[mx.array, mx.array], mx.array]: The logits processor. It
+        operates on a single sequence (as the other processors here do).
+    """
+    if max_think_tokens <= 0:
+        raise ValueError(f"max_think_tokens must be positive, got {max_think_tokens}")
+
+    state = {
+        "n": 0,  # tokens consumed from the running `tokens` array so far
+        "in_think": think_open is None,
+        "ids": [],  # ids seen inside the current channel
+        "since_check": 0,
+    }
+
+    def reasoning_budget_processor(tokens, logits):
+        new = tokens[state["n"] :].tolist()
+        state["n"] = len(tokens)
+        for tid in new:
+            if tid == think_close:
+                state["in_think"] = False
+                state["ids"] = []
+                state["since_check"] = 0
+            elif think_open is not None and tid == think_open:
+                state["in_think"] = True
+                state["ids"] = []
+                state["since_check"] = 0
+            elif state["in_think"]:
+                state["ids"].append(tid)
+
+        if not state["in_think"]:
+            return logits
+
+        ids = state["ids"]
+        trip = len(ids) >= max_think_tokens
+        if not trip:
+            state["since_check"] += len(new)
+            if state["since_check"] >= check_every:
+                state["since_check"] = 0
+                trip = _is_token_cycle(ids, max_cycle, min_cycle_span) or (
+                    tokenizer is not None
+                    and _is_line_repetition(tokenizer.decode(ids[-1500:]))
+                )
+
+        if not trip:
+            return logits
+
+        # Force the channel-close token: -inf everywhere else so the sampler
+        # (greedy or stochastic) must emit `think_close` next.
+        forced = mx.full(logits.shape, -float("inf"), dtype=logits.dtype)
+        forced[:, think_close] = 0.0
+        return forced
+
+    return reasoning_budget_processor

--- a/tests/test_sample_utils.py
+++ b/tests/test_sample_utils.py
@@ -1,3 +1,4 @@
+import math
 import unittest
 
 import mlx.core as mx
@@ -146,6 +147,93 @@ class TestSampleUtils(unittest.TestCase):
         # Tokens not in context not penalized
         self.assertAlmostEqual(result[0, 2].item(), 0.0)
         self.assertAlmostEqual(result[0, 3].item(), 0.0)
+
+    def test_reasoning_budget_hard_cap(self):
+        from mlx_lm.sample_utils import make_reasoning_budget
+
+        close, vocab = 5, 10
+        proc = make_reasoning_budget(think_close=close, max_think_tokens=8)
+        logits = mx.zeros((1, vocab))
+
+        toks = []
+        # 7 tokens inside the (implicitly open) channel: under budget, untouched
+        for i in range(7):
+            toks.append(i % 4)  # content ids, never the close id
+            out = proc(mx.array(toks), logits)
+            self.assertTrue(mx.all(out == logits).item())
+        # 8th token hits the budget -> close is forced
+        toks.append(3)
+        out = proc(mx.array(toks), logits)
+        self.assertEqual(int(mx.argmax(out[0]).item()), close)
+        self.assertEqual(out[0, close].item(), 0.0)
+        self.assertTrue(math.isinf(out[0, 0].item()))
+
+    def test_reasoning_budget_resets_on_natural_close(self):
+        from mlx_lm.sample_utils import make_reasoning_budget
+
+        proc = make_reasoning_budget(think_close=5, max_think_tokens=4)
+        logits = mx.zeros((1, 8))
+        toks = []
+        # Channel closes on its own after two tokens (id 5)...
+        for t in [0, 1, 5]:
+            toks.append(t)
+            proc(mx.array(toks), logits)
+        # ...so subsequent tokens are outside it and never trigger a force,
+        # even well past the budget.
+        for t in range(10):
+            toks.append(t % 3)
+            out = proc(mx.array(toks), logits)
+            self.assertTrue(mx.all(out == logits).item())
+
+    def test_reasoning_budget_open_token_gates(self):
+        from mlx_lm.sample_utils import make_reasoning_budget
+
+        proc = make_reasoning_budget(think_close=5, max_think_tokens=4, think_open=4)
+        logits = mx.zeros((1, 8))
+        toks = []
+        # Before the open token, content does not count toward the budget.
+        for _ in range(6):
+            toks.append(0)
+            out = proc(mx.array(toks), logits)
+            self.assertTrue(mx.all(out == logits).item())
+        # Open the channel, then 4 tokens hit the budget.
+        toks.append(4)
+        proc(mx.array(toks), logits)
+        forced = None
+        for i in range(4):
+            toks.append(i % 2)  # 0/1, not the open/close ids
+            forced = proc(mx.array(toks), logits)
+        self.assertEqual(int(mx.argmax(forced[0]).item()), 5)
+
+    def test_reasoning_budget_token_cycle(self):
+        from mlx_lm.sample_utils import make_reasoning_budget
+
+        proc = make_reasoning_budget(
+            think_close=5, max_think_tokens=10_000, check_every=4
+        )
+        logits = mx.zeros((1, 10))
+        toks, out = [], None
+        for _ in range(20):  # a period-2 loop that never terminates
+            toks += [7, 8]
+            out = proc(mx.array(toks), logits)
+        self.assertEqual(int(mx.argmax(out[0]).item()), 5)
+
+    def test_reasoning_budget_line_repetition(self):
+        from mlx_lm.sample_utils import make_reasoning_budget
+
+        class _Tok:
+            def decode(self, ids):
+                return "this is the same reasoning line\n" * 4
+
+        proc = make_reasoning_budget(
+            think_close=5, max_think_tokens=10_000, tokenizer=_Tok(), check_every=1
+        )
+        logits = mx.zeros((1, 10))
+        toks, out = [], None
+        for i in range(3):
+            toks.append(i)
+            out = proc(mx.array(toks), logits)
+        self.assertEqual(int(mx.argmax(out[0]).item()), 5)
 
     def test_make_logits_processors(self):
         from mlx_lm.sample_utils import make_logits_processors


### PR DESCRIPTION
## What

Adds `make_reasoning_budget(...)` to `sample_utils.py` — a logits processor that bounds a runaway reasoning channel.

## Why

Reasoning models routinely enter a thinking channel and never leave it: they find an answer, then loop or over-deliberate until the token cap, producing a long trace and no usable answer. In our testing this was the single dominant failure mode for reasoning models (e.g. a high-effort prompt burning a 14k-token cap in ~177s with no final answer). Soft sampling pressure does **not** reliably bound it — `repetition_penalty` is knife-edge (one value cures a case, a neighbor under-corrects or still runs away), because the problem is structural (never emitting the close token), not distributional.

The robust cure is a **hard, adaptive cap**: run normally while the model reasons, and only when the reasoning is provably running away, force the channel-close token so generation leaves the channel and answers from what it has. A trip fires on any of:
- a hard budget of `max_think_tokens` spent in the channel;
- a repeated token cycle in the channel tail (decode-free — catches loops in flowing prose);
- a repeated substantive line (only when a `tokenizer` is passed).

## Design

- Uses the existing `logits_processors` hook (`Callable[[tokens, logits], logits]`), so it composes with samplers and the other penalties and needs no changes to the generation loop.
- **Model-agnostic**: the caller passes the close (and optional open) token ids, so it works for any reasoning template — Qwen `</think>`, a harmony channel close, etc.
- **Opt-in**: intentionally *not* added to `make_logits_processors`, since it requires model-specific token ids. You add it explicitly.

```python
from mlx_lm.sample_utils import make_reasoning_budget

think_close = tokenizer.encode("</think>", add_special_tokens=False)[0]
processor = make_reasoning_budget(think_close, max_think_tokens=2000, tokenizer=tokenizer)

for resp in stream_generate(model, tokenizer, prompt, logits_processors=[processor]):
    ...
```

## Tests

`python -m unittest tests.test_sample_utils` — adds 5 cases (hard budget, reset on natural close, open-token gating, token-cycle, line-repetition); all pass. `black==25.1.0` and `isort --profile=black` clean.

## Notes

Happy to adjust naming, defaults, or scope — including moving it out of `sample_utils.py` if you'd prefer a separate module. The soft-landing "wrap up" nudge and answer-harvesting we use around this live in the serving layer and are intentionally out of scope here; this PR is just the core, reusable stopping primitive.
