### PR TITLE
Fix float32 promotion in BatchKVCache/BatchRotatingKVCache extend()

### DIFF
--- a/mlx_lm/models/cache.py
+++ b/mlx_lm/models/cache.py
@@ -1059,6 +1059,7 @@ class BatchKVCache(_BaseCache):
             B, H, L2, D = other.keys.shape
             M = other.values.shape[3]
         max_size = max(L1, L2)
+        dtype = (self.keys if self.keys is not None else other.keys).dtype
 
         # Pad the keys and values so they are right-justified
         # with the index and the same size
@@ -1066,8 +1067,8 @@ class BatchKVCache(_BaseCache):
             k, v = c.keys, c.values
             if k is None:
                 Bc = c.offset.shape[0]
-                k = mx.array([]).reshape(Bc, H, 0, D)
-                v = mx.array([]).reshape(Bc, H, 0, M)
+                k = mx.zeros((Bc, H, 0, D), dtype=dtype)
+                v = mx.zeros((Bc, H, 0, M), dtype=dtype)
             left = max_idx - c._idx
             right = max_size - k.shape[2] - left
             if right < 0:
@@ -1397,14 +1398,15 @@ class BatchRotatingKVCache(_BaseCache):
             B, H, L2, D = other.keys.shape
             M = other.values.shape[3]
         max_size = max(L1, L2)
+        dtype = (self.keys if self.keys is not None else other.keys).dtype
 
         def pad(c):
             left = max_idx - c._idx
             k, v = c.keys, c.values
             if k is None:
                 Bc = c.offset.shape[0]
-                k = mx.array([]).reshape(Bc, H, 0, D)
-                v = mx.array([]).reshape(Bc, H, 0, M)
+                k = mx.zeros((Bc, H, 0, D), dtype=dtype)
+                v = mx.zeros((Bc, H, 0, M), dtype=dtype)
             right = max_size - k.shape[2] - left
             if right < 0:
                 k = k[..., :right, :]

--- a/mlx_lm/models/cache.py
+++ b/mlx_lm/models/cache.py
@@ -1050,6 +1050,7 @@ class BatchKVCache(_BaseCache):
             B, H, L2, D = other.keys.shape
             M = other.values.shape[3]
         max_size = max(L1, L2)
+        dtype = (self.keys if self.keys is not None else other.keys).dtype
 
         # Pad the keys and values so they are right-justified
         # with the index and the same size
@@ -1057,8 +1058,8 @@ class BatchKVCache(_BaseCache):
             k, v = c.keys, c.values
             if k is None:
                 Bc = c.offset.shape[0]
-                k = mx.array([]).reshape(Bc, H, 0, D)
-                v = mx.array([]).reshape(Bc, H, 0, M)
+                k = mx.zeros((Bc, H, 0, D), dtype=dtype)
+                v = mx.zeros((Bc, H, 0, M), dtype=dtype)
             left = max_idx - c._idx
             right = max_size - k.shape[2] - left
             if right < 0:
@@ -1388,14 +1389,15 @@ class BatchRotatingKVCache(_BaseCache):
             B, H, L2, D = other.keys.shape
             M = other.values.shape[3]
         max_size = max(L1, L2)
+        dtype = (self.keys if self.keys is not None else other.keys).dtype
 
         def pad(c):
             left = max_idx - c._idx
             k, v = c.keys, c.values
             if k is None:
                 Bc = c.offset.shape[0]
-                k = mx.array([]).reshape(Bc, H, 0, D)
-                v = mx.array([]).reshape(Bc, H, 0, M)
+                k = mx.zeros((Bc, H, 0, D), dtype=dtype)
+                v = mx.zeros((Bc, H, 0, M), dtype=dtype)
             right = max_size - k.shape[2] - left
             if right < 0:
                 k = k[..., :right, :]

--- a/tests/test_prompt_cache.py
+++ b/tests/test_prompt_cache.py
@@ -718,6 +718,37 @@ class TestPromptCache(unittest.TestCase):
         self.assertEqual(batch_full.keys.shape[0], 5)
         self.assertEqual(batch_full.offset.shape[0], 5)
 
+    def test_extend_with_empty_batch_cache_preserves_dtype(self):
+        """Extending a batch cache when one side has keys=None should keep the
+        dtype of the non-empty side. The placeholder used to default to
+        float32, so mx.concatenate silently promoted the whole K/V cache."""
+        H, D = 8, 64
+
+        def make_batch(cls, n, with_content, **kwargs):
+            caches = [cls(**kwargs) for _ in range(n)]
+            if with_content:
+                for c in caches:
+                    kv = mx.ones((1, H, 5, D), mx.bfloat16)
+                    c.update_and_fetch(kv, kv)
+            if cls is RotatingKVCache:
+                return BatchRotatingKVCache.merge(caches)
+            return BatchKVCache.merge(caches)
+
+        for cls, kwargs in ((KVCache, {}), (RotatingKVCache, {"max_size": 512})):
+            # Non-empty extended with empty (new sequence joins a batch)
+            batch = make_batch(cls, 2, True, **kwargs)
+            empty = make_batch(cls, 1, False, **kwargs)
+            batch.extend(empty)
+            self.assertEqual(batch.keys.dtype, mx.bfloat16)
+            self.assertEqual(batch.values.dtype, mx.bfloat16)
+
+            # Empty extended with non-empty
+            empty = make_batch(cls, 1, False, **kwargs)
+            batch = make_batch(cls, 2, True, **kwargs)
+            empty.extend(batch)
+            self.assertEqual(empty.keys.dtype, mx.bfloat16)
+            self.assertEqual(empty.values.dtype, mx.bfloat16)
+
     def test_arrays_cache_extend_with_empty(self):
         # test simple merge
         c1 = ArraysCache(2)

--- a/tests/test_prompt_cache.py
+++ b/tests/test_prompt_cache.py
@@ -717,6 +717,37 @@ class TestPromptCache(unittest.TestCase):
         self.assertEqual(batch_full.keys.shape[0], 5)
         self.assertEqual(batch_full.offset.shape[0], 5)
 
+    def test_extend_with_empty_batch_cache_preserves_dtype(self):
+        """Extending a batch cache when one side has keys=None should keep the
+        dtype of the non-empty side. The placeholder used to default to
+        float32, so mx.concatenate silently promoted the whole K/V cache."""
+        H, D = 8, 64
+
+        def make_batch(cls, n, with_content, **kwargs):
+            caches = [cls(**kwargs) for _ in range(n)]
+            if with_content:
+                for c in caches:
+                    kv = mx.ones((1, H, 5, D), mx.bfloat16)
+                    c.update_and_fetch(kv, kv)
+            if cls is RotatingKVCache:
+                return BatchRotatingKVCache.merge(caches)
+            return BatchKVCache.merge(caches)
+
+        for cls, kwargs in ((KVCache, {}), (RotatingKVCache, {"max_size": 512})):
+            # Non-empty extended with empty (new sequence joins a batch)
+            batch = make_batch(cls, 2, True, **kwargs)
+            empty = make_batch(cls, 1, False, **kwargs)
+            batch.extend(empty)
+            self.assertEqual(batch.keys.dtype, mx.bfloat16)
+            self.assertEqual(batch.values.dtype, mx.bfloat16)
+
+            # Empty extended with non-empty
+            empty = make_batch(cls, 1, False, **kwargs)
+            batch = make_batch(cls, 2, True, **kwargs)
+            empty.extend(batch)
+            self.assertEqual(empty.keys.dtype, mx.bfloat16)
+            self.assertEqual(empty.values.dtype, mx.bfloat16)
+
     def test_arrays_cache_extend_with_empty(self):
         # test simple merge
         c1 = ArraysCache(2)


### PR DESCRIPTION
When a new sequence is inserted into a running batch, `extend()` creates the placeholder for the empty side with `mx.array([]).reshape(...)`, which is float32. The `mx.concatenate` right after then promotes the whole merged K/V buffer to float32.

That doubles KV memory for the batch, and it also makes generation depend on scheduling: whether a given request runs attention against bf16 or fp32 K/V depends on whether another request happened to join its batch mid-flight. For most models the numeric difference is negligible, but I hit this with a model with large activation outliers where it flips entire generations — same prompt, temp 0, different output depending on batch insertion order. Took a while to track down.

Repro:

```python
import mlx.core as mx
from mlx_lm.models.cache import BatchKVCache, KVCache

c = KVCache()
kv = mx.ones((1, 8, 5, 64), mx.bfloat16)
c.update_and_fetch(kv, kv)
batch = BatchKVCache.merge([c])
print(batch.keys.dtype)  # bfloat16

batch.extend(BatchKVCache.merge([KVCache()]))  # a new sequence joins the batch
print(batch.keys.dtype)  # float32 before this fix
```

The fix creates the placeholder with the dtype of the non-empty side, which is how `merge()` and `ArraysCache.extend()` already handle it (the both-None case returns early, so one side always has keys). Same change in `BatchRotatingKVCache.extend`.

Added a regression test in `tests/test_prompt_cache.py` covering both cache classes and both extend directions; it fails on current main. `test_prompt_cache.py` and `test_generate.py` both pass with the fix.
