### PR TITLE
Fix LRUPromptCache: return one-token prefix matches and refresh LRU recency on fetch

### DIFF
--- a/mlx_lm/models/cache.py
+++ b/mlx_lm/models/cache.py
@@ -1599,7 +1599,7 @@ class PromptTrie:
 
         # Check if we found a prefix at any point
         shorter = None
-        if last_index > 0:
+        if last_index >= 0:
             shorter = tokens[: last_index + 1]
 
         # Check for sequences that are longer
@@ -1646,6 +1646,16 @@ class LRUPromptCache:
                 except ValueError:
                     pass
 
+        def touch(self, model: Any, tokens: List[Any]):
+            for cache_type in self._ordering:
+                lru = self._lrus[cache_type]
+                try:
+                    lru.remove((model, tokens))
+                except ValueError:
+                    continue
+                lru.append((model, tokens))
+                break
+
         def pop(self):
             i = 0
             while i + 1 < len(self._ordering):
@@ -1675,6 +1685,7 @@ class LRUPromptCache:
         result = self._trie.search(model, tokens)
         if result.exact is not None:
             cache_entry = self._trie.get(result.model, result.exact)
+            self._lru.touch(result.model, result.exact)
             return copy.deepcopy(cache_entry.prompt_cache), []
 
         short_length = len(result.shorter) if result.shorter is not None else 0
@@ -1685,10 +1696,12 @@ class LRUPromptCache:
                 prefix = min(len(tokens) - 1, result.common_prefix)
                 num_to_trim = len(result.longer) - prefix
                 trim_prompt_cache(cache, num_to_trim)
+                self._lru.touch(result.model, result.longer)
                 return cache, tokens[prefix:]
 
         if short_length > 0:
             cache_entry = self._trie.get(result.model, result.shorter)
+            self._lru.touch(result.model, result.shorter)
             return copy.deepcopy(cache_entry.prompt_cache), tokens[short_length:]
 
         return None, tokens

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -73,22 +73,29 @@ class DummyModelProvider:
 
 
 class MockCache:
-    def __init__(self, value, is_trimmable: bool = True):
-        self.value = value
+    """A mock KV cache whose state is the list of tokens it was computed from,
+    so tests can check that a fetched cache's contents match the tokens it is
+    keyed and served under."""
+
+    def __init__(self, tokens, is_trimmable: bool = True):
+        self.tokens = list(tokens)
         self._is_trimmable = is_trimmable
 
     @property
     def nbytes(self):
-        return len(self.value)
+        return len(self.tokens)
 
     def __eq__(self, other):
-        return other.value == self.value
+        return other.tokens == self.tokens
 
     def is_trimmable(self):
         return self._is_trimmable
 
     def trim(self, n):
         assert self._is_trimmable
+        n = min(n, len(self.tokens))
+        if n > 0:
+            self.tokens = self.tokens[:-n]
         return n
 
 
@@ -571,71 +578,107 @@ class TestLRUPromptCache(unittest.TestCase):
     def test_lru(self):
         cache = LRUPromptCache(max_size=2)
         model = ("test", None, None)
-        cache.insert_cache(model, [1, 2], [MockCache("test1")])
-        cache.insert_cache(model, [2, 3], [MockCache("test2")])
+        cache.insert_cache(model, [1, 2], [MockCache([1, 2])])
+        cache.insert_cache(model, [2, 3], [MockCache([2, 3])])
 
         c, t = cache.fetch_nearest_cache(model, [1, 2])
-        self.assertEqual(c, [MockCache("test1")])
+        self.assertEqual(c, [MockCache([1, 2])])
         self.assertEqual(t, [])
         c, t = cache.fetch_nearest_cache(model, [1])
-        self.assertEqual(c, [MockCache("test1")])
+        self.assertEqual(c, [MockCache([])])
         self.assertEqual(t, [1])
         c, t = cache.fetch_nearest_cache(model, [1, 3, 4])
-        self.assertEqual(c, [MockCache("test1")])
+        self.assertEqual(c, [MockCache([1])])
         self.assertEqual(t, [3, 4])
         c, t = cache.fetch_nearest_cache(model, [2, 3, 4])
-        self.assertEqual(c, [MockCache("test2")])
+        self.assertEqual(c, [MockCache([2, 3])])
         self.assertEqual(t, [4])
         c, t = cache.fetch_nearest_cache(model, [2, 4, 5])
-        self.assertEqual(c, [MockCache("test2")])
+        self.assertEqual(c, [MockCache([2])])
         self.assertEqual(t, [4, 5])
 
-        cache.insert_cache(model, [1, 2], [MockCache("test1")])
-        cache.insert_cache(model, [2, 3], [MockCache("test2")])
-        cache.insert_cache(model, [3, 4], [MockCache("test3")])
+        cache.insert_cache(model, [1, 2], [MockCache([1, 2])])
+        cache.insert_cache(model, [2, 3], [MockCache([2, 3])])
+        cache.insert_cache(model, [3, 4], [MockCache([3, 4])])
 
         c, t = cache.fetch_nearest_cache(model, [1, 2])
         self.assertEqual(c, None)
         self.assertEqual(t, [1, 2])
         c, t = cache.fetch_nearest_cache(model, [2, 3])
-        self.assertEqual(c, [MockCache("test2")])
+        self.assertEqual(c, [MockCache([2, 3])])
         self.assertEqual(t, [])
         c, t = cache.fetch_nearest_cache(model, [3, 4])
-        self.assertEqual(c, [MockCache("test3")])
+        self.assertEqual(c, [MockCache([3, 4])])
         self.assertEqual(t, [])
 
-        cache.insert_cache(model, [4, 5], [MockCache("test4")], cache_type="user")
+        cache.insert_cache(model, [4, 5], [MockCache([4, 5])], cache_type="user")
         c, t = cache.fetch_nearest_cache(model, [2, 3])
         self.assertEqual(c, None)
         self.assertEqual(t, [2, 3])
         c, t = cache.fetch_nearest_cache(model, [3, 4])
-        self.assertEqual(c, [MockCache("test3")])
+        self.assertEqual(c, [MockCache([3, 4])])
         self.assertEqual(t, [])
         c, t = cache.fetch_nearest_cache(model, [4, 5])
-        self.assertEqual(c, [MockCache("test4")])
+        self.assertEqual(c, [MockCache([4, 5])])
         self.assertEqual(t, [])
 
-        cache.insert_cache(model, [5, 6], [MockCache("test5")])
-        cache.insert_cache(model, [6, 7], [MockCache("test6")])
+        cache.insert_cache(model, [5, 6], [MockCache([5, 6])])
+        cache.insert_cache(model, [6, 7], [MockCache([6, 7])])
         c, t = cache.fetch_nearest_cache(model, [5, 6])
         self.assertEqual(c, None)
         self.assertEqual(t, [5, 6])
         c, t = cache.fetch_nearest_cache(model, [6, 7])
-        self.assertEqual(c, [MockCache("test6")])
+        self.assertEqual(c, [MockCache([6, 7])])
         self.assertEqual(t, [])
         c, t = cache.fetch_nearest_cache(model, [4, 5])
-        self.assertEqual(c, [MockCache("test4")])
+        self.assertEqual(c, [MockCache([4, 5])])
         self.assertEqual(t, [])
+
+    def test_lru_one_token_prefix(self):
+        cache = LRUPromptCache(max_size=10)
+        model = ("test", None, None)
+
+        # A cached one-token prefix should be reusable, also for caches that
+        # cannot be trimmed (which can only be reused via prefix matches).
+        cache.insert_cache(model, [7], [MockCache([7], is_trimmable=False)])
+        c, t = cache.fetch_nearest_cache(model, [7, 8, 9])
+        self.assertEqual(c, [MockCache([7])])
+        self.assertEqual(t, [8, 9])
+
+    def test_lru_fetch_refreshes_recency(self):
+        cache = LRUPromptCache(max_size=2)
+        model = ("test", None, None)
+
+        cache.insert_cache(model, [1, 2], [MockCache([1, 2])])
+        cache.insert_cache(model, [3, 4], [MockCache([3, 4])])
+
+        # Fetching [1, 2] makes it the most recently used entry, so inserting
+        # a third entry should evict [3, 4] instead.
+        cache.fetch_nearest_cache(model, [1, 2])
+        cache.insert_cache(model, [5, 6], [MockCache([5, 6])])
+        c, _ = cache.fetch_nearest_cache(model, [1, 2])
+        self.assertEqual(c, [MockCache([1, 2])])
+        c, t = cache.fetch_nearest_cache(model, [3, 4])
+        self.assertEqual(c, None)
+        self.assertEqual(t, [3, 4])
+
+        # Partial (shorter/longer) hits refresh recency as well.
+        cache.fetch_nearest_cache(model, [1, 2, 9])
+        cache.insert_cache(model, [7, 8], [MockCache([7, 8])])
+        c, _ = cache.fetch_nearest_cache(model, [1, 2])
+        self.assertEqual(c, [MockCache([1, 2])])
+        c, _ = cache.fetch_nearest_cache(model, [5, 6])
+        self.assertEqual(c, None)
 
     def test_insert_trimmable_cache_removes_immediate_prefix(self):
         cache = LRUPromptCache(max_size=10)
         model = ("test", None, None)
 
-        cache.insert_cache(model, [1, 2], [MockCache("ab")])
+        cache.insert_cache(model, [1, 2], [MockCache([1, 2])])
         self.assertEqual(len(cache), 1)
         self.assertEqual(cache.nbytes, 2)
 
-        cache.insert_cache(model, [1, 2, 3], [MockCache("abc")])
+        cache.insert_cache(model, [1, 2, 3], [MockCache([1, 2, 3])])
         self.assertEqual(len(cache), 1)
         self.assertEqual(cache.nbytes, 3)
 
@@ -643,9 +686,9 @@ class TestLRUPromptCache(unittest.TestCase):
         cache = LRUPromptCache(max_size=10)
         model = ("test", None, None)
 
-        cache.insert_cache(model, [], [MockCache("root")])
+        cache.insert_cache(model, [], [MockCache([])])
         self.assertEqual(len(cache), 1)
-        self.assertEqual(cache.nbytes, 4)
+        self.assertEqual(cache.nbytes, 0)
 
         c, t = cache.fetch_nearest_cache(model, [])
         self.assertIsNotNone(c)
@@ -655,8 +698,8 @@ class TestLRUPromptCache(unittest.TestCase):
         cache = LRUPromptCache(max_size=10)
         model = ("test", None, None)
 
-        cache.insert_cache(model, [], [MockCache("root")])
-        cache.insert_cache(model, [1], [MockCache("a")])
+        cache.insert_cache(model, [], [MockCache([])])
+        cache.insert_cache(model, [1], [MockCache([1])])
 
         c, t = cache.fetch_nearest_cache(model, [])
         self.assertIsNone(c)
@@ -666,10 +709,10 @@ class TestLRUPromptCache(unittest.TestCase):
         cache = LRUPromptCache(max_size=100, max_bytes=10)
         model = ("test", None, None)
 
-        cache.insert_cache(model, [1, 2], [MockCache("aaa")])
-        cache.insert_cache(model, [3, 4], [MockCache("bbb")])
-        cache.insert_cache(model, [4, 5], [MockCache("ccc")])
-        cache.insert_cache(model, [6, 7], [MockCache("ddd")])
+        cache.insert_cache(model, [1, 2, 3], [MockCache([1, 2, 3])])
+        cache.insert_cache(model, [4, 5, 6], [MockCache([4, 5, 6])])
+        cache.insert_cache(model, [7, 8, 9], [MockCache([7, 8, 9])])
+        cache.insert_cache(model, [10, 11, 12], [MockCache([10, 11, 12])])
 
         self.assertEqual(len(cache), 3)
         self.assertEqual(cache.nbytes, 9)
@@ -678,12 +721,12 @@ class TestLRUPromptCache(unittest.TestCase):
         self.assertEqual(len(cache), 2)
         self.assertEqual(cache.nbytes, 6)
 
-        c, t = cache.fetch_nearest_cache(model, [1, 2])
+        c, t = cache.fetch_nearest_cache(model, [1, 2, 3])
         self.assertEqual(c, None)
-        self.assertEqual(t, [1, 2])
-        c, t = cache.fetch_nearest_cache(model, [3, 4])
+        self.assertEqual(t, [1, 2, 3])
+        c, t = cache.fetch_nearest_cache(model, [4, 5, 6])
         self.assertEqual(c, None)
-        self.assertEqual(t, [3, 4])
+        self.assertEqual(t, [4, 5, 6])
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Fixes #1495.

Two small fixes in the server's `LRUPromptCache`, plus a `MockCache` upgrade so the tests can catch this class of bug:

1. **`PromptTrie.search` never returned a one-token prefix match.** `last_index` is the index of the deepest node holding a value (`-1` = none), so a stored one-token key matches at `last_index == 0` and the shorter-prefix check needs `>= 0`, not `> 0`. Before this change the entry leaked out as `longer=[t]` instead, which the longer branch happens to serve for trimmable caches (deepcopy + trim 0) — but for non-trimmable caches the entry was unreachable: the longer branch is skipped and the fetch returned `(None, tokens)`, a full recompute of a cached prefix.

2. **Fetches never refreshed recency, so eviction was FIFO, not LRU.** `CacheOrder` only recorded insertion order and `fetch_nearest_cache` never touched it, so a hot entry (e.g. a shared system prompt) could be evicted while cold entries survived. `fetch_nearest_cache` now refreshes the hit entry's position on exact, shorter, and longer hits via a new `CacheOrder.touch`. The per-type eviction priority is unchanged.

3. **`MockCache` now has real content semantics**: its state is the token list it was computed from, `trim()` actually slices it and returns the true trimmed count, and `__eq__` compares content. The existing `test_lru` assertions now verify that a fetched cache's contents match the tokens it is served under (previously `trim()` was a no-op and `__eq__` compared an opaque value, so trie navigation was tested but key↔state correspondence was not). Existing tests updated accordingly; two regression tests added (`test_lru_one_token_prefix`, `test_lru_fetch_refreshes_recency`).

Both defects and the repros are described in detail in #1495. `python -m unittest tests.test_server.TestLRUPromptCache` passes (8 tests); `black` clean.
