### PR TITLE
Text-based state machine

### DIFF
--- a/mlx_lm/generate.py
+++ b/mlx_lm/generate.py
@@ -10,16 +10,7 @@ import time
 from collections import deque
 from dataclasses import dataclass
 from functools import partial
-from typing import (
-    Any,
-    Callable,
-    Generator,
-    List,
-    Optional,
-    Sequence,
-    Tuple,
-    Union,
-)
+from typing import Any, Callable, Generator, List, Optional, Sequence, Tuple, Union
 
 import mlx.core as mx
 import mlx.nn as nn
@@ -940,65 +931,158 @@ def _step_trie(node, trie, x):
     return node
 
 
-class SequenceStateMachine:
-    """A state machine that uses one Aho-Corasick trie per state to efficiently
-    track state across a generated sequence.
+class StopSequenceMatcher:
+    """Detect stop sequences in a stream of tokens using an Aho-Corasick trie.
 
-    The transitions are provided as state -> [(sequence, new_state)].
-
-    Example:
-
-        sm = SequenceStateMachine(
-            transitions={
-                "normal": [
-                    (think_start_tokens, "reasoning"),
-                    (tool_start_tokens, "tool"),
-                    (eos, None),
-                ],
-                "reasoning": [
-                    (think_end_tokens, "normal"),
-                    (eos, None),
-                ],
-                "tool": [
-                    (tool_end_tokens, None),
-                    (eos, None)
-                ],
-            },
-            initial="normal"
-        )
+    Any matched sequence signals stop. Used by the batch generator for EOS and
+    stop word detection.
     """
 
-    def __init__(self, transitions={}, initial="normal"):
-        self._initial = initial
-        self._states = {}
-        for src, edges in transitions.items():
-            sequences, dst = zip(*edges)
-            self._states[src] = (_build_trie(sequences), dst)
-        if not self._states:
-            self._states[initial] = (_build_trie([]), [])
+    def __init__(self, stop_sequences=None):
+        self._trie = _build_trie(stop_sequences) if stop_sequences else {}
 
     def __deepcopy__(self, memo):
-        new = object.__new__(SequenceStateMachine)
-        new._initial = self._initial
-        new._states = self._states
+        new = object.__new__(StopSequenceMatcher)
+        new._trie = self._trie
         return new
 
     def make_state(self):
-        return (self._initial, self._states[self._initial][0], self._states)
+        return self._trie
 
     @staticmethod
-    def match(state, x):
-        s, n, states = state
-        n = _step_trie(n, states[s][0], x)
+    def match(state, trie, x):
+        """Advance by one token. Returns (new_state, matched)."""
+        node = _step_trie(state, trie, x)
+        return node, node.get("__match__") is not None
 
-        seq = None
-        match = n.get("__match__")
-        if match is not None:
-            seq = match[0]
-            s = states[s][1][match[1]]
-            n = states[s][0] if s is not None else None
 
-        return (s, n, states), seq, s
+class TextStateMachine:
+    """A state machine that matches decoded text to track state transitions
+    (reasoning, tool calling) and strip the matched control sequences from the
+    output.
+
+    Transitions are provided as state -> [(text, new_state)]. Matching on text
+    rather than token ids is robust to tokenization differences (e.g. a
+    marker's trailing ``>`` being merged with the following byte).
+
+    The runtime state carries a buffer holding text that might be part of a
+    control sequence. Text is only emitted once it is known not to be part of
+    any match.
+
+    Example:
+
+        sm = TextStateMachine(
+            transitions={
+                "normal": [("<think>", "reasoning"), ("<tool_call>", "tool")],
+                "reasoning": [("</think>", "normal")],
+                "tool": [("</tool_call>", "normal")],
+            },
+        )
+        state = sm.make_state(initial="normal")
+    """
+
+    def __init__(self, transitions=None):
+        self._states = {}
+        for src, edges in (transitions or {}).items():
+            strings, dst = zip(*edges) if edges else ([], [])
+            self._states[src] = (_build_trie(strings), dst)
+
+    def make_state(self, initial="normal"):
+        """Create a fresh runtime state (state_name, trie_node, states, buffer)."""
+        if initial not in self._states:
+            self._states[initial] = (_build_trie([]), [])
+        return (initial, self._states[initial][0], self._states, "")
+
+    @staticmethod
+    def step(state, text):
+        """Consume a chunk of decoded text.
+
+        Returns (new_state, emittable_text, current_state_name) where
+        emittable_text is the text safe to show (control sequences stripped,
+        possible partial matches held back in the buffer).
+        """
+        s, n, states, buf = state
+        buf += text
+        trie = states[s][0]
+        emittable = ""
+        # buf[:consumed] has been emitted or discarded; buf[consumed:] pending.
+        consumed = 0
+
+        for i in range(len(buf)):
+            ch = buf[i]
+            while ch not in n and n is not trie:
+                n = n["__fail__"]
+            if ch in n:
+                n = n[ch]
+
+            match = n.get("__match__")
+            if match is not None:
+                match_start = i + 1 - len(match[0])
+                emittable += buf[consumed:match_start]
+                consumed = i + 1
+                s = states[s][1][match[1]]
+                if s is None:
+                    return (s, None, states, buf[consumed:]), emittable, s
+                trie = states[s][0]
+                n = trie
+            elif n is trie:
+                # At the root: no partial match in progress, everything is safe.
+                emittable += buf[consumed : i + 1]
+                consumed = i + 1
+
+        return (s, n, states, buf[consumed:]), emittable, s
+
+    @staticmethod
+    def flush(state):
+        """Emit the remaining buffer (use on finish_reason="length")."""
+        s, n, states, buf = state
+        trie = states[s][0] if s is not None else None
+        return (s, trie, states, ""), buf, s
+
+    @staticmethod
+    def discard(state):
+        """Drop the remaining buffer (use on finish_reason="stop")."""
+        s, n, states, buf = state
+        trie = states[s][0] if s is not None else None
+        return (s, trie, states, ""), s
+
+
+def make_stop_matcher(tokenizer, stop_words=None):
+    """Build a StopSequenceMatcher from EOS tokens and stop words."""
+    stop_sequences = [(t,) for t in tokenizer.eos_token_ids]
+    for w in stop_words or []:
+        stop_sequences.append(tuple(tokenizer.encode(w, add_special_tokens=False)))
+    return StopSequenceMatcher(stop_sequences)
+
+
+def make_text_state_machine(tokenizer, stop_words=None):
+    """Build a TextStateMachine with reasoning/tool transitions and stop words.
+
+    Stop words are added as self-transitions in every state so they are
+    stripped from the output without changing state.
+    """
+    transitions = {}
+
+    if tokenizer.has_thinking:
+        transitions.setdefault("normal", []).append(
+            (tokenizer.think_start, "reasoning")
+        )
+        transitions["reasoning"] = [(tokenizer.think_end, "normal")]
+
+    if tokenizer.has_tool_calling:
+        transitions.setdefault("normal", []).append((tokenizer.tool_call_start, "tool"))
+        if tokenizer.has_thinking:
+            transitions["reasoning"].append((tokenizer.tool_call_start, "tool"))
+        transitions["tool"] = (
+            [(tokenizer.tool_call_end, "normal")] if tokenizer.tool_call_end else []
+        )
+
+    if stop_words:
+        for state_name in set(transitions) | {"normal"}:
+            for w in stop_words:
+                transitions.setdefault(state_name, []).append((w, state_name))
+
+    return TextStateMachine(transitions or None)
 
 
 class PromptProcessingBatch:
@@ -1028,7 +1112,7 @@ class PromptProcessingBatch:
         logits_processors: Optional[
             List[List[Callable[[mx.array, mx.array], mx.array]]]
         ] = None,
-        state_machines: Optional[List[SequenceStateMachine]] = None,
+        stop_matchers: Optional[List[StopSequenceMatcher]] = None,
         max_tokens: Optional[List[int]] = None,
     ):
         self.model = model
@@ -1042,10 +1126,10 @@ class PromptProcessingBatch:
         self.logits_processors = (
             logits_processors if logits_processors is not None else []
         )
-        self.state_machines = (
-            state_machines
-            if state_machines is not None
-            else [SequenceStateMachine()] * len(uids)
+        self.stop_matchers = (
+            stop_matchers
+            if stop_matchers is not None
+            else [StopSequenceMatcher()] * len(uids)
         )
         self.max_tokens = (
             max_tokens
@@ -1077,7 +1161,7 @@ class PromptProcessingBatch:
         self.samplers.extend(samplers)
         self.logits_processors.extend(logits_processors)
         self.max_tokens.extend(batch.max_tokens)
-        self.state_machines.extend(batch.state_machines)
+        self.stop_matchers.extend(batch.stop_matchers)
 
     def _copy(self):
         new_batch = self.__class__.__new__(self.__class__)
@@ -1089,7 +1173,7 @@ class PromptProcessingBatch:
         new_batch.samplers = list(self.samplers)
         new_batch.fallback_sampler = self.fallback_sampler
         new_batch.logits_processors = list(self.logits_processors)
-        new_batch.state_machines = list(self.state_machines)
+        new_batch.stop_matchers = list(self.stop_matchers)
         new_batch.max_tokens = list(self.max_tokens)
         return new_batch
 
@@ -1119,7 +1203,7 @@ class PromptProcessingBatch:
         else:
             self.logits_processors = [[]] * len(keep)
         self.max_tokens = [self.max_tokens[idx] for idx in keep]
-        self.state_machines = [self.state_machines[idx] for idx in keep]
+        self.stop_matchers = [self.stop_matchers[idx] for idx in keep]
 
     def prompt(self, tokens: List[List[int]]):
         """
@@ -1192,7 +1276,7 @@ class PromptProcessingBatch:
             self.samplers,
             self.fallback_sampler,
             self.logits_processors,
-            self.state_machines,
+            self.stop_matchers,
             self.max_tokens,
         )
 
@@ -1222,7 +1306,7 @@ class PromptProcessingBatch:
             samplers=[],
             logits_processors=[],
             max_tokens=[],
-            state_machines=[],
+            stop_matchers=[],
         )
 
 
@@ -1240,8 +1324,6 @@ class GenerationBatch:
         token: int
         logprobs: mx.array
         finish_reason: Optional[str]
-        current_state: Optional[str]
-        match_sequence: Optional[List[int]]
         prompt_cache: Optional[List[Any]]
         all_tokens: Optional[List[int]]
 
@@ -1257,7 +1339,7 @@ class GenerationBatch:
         logits_processors: Optional[
             List[List[Callable[[mx.array, mx.array], mx.array]]]
         ],
-        state_machines: List[SequenceStateMachine],
+        stop_matchers: List[StopSequenceMatcher],
         max_tokens: List[int],
     ):
         self.model = model
@@ -1268,7 +1350,7 @@ class GenerationBatch:
         self.samplers = samplers
         self.fallback_sampler = fallback_sampler
         self.logits_processors = logits_processors
-        self.state_machines = state_machines
+        self.stop_matchers = stop_matchers
         self.max_tokens = max_tokens
 
         if self.samplers and len(self.samplers) != len(self.uids):
@@ -1282,7 +1364,7 @@ class GenerationBatch:
         self._next_logprobs = []
         self._token_context = [TokenBuffer(t) for t in tokens]
         self._num_tokens = [0] * len(self.uids)
-        self._matcher_states = [m.make_state() for m in state_machines]
+        self._matcher_states = [m.make_state() for m in stop_matchers]
 
         if self.uids:
             self._step()
@@ -1298,7 +1380,7 @@ class GenerationBatch:
         self.samplers.extend(batch.samplers)
         self.logits_processors.extend(batch.logits_processors)
         self.max_tokens.extend(batch.max_tokens)
-        self.state_machines.extend(batch.state_machines)
+        self.stop_matchers.extend(batch.stop_matchers)
         if self._current_tokens is None:
             self._current_tokens = batch._current_tokens
             self._current_logprobs = batch._current_logprobs
@@ -1394,7 +1476,7 @@ class GenerationBatch:
         if any(self.logits_processors):
             self.logits_processors = [self.logits_processors[idx] for idx in keep]
         self.max_tokens = [self.max_tokens[idx] for idx in keep]
-        self.state_machines = [self.state_machines[idx] for idx in keep]
+        self.stop_matchers = [self.stop_matchers[idx] for idx in keep]
 
         self._next_tokens = self._next_tokens[keep] if keep else None
         self._next_logprobs = [self._next_logprobs[idx] for idx in keep]
@@ -1418,16 +1500,17 @@ class GenerationBatch:
         responses = []
         for i in range(len(self.uids)):
             finish_reason = None
-            match_sequence = None
 
             self._num_tokens[i] += 1
             if self._num_tokens[i] >= self.max_tokens[i]:
                 finish_reason = "length"
 
-            self._matcher_states[i], match_sequence, current_state = (
-                self.state_machines[i].match(self._matcher_states[i], tokens[i])
+            self._matcher_states[i], matched = StopSequenceMatcher.match(
+                self._matcher_states[i],
+                self.stop_matchers[i]._trie,
+                tokens[i],
             )
-            if match_sequence is not None and current_state is None:
+            if matched:
                 finish_reason = "stop"
 
             if finish_reason is not None:
@@ -1437,8 +1520,6 @@ class GenerationBatch:
                         token=tokens[i],
                         logprobs=logprobs[i],
                         finish_reason=finish_reason,
-                        current_state=current_state,
-                        match_sequence=match_sequence,
                         prompt_cache=self.extract_cache(i),
                         all_tokens=self.tokens[i],
                     )
@@ -1451,8 +1532,6 @@ class GenerationBatch:
                         token=tokens[i],
                         logprobs=logprobs[i],
                         finish_reason=None,
-                        match_sequence=match_sequence,
-                        current_state=current_state,
                         prompt_cache=None,
                         all_tokens=None,
                     )
@@ -1479,7 +1558,7 @@ class GenerationBatch:
             samplers=[],
             logits_processors=[],
             max_tokens=[],
-            state_machines=[],
+            stop_matchers=[],
         )
 
 
@@ -1522,9 +1601,8 @@ class BatchGenerator:
 
         self._stream = stream or generation_stream
 
-        self._default_state_machine = SequenceStateMachine(
-            {"normal": [(seq, None) for seq in stop_tokens]} if stop_tokens else {},
-            initial="normal",
+        self._default_stop_matcher = StopSequenceMatcher(
+            stop_tokens if stop_tokens else None,
         )
         self._uid_count = 0
         self._prompt_batch = PromptProcessingBatch.empty(
@@ -1592,7 +1670,7 @@ class BatchGenerator:
         logits_processors: Optional[
             List[List[Callable[[mx.array, mx.array], mx.array]]]
         ] = None,
-        state_machines: Optional[List[SequenceStateMachine]] = None,
+        stop_matchers: Optional[List[StopSequenceMatcher]] = None,
     ):
         return self.insert_segments(
             [[p] for p in prompts],
@@ -1601,7 +1679,7 @@ class BatchGenerator:
             all_tokens,
             samplers,
             logits_processors,
-            state_machines,
+            stop_matchers,
         )
 
     def insert_segments(
@@ -1614,7 +1692,7 @@ class BatchGenerator:
         logits_processors: Optional[
             List[List[Callable[[mx.array, mx.array], mx.array]]]
         ] = None,
-        state_machines: Optional[List[SequenceStateMachine]] = None,
+        stop_matchers: Optional[List[StopSequenceMatcher]] = None,
     ):
         uids = []
 
@@ -1624,9 +1702,7 @@ class BatchGenerator:
         logits_processors = logits_processors or (
             [self.logits_processors] * len(segments)
         )
-        state_machines = state_machines or (
-            [self._default_state_machine] * len(segments)
-        )
+        stop_matchers = stop_matchers or ([self._default_stop_matcher] * len(segments))
 
         caches = caches or [None] * len(segments)
         for i in range(len(segments)):
@@ -1640,7 +1716,7 @@ class BatchGenerator:
             all_tokens,
             samplers,
             logits_processors,
-            state_machines,
+            stop_matchers,
         ):
             seq = list(seq)
             if len(seq[-1]) != 1:
@@ -1739,7 +1815,7 @@ class BatchGenerator:
         samplers = []
         logits_processors = []
         max_tokens = []
-        state_machines = []
+        stop_matchers = []
         for _ in range(n):
             sequence = self._unprocessed_sequences.popleft()
             uids.append(sequence[0])
@@ -1748,7 +1824,7 @@ class BatchGenerator:
             samplers.append(sequence[5])
             logits_processors.append(sequence[6])
             max_tokens.append(sequence[2])
-            state_machines.append(sequence[7])
+            stop_matchers.append(sequence[7])
             self._currently_processing.append(
                 [sequence[1], 0, sum(len(s) for s in sequence[1])]
             )
@@ -1762,7 +1838,7 @@ class BatchGenerator:
             samplers=samplers,
             fallback_sampler=self.sampler,
             logits_processors=logits_processors,
-            state_machines=state_machines,
+            stop_matchers=stop_matchers,
             max_tokens=max_tokens,
         )
 

--- a/mlx_lm/server.py
+++ b/mlx_lm/server.py
@@ -9,8 +9,7 @@ import socket
 import time
 import uuid
 import warnings
-from collections import deque
-from dataclasses import dataclass, replace
+from dataclasses import dataclass
 from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
 from pathlib import Path
 from queue import Empty as QueueEmpty
@@ -35,13 +34,13 @@ from huggingface_hub import scan_cache_dir
 from ._version import __version__
 from .generate import (
     BatchGenerator,
-    SequenceStateMachine,
+    StopSequenceMatcher,
+    TextStateMachine,
+    make_stop_matcher,
+    make_text_state_machine,
     stream_generate,
 )
-from .models.cache import (
-    LRUPromptCache,
-    make_prompt_cache,
-)
+from .models.cache import LRUPromptCache, make_prompt_cache
 from .sample_utils import make_logits_processors, make_sampler
 from .utils import _parse_size, load, sharded_load
 
@@ -211,7 +210,8 @@ class GenerationContext:
     has_thinking: bool
     tool_parser: Callable[[str, Any], Dict]
 
-    sequences: Dict[Tuple[int], str]
+    text_sm: TextStateMachine
+    initial_state: str
 
     prompt: List[int]
     prompt_cache_count: int = -1
@@ -226,27 +226,9 @@ class GenerationContext:
 class Response:
     text: str
     token: int
-    state: str
-    match: Tuple[int]
     logprob: float
     finish_reason: Optional[str]
     top_tokens: Tuple[Dict[str, Any]]
-
-
-def _process_control_tokens(ctx, token_stream):
-    buffer_size = max(len(s) for s in ctx.sequences)
-    buffered_stream = deque()
-
-    for tok in token_stream:
-        buffered_stream.append(tok)
-        if tok.match is not None:
-            popped = [buffered_stream.pop() for _ in tok.match]
-            for t in reversed(popped):
-                buffered_stream.append(replace(t, text=""))
-        if len(buffered_stream) >= buffer_size:
-            yield buffered_stream.popleft()
-    while len(buffered_stream) > 0:
-        yield buffered_stream.popleft()
 
 
 class TimeBudget:
@@ -623,64 +605,21 @@ class ResponseGenerator:
 
         return prompt, segments, segment_types, initial_state
 
-    def _make_state_machine(
-        self, model_key, tokenizer, stop_words, initial_state="normal"
-    ):
-        """Make a new SequenceStateMachine or fetch it if we 've made it before.
-
-        Return also a dictionary that maps the token sequences in the state
-        machine to their strings.
-        """
-        cache_key = (model_key, tuple(stop_words), initial_state)
+    def _make_state_machine(self, model_key, tokenizer, stop_words):
+        """Make (and cache) a StopSequenceMatcher and TextStateMachine."""
+        cache_key = (model_key, tuple(stop_words))
         rs = self._state_machine_cache.get(cache_key)
         if rs is not None:
             return rs
 
-        # Will hold the state machine transitions and the sequences map to
-        # strings.
-        transitions = {}
-        sequences = {}
+        stop_matcher = make_stop_matcher(tokenizer, stop_words)
+        text_sm = make_text_state_machine(tokenizer, stop_words)
 
-        # Add all the stop sequences
-        common_stops = []
-        for t in tokenizer.eos_token_ids:
-            sequences[(t,)] = tokenizer.convert_ids_to_tokens(t)
-            common_stops.append(((t,), None))
-        for w in stop_words:
-            t = tuple(tokenizer.encode(w, add_special_tokens=False))
-            sequences[t] = w
-            common_stops.append((t, None))
-
-        # From normal to stop
-        transitions["normal"] = list(common_stops)
-
-        # Reasoning related transitions
-        if tokenizer.has_thinking:
-            ts = tokenizer.think_start_tokens
-            te = tokenizer.think_end_tokens
-            transitions["normal"].append((ts, "reasoning"))
-            transitions["reasoning"] = [(te, "normal")]
-            transitions["reasoning"].extend(common_stops)
-            sequences[ts] = tokenizer.think_start
-            sequences[te] = tokenizer.think_end
-
-        # Tool calling relating transitions
-        if tokenizer.has_tool_calling:
-            ts = tokenizer.tool_call_start_tokens
-            te = tokenizer.tool_call_end_tokens
-            transitions["normal"].append((ts, "tool"))
-            transitions["tool"] = [(te, "normal")] if te else []
-            transitions["tool"].extend(common_stops)
-            sequences[ts] = tokenizer.tool_call_start
-            if te:
-                sequences[te] = tokenizer.tool_call_end
-
-        sm = SequenceStateMachine(transitions, initial=initial_state)
         if len(self._state_machine_cache) > 100:
             self._state_machine_cache.clear()
-        self._state_machine_cache[cache_key] = (sm, sequences)
+        self._state_machine_cache[cache_key] = (stop_matcher, text_sm)
 
-        return sm, sequences
+        return stop_matcher, text_sm
 
     def _is_batchable(self, args):
         return self.model_provider.is_batchable and args.seed is None
@@ -742,11 +681,10 @@ class ResponseGenerator:
                         rqueue.put(e)
                         continue
 
-                    sm, sequences = self._make_state_machine(
+                    stop_matcher, text_sm = self._make_state_machine(
                         self.model_provider.model_key,
                         tokenizer,
                         args.stop_words,
-                        initial_state,
                     )
 
                     self._log_cache_stats()
@@ -767,7 +705,8 @@ class ResponseGenerator:
                         has_tool_calling=tokenizer.has_tool_calling,
                         has_thinking=tokenizer.has_thinking,
                         tool_parser=tokenizer.tool_parser,
-                        sequences=sequences,
+                        text_sm=text_sm,
+                        initial_state=initial_state,
                         prompt=prompt,
                         prompt_cache_count=prompt_cache_count,
                     )
@@ -780,7 +719,7 @@ class ResponseGenerator:
                         all_tokens=[prompt[:prompt_cache_count]],
                         samplers=[_make_sampler(args, tokenizer)],
                         logits_processors=[_make_logits_processors(args)],
-                        state_machines=[sm],
+                        stop_matchers=[stop_matcher],
                     )
                     batch_results[uid] = {
                         "ctx": ctx,
@@ -881,13 +820,23 @@ class ResponseGenerator:
 
                     for r in gen_responses:
                         result = batch_results[r.uid]
-                        result["detokenizer"].add_token(r.token)
+
+                        # Don't decode the final stop token
+                        if r.finish_reason == "stop":
+                            result["detokenizer"].finalize()
+                            text = result["detokenizer"].last_segment
+                        elif r.finish_reason == "length":
+                            result["detokenizer"].add_token(r.token)
+                            result["detokenizer"].finalize()
+                            text = result["detokenizer"].last_segment
+                        else:
+                            result["detokenizer"].add_token(r.token)
+                            text = result["detokenizer"].last_segment
+
                         result["rqueue"].put(
                             Response(
-                                result["detokenizer"].last_segment,
+                                text,
                                 r.token,
-                                r.current_state,
-                                r.match_sequence,
                                 r.logprobs[r.token].item(),
                                 r.finish_reason,
                                 _format_top_logprobs(
@@ -934,20 +883,19 @@ class ResponseGenerator:
 
             # Prepare the prompt and state machine
             prompt, _, _, initial_state = self._tokenize(tokenizer, request, args)
-            sm, sequences = self._make_state_machine(
+            stop_matcher, text_sm = self._make_state_machine(
                 self.model_provider.model_key,
                 tokenizer,
                 args.stop_words,
-                initial_state=initial_state,
             )
-            sm_state = sm.make_state()
 
             # Start the generation context
             ctx = GenerationContext(
                 has_thinking=tokenizer.has_thinking,
                 has_tool_calling=tokenizer.has_tool_calling,
                 tool_parser=tokenizer.tool_parser,
-                sequences=sequences,
+                text_sm=text_sm,
+                initial_state=initial_state,
                 prompt=prompt,
             )
             rqueue.put(ctx)
@@ -973,6 +921,7 @@ class ResponseGenerator:
                     cache += make_prompt_cache(self.model_provider.draft_model)
 
             # Process the prompt and generate tokens
+            stop_state = stop_matcher.make_state()
             for gen in stream_generate(
                 model=model,
                 tokenizer=tokenizer,
@@ -987,15 +936,18 @@ class ResponseGenerator:
                 prefill_step_size=self.cli_args.prefill_step_size,
             ):
                 finish_reason = gen.finish_reason
-                sm_state, match_sequence, current_state = sm.match(sm_state, gen.token)
-                if match_sequence is not None and current_state is None:
+
+                # Token-level stop word detection
+                stop_state, matched = StopSequenceMatcher.match(
+                    stop_state, stop_matcher._trie, gen.token
+                )
+                if matched:
                     finish_reason = "stop"
+
                 rqueue.put(
                     Response(
                         gen.text,
                         gen.token,
-                        current_state,
-                        match_sequence,
                         gen.logprobs[gen.token].item(),
                         finish_reason,
                         _format_top_logprobs(
@@ -1049,7 +1001,7 @@ class ResponseGenerator:
         if isinstance(ctx, Exception):
             raise ctx
 
-        return ctx, _process_control_tokens(ctx, _inner())
+        return ctx, _inner()
 
     @property
     def cli_args(self):
@@ -1439,8 +1391,11 @@ class APIHandler(BaseHTTPRequestHandler):
         # Tool call formatter
         tool_formatter = ToolCallFormatter(ctx.tool_parser, request.tools, self.stream)
 
+        # Initialize the text state machine
+        sm_state = ctx.text_sm.make_state(ctx.initial_state)
+
         # Variables to save the generated text, tokens, logprobs, tools etc
-        prev_state = None
+        prev_state = ctx.initial_state
         finish_reason = "stop"
         reasoning_text = ""
         made_tool_call = False
@@ -1455,18 +1410,32 @@ class APIHandler(BaseHTTPRequestHandler):
             for gen in response:
                 logging.debug(gen.text)
 
-                # Collect the text according to our current state and state
-                # transitions. Reasoning or tool or normal text.
-                if gen.state == "reasoning":
-                    reasoning_text += gen.text
-                elif gen.state == "tool":
-                    tool_text += gen.text
-                elif gen.state == "normal":
+                # Advance the text state machine to strip control sequences
+                if gen.finish_reason == "stop":
+                    sm_state, current_state = TextStateMachine.discard(sm_state)
+                    clean_text = ""
+                elif gen.finish_reason == "length":
+                    sm_state, clean_text, current_state = TextStateMachine.step(
+                        sm_state, gen.text
+                    )
+                    sm_state, flushed, current_state = TextStateMachine.flush(sm_state)
+                    clean_text += flushed
+                else:
+                    sm_state, clean_text, current_state = TextStateMachine.step(
+                        sm_state, gen.text
+                    )
+
+                # Collect the clean text by state: reasoning, tool, or normal
+                if current_state == "reasoning":
+                    reasoning_text += clean_text
+                elif current_state == "tool":
+                    tool_text += clean_text
+                elif current_state == "normal":
                     if prev_state == "tool":
                         tool_calls.append(tool_text)
                         tool_text = ""
                         made_tool_call = True
-                    text += gen.text
+                    text += clean_text
 
                 # Add the tokens and logprobs to the vars.
                 tokens.append(gen.token)
@@ -1477,7 +1446,7 @@ class APIHandler(BaseHTTPRequestHandler):
 
                 if (
                     self.stream
-                    and gen.state != "tool"
+                    and current_state != "tool"
                     and (text or tool_calls or reasoning_text)
                 ):
                     resp = self.generate_response(
@@ -1495,7 +1464,7 @@ class APIHandler(BaseHTTPRequestHandler):
                 if gen.finish_reason is not None:
                     finish_reason = gen.finish_reason
 
-                prev_state = gen.state
+                prev_state = current_state
 
             if prev_state == "tool" and tool_text:
                 tool_calls.append(tool_text)

--- a/tests/test_generate.py
+++ b/tests/test_generate.py
@@ -9,7 +9,7 @@ import mlx.core as mx
 from mlx_lm.generate import (
     BatchGenerator,
     GenerationResponse,
-    SequenceStateMachine,
+    StopSequenceMatcher,
     batch_generate,
     generate,
     generate_step,
@@ -470,17 +470,17 @@ class TestGenerate(unittest.TestCase):
         self.assertEqual(responses[uid1].token, 2)
         self.assertEqual(responses[uid2].token, 3)
 
-    def test_batch_generate_with_state_machines(self):
-        """Test that batch_generate with per-sequence state_machines stops on different tokens."""
+    def test_batch_generate_with_stop_matchers(self):
+        """Test that batch_generate with per-sequence stop_matchers stops on different tokens."""
         batch_gen = BatchGenerator(
             self.model,
             max_tokens=10,
         )
         prompt = self.tokenizer.encode("hello")
 
-        sm_0 = SequenceStateMachine({"normal": [([0], None)]}, initial="normal")
-        sm_1 = SequenceStateMachine({"normal": [([1], None)]}, initial="normal")
-        sm_2 = SequenceStateMachine({"normal": [([2], None)]}, initial="normal")
+        sm_0 = StopSequenceMatcher([[0]])
+        sm_1 = StopSequenceMatcher([[1]])
+        sm_2 = StopSequenceMatcher([[2]])
 
         processor_0 = make_logits_processors({0: 2000.0})
         processor_1 = make_logits_processors({1: 2000.0})
@@ -489,7 +489,7 @@ class TestGenerate(unittest.TestCase):
         uid0, uid1, uid2 = batch_gen.insert(
             [prompt, prompt, prompt],
             logits_processors=[processor_0, processor_1, processor_2],
-            state_machines=[sm_0, sm_1, sm_2],
+            stop_matchers=[sm_0, sm_1, sm_2],
         )
 
         responses = batch_gen.next_generated()
@@ -501,9 +501,6 @@ class TestGenerate(unittest.TestCase):
         self.assertEqual(responses[uid0].finish_reason, "stop")
         self.assertEqual(responses[uid1].finish_reason, "stop")
         self.assertEqual(responses[uid2].finish_reason, "stop")
-        self.assertEqual(responses[uid0].match_sequence, (0,))
-        self.assertEqual(responses[uid1].match_sequence, (1,))
-        self.assertEqual(responses[uid2].match_sequence, (2,))
 
     def test_batch_continued_generation(self):
         for rotating in [False, True]:

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -4,20 +4,14 @@ import http
 import io
 import json
 import threading
-import types
 import unittest
 
 import mlx.core as mx
 import requests
 
+from mlx_lm.generate import TextStateMachine
 from mlx_lm.models.cache import KVCache
-from mlx_lm.server import (
-    APIHandler,
-    LRUPromptCache,
-    Response,
-    ResponseGenerator,
-    _process_control_tokens,
-)
+from mlx_lm.server import APIHandler, LRUPromptCache, Response, ResponseGenerator
 from mlx_lm.utils import load
 
 
@@ -92,69 +86,109 @@ class MockCache:
         return n
 
 
-class TestProcessControlTokens(unittest.TestCase):
-    @staticmethod
-    def _r(text, state, match=None):
-        return Response(text, 0, state, match, 0.0, None, ())
+class TestTextStateMachine(unittest.TestCase):
+    """Test the TextStateMachine buffering and stripping behavior."""
 
-    def test_single_tool_call_passes_body_with_open_and_close_crossings(self):
-        r = self._r
-        stream = [
-            r("hi ", "normal"),
-            r("<tool_call>", "tool", match=(0,)),
-            r("body", "tool"),
-            r("</tool_call>", "normal", match=(1,)),
-            r(" bye", "normal"),
-        ]
-        ctx = types.SimpleNamespace(
-            sequences={(0,): "<tool_call>", (1,): "</tool_call>"}
+    def test_strips_control_sequences(self):
+        sm = TextStateMachine(
+            {
+                "normal": [("<tool_call>", "tool")],
+                "tool": [("</tool_call>", "normal")],
+            }
         )
-        out = list(_process_control_tokens(ctx, iter(stream)))
+        state = sm.make_state()
+        state, text, s = sm.step(state, "hi <tool_call>body</tool_call> bye")
+        state, rest, s = sm.flush(state)
+        full = text + rest
+        self.assertEqual(full, "hi body bye")
 
-        self.assertEqual("".join(t.text for t in out), "hi body bye")
-        states = [t.state for t in out]
-        self.assertEqual(sum(1 for a, b in zip(states, states[1:]) if a != b), 2)
-
-    def test_back_to_back_tool_calls_emit_state_crossings(self):
-        r = self._r
-        stream = [
-            r("<tool_call>", "tool", match=(0,)),
-            r("call1_body", "tool"),
-            r("</tool_call>", "normal", match=(1,)),
-            r("<tool_call>", "tool", match=(0,)),
-            r("call2_body", "tool"),
-            r("</tool_call>", "normal", match=(1,)),
-        ]
-        ctx = types.SimpleNamespace(
-            sequences={(0,): "<tool_call>", (1,): "</tool_call>"}
+    def test_back_to_back_tool_calls(self):
+        sm = TextStateMachine(
+            {
+                "normal": [("<tool_call>", "tool")],
+                "tool": [("</tool_call>", "normal")],
+            }
         )
-        out = list(_process_control_tokens(ctx, iter(stream)))
+        state = sm.make_state()
+        state, t1, s = sm.step(state, "<tool_call>call1</tool_call>")
+        state, t2, s = sm.step(state, "<tool_call>call2</tool_call>")
+        state, rest, s = sm.flush(state)
+        full = t1 + t2 + rest
+        self.assertEqual(full, "call1call2")
 
-        self.assertEqual("".join(t.text for t in out), "call1_bodycall2_body")
-        states = [t.state for t in out]
-        crossings = sum(
-            1 for a, b in zip(states, states[1:]) if a == "tool" and b == "normal"
+    def test_partial_match_buffered_then_flushed(self):
+        sm = TextStateMachine(
+            {
+                "normal": [("<tool_call>", "tool")],
+                "tool": [("</tool_call>", "normal")],
+            }
         )
-        self.assertEqual(crossings, 2)
+        # First enter tool state
+        state = sm.make_state()
+        state, text, s = sm.step(state, "<tool_call>body</")
+        self.assertEqual(s, "tool")
+        # 'body' is emitted, '</' is buffered (partial match of '</tool_call>')
+        self.assertEqual(text, "body")
+        # flush releases the buffered text
+        state, rest, s = sm.flush(state)
+        self.assertEqual(rest, "</")
 
-    def test_multi_token_match_preserves_order(self):
-        r = self._r
-        match = (10, 11, 12)
-        stream = [
-            r("body", "tool"),
-            r("</", "tool"),
-            r("tool", "tool"),
-            r("_call>", "normal", match=match),
-            r(" ok", "normal"),
-        ]
-        ctx = types.SimpleNamespace(sequences={match: "</tool_call>"})
-        out = list(_process_control_tokens(ctx, iter(stream)))
-
-        self.assertEqual([t.text for t in out], ["body", "", "", "", " ok"])
-        self.assertEqual(
-            [t.state for t in out],
-            ["tool", "tool", "tool", "normal", "normal"],
+    def test_discard_drops_buffer(self):
+        sm = TextStateMachine(
+            {
+                "normal": [("STOP", "normal")],
+            }
         )
+        state = sm.make_state()
+        state, text, s = sm.step(state, "hello ST")
+        self.assertEqual(text, "hello ")
+        # discard drops the buffered 'ST'
+        state, s = sm.discard(state)
+        self.assertEqual(s, "normal")
+
+    def test_stop_words_stripped(self):
+        sm = TextStateMachine(
+            {
+                "normal": [("STOP", "normal")],
+            }
+        )
+        state = sm.make_state()
+        state, text, s = sm.step(state, "hello STOP world")
+        state, rest, s = sm.flush(state)
+        self.assertEqual(text + rest, "hello  world")
+
+    def test_reasoning_to_tool_transition(self):
+        # A tool call started inside a reasoning block must enter "tool".
+        sm = TextStateMachine(
+            {
+                "normal": [("<think>", "reasoning"), ("<tool>", "tool")],
+                "reasoning": [("</think>", "normal"), ("<tool>", "tool")],
+                "tool": [("</tool>", "normal")],
+            }
+        )
+        state = sm.make_state()
+        state, _, s = sm.step(state, "<think>hmm")
+        self.assertEqual(s, "reasoning")
+        state, _, s = sm.step(state, "<tool>")
+        self.assertEqual(s, "tool")
+        state, _, s = sm.step(state, "</tool>")
+        self.assertEqual(s, "normal")
+
+    def test_empty_end_marker_stays_in_tool_on_discard(self):
+        # Models with an empty tool_call_end (e.g. Mistral) never leave "tool";
+        # discard on stop must preserve the state so the tool call is flushed.
+        sm = TextStateMachine(
+            {
+                "normal": [("[TOOL_CALLS]", "tool")],
+                "tool": [],
+            }
+        )
+        state = sm.make_state()
+        state, text, s = sm.step(state, "[TOOL_CALLS]f[ARGS]{}")
+        self.assertEqual(s, "tool")
+        self.assertEqual(text, "f[ARGS]{}")
+        state, s = sm.discard(state)
+        self.assertEqual(s, "tool")
 
 
 class TestServer(unittest.TestCase):
@@ -293,19 +327,26 @@ class TestServer(unittest.TestCase):
             def convert_ids_to_tokens(self, t):
                 return f"<eos{t}>"
 
-        sm, _ = self.response_generator._make_state_machine(
+            def encode(self, text, add_special_tokens=False):
+                return []
+
+        stop_matcher, text_sm = self.response_generator._make_state_machine(
             ("fake-empty-end", None, None),
             FakeTokenizer(),
             stop_words=[],
         )
-        state = sm.make_state()
-        state, _, s = sm.match(state, 100)
+
+        # Verify the text state machine strips tool call markers
+        text_state = text_sm.make_state()
+        text_state, clean_text, s = text_sm.step(text_state, "hello[TOOL_CALLS]body")
         self.assertEqual(s, "tool")
-        for tok in [42, 43, 44]:
-            state, _, s = sm.match(state, tok)
-            self.assertEqual(s, "tool")
-        state, _, s = sm.match(state, 2)
-        self.assertIsNone(s)
+        # 'hello' is before the match, 'body' flows through (no tool_call_end)
+        self.assertEqual(clean_text, "hellobody")
+
+        # Verify EOS stops via the stop matcher
+        stop_state = stop_matcher.make_state()
+        stop_state, matched = stop_matcher.match(stop_state, stop_matcher._trie, 2)
+        self.assertTrue(matched)
 
     def test_handle_models(self):
         url = f"http://localhost:{self.port}/v1/models"


### PR DESCRIPTION
The token based SequenceStateMachine has a design flaw that makes it impossible to identify the state change because substrings can be encoded in different ways.

This replaces it with TextStateMachine so we switch state on the actual string and not the tokens. It also introduces a StopSequenceMatcher that can be used to make sure that generation stops on specific token sequences.

This fixes #1373, #1447, #1406, #1336, #1160 .