### PR TITLE
Prompt cache: never reuse KV that fails to trim to the keyed prefix

### DIFF
--- a/mlx_lm/models/cache.py
+++ b/mlx_lm/models/cache.py
@@ -104,11 +104,13 @@ def trim_prompt_cache(cache: List[Any], num_tokens: int) -> List[Any]:
         num_tokens (int): The number of tokens to trim.
 
     Returns:
-        (int): The number of tokens that were trimmed.
+        (int): The number of tokens that were trimmed from every layer. If
+        this is less than ``num_tokens`` the trim was incomplete and the cache
+        should not be reused as an exact prefix.
     """
     if not can_trim_prompt_cache(cache) or len(cache) == 0:
         return 0
-    return [c.trim(num_tokens) for c in cache][0]
+    return min(c.trim(num_tokens) for c in cache)
 
 
 def create_attention_mask(
@@ -213,6 +215,9 @@ class ConcatenateKVCache(_BaseCache):
 
     def trim(self, n):
         n = min(self.offset, n)
+        if n > 0 and self.keys is not None:
+            self.keys = self.keys[..., : self.offset - n, :]
+            self.values = self.values[..., : self.offset - n, :]
         self.offset -= n
         return n
 
@@ -1684,8 +1689,11 @@ class LRUPromptCache:
                 cache = copy.deepcopy(cache_entry.prompt_cache)
                 prefix = min(len(tokens) - 1, result.common_prefix)
                 num_to_trim = len(result.longer) - prefix
-                trim_prompt_cache(cache, num_to_trim)
-                return cache, tokens[prefix:]
+                # Only reuse the cache if every layer trimmed the full amount;
+                # otherwise the state no longer corresponds to tokens[:prefix]
+                # and reusing it would produce wrong output.
+                if trim_prompt_cache(cache, num_to_trim) == num_to_trim:
+                    return cache, tokens[prefix:]
 
         if short_length > 0:
             cache_entry = self._trie.get(result.model, result.shorter)

--- a/tests/test_prompt_cache.py
+++ b/tests/test_prompt_cache.py
@@ -15,7 +15,9 @@ from mlx_lm.models.cache import (
     BatchRotatingKVCache,
     CacheList,
     ChunkedKVCache,
+    ConcatenateKVCache,
     KVCache,
+    LRUPromptCache,
     QuantizedKVCache,
     RotatingKVCache,
     load_prompt_cache,
@@ -767,6 +769,84 @@ class TestPromptCache(unittest.TestCase):
         mask = create_attention_mask(h, c, window_size=4)
         expected = create_causal_mask(1, offset=32, window_size=4)
         self.assertTrue(mx.array_equal(mask, expected))
+
+
+class TestPromptCacheReuseContract(unittest.TestCase):
+    """Reuse must never return KV state that doesn't match the keyed prefix
+    (ml-explore/mlx-lm#1494)."""
+
+    def _position_kv(self, start, end):
+        # KV for position p is the scalar p so cache contents are
+        # self-describing.
+        pos = mx.arange(start, end, dtype=mx.float32).reshape(1, 1, end - start, 1)
+        return mx.broadcast_to(pos, (1, 1, end - start, 4))
+
+    def _prefill(self, cache, start, end, step=256):
+        # Feed tokens the way llama4 does: slide the window, then update.
+        for lo in range(start, end, step):
+            hi = min(lo + step, end)
+            kv = self._position_kv(lo, hi)
+            for c in cache:
+                if isinstance(c, ChunkedKVCache):
+                    c.maybe_trim_front()
+                c.update_and_fetch(kv, kv)
+
+    def test_fetch_with_slid_chunked_cache_recomputes(self):
+        cache = [KVCache(), ChunkedKVCache(chunk_size=512)]
+        self._prefill(cache, 0, 1024)
+        self.assertGreater(cache[1].start_position, 0)
+
+        lru = LRUPromptCache(max_size=10)
+        model = ("test", None, None)
+        lru.insert_cache(model, list(range(1024)), cache, cache_type="system")
+
+        # A request sharing a short prefix must fall back to recompute
+        # instead of reusing KV that no longer covers the prefix (the chunked
+        # layer can only trim back to its window, so the trim is incomplete).
+        request = list(range(32))
+        fetched, rest = lru.fetch_nearest_cache(model, request)
+        self.assertIsNone(fetched)
+        self.assertEqual(rest, request)
+
+    def test_fetch_longer_falls_back_when_trim_incomplete(self):
+        class PartialTrimCache:
+            def __init__(self, offset, max_trim):
+                self.offset = offset
+                self.max_trim = max_trim
+
+            @property
+            def nbytes(self):
+                return self.offset
+
+            def is_trimmable(self):
+                return True
+
+            def trim(self, n):
+                n = min(self.max_trim, n)
+                self.offset -= n
+                return n
+
+        lru = LRUPromptCache(max_size=10)
+        model = ("test", None, None)
+        lru.insert_cache(model, list(range(16)), [PartialTrimCache(16, 4)])
+
+        # Trimming 16 -> 8 needs 8 tokens but the cache can only trim 4,
+        # so the entry must not be reused.
+        fetched, rest = lru.fetch_nearest_cache(model, list(range(8)) + [99])
+        self.assertIsNone(fetched)
+        self.assertEqual(rest, list(range(8)) + [99])
+
+    def test_concatenate_cache_trim_drops_kv(self):
+        cache = ConcatenateKVCache()
+        kv = self._position_kv(0, 8)
+        cache.update_and_fetch(kv, kv)
+        self.assertEqual(cache.trim(4), 4)
+        self.assertEqual(cache.offset, 4)
+
+        new = self._position_kv(100, 101)
+        keys, _ = cache.update_and_fetch(new, new)
+        self.assertEqual(cache.offset, 5)
+        self.assertEqual(keys[0, 0, :, 0].tolist(), [0.0, 1.0, 2.0, 3.0, 100.0])
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Part 1 of 2 addressing #1494. This PR is the general trim/reuse correctness guards; the follow-up (#1503) adds the slid-window prefix guard on top.

`mlx_lm.server`'s prompt-cache prefix reuse (`LRUPromptCache.fetch_nearest_cache`) can serve KV state that no longer matches the token prefix it is keyed under, producing silently wrong output instead of falling back to recompute. This PR adds three defensive guards so a partial or lossy trim can never be reused:

1. **`trim_prompt_cache` returns the minimum tokens trimmed across all layers**, not layer 0's count. With mixed cache types (e.g. a full `KVCache` beside a windowed `ChunkedKVCache`), layer 0 can trim the full requested amount while another layer cannot. Returning layer 0 alone hides the shortfall.
2. **The `fetch_nearest_cache` longer branch only reuses when the trim removed the full requested amount** (`trim_prompt_cache(cache, n) == n`); otherwise it falls back to a shorter hit or recompute. This is co-dependent with (1): the guard is only meaningful once the return value reflects every layer.
3. **`ConcatenateKVCache.trim` now slices the stored `keys`/`values`** instead of only decrementing `offset`. Previously `update_and_fetch` recomputed `offset` from `keys.shape[-2]`, so a later update resurrected the "trimmed" tokens and their KV — a standalone bug independent of the reuse path.

### Tests
`TestPromptCacheReuseContract` in `tests/test_prompt_cache.py`:
- a slid `ChunkedKVCache` sharing a short prefix falls back to recompute (the min + trim-count guard catch the under-trim);
- a synthetic partial-trim cache is refused;
- `ConcatenateKVCache.trim` drops the KV so a subsequent update cannot resurrect it.

### Note
This PR closes the specific repro in #1494. There is a further case — a prefix that lands inside a slid window but behind the chunk boundary, where the trim count *does* fit — that the follow-up PR closes with a fetch-scoped guard. Splitting so the general guards can land independently.
