### PR TITLE
Prompt cache: don't reuse a slid windowed cache as a keyed prefix

### DIFF
--- a/mlx_lm/models/cache.py
+++ b/mlx_lm/models/cache.py
@@ -104,11 +104,13 @@ def trim_prompt_cache(cache: List[Any], num_tokens: int) -> List[Any]:
         num_tokens (int): The number of tokens to trim.
 
     Returns:
-        (int): The number of tokens that were trimmed.
+        (int): The number of tokens that were trimmed from every layer. If
+        this is less than ``num_tokens`` the trim was incomplete and the cache
+        should not be reused as an exact prefix.
     """
     if not can_trim_prompt_cache(cache) or len(cache) == 0:
         return 0
-    return [c.trim(num_tokens) for c in cache][0]
+    return min(c.trim(num_tokens) for c in cache)
 
 
 def create_attention_mask(
@@ -213,6 +215,9 @@ class ConcatenateKVCache(_BaseCache):
 
     def trim(self, n):
         n = min(self.offset, n)
+        if n > 0 and self.keys is not None:
+            self.keys = self.keys[..., : self.offset - n, :]
+            self.values = self.values[..., : self.offset - n, :]
         self.offset -= n
         return n
 
@@ -1684,8 +1689,11 @@ class LRUPromptCache:
                 cache = copy.deepcopy(cache_entry.prompt_cache)
                 prefix = min(len(tokens) - 1, result.common_prefix)
                 num_to_trim = len(result.longer) - prefix
-                trim_prompt_cache(cache, num_to_trim)
-                return cache, tokens[prefix:]
+                # Only reuse the cache if every layer trimmed the full amount;
+                # otherwise the state no longer corresponds to tokens[:prefix]
+                # and reusing it would produce wrong output.
+                if trim_prompt_cache(cache, num_to_trim) == num_to_trim:
+                    return cache, tokens[prefix:]
 
         if short_length > 0:
             cache_entry = self._trie.get(result.model, result.shorter)

--- a/mlx_lm/models/cache.py
+++ b/mlx_lm/models/cache.py
@@ -113,6 +113,18 @@ def trim_prompt_cache(cache: List[Any], num_tokens: int) -> List[Any]:
     return min(c.trim(num_tokens) for c in cache)
 
 
+def _cache_window_has_slid(cache: List[Any]) -> bool:
+    """Whether any layer has physically dropped leading tokens.
+
+    A windowed cache such as ``ChunkedKVCache`` advances ``start_position``
+    once its window slides, discarding the earliest tokens. ``trim`` can only
+    remove tokens back to ``start_position``, so it can no longer reconstruct
+    an arbitrary shorter prefix even when the requested trim count fits inside
+    the retained window. Such a cache must not be reused as a keyed prefix.
+    """
+    return any(getattr(c, "start_position", 0) > 0 for c in cache)
+
+
 def create_attention_mask(
     N: int, offset: int, return_array: bool, window_size: Optional[int]
 ):
@@ -1685,7 +1697,13 @@ class LRUPromptCache:
         short_length = len(result.shorter) if result.shorter is not None else 0
         if result.longer is not None and result.common_prefix > short_length:
             cache_entry = self._trie.get(result.model, result.longer)
-            if can_trim_prompt_cache(cache_entry.prompt_cache):
+            # A cache whose window has slid can no longer be trimmed back to an
+            # arbitrary prefix: even a trim count that fits inside the retained
+            # window leaves the leading in-chunk tokens missing, so the state
+            # would not match tokens[:prefix]. Fall back to recompute instead.
+            if can_trim_prompt_cache(
+                cache_entry.prompt_cache
+            ) and not _cache_window_has_slid(cache_entry.prompt_cache):
                 cache = copy.deepcopy(cache_entry.prompt_cache)
                 prefix = min(len(tokens) - 1, result.common_prefix)
                 num_to_trim = len(result.longer) - prefix

--- a/tests/test_prompt_cache.py
+++ b/tests/test_prompt_cache.py
@@ -848,6 +848,61 @@ class TestPromptCacheReuseContract(unittest.TestCase):
         self.assertEqual(cache.offset, 5)
         self.assertEqual(keys[0, 0, :, 0].tolist(), [0.0, 1.0, 2.0, 3.0, 100.0])
 
+    def test_fetch_slid_chunked_cache_behind_window_recomputes(self):
+        # End-to-end: a slid ChunkedKVCache where the requested prefix lands
+        # inside the retained window but behind the current chunk boundary, so
+        # the full trim succeeds yet leading in-chunk tokens are gone.
+        cache = [KVCache(), ChunkedKVCache(chunk_size=512)]
+        self._prefill(cache, 0, 1024)
+        start = cache[1].start_position
+        self.assertGreater(start, 0)
+        # Prefix just past start_position but still inside the first chunk: a
+        # fresh prefill of these tokens would not have slid and would attend
+        # over [0, prefix); the trimmed slid cache is missing [0, start).
+        prefix_len = start + 8
+        self.assertLess(prefix_len, 512)
+
+        lru = LRUPromptCache(max_size=10)
+        model = ("test", None, None)
+        lru.insert_cache(model, list(range(1024)), cache, cache_type="system")
+
+        request = list(range(prefix_len)) + [9999]
+        fetched, rest = lru.fetch_nearest_cache(model, request)
+        self.assertIsNone(fetched)
+        self.assertEqual(rest, request)
+
+    def test_fetch_refuses_reuse_when_window_has_slid(self):
+        # A slid window (start_position > 0) can pass the trim-count guard yet
+        # still be missing leading in-chunk tokens, so it must not be reused.
+        class SlidCache:
+            def __init__(self, offset, start_position):
+                self.offset = offset
+                self.start_position = start_position
+
+            @property
+            def nbytes(self):
+                return self.offset
+
+            def is_trimmable(self):
+                return True
+
+            def trim(self, n):
+                n = min(self.offset - self.start_position, n)
+                self.offset -= n
+                return n
+
+        lru = LRUPromptCache(max_size=10)
+        model = ("test", None, None)
+        lru.insert_cache(model, list(range(16)), [SlidCache(16, 4)])
+
+        # Trimming 16 -> 8 removes 8 tokens, which fits inside the retained
+        # window (16 - 4 = 12 >= 8), so the trim-count guard alone would reuse
+        # it -- but tokens [0, 4) are gone, so reuse must fall back.
+        request = list(range(8)) + [99]
+        fetched, rest = lru.fetch_nearest_cache(model, request)
+        self.assertIsNone(fetched)
+        self.assertEqual(rest, request)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_prompt_cache.py
+++ b/tests/test_prompt_cache.py
@@ -15,7 +15,9 @@ from mlx_lm.models.cache import (
     BatchRotatingKVCache,
     CacheList,
     ChunkedKVCache,
+    ConcatenateKVCache,
     KVCache,
+    LRUPromptCache,
     QuantizedKVCache,
     RotatingKVCache,
     load_prompt_cache,
@@ -767,6 +769,84 @@ class TestPromptCache(unittest.TestCase):
         mask = create_attention_mask(h, c, window_size=4)
         expected = create_causal_mask(1, offset=32, window_size=4)
         self.assertTrue(mx.array_equal(mask, expected))
+
+
+class TestPromptCacheReuseContract(unittest.TestCase):
+    """Reuse must never return KV state that doesn't match the keyed prefix
+    (ml-explore/mlx-lm#1494)."""
+
+    def _position_kv(self, start, end):
+        # KV for position p is the scalar p so cache contents are
+        # self-describing.
+        pos = mx.arange(start, end, dtype=mx.float32).reshape(1, 1, end - start, 1)
+        return mx.broadcast_to(pos, (1, 1, end - start, 4))
+
+    def _prefill(self, cache, start, end, step=256):
+        # Feed tokens the way llama4 does: slide the window, then update.
+        for lo in range(start, end, step):
+            hi = min(lo + step, end)
+            kv = self._position_kv(lo, hi)
+            for c in cache:
+                if isinstance(c, ChunkedKVCache):
+                    c.maybe_trim_front()
+                c.update_and_fetch(kv, kv)
+
+    def test_fetch_with_slid_chunked_cache_recomputes(self):
+        cache = [KVCache(), ChunkedKVCache(chunk_size=512)]
+        self._prefill(cache, 0, 1024)
+        self.assertGreater(cache[1].start_position, 0)
+
+        lru = LRUPromptCache(max_size=10)
+        model = ("test", None, None)
+        lru.insert_cache(model, list(range(1024)), cache, cache_type="system")
+
+        # A request sharing a short prefix must fall back to recompute
+        # instead of reusing KV that no longer covers the prefix (the chunked
+        # layer can only trim back to its window, so the trim is incomplete).
+        request = list(range(32))
+        fetched, rest = lru.fetch_nearest_cache(model, request)
+        self.assertIsNone(fetched)
+        self.assertEqual(rest, request)
+
+    def test_fetch_longer_falls_back_when_trim_incomplete(self):
+        class PartialTrimCache:
+            def __init__(self, offset, max_trim):
+                self.offset = offset
+                self.max_trim = max_trim
+
+            @property
+            def nbytes(self):
+                return self.offset
+
+            def is_trimmable(self):
+                return True
+
+            def trim(self, n):
+                n = min(self.max_trim, n)
+                self.offset -= n
+                return n
+
+        lru = LRUPromptCache(max_size=10)
+        model = ("test", None, None)
+        lru.insert_cache(model, list(range(16)), [PartialTrimCache(16, 4)])
+
+        # Trimming 16 -> 8 needs 8 tokens but the cache can only trim 4,
+        # so the entry must not be reused.
+        fetched, rest = lru.fetch_nearest_cache(model, list(range(8)) + [99])
+        self.assertIsNone(fetched)
+        self.assertEqual(rest, list(range(8)) + [99])
+
+    def test_concatenate_cache_trim_drops_kv(self):
+        cache = ConcatenateKVCache()
+        kv = self._position_kv(0, 8)
+        cache.update_and_fetch(kv, kv)
+        self.assertEqual(cache.trim(4), 4)
+        self.assertEqual(cache.offset, 4)
+
+        new = self._position_kv(100, 101)
+        keys, _ = cache.update_and_fetch(new, new)
+        self.assertEqual(cache.offset, 5)
+        self.assertEqual(keys[0, 0, :, 0].tolist(), [0.0, 1.0, 2.0, 3.0, 100.0])
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Part 2 of 2 addressing #1494. **Stacks on #1502** — until that merges this PR shows both commits; review the second commit ("Don't reuse a slid windowed cache as a keyed prefix"), or merge #1502 first and GitHub will narrow this to the delta.

#1502's trim-count guard is necessary but not sufficient. Even when every layer trims the *full* requested amount, a `ChunkedKVCache` whose window has slid (`start_position > 0`) can still be wrong to reuse: if the shared prefix `P` lands inside the retained window but behind the current attention-chunk boundary, the trimmed window `[start_position, P)` is missing the leading in-chunk tokens `[0, start_position)` that a fresh prefill of `P` tokens would attend to (llama4 builds its chunk mask from `start = cache[0].start_position`). The trim count matches, so #1502 alone would reuse it and emit silently wrong output.

This PR refuses the trim-based longer-branch reuse when any layer reports `start_position > 0` (new `_cache_window_has_slid`), falling back to a shorter hit or recompute.

### Why a fetch-scoped guard and not `ChunkedKVCache.is_trimmable()`
Making `is_trimmable()` return `start_position == 0` looks simpler but is unsafe: `is_trimmable`/`trim` are also on the speculative-decoding rewind path (`generate.py` `_rewind_cache`), which checks trimmability once at startup and then calls `trim_prompt_cache` on every draft rejection **ignoring the return value**. Once a llama4 chunked window slides mid-generation, a global `is_trimmable() -> False` would make those rewinds silently trim nothing and leave rejected KV resident — corrupting output in exactly the model family this is meant to protect. A slid chunked cache *can* still do the small suffix rewinds spec decoding needs; only arbitrary-prefix reuse is unsafe. Keeping the guard inside `fetch_nearest_cache` leaves the global trim/rewind contract untouched. (This also relates to #1437, which moves `RotatingKVCache` in the trimmable-after-wrap direction; a rotating ring keeps its logical prefix recoverable, a slid chunked window does not.)

### Tests
Added to `TestPromptCacheReuseContract`:
- an end-to-end slid `ChunkedKVCache` where the prefix is behind the chunk boundary and the trim fully succeeds — must recompute;
- a structural case (a fake slid cache) that passes the trim-count guard but is refused.

### Known follow-up (not in this PR)
`insert_cache` still evicts shorter prefix entries when a slid cache is inserted (it passes `can_trim_prompt_cache`), so fetch then recomputes where a shorter entry could have helped. Correctness is unaffected; this is a reuse-efficiency improvement for a later change.
