### PR TITLE
rope_utils: honor an explicit `attention_factor` in YaRN scaling

### DIFF
--- a/mlx_lm/models/rope_utils.py
+++ b/mlx_lm/models/rope_utils.py
@@ -138,6 +138,7 @@ class YarnRoPE(nn.Module):
         beta_slow=1,
         mscale=1,
         mscale_all_dim=0,
+        attention_factor=None,
     ):
         super().__init__()
 
@@ -168,9 +169,15 @@ class YarnRoPE(nn.Module):
             )
             return mx.clip(linear_func, 0, 1)
 
-        self.mscale = yarn_get_mscale(scaling_factor, mscale) / yarn_get_mscale(
-            scaling_factor, mscale_all_dim
-        )
+        if attention_factor is not None:
+            # HF semantics: an explicit `attention_factor` in rope_scaling
+            # overrides the computed YaRN attention scaling (e.g. 1.0 disables
+            # it). Without this, models that set the field get the wrong mscale.
+            self.mscale = attention_factor
+        else:
+            self.mscale = yarn_get_mscale(scaling_factor, mscale) / yarn_get_mscale(
+                scaling_factor, mscale_all_dim
+            )
         freq_extra = base ** (mx.arange(0, dims, 2, dtype=mx.float32) / dims)
         freq_inter = scaling_factor * freq_extra
         low, high = yarn_find_correction_range()
@@ -268,6 +275,7 @@ def initialize_rope(
                 "beta_slow",
                 "mscale",
                 "mscale_all_dim",
+                "attention_factor",
             ]
             if key in scaling_config
         }

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -1,6 +1,7 @@
 # Copyright © 2024 Apple Inc.
 import copy
 import importlib
+import math
 import unittest
 
 import mlx.core as mx
@@ -302,6 +303,33 @@ class TestModels(unittest.TestCase):
         rope(x)
         mx.eval(x)
         self.assertTrue((x == 1).all())
+
+    def test_yarn_rope_attention_factor(self):
+        # Default: mscale is the computed YaRN attention scaling.
+        default = rope_utils.YarnRoPE(dims=8, scaling_factor=16.0)
+        expected = 0.1 * math.log(16.0) + 1.0  # yarn_get_mscale(16, 1) / (…, 0)
+        self.assertAlmostEqual(default.mscale, expected, places=6)
+        self.assertNotAlmostEqual(default.mscale, 1.0, places=3)
+
+        # Explicit attention_factor overrides the computed mscale (HF semantics).
+        overridden = rope_utils.YarnRoPE(
+            dims=8, scaling_factor=16.0, attention_factor=1.0
+        )
+        self.assertEqual(overridden.mscale, 1.0)
+
+        # And it plumbs through initialize_rope from rope_scaling config.
+        rope = rope_utils.initialize_rope(
+            8,
+            base=100,
+            traditional=False,
+            scaling_config={
+                "rope_type": "yarn",
+                "factor": 16.0,
+                "attention_factor": 0.75,
+            },
+        )
+        self.assertIsInstance(rope, rope_utils.YarnRoPE)
+        self.assertEqual(rope.mscale, 0.75)
 
     def test_quantized_sdpa(self):
         cache = KVCache()


### PR DESCRIPTION
## What

`YarnRoPE` always computes its attention scaling (`mscale`) from the YaRN
formula. HuggingFace `transformers` lets a checkpoint override that with an
explicit `rope_scaling.attention_factor` — and when the field is present it
**replaces** the computed value (e.g. `attention_factor: 1.0` disables the
scaling entirely). This adds the same behavior: an optional `attention_factor`
that, when set, is used verbatim; otherwise the existing computed `mscale` is
unchanged.

## Why it matters

Today a YaRN checkpoint that sets `attention_factor` is loaded in mlx-lm with the
**wrong** attention scale — the model runs with mlx-lm's computed `mscale` instead
of the value its config specifies. The mscale multiplier applies at every
position whenever YaRN is active, so this is a constant logit-scale deviation
from the reference implementation. Configs that do not set the field are
completely unaffected (bit-for-bit identical).

The field is used in the wild: `allenai/Olmo-3-32B-Think` ships
`rope_scaling = {"rope_type": "yarn", "attention_factor": 1.2079…, …}` (there the
explicit value happens to equal the computed default, so it stays bit-identical),
and the `attention_factor: 1.0` "disable scaling" pattern appears in newer
checkpoints via transformers-v5 `rope_parameters`. Honoring the field is required
for HF parity whenever the explicit value differs from the computed one.

## Provenance

Parity fix with `transformers` YaRN handling (the `attention_factor` field of
`rope_scaling`). No new method, no novelty — just matching the reference
semantics.

## How

- `YarnRoPE.__init__` gains `attention_factor=None`. When not `None`,
  `self.mscale = attention_factor`; otherwise the computed
  `yarn_get_mscale(...) / yarn_get_mscale(...)` as before.
- `initialize_rope` forwards `attention_factor` from `rope_scaling` into
  `YarnRoPE` alongside the other YaRN kwargs (only when the key is present).

Total: +11 / −3 in `rope_utils.py`.

Scope note: `deepseek_v2.py` carries its own private `YarnRoPE` copy that does not
read the field; it is untouched here (no known deepseek config sets it).
`deepseek_v3` uses `initialize_rope` and picks the fix up automatically.

## Tests

`test_yarn_rope_attention_factor` in `tests/test_models.py`:
- default (no `attention_factor`) → `mscale` equals the computed YaRN value;
- explicit `attention_factor=1.0` → `mscale == 1.0` (override, disables scaling);
- via `initialize_rope({"rope_type": "yarn", "factor": 16, "attention_factor":
  0.75})` → the constructed `YarnRoPE.mscale == 0.75`.

The existing `test_yarn_rope_no_mutation` / `test_rope` still pass (default path
unchanged). `black`/`isort` clean (pinned 25.1.0 / 6.0.0).