### PR TITLE
Quantized KV cache: use the fused SDPA kernel for prefill-shaped attention (2.66x TTFT at 10k ctx)

### DIFF
--- a/mlx_lm/models/base.py
+++ b/mlx_lm/models/base.py
@@ -1,6 +1,7 @@
 # Copyright © 2023-2024 Apple Inc.
 
 import inspect
+import os
 from dataclasses import dataclass
 from typing import Any, Optional
 
@@ -61,6 +62,26 @@ def create_ssm_mask(h, cache=None):
     return None
 
 
+# Above this many query rows, dequantize K/V and use the fused flash kernel
+# instead of the decomposed qmm->softmax->qmm path. The decomposed path
+# materializes an (n_heads, L, S) scores matrix to memory, which loses to
+# flash attention once L is large (prefill chunks); below the threshold the
+# decomposed path wins because it reads the smaller quantized K/V bytes and
+# skips the full dequant. Measured crossovers on M5 Max (S=2k..32k, bits 4/8
+# identical): L=128 for GQA (n_repeats>=2), L=192 for MHA (n_repeats==1) where
+# the fp16 K/V dequant transient is proportionally larger. These are
+# M5-measured defaults, not universal constants; MLX_LM_QSDPA_FLASH_MIN_L
+# overrides both (0 or negative disables the flash route entirely).
+_QSDPA_ENV = os.environ.get("MLX_LM_QSDPA_FLASH_MIN_L")
+if _QSDPA_ENV is not None and int(_QSDPA_ENV) <= 0:
+    _QUANT_SDPA_FLASH_MIN_L_GQA = _QUANT_SDPA_FLASH_MIN_L_MHA = float("inf")
+elif _QSDPA_ENV is not None:
+    _QUANT_SDPA_FLASH_MIN_L_GQA = _QUANT_SDPA_FLASH_MIN_L_MHA = int(_QSDPA_ENV)
+else:
+    _QUANT_SDPA_FLASH_MIN_L_GQA = 128
+    _QUANT_SDPA_FLASH_MIN_L_MHA = 192
+
+
 def quantized_scaled_dot_product_attention(
     queries: mx.array,
     q_keys: tuple[mx.array, mx.array, mx.array],
@@ -73,6 +94,22 @@ def quantized_scaled_dot_product_attention(
     B, n_q_heads, L, D = queries.shape
     n_kv_heads = q_keys[0].shape[-3]
     n_repeats = n_q_heads // n_kv_heads
+
+    flash_min_l = (
+        _QUANT_SDPA_FLASH_MIN_L_MHA
+        if n_repeats == 1
+        else _QUANT_SDPA_FLASH_MIN_L_GQA
+    )
+    if L >= flash_min_l:
+        # Large-L (prefill-shaped) case: the transient fp16 K/V costs
+        # S * n_kv_heads * D * 4 bytes but avoids the O(L*S) scores
+        # round-trip; measured 1.3-2.5x faster than the decomposed path
+        # beyond the crossover on all repeat/bits combinations.
+        keys = mx.dequantize(*q_keys, group_size=group_size, bits=bits)
+        values = mx.dequantize(*q_values, group_size=group_size, bits=bits)
+        return mx.fast.scaled_dot_product_attention(
+            queries, keys, values, scale=scale, mask=mask
+        )
 
     queries *= scale
 


### PR DESCRIPTION
### Problem

`quantized_scaled_dot_product_attention` always runs the decomposed path —
`quantized_matmul(Q, Kᵀ)` → `softmax` → `quantized_matmul(scores, V)` — which
materializes the full `(n_heads, L, S)` scores tensor to memory. For decode
(L=1) that's the right call: it reads the smaller quantized K/V bytes and skips
any dequantization, and we measured it at parity with (or ahead of) the fused
fp16 kernel at long context. But for **prefill-shaped calls** (L = hundreds,
i.e. every prompt-processing chunk when generating with `--kv-bits`), the
scores tensor reaches hundreds of MB to ~1 GB and the decomposed path loses
badly to simply dequantizing K/V and calling
`mx.fast.scaled_dot_product_attention`.

This is why long-prompt generation with `--kv-bits` currently pays a large
TTFT penalty vs fp16 cache.

### Change

When `L >= threshold`, dequantize K/V (transient, `S · n_kv_heads · D · 4`
bytes) and call the fused kernel; otherwise keep the decomposed path
unchanged. Thresholds measured on M5 Max with bits ∈ {4, 8} (crossover
identical for both): **128** for GQA (`n_repeats ≥ 2`; swept S = 2k–32k),
**192** for MHA (`n_repeats == 1`, where the dequant transient is
proportionally larger; full grid at S = 16k plus 2k/32k spot-checks).

These are M5-measured defaults, not universal constants:
`MLX_LM_QSDPA_FLASH_MIN_L` overrides both (`<= 0` disables the flash route,
restoring today's behavior exactly).

### Measurements (M5 Max, 40-core, macOS 26; GQA 32/8, head_dim 128, gs64)

Kernel-level, 4-bit KV, causal mask (decomposed → routed):

| S | L | before | after | speedup |
|---|---|---|---|---|
| 4096 | 512 | 2.67 ms | 1.09 ms | 2.46× |
| 16384 | 512 | 10.26 ms | 3.46 ms | 2.96× |
| 32768 | 256 | 10.48 ms | 3.87 ms | 2.71× |

End-to-end (Qwen3-0.6B-4bit, `kv_bits=8`, 10,081-token prompt, ABAB
interleaved): **TTFT 1.36 s → 0.51 s (2.66× on this exact branch)**, first token identical, decode
throughput unchanged.

Boundary sweep (why two thresholds): crossover L≈128 at n_repeats ∈ {2, 4}
(measured across S = 2k–32k) and L≈192 at n_repeats = 1 (full L-grid at
S = 16k, plus spot-checks at S = 2k and 32k confirming the flash route wins at
L = 192 on both extremes: 1.17× and 1.38×). Bits 4/8 give identical
crossovers. Below threshold the decomposed path stays faster (up to 2.9× at
small L / long S), so this PR routes only above it.

### Correctness

- Parity vs the decomposed path on (S, L) × {no-mask, `"causal"`, additive,
  boolean} — max |Δ| ≤ 5e-4 (fp16 accumulation-order tolerance), and exact
  argmax/first-token parity end-to-end.
- Threshold edges (L = 127 GQA / 191 MHA) take the identical decomposed code
  path (bitwise-identical output).
- The existing `Dq == Dk == Dv` contract of the decomposed path is unchanged.

### Related

The decomposed path's small-L advantage interacts with a separate fp16 SDPA
kernel-routing gap at L=8→12 reported in ml-explore/mlx#3826 — the thresholds
here deliberately sit above that window.

Bench + parity scripts available on request (boundary sweep, mask parity,
end-to-end TTFT A/B).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
