### PR TITLE
dwq: error out when --model is already quantized and no student is given

### DIFF
--- a/mlx_lm/quant/dwq.py
+++ b/mlx_lm/quant/dwq.py
@@ -391,6 +391,14 @@ def main():
         if "quantization" not in config:
             raise ValueError("Quantized model must already be quantized.")
     else:
+        if "quantization" in config:
+            raise ValueError(
+                "--model is already quantized, so quantizing it again to make "
+                "the student is a no-op and DWQ would have (almost) nothing to "
+                "train. Pass the student explicitly via --quantized-model "
+                "(e.g. a lower-bit quantization of the same base model), or "
+                "use the unquantized base model as --model."
+            )
         q_model = copy.deepcopy(model)
         _, config = quantize_model(
             q_model,


### PR DESCRIPTION
Passing an already-quantized model as `--model` without `--quantized-model` silently builds the student by re-quantizing the quantized weights — only ~0.01% of parameters end up trainable and the full training run proceeds with no warning, distilling essentially nothing. (Hit in practice distilling an 8-bit model down to 4-bit: the correct invocation needs the 4-bit student passed explicitly via `--quantized-model`.)

This raises a `ValueError` with a hint instead:

```
--model is already quantized, so quantizing it again to make the student is a
no-op and DWQ would have (almost) nothing to train. Pass the student explicitly
via --quantized-model (e.g. a lower-bit quantization of the same base model),
or use the unquantized base model as --model.
```

Verified: the guard fires immediately on a quantized `--model` (e.g. `mlx-community/Qwen3-0.6B-4bit`); unquantized models flow through unchanged.

One related observation from the same experiments, for context rather than as a code change: the final-vs-initial validation warning measures KL to the teacher (fidelity), which can diverge from downstream quality — we had runs that tripped the warning while improving held-out perplexity over the RTN starting point. Might be worth a wording tweak someday, but out of scope here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
