### PR TITLE
Fail closed on RotatingKVCache.trim after the ring wraps

### DIFF
--- a/mlx_lm/models/cache.py
+++ b/mlx_lm/models/cache.py
@@ -543,6 +543,17 @@ class RotatingKVCache(_BaseCache):
         return self.offset < self.max_size
 
     def trim(self, n):
+        if not self.is_trimmable():
+            # Fail closed. Once the ring has wrapped (offset >= max_size) the
+            # evicted entries are gone, so decrementing offset/_idx would
+            # silently corrupt the window rather than trim it. The public
+            # trim_prompt_cache path already guards on is_trimmable(); this
+            # protects direct callers (e.g. speculative rollback) too.
+            raise RuntimeError(
+                f"Cannot trim a RotatingKVCache that has wrapped (offset "
+                f"{self.offset} >= max_size {self.max_size}); the evicted "
+                f"entries are gone. Check is_trimmable() before calling trim()."
+            )
         n = min(self.offset, n)
         self.offset -= n
         self._idx -= n

--- a/tests/test_prompt_cache.py
+++ b/tests/test_prompt_cache.py
@@ -262,6 +262,31 @@ class TestPromptCache(unittest.TestCase):
         num_trimmed = trim_prompt_cache(cache, 4)
         self.assertEqual(num_trimmed, 3)
 
+    def test_rotating_cache_trim_fails_closed_after_wrap(self):
+        # Fill a RotatingKVCache past its window so the ring wraps.
+        cache = RotatingKVCache(max_size=6)
+        x = mx.random.uniform(shape=(1, 8, 10, 4))
+        cache.update_and_fetch(x, x)
+
+        # Once wrapped the cache is not trimmable: the public path is a no-op...
+        self.assertFalse(cache.is_trimmable())
+        self.assertEqual(trim_prompt_cache([cache], 4), 0)
+
+        # ...and a direct trim() call fails closed instead of silently
+        # decrementing offset/_idx and corrupting the window.
+        offset_before, idx_before = cache.offset, cache._idx
+        with self.assertRaises(RuntimeError):
+            cache.trim(4)
+        self.assertEqual(cache.offset, offset_before)
+        self.assertEqual(cache._idx, idx_before)
+
+        # An unwrapped rotating cache still trims normally.
+        cache = RotatingKVCache(max_size=6)
+        x = mx.random.uniform(shape=(1, 8, 5, 4))
+        cache.update_and_fetch(x, x)
+        self.assertTrue(cache.is_trimmable())
+        self.assertEqual(cache.trim(4), 4)
+
     def test_trim_cache_with_generate(self):
         model, tokenizer = self.model, self.tokenizer
         prompt = tokenizer.encode("this is a prompt", return_tensors="mlx")[0]


### PR DESCRIPTION
### What

`RotatingKVCache.trim()` silently corrupts the window if it is called after the ring has wrapped (`offset >= max_size`). At that point the evicted entries are gone, but the current body still runs `n = min(self.offset, n); self.offset -= n; self._idx -= n`, decrementing the bookkeeping as if the trimmed tokens were still present.

This makes `trim()` fail closed: it raises when the cache is not trimmable, matching `is_trimmable()` (`offset < max_size`).

### Why it isn't caught today

The public `trim_prompt_cache()` path already guards on `can_trim_prompt_cache()` / `is_trimmable()`, so this is **not reachable through the normal API** — `trim_prompt_cache` returns `0` for a wrapped rotating cache (there's an existing test for that).

The gap is for **direct** `trim()` callers. Speculative-decoding / rollback code that snapshots a cache and rewinds it by calling `trim()` on the primitive can land on a wrapped `RotatingKVCache` and get silent state corruption with no error, rather than a clear failure. This is a defense-in-depth hardening of the primitive itself.

### Behavior change

None for legitimate callers. Every in-tree caller reaches `trim()` only through `is_trimmable()` / `can_trim_prompt_cache()` gating (`trim_prompt_cache`, and `CacheList.trim` which is itself gated by all-children `is_trimmable()`), so `offset < max_size` always holds there. The only path whose behavior changes is the previously-silent post-wrap corruption, which now raises.

If you'd prefer `trim()` to return `0` (mirroring `trim_prompt_cache`) rather than raise, that's a one-line change — I went with `raise` because a direct trim on a wrapped cache is a programming error, not a no-op.

### Test

`tests/test_prompt_cache.py::test_rotating_cache_trim_fails_closed_after_wrap`: wraps a `RotatingKVCache`, asserts the public path is a no-op, asserts a direct `trim()` raises and leaves `offset`/`_idx` unchanged, and asserts an unwrapped cache still trims normally. It fails on `main` (silent decrement) and passes with this change.

`black` and `isort --profile black` clean.
