### PR TITLE
Keep the server generation loop alive when a batched request fails

### DIFF
--- a/mlx_lm/generate.py
+++ b/mlx_lm/generate.py
@@ -1147,12 +1147,12 @@ class PromptProcessingBatch:
         if not any(self.samplers):
             self.samplers = [None] * len(self.uids)
         if not any(self.logits_processors):
-            self.logits_processors = [None] * len(self.uids)
+            self.logits_processors = [[]] * len(self.uids)
         samplers = batch.samplers if any(batch.samplers) else [None] * len(batch.uids)
         logits_processors = (
             batch.logits_processors
             if any(batch.logits_processors)
-            else [None] * len(batch.uids)
+            else [[]] * len(batch.uids)
         )
 
         self.uids.extend(batch.uids)

--- a/mlx_lm/server.py
+++ b/mlx_lm/server.py
@@ -674,50 +674,51 @@ class ResponseGenerator:
                         prompt, segments, segment_types, initial_state = self._tokenize(
                             current_tokenizer, request, args
                         )
+
+                        stop_matcher, text_sm = self._make_state_machine(
+                            self.model_provider.model_key,
+                            tokenizer,
+                            args.stop_words,
+                        )
+
+                        self._log_cache_stats()
+                        cache, rest = self.prompt_cache.fetch_nearest_cache(
+                            current_model_key, prompt
+                        )
+                        prompt_cache_count = len(prompt) - len(rest)
+                        N = prompt_cache_count
+                        while N > 0:
+                            if N >= len(segments[0]):
+                                N -= len(segments.pop(0))
+                                segment_types.pop(0)
+                            else:
+                                segments[0] = segments[0][N:]
+                                break
+
+                        ctx = GenerationContext(
+                            has_tool_calling=tokenizer.has_tool_calling,
+                            has_thinking=tokenizer.has_thinking,
+                            tool_parser=tokenizer.tool_parser,
+                            text_sm=text_sm,
+                            initial_state=initial_state,
+                            prompt=prompt,
+                            prompt_cache_count=prompt_cache_count,
+                        )
+
+                        (uid,) = batch_generator.insert_segments(
+                            segments=[segments],
+                            max_tokens=[args.max_tokens],
+                            caches=[cache],
+                            all_tokens=[prompt[:prompt_cache_count]],
+                            samplers=[_make_sampler(args, tokenizer)],
+                            logits_processors=[_make_logits_processors(args)],
+                            stop_matchers=[stop_matcher],
+                        )
                     except Exception as e:
                         rqueue.put(e)
                         continue
 
-                    stop_matcher, text_sm = self._make_state_machine(
-                        self.model_provider.model_key,
-                        tokenizer,
-                        args.stop_words,
-                    )
-
-                    self._log_cache_stats()
-                    cache, rest = self.prompt_cache.fetch_nearest_cache(
-                        current_model_key, prompt
-                    )
-                    prompt_cache_count = len(prompt) - len(rest)
-                    N = prompt_cache_count
-                    while N > 0:
-                        if N >= len(segments[0]):
-                            N -= len(segments.pop(0))
-                            segment_types.pop(0)
-                        else:
-                            segments[0] = segments[0][N:]
-                            break
-
-                    ctx = GenerationContext(
-                        has_tool_calling=tokenizer.has_tool_calling,
-                        has_thinking=tokenizer.has_thinking,
-                        tool_parser=tokenizer.tool_parser,
-                        text_sm=text_sm,
-                        initial_state=initial_state,
-                        prompt=prompt,
-                        prompt_cache_count=prompt_cache_count,
-                    )
                     rqueue.put(ctx)
-
-                    (uid,) = batch_generator.insert_segments(
-                        segments=[segments],
-                        max_tokens=[args.max_tokens],
-                        caches=[cache],
-                        all_tokens=[prompt[:prompt_cache_count]],
-                        samplers=[_make_sampler(args, tokenizer)],
-                        logits_processors=[_make_logits_processors(args)],
-                        stop_matchers=[stop_matcher],
-                    )
                     batch_results[uid] = {
                         "ctx": ctx,
                         "rqueue": rqueue,
@@ -773,97 +774,121 @@ class ResponseGenerator:
 
             # No request so serve from the current batch
             elif batch_generator is not None:
-                if len(batch_results) == 0:
-                    if drain_batch:
-                        current_model = None
-                        current_sampling = None
-                        current_tokenizer = None
-                        current_model_key = None
-                        batch_generator.close()
-                        batch_generator = None
-                        drain_batch = False
-                    continue
+                try:
+                    if len(batch_results) == 0:
+                        if drain_batch:
+                            current_model = None
+                            current_sampling = None
+                            current_tokenizer = None
+                            current_model_key = None
+                            batch_generator.close()
+                            batch_generator = None
+                            drain_batch = False
+                        continue
 
-                uids_to_remove = []
-                for _ in self._time_budget:
-                    prompt_responses, gen_responses = batch_generator.next()
-                    if not prompt_responses and not gen_responses:
-                        break
+                    uids_to_remove = []
+                    for _ in self._time_budget:
+                        prompt_responses, gen_responses = batch_generator.next()
+                        if not prompt_responses and not gen_responses:
+                            break
 
-                    # Progress report for prompt processing
-                    for r in prompt_responses:
-                        result = batch_results[r.uid]
-                        result["rqueue"].put(r.progress)
-                        if result["ctx"]._should_stop:
-                            uids_to_remove.append(r.uid)
+                        # Progress report for prompt processing
+                        for r in prompt_responses:
+                            result = batch_results[r.uid]
+                            result["rqueue"].put(r.progress)
+                            if result["ctx"]._should_stop:
+                                uids_to_remove.append(r.uid)
 
-                    # Save the caches at end of segments
-                    eos_ids = [
-                        r.uid
-                        for r in prompt_responses
-                        if r.end_of_segment
-                        and not r.end_of_prompt
-                        and batch_results[r.uid]["segment_types"]
-                    ]
-                    caches = batch_generator.extract_cache(eos_ids)
-                    for uid, (cache, cache_key) in caches.items():
-                        self.prompt_cache.insert_cache(
-                            self.model_provider.model_key,
-                            cache_key[:],
-                            cache,
-                            cache_type=batch_results[uid]["segment_types"].pop(),
-                        )
-                    del caches
-
-                    for r in gen_responses:
-                        result = batch_results[r.uid]
-
-                        # Don't decode the final stop token
-                        if r.finish_reason == "stop":
-                            result["detokenizer"].finalize()
-                            text = result["detokenizer"].last_segment
-                        elif r.finish_reason == "length":
-                            result["detokenizer"].add_token(r.token)
-                            result["detokenizer"].finalize()
-                            text = result["detokenizer"].last_segment
-                        else:
-                            result["detokenizer"].add_token(r.token)
-                            text = result["detokenizer"].last_segment
-
-                        result["rqueue"].put(
-                            Response(
-                                text,
-                                r.token,
-                                r.logprobs[r.token].item(),
-                                r.finish_reason,
-                                _format_top_logprobs(
-                                    r.logprobs,
-                                    result["top_logprobs"],
-                                    current_tokenizer,
-                                ),
-                            )
-                        )
-
-                        if r.finish_reason is not None:
-                            result["rqueue"].put(None)
+                        # Save the caches at end of segments
+                        eos_ids = [
+                            r.uid
+                            for r in prompt_responses
+                            if r.end_of_segment
+                            and not r.end_of_prompt
+                            and batch_results[r.uid]["segment_types"]
+                        ]
+                        caches = batch_generator.extract_cache(eos_ids)
+                        for uid, (cache, cache_key) in caches.items():
                             self.prompt_cache.insert_cache(
-                                current_model_key,
-                                r.all_tokens[:],
-                                r.prompt_cache,
-                                cache_type="assistant",
+                                self.model_provider.model_key,
+                                cache_key[:],
+                                cache,
+                                cache_type=batch_results[uid]["segment_types"].pop(),
                             )
-                            del batch_results[r.uid]
+                        del caches
 
-                        if result["ctx"]._should_stop:
-                            uids_to_remove.append(r.uid)
+                        for r in gen_responses:
+                            result = batch_results[r.uid]
 
-                uids_to_remove = self._share_object(uids_to_remove)
-                if uids_to_remove:
-                    batch_generator.remove(uids_to_remove)
-                    for uid in uids_to_remove:
-                        # It may have already been removed during
-                        # generation
-                        batch_results.pop(uid, None)
+                            # Don't decode the final stop token
+                            if r.finish_reason == "stop":
+                                result["detokenizer"].finalize()
+                                text = result["detokenizer"].last_segment
+                            elif r.finish_reason == "length":
+                                result["detokenizer"].add_token(r.token)
+                                result["detokenizer"].finalize()
+                                text = result["detokenizer"].last_segment
+                            else:
+                                result["detokenizer"].add_token(r.token)
+                                text = result["detokenizer"].last_segment
+
+                            result["rqueue"].put(
+                                Response(
+                                    text,
+                                    r.token,
+                                    r.logprobs[r.token].item(),
+                                    r.finish_reason,
+                                    _format_top_logprobs(
+                                        r.logprobs,
+                                        result["top_logprobs"],
+                                        current_tokenizer,
+                                    ),
+                                )
+                            )
+
+                            if r.finish_reason is not None:
+                                result["rqueue"].put(None)
+                                self.prompt_cache.insert_cache(
+                                    current_model_key,
+                                    r.all_tokens[:],
+                                    r.prompt_cache,
+                                    cache_type="assistant",
+                                )
+                                del batch_results[r.uid]
+
+                            if result["ctx"]._should_stop:
+                                uids_to_remove.append(r.uid)
+
+                    uids_to_remove = self._share_object(uids_to_remove)
+                    if uids_to_remove:
+                        batch_generator.remove(uids_to_remove)
+                        for uid in uids_to_remove:
+                            # It may have already been removed during
+                            # generation
+                            batch_results.pop(uid, None)
+                except Exception as e:
+                    # An uncaught exception here used to kill the generation
+                    # thread while the HTTP threads kept accepting requests
+                    # that could never be answered. Fail the in-flight
+                    # requests and keep serving; queued requests are retried
+                    # with a fresh batch generator.
+                    logging.exception(
+                        "Generation batch failed. Failing the in-flight "
+                        "requests and continuing to serve."
+                    )
+                    for result in batch_results.values():
+                        result["rqueue"].put(e)
+                    batch_results = {}
+                    try:
+                        batch_generator.close()
+                    except Exception:
+                        logging.exception("Failed to close the batch generator.")
+                    batch_generator = None
+                    current_model = None
+                    current_sampling = None
+                    current_tokenizer = None
+                    current_model_key = None
+                    drain_batch = False
 
     def _serve_single(self, request):
         rqueue, request, args = request
@@ -978,6 +1003,11 @@ class ResponseGenerator:
         generation_args: GenerationArguments,
         progress_callback: Optional[Callable[[int, int], None]] = None,
     ):
+        if not self._generation_thread.is_alive():
+            raise RuntimeError(
+                "The generation thread is not running. The server needs to "
+                "be restarted."
+            )
         response_queue = Queue()
         self.requests.put((response_queue, request, generation_args))
 

--- a/tests/test_generate.py
+++ b/tests/test_generate.py
@@ -213,6 +213,36 @@ class TestGenerate(unittest.TestCase):
                 self.assertTrue(mx.allclose(blp, lp))
                 break
 
+    def test_batch_extend_mixed_logits_processors(self):
+        # Regression test for a sequence without logits processors entering
+        # the prompt batch alone, which left a None placeholder behind. A
+        # sequence with processors joining a step later produced a mixed
+        # [None, [...]] list, and when both moved to generation in the same
+        # step, GenerationBatch._step raised
+        # "TypeError: 'NoneType' object is not iterable".
+        filler = self.tokenizer.encode("hello " * 40)
+        gen = BatchGenerator(
+            self.model,
+            max_tokens=4,
+            prefill_batch_size=2,
+            prefill_step_size=8,
+        )
+        procs = make_logits_processors(repetition_penalty=1.5)
+
+        # 20 tokens prefill as 8 + 8 + 3; the 15-token sequence inserted one
+        # step later prefills as 8 + 6 so both finish on the same step.
+        (uid_a,) = gen.insert([filler[:20]], logits_processors=[[]])
+        gen.next()
+        (uid_b,) = gen.insert([filler[:15]], logits_processors=[procs])
+
+        finished = set()
+        for _ in range(100):
+            _, gen_responses = gen.next()
+            finished.update(r.uid for r in gen_responses if r.finish_reason is not None)
+            if {uid_a, uid_b} <= finished:
+                break
+        self.assertEqual(finished, {uid_a, uid_b})
+
     def test_many_batches(self):
 
         prompts = [

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -5,15 +5,20 @@ import io
 import json
 import threading
 import unittest
+from unittest import mock
 
 import mlx.core as mx
 import requests
 
-from mlx_lm.generate import TextStateMachine
+from mlx_lm.generate import BatchGenerator, TextStateMachine
 from mlx_lm.models.cache import KVCache
 from mlx_lm.server import (
     APIHandler,
+    CompletionRequest,
+    GenerationArguments,
+    LogitsProcessorArguments,
     LRUPromptCache,
+    ModelDescription,
     Response,
     ResponseGenerator,
     SamplingArguments,
@@ -563,6 +568,74 @@ class TestKeepalive(unittest.TestCase):
             keepalive_callback(3072, 4096)
         except Exception as e:
             self.fail(f"Callback should handle BrokenPipeError: {e}")
+
+
+class TestResponseGeneratorResilience(unittest.TestCase):
+
+    @staticmethod
+    def _make_request():
+        request = CompletionRequest(
+            request_type="chat",
+            prompt="",
+            messages=[{"role": "user", "content": "Hi"}],
+            tools=None,
+            role_mapping=None,
+        )
+        args = GenerationArguments(
+            model=ModelDescription(model="default_model", draft=None, adapter=None),
+            sampling=SamplingArguments(
+                temperature=0.0,
+                top_p=1.0,
+                top_k=0,
+                min_p=0.0,
+                xtc_probability=0.0,
+                xtc_threshold=0.0,
+            ),
+            logits=LogitsProcessorArguments(
+                logit_bias=None,
+                repetition_penalty=None,
+                repetition_context_size=20,
+                presence_penalty=None,
+                presence_context_size=20,
+                frequency_penalty=None,
+                frequency_context_size=20,
+            ),
+            stop_words=[],
+            max_tokens=4,
+            num_draft_tokens=0,
+            logprobs=False,
+            top_logprobs=0,
+            seed=None,
+            chat_template_kwargs=None,
+        )
+        return request, args
+
+    def test_generation_thread_survives_batch_exception(self):
+        # Regression test: an uncaught exception in the generation loop used
+        # to kill the generation thread while the HTTP server kept accepting
+        # requests that could never be answered.
+        response_generator = ResponseGenerator(DummyModelProvider(), LRUPromptCache())
+        try:
+            request, args = self._make_request()
+
+            with mock.patch.object(
+                BatchGenerator, "next", side_effect=RuntimeError("boom")
+            ):
+                _, responses = response_generator.generate(request, args)
+                with self.assertRaises(RuntimeError):
+                    for _ in responses:
+                        pass
+
+            # The generation thread must survive and keep serving
+            self.assertTrue(response_generator._generation_thread.is_alive())
+
+            request, args = self._make_request()
+            _, responses = response_generator.generate(request, args)
+            responses = list(responses)
+            self.assertTrue(len(responses) > 0)
+            self.assertEqual(responses[-1].finish_reason, "length")
+        finally:
+            response_generator.stop_and_join()
 
 
 class TestLRUPromptCache(unittest.TestCase):


### PR DESCRIPTION
Fixes #1505 (and one of the concrete crashes reported there).

## The problem

As reported in #1505, when `Thread-1 (_generate)` dies from any uncaught exception, `mlx_lm.server` turns into a zombie: `ThreadingHTTPServer` keeps accepting connections, but every request blocks forever in `ResponseGenerator.generate()` on a queue no worker will ever service, in-flight requests never resolve, and `/health` still returns `{"status": "ok"}`. I reproduced this end-to-end on current main with nothing but two plain HTTP requests (M1, 16GB, `Llama-3.2-1B-Instruct-4bit`, `--prompt-concurrency 2`):

1. request A: long prompt (~5k tokens), **no** sampling penalties
2. ~1s later, request B: long prompt (~3k tokens), **with** `repetition_penalty`

Result: `TypeError: 'NoneType' object is not iterable` at `generate.py:1428`, generation thread dead, both requests hang, all subsequent requests hang, `/health` still ok — one of the exact exceptions listed in the issue.

## Root cause of that TypeError

`PromptProcessingBatch.extend` uses `None` placeholders when no sequence so far has logits processors:

- A enters the prompt batch alone → `self.logits_processors = [None]`
- B (with processors) joins a step later → `[None, [processor]]`
- both finish prefill in the same step → `split().generate()` → `GenerationBatch._step` iterates entry `None` → `TypeError`

Everything else in the file treats "no processors" as an empty list (`filter()` uses `[[]] * len(keep)`); `extend` is the one place that violates the invariant. The sampler `None` placeholders are fine — the use site falls back (`self.samplers[e] or self.fallback_sampler`) — so those are left untouched.

## Changes

- **`generate.py`**: empty-list placeholders in `PromptProcessingBatch.extend`, consistent with `filter()`. This also keeps the `any(...)`-gated fast path (all-empty still skips the processor loop).
- **`server.py`**: the design fix for #1505 —
  - batch **admission** path: the whole per-request block (state machine, cache fetch, `insert_segments`) is now covered by the same per-request exception handling that `_tokenize` and `_serve_single` already had, so one bad request fails with an error response instead of taking down the thread. The context is only handed to the client after the request is actually registered in the batch.
  - batch **serving** path: an exception now fails the in-flight requests with the exception (clients get an error instead of a hang), logs the traceback, closes and resets the batch generator, and keeps serving. Queued requests are retried against a fresh generator; a poison request can't loop because it fails from inside `batch_results` on the next crash.
  - `ResponseGenerator.generate()` raises immediately if the generation thread is not alive, so any residual way to kill the thread turns into error responses rather than infinite client hangs.

This also covers the other exceptions listed in #1505 (`[metal::malloc]` resource-limit errors under sustained load, etc.): the batch is dropped, the affected requests get errors, and the server keeps serving instead of bricking.

## Tests

- `tests/test_generate.py::test_batch_extend_mixed_logits_processors` — deterministic regression test for the mixed-placeholder crash (staggered inserts sized to co-finish prefill); fails with `TypeError` on current main, passes with the fix.
- `tests/test_server.py::TestResponseGeneratorResilience` — injects a `RuntimeError` into `BatchGenerator.next`, asserts the caller receives the exception, the generation thread survives, and a subsequent request completes normally.
- Full `tests/test_server.py` (25) and `tests/test_generate.py` (27) pass locally on an M1.
- End-to-end: the two-request scenario above completes cleanly on the fixed build (both `finish_reason: length`, no traceback, follow-up requests fine).