### PR TITLE
Fail fast when the generation thread stops

### DIFF
--- a/mlx_lm/server.py
+++ b/mlx_lm/server.py
@@ -14,7 +14,7 @@ from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
 from pathlib import Path
 from queue import Empty as QueueEmpty
 from queue import Queue
-from threading import Thread
+from threading import Event, Thread
 from typing import (
     Any,
     Callable,
@@ -231,6 +231,10 @@ class Response:
     top_tokens: Tuple[Dict[str, Any]]
 
 
+class GenerationThreadError(RuntimeError):
+    """Raised when the generation thread is no longer available."""
+
+
 class TimeBudget:
     def __init__(self, budget=0.5, iterations=25, sync_frequency=10):
         self._is_distributed = mx.distributed.init().size() > 1
@@ -430,7 +434,8 @@ class ResponseGenerator:
         self._is_distributed = mx.distributed.init().size() > 1
         self._rank = mx.distributed.init().rank()
         self._stop = False
-        self._generation_thread = Thread(target=self._generate)
+        self._generation_stopped = Event()
+        self._generation_thread = Thread(target=self._run_generation)
         self._generation_thread.start()
 
     def stop_and_join(self):
@@ -439,6 +444,31 @@ class ResponseGenerator:
 
     def join(self):
         self._generation_thread.join()
+
+    def _run_generation(self):
+        try:
+            self._generate()
+        finally:
+            self._generation_stopped.set()
+
+    @property
+    def is_healthy(self):
+        return (
+            not self._stop
+            and not self._generation_stopped.is_set()
+            and self._generation_thread.is_alive()
+        )
+
+    def _get_response(self, response_queue):
+        while True:
+            try:
+                return response_queue.get(timeout=0.1)
+            except QueueEmpty:
+                if not self.is_healthy:
+                    raise GenerationThreadError(
+                        "The generation thread is not running. "
+                        "The server needs to be restarted."
+                    ) from None
 
     def _log_cache_stats(self):
         n_sequences = len(self.prompt_cache)
@@ -981,12 +1011,18 @@ class ResponseGenerator:
         generation_args: GenerationArguments,
         progress_callback: Optional[Callable[[int, int], None]] = None,
     ):
+        if not self.is_healthy:
+            raise GenerationThreadError(
+                "The generation thread is not running. "
+                "The server needs to be restarted."
+            )
+
         response_queue = Queue()
         self.requests.put((response_queue, request, generation_args))
 
         def _inner():
             while True:
-                response = response_queue.get()
+                response = self._get_response(response_queue)
                 if response is None:
                     break
                 if isinstance(response, Exception):
@@ -997,7 +1033,7 @@ class ResponseGenerator:
                     continue
                 yield response
 
-        ctx = response_queue.get()
+        ctx = self._get_response(response_queue)
         if isinstance(ctx, Exception):
             raise ctx
 
@@ -1045,6 +1081,14 @@ class APIHandler(BaseHTTPRequestHandler):
         self.send_header("Content-type", "text/event-stream")
         self.send_header("Cache-Control", "no-cache")
         self._set_cors_headers()
+
+    def _send_json_error(self, status_code, error):
+        response = json.dumps({"error": str(error)}).encode()
+        self._set_completion_headers(status_code)
+        self.send_header("Content-Length", str(len(response)))
+        self.end_headers()
+        self.wfile.write(response)
+        self.wfile.flush()
 
     def do_OPTIONS(self):
         self._set_completion_headers(204)
@@ -1373,10 +1417,11 @@ class APIHandler(BaseHTTPRequestHandler):
                 args,
                 progress_callback=keepalive_callback,
             )
+        except GenerationThreadError as e:
+            self._send_json_error(503, e)
+            return
         except Exception as e:
-            self._set_completion_headers(404)
-            self.end_headers()
-            self.wfile.write(json.dumps({"error": str(e)}).encode())
+            self._send_json_error(404, e)
             return
 
         # Prepare the headers
@@ -1385,7 +1430,6 @@ class APIHandler(BaseHTTPRequestHandler):
             self.end_headers()
             logging.debug("Starting stream:")
         else:
-            self._set_completion_headers(200)
             logging.debug("Starting completion:")
 
         # Tool call formatter
@@ -1513,10 +1557,22 @@ class APIHandler(BaseHTTPRequestHandler):
                     logging.debug(f"Outgoing Response: {response_debug}")
 
                 response_json = json.dumps(resp).encode()
+                self._set_completion_headers(200)
                 self.send_header("Content-Length", str(len(response_json)))
                 self.end_headers()
                 self.wfile.write(response_json)
                 self.wfile.flush()
+        except GenerationThreadError as e:
+            if self.stream:
+                error = json.dumps({"error": str(e)})
+                try:
+                    self.wfile.write(f"data: {error}\n\n".encode())
+                    self.wfile.flush()
+                except (BrokenPipeError, ConnectionResetError, OSError):
+                    pass
+                self.close_connection = True
+            else:
+                self._send_json_error(503, e)
         finally:
             ctx.stop()
 
@@ -1603,10 +1659,15 @@ class APIHandler(BaseHTTPRequestHandler):
         """
         Handle a GET request for the /health endpoint.
         """
-        self._set_completion_headers(200)
+        healthy = self.response_generator.is_healthy
+        status_code = 200 if healthy else 503
+        response = json.dumps({"status": "ok" if healthy else "unhealthy"}).encode()
+
+        self._set_completion_headers(status_code)
+        self.send_header("Content-Length", str(len(response)))
         self.end_headers()
 
-        self.wfile.write('{"status": "ok"}'.encode())
+        self.wfile.write(response)
         self.wfile.flush()
 
     def handle_models_request(self):

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -4,14 +4,24 @@ import http
 import io
 import json
 import threading
+import time
 import unittest
+from queue import Empty
+from unittest import mock
 
 import mlx.core as mx
 import requests
 
 from mlx_lm.generate import TextStateMachine
 from mlx_lm.models.cache import KVCache
-from mlx_lm.server import APIHandler, LRUPromptCache, Response, ResponseGenerator
+from mlx_lm.server import (
+    APIHandler,
+    GenerationContext,
+    GenerationThreadError,
+    LRUPromptCache,
+    Response,
+    ResponseGenerator,
+)
 from mlx_lm.utils import load
 
 
@@ -84,6 +94,30 @@ class MockCache:
     def trim(self, n):
         assert self._is_trimmable
         return n
+
+
+class ControlledResponseGenerator(ResponseGenerator):
+    def __init__(self, target):
+        self._target = target
+        cli_args = type(
+            "obj",
+            (object,),
+            {
+                "allowed_origins": ["*"],
+                "model": None,
+                "num_draft_tokens": 0,
+                "max_tokens": 8,
+                "temp": 0.0,
+                "top_p": 1.0,
+                "top_k": 0,
+                "min_p": 0.0,
+            },
+        )
+        provider = type("obj", (object,), {"cli_args": cli_args})()
+        super().__init__(provider, LRUPromptCache())
+
+    def _generate(self):
+        self._target(self)
 
 
 class TestTextStateMachine(unittest.TestCase):
@@ -556,6 +590,162 @@ class TestKeepalive(unittest.TestCase):
             keepalive_callback(3072, 4096)
         except Exception as e:
             self.fail(f"Callback should handle BrokenPipeError: {e}")
+
+
+class TestGenerationThreadFailure(unittest.TestCase):
+    def test_pending_and_future_requests_fail_when_thread_dies(self):
+        started = threading.Event()
+        fail = threading.Event()
+
+        def crash(_):
+            started.set()
+            fail.wait()
+            raise RuntimeError("worker exploded")
+
+        with mock.patch("threading.excepthook"):
+            response_generator = ControlledResponseGenerator(crash)
+            errors = []
+            clients = []
+            try:
+                self.assertTrue(started.wait(timeout=2))
+
+                def generate():
+                    try:
+                        response_generator.generate(None, None)
+                    except Exception as e:
+                        errors.append(e)
+
+                clients = [
+                    threading.Thread(target=generate, daemon=True) for _ in range(2)
+                ]
+                for client in clients:
+                    client.start()
+
+                deadline = time.monotonic() + 2
+                while response_generator.requests.qsize() < len(clients):
+                    self.assertLess(time.monotonic(), deadline)
+                    time.sleep(0.01)
+            finally:
+                fail.set()
+                response_generator._generation_thread.join(timeout=2)
+
+            for client in clients:
+                client.join(timeout=2)
+
+        if any(client.is_alive() for client in clients):
+            while True:
+                try:
+                    response_queue, *_ = response_generator.requests.get_nowait()
+                except Empty:
+                    break
+                response_queue.put(RuntimeError("test cleanup"))
+            for client in clients:
+                client.join(timeout=2)
+
+        self.assertTrue(all(not client.is_alive() for client in clients))
+        self.assertEqual(len(errors), len(clients))
+        self.assertTrue(all(isinstance(e, GenerationThreadError) for e in errors))
+
+        queued_requests = response_generator.requests.qsize()
+        with self.assertRaisesRegex(GenerationThreadError, "needs to be restarted"):
+            response_generator.generate(None, None)
+        self.assertEqual(response_generator.requests.qsize(), queued_requests)
+
+    def test_response_iterator_fails_when_thread_dies(self):
+        context_sent = threading.Event()
+        fail = threading.Event()
+
+        def crash(response_generator):
+            response_queue, *_ = response_generator._next_request(timeout=2)
+            response_queue.put(object())
+            context_sent.set()
+            fail.wait()
+            raise RuntimeError("worker exploded")
+
+        with mock.patch("threading.excepthook"):
+            response_generator = ControlledResponseGenerator(crash)
+            try:
+                _, responses = response_generator.generate(None, None)
+                self.assertTrue(context_sent.wait(timeout=2))
+            finally:
+                fail.set()
+                response_generator._generation_thread.join(timeout=2)
+
+            with self.assertRaisesRegex(GenerationThreadError, "needs to be restarted"):
+                next(responses)
+
+    def test_inflight_http_response_terminates_when_thread_dies(self):
+        payload = {
+            "messages": [{"role": "user", "content": "Hello"}],
+            "max_tokens": 1,
+        }
+
+        for stream in (False, True):
+            with self.subTest(stream=stream), mock.patch("threading.excepthook"):
+
+                def crash(response_generator):
+                    response_queue, *_ = response_generator._next_request(timeout=5)
+                    response_queue.put(
+                        GenerationContext(
+                            has_tool_calling=False,
+                            has_thinking=False,
+                            tool_parser=lambda *_: {},
+                            text_sm=TextStateMachine(),
+                            initial_state="normal",
+                            prompt=[],
+                        )
+                    )
+                    raise RuntimeError("worker exploded")
+
+                response_generator = ControlledResponseGenerator(crash)
+                httpd = http.server.HTTPServer(
+                    ("localhost", 0),
+                    lambda *args, **kwargs: APIHandler(
+                        response_generator,
+                        *args,
+                        system_fingerprint="test",
+                        **kwargs,
+                    ),
+                )
+                server_thread = threading.Thread(
+                    target=httpd.serve_forever, daemon=True
+                )
+                server_thread.start()
+                base_url = f"http://localhost:{httpd.server_port}"
+
+                try:
+                    health = requests.get(f"{base_url}/health", timeout=2)
+                    self.assertEqual(health.status_code, 200)
+
+                    payload["stream"] = stream
+                    response = requests.post(
+                        f"{base_url}/v1/chat/completions",
+                        json=payload,
+                        timeout=2,
+                    )
+                    if stream:
+                        self.assertEqual(response.status_code, 200)
+                        self.assertIn('data: {"error":', response.text)
+                        self.assertNotIn("[DONE]", response.text)
+                    else:
+                        self.assertEqual(response.status_code, 503)
+                        self.assertIn("needs to be restarted", response.json()["error"])
+
+                    health = requests.get(f"{base_url}/health", timeout=2)
+                    self.assertEqual(health.status_code, 503)
+                    self.assertEqual(health.json(), {"status": "unhealthy"})
+
+                    response = requests.post(
+                        f"{base_url}/v1/chat/completions",
+                        json=payload,
+                        timeout=2,
+                    )
+                    self.assertEqual(response.status_code, 503)
+                finally:
+                    response_generator._generation_thread.join(timeout=2)
+                    httpd.shutdown()
+                    httpd.server_close()
+                    server_thread.join(timeout=1)
 
 
 class TestLRUPromptCache(unittest.TestCase):


### PR DESCRIPTION
If the generation thread crashes, the HTTP server currently stays up but can no longer answer completion requests. This change makes requests fail quickly, returns 503 from /health, and closes active streams with an error so a supervisor can safely restart the process.

Addresses #1505 and complements #1513
