### PR TITLE
Capture anchor-stride prefix reuse on the batched path

### DIFF
--- a/benchmarks/bench_prompt_cache_anchor_stride.py
+++ b/benchmarks/bench_prompt_cache_anchor_stride.py
@@ -1,0 +1,489 @@
+"""Benchmark the prompt-cache prefix-anchor-stride API (upstream PR).
+
+Exercises the NEW public API in ``mlx_lm.models.cache``:
+
+  * ``PrefixAnchorCapture(cache, stride)`` -- a
+    ``prompt_progress_callback(processed, total)``-compatible callable wired into
+    ``generate_step``. It deep-copies the live cache at stride boundaries during
+    the prefill the server is doing anyway, recording ``PrefixAnchor`` snapshots.
+  * ``LRUPromptCache.insert_anchors(model, tokens, anchors)`` -- stores each
+    snapshot as an ordinary *shorter* trie entry. Retrieval is unchanged:
+    ``fetch_nearest_cache`` finds the longest stored shorter prefix + tail.
+
+The scenario that distinguishes the anchor API from plain upstream
+``LRUPromptCache``: a long SHARED prefix followed by DIVERGENT tails --
+``req_a = P + tail_a``, ``req_b = P + tail_b``. Upstream's ``fetch_nearest_cache``
+can reuse ``P`` for ``req_b`` only by *trimming* the stored ``req_a`` cache back
+to ``|P|``; for a NON-TRIMMABLE cache (recurrent/hybrid models whose caches
+report ``can_trim_prompt_cache == False``, e.g. ``ArraysCache``) that path is
+skipped, so ``req_b`` re-prefills from scratch (reused == 0). Anchor-stride
+pre-saved an exact shorter snapshot at each stride boundary of ``req_a``, so
+``req_b`` reuses up to the nearest anchor ``<= |P|``.
+
+Two modes:
+
+  synthetic (default, CPU, no download)
+      Builds a genuinely tiny NON-TRIMMABLE recurrent nn model whose
+      ``make_prompt_cache`` yields ``ArraysCache`` per layer, and drives a real
+      prefill through ``mlx_lm.generate.generate_step`` with a
+      ``PrefixAnchorCapture`` wired as ``prompt_progress_callback`` (the intended
+      usage). Proves: upstream reuses 0 across the divergent tail; anchor mode
+      reuses the nearest-anchor prefix; and the anchor-reused continuation is
+      next-token-IDENTICAL to a cold full prefill.
+
+  --model PATH (optional, real recurrent/hybrid model)
+      Mirrors ``bench_prefix_cache_vs_upstream.py``: cold full prefill of req_b
+      vs upstream ``LRUPromptCache`` reuse vs anchor-stride reuse, reporting
+      reused-tokens and prefill/TTFT ms per arm, each gated on next-token
+      equivalence vs cold. The anchor arm captures during req_a's prefill (not a
+      separate manual re-prefill). Prefill/TTFT is reported separately from
+      decode throughput; no decode-token/s win is claimed.
+
+  # synthetic (default)
+  /Users/pierrelamy/Desktop/mlx-uag/.venv-mlxmain/bin/python \
+      benchmarks/bench_prompt_cache_anchor_stride.py --stride 128 --target 600
+
+  # real recurrent/hybrid model
+  .venv/bin/python benchmarks/bench_prompt_cache_anchor_stride.py \
+      --model ~/.cache/huggingface/hub/models--.../snapshots/* \
+      --stride 128 --target 4096
+"""
+
+import argparse
+import copy
+import json
+import os
+import random
+import sys
+import time
+
+# Prefer THIS worktree's mlx_lm (which carries the anchor API) over any mlx_lm
+# installed in the interpreter's site-packages.
+_REPO_ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+if _REPO_ROOT not in sys.path:
+    sys.path.insert(0, _REPO_ROOT)
+
+import mlx.core as mx  # noqa: E402
+import mlx.nn as nn  # noqa: E402
+
+from mlx_lm.generate import generate_step  # noqa: E402
+from mlx_lm.models.cache import (  # noqa: E402
+    ArraysCache,
+    LRUPromptCache,
+    PrefixAnchorCapture,
+    can_trim_prompt_cache,
+    make_prompt_cache,
+)
+
+# One string key stands in for the model in the trie (the module object is
+# unhashable); upstream's server keys the same way.
+MODEL_KEY = "bench-anchor-model"
+
+
+# --------------------------------------------------------------------------- #
+# Tiny non-trimmable recurrent model (synthetic mode)
+# --------------------------------------------------------------------------- #
+class _RecurrentCell(nn.Module):
+    """A minimal per-token linear recurrence: h_t = tanh(Wx x_t + Wh h_{t-1}).
+
+    The final hidden state depends on the ENTIRE processed prefix and is computed
+    identically per token regardless of how prefill is chunked -- exactly the
+    property that makes reuse-from-a-shorter-prefix bitwise-equivalent to a cold
+    full prefill.
+    """
+
+    def __init__(self, dim: int):
+        super().__init__()
+        self.Wx = nn.Linear(dim, dim, bias=False)
+        self.Wh = nn.Linear(dim, dim, bias=False)
+
+    def __call__(self, x, cache):
+        B, T, D = x.shape
+        h = None if cache is None else cache[0]
+        if h is None:
+            h = mx.zeros((B, D), dtype=x.dtype)
+        outs = []
+        for t in range(T):
+            h = mx.tanh(self.Wx(x[:, t]) + self.Wh(h))
+            outs.append(h)
+        if cache is not None:
+            cache[0] = h  # store the final hidden state (the recurrent state)
+        return mx.stack(outs, axis=1)
+
+
+class TinyRecurrentModel(nn.Module):
+    """A genuinely tiny recurrent LM whose cache is a non-trimmable ArraysCache.
+
+    ``make_cache`` returns one single-slot ``ArraysCache`` per layer.
+    ``can_trim_prompt_cache`` is False for it, so this reproduces the
+    recurrent/hybrid situation the anchor API targets, on the CPU, with no
+    download.
+    """
+
+    def __init__(self, vocab: int, dim: int, n_layers: int):
+        super().__init__()
+        self.embed = nn.Embedding(vocab, dim)
+        self.layers = [_RecurrentCell(dim) for _ in range(n_layers)]
+        self.out = nn.Linear(dim, vocab, bias=False)
+
+    def make_cache(self):
+        return [ArraysCache(1) for _ in self.layers]
+
+    def __call__(self, inputs, cache=None):
+        x = self.embed(inputs)
+        if cache is None:
+            cache = [None] * len(self.layers)
+        for layer, c in zip(self.layers, cache):
+            x = layer(x, c)
+        return self.out(x)
+
+
+def build_tiny_model(vocab: int, dim: int, n_layers: int, seed: int):
+    mx.random.seed(seed)
+    model = TinyRecurrentModel(vocab, dim, n_layers)
+    mx.eval(model.parameters())
+    return model
+
+
+def build_synthetic_tokens(vocab: int, target: int, tail: int, seed: int):
+    """Deterministic shared prefix P (len ``target``) + two divergent tails.
+
+    Returns ``(req_a, req_b, shared_prefix_len)``; the tails are guaranteed to
+    differ at their first token so the shared prefix is exactly ``target``.
+    """
+    rng = random.Random(seed)
+    prefix = [rng.randrange(vocab) for _ in range(target)]
+    tail_a = [rng.randrange(vocab) for _ in range(tail)]
+    tail_b = [rng.randrange(vocab) for _ in range(tail)]
+    if tail_b[0] == tail_a[0]:
+        tail_b[0] = (tail_a[0] + 1) % vocab
+    return prefix + tail_a, prefix + tail_b, target
+
+
+# --------------------------------------------------------------------------- #
+# Shared helpers
+# --------------------------------------------------------------------------- #
+def common_prefix_len(a, b):
+    n = 0
+    for x, y in zip(a, b):
+        if x != y:
+            break
+        n += 1
+    return n
+
+
+def next_tok(model, cache, ids):
+    """Argmax next token from ``ids`` fed through ``cache`` (may be pre-filled)."""
+    logits = model(mx.array([ids]), cache=cache)
+    mx.eval(logits)
+    return int(mx.argmax(logits[0, -1]).item())
+
+
+def timed_next(model, cache, ids):
+    t0 = time.perf_counter()
+    tk = next_tok(model, cache, ids)
+    return tk, time.perf_counter() - t0
+
+
+def cache_classes(cache):
+    return [type(c).__name__ for c in cache]
+
+
+def serve_and_capture(model, tokens, stride):
+    """Serve ``tokens`` via a real prefill, capturing anchors as a byproduct.
+
+    Wires ``PrefixAnchorCapture`` as ``generate_step``'s
+    ``prompt_progress_callback`` and sets ``prefill_step_size == stride`` so the
+    callback fires at each stride boundary. Consuming one token forces the full
+    prefill. Returns ``(full_cache, capture)``.
+    """
+    cache = make_prompt_cache(model)
+    capture = PrefixAnchorCapture(cache, stride)
+    gen = generate_step(
+        mx.array(tokens),
+        model,
+        max_tokens=1,
+        prompt_cache=cache,
+        prompt_progress_callback=capture,
+        prefill_step_size=stride,
+    )
+    next(gen)  # drive prefill + final callback
+    mx.eval([c.state for c in cache])
+    return cache, capture
+
+
+# --------------------------------------------------------------------------- #
+# Core case (shared by both modes)
+# --------------------------------------------------------------------------- #
+def run_case(model, req_a, req_b, shared_pref, stride):
+    if shared_pref <= stride:
+        raise RuntimeError(f"shared prefix {shared_pref} <= stride {stride}")
+
+    # Reference: cold full prefill of req_b (before any reuse).
+    cold_cache = make_prompt_cache(model)
+    trimmable = can_trim_prompt_cache(cold_cache)
+    classes = cache_classes(cold_cache)
+    cold_tok, cold_s = timed_next(model, cold_cache, req_b)
+
+    # Serve req_a once, capturing shorter-prefix anchors during its prefill.
+    cache_a, capture = serve_and_capture(model, req_a, stride)
+    anchor_lengths = [a.length for a in capture.anchors]
+
+    # ---- UPSTREAM arm: real LRUPromptCache, NO anchors ----
+    store_up = LRUPromptCache(max_size=64)
+    store_up.insert_cache(
+        MODEL_KEY, req_a, copy.deepcopy(cache_a), cache_type="assistant"
+    )
+    t0 = time.perf_counter()
+    up_cache, up_rest = store_up.fetch_nearest_cache(MODEL_KEY, req_b)
+    up_fetch_s = time.perf_counter() - t0
+    if up_cache is None:
+        up_cache, up_rest = make_prompt_cache(model), req_b
+    up_reused = len(req_b) - len(up_rest)
+    up_tok, up_prefill_s = timed_next(model, up_cache, up_rest)
+    up_ttft = up_fetch_s + up_prefill_s
+
+    # ---- ANCHOR arm: same store + insert_anchors ----
+    store_an = LRUPromptCache(max_size=64)
+    store_an.insert_cache(
+        MODEL_KEY, req_a, copy.deepcopy(cache_a), cache_type="assistant"
+    )
+    store_an.insert_anchors(MODEL_KEY, req_a, capture.anchors, cache_type="assistant")
+    t0 = time.perf_counter()
+    an_cache, an_rest = store_an.fetch_nearest_cache(MODEL_KEY, req_b)
+    an_fetch_s = time.perf_counter() - t0
+    if an_cache is None:
+        an_cache, an_rest = make_prompt_cache(model), req_b
+    an_reused = len(req_b) - len(an_rest)
+    an_tok, an_prefill_s = timed_next(model, an_cache, an_rest)
+    an_ttft = an_fetch_s + an_prefill_s
+
+    expected_anchor = (shared_pref // stride) * stride
+
+    return {
+        "capture_enabled": bool(capture.enabled),
+        "trimmable": bool(trimmable),
+        "cache_classes": classes,
+        "prompt_tokens": len(req_b),
+        "shared_prefix_tokens": shared_pref,
+        "stride": stride,
+        "anchor_lengths": anchor_lengths,
+        "expected_anchor_len": expected_anchor,
+        # reuse capability (the headline)
+        "upstream_reused_tokens": up_reused,
+        "anchor_reused_tokens": an_reused,
+        # TTFT (ms) -- prefill only, decode excluded by construction
+        "cold_ttft_ms": round(cold_s * 1e3, 3),
+        "upstream_ttft_ms": round(up_ttft * 1e3, 3),
+        "anchor_ttft_ms": round(an_ttft * 1e3, 3),
+        "anchor_vs_upstream": round(up_ttft / an_ttft, 3) if an_ttft else None,
+        "anchor_vs_cold": round(cold_s / an_ttft, 3) if an_ttft else None,
+        # correctness gates (must all hold)
+        "cold_next_token": cold_tok,
+        "upstream_next_equiv": up_tok == cold_tok,
+        "anchor_next_equiv": an_tok == cold_tok,
+    }
+
+
+# --------------------------------------------------------------------------- #
+# Real-model mode (--model)
+# --------------------------------------------------------------------------- #
+_SHARED_SEED = (
+    "You are a senior engineer reviewing a large local codebase. Preserve "
+    "existing behavior, cite exact files and line numbers, and never propose a "
+    "broad rewrite. The stable shared project context follows and is identical "
+    "across every request in this session.\n\n"
+)
+_FILLER = (
+    "Context note: request-level prompt reuse should avoid recomputing the "
+    "stable system, chat-history, retrieved-document, and few-shot prefixes on "
+    "every call. The correctness gate is cold-vs-warm next-token equivalence; "
+    "prefill/TTFT is reported separately from decode throughput.\n"
+)
+_TAIL_A = "List the first two acceptance gates for prefix-cache reuse."
+_TAIL_B = "Explain why this is a prefill win and not a decode-token/s win, in detail."
+
+
+def _to_ids(tok, prompt):
+    return list(tok.encode(prompt))
+
+
+def _render(tok, shared, tail):
+    msgs = [{"role": "system", "content": shared}, {"role": "user", "content": tail}]
+    try:
+        p = tok.apply_chat_template(msgs, add_generation_prompt=True)
+        return [int(t) for t in p]
+    except Exception:
+        return _to_ids(tok, shared + "\n\nUser: " + tail + "\nAssistant:")
+
+
+def _build_shared(tok, target):
+    base = len(_render(tok, _SHARED_SEED, _TAIL_A))
+    one = len(_render(tok, _SHARED_SEED + _FILLER, _TAIL_A))
+    per = max(1, one - base)
+    n = max(0, (target - base) // per)
+    shared = _SHARED_SEED + _FILLER * n
+    while len(_render(tok, shared, _TAIL_A)) < target:
+        shared += _FILLER
+    return shared
+
+
+def run_real(model_path, target, stride):
+    from mlx_lm import load
+
+    model, tok = load(model_path)
+    mx.eval(model.parameters())
+    # warm up compile / first-call so timings are steady-state
+    serve_and_capture(model, _to_ids(tok, "warmup prompt for compile"), stride)
+
+    shared = _build_shared(tok, target)
+    req_a = _render(tok, shared, _TAIL_A)
+    req_b = _render(tok, shared, _TAIL_B)
+    shared_pref = common_prefix_len(req_a, req_b)
+
+    # warm the req_b prefill shape so the cold reference is steady-state
+    serve_and_capture(model, req_b, stride)
+
+    row = run_case(model, req_a, req_b, shared_pref, stride)
+    row["mode"] = "real"
+    row["model"] = model_path
+    return [row]
+
+
+# --------------------------------------------------------------------------- #
+# Synthetic mode
+# --------------------------------------------------------------------------- #
+def run_synthetic(target, stride, vocab, dim, n_layers, tail, seed):
+    model = build_tiny_model(vocab, dim, n_layers, seed)
+    req_a, req_b, shared_pref = build_synthetic_tokens(vocab, target, tail, seed)
+    row = run_case(model, req_a, req_b, shared_pref, stride)
+    row["mode"] = "synthetic"
+    row["model"] = f"TinyRecurrentModel(vocab={vocab},dim={dim},layers={n_layers})"
+    return [row]
+
+
+# --------------------------------------------------------------------------- #
+# Gates + reporting
+# --------------------------------------------------------------------------- #
+def aggregate_failures(rows):
+    """Every case must: gate both next-token equivs true, upstream reuse == 0,
+    and anchor reuse == the nearest stride boundary <= shared prefix."""
+    failures = []
+    for row in rows:
+        for gate in ("upstream_next_equiv", "anchor_next_equiv"):
+            if row.get(gate) is not True:
+                failures.append({"check": gate, "value": row.get(gate)})
+        if row.get("upstream_reused_tokens") != 0:
+            failures.append(
+                {
+                    "check": "upstream_reuses_zero",
+                    "value": row["upstream_reused_tokens"],
+                }
+            )
+        if row.get("anchor_reused_tokens") != row.get("expected_anchor_len"):
+            failures.append(
+                {
+                    "check": "anchor_reuses_nearest_anchor",
+                    "value": row.get("anchor_reused_tokens"),
+                    "expected": row.get("expected_anchor_len"),
+                }
+            )
+    return failures
+
+
+def print_summary(rows, failures):
+    print("\n=== prompt-cache anchor-stride benchmark ===")
+    for row in rows:
+        print(f"\nmode={row['mode']}  model={row['model']}")
+        print(f"  cache_classes        : {row['cache_classes']}")
+        print(f"  trimmable            : {row['trimmable']}")
+        print(f"  capture_enabled      : {row['capture_enabled']}")
+        print(
+            f"  prompt/shared/stride : "
+            f"{row['prompt_tokens']}/{row['shared_prefix_tokens']}/{row['stride']}"
+        )
+        print(f"  anchors captured     : {row['anchor_lengths']}")
+        print(
+            f"  reused tokens        : "
+            f"upstream={row['upstream_reused_tokens']}  "
+            f"anchor={row['anchor_reused_tokens']}  "
+            f"(nearest-anchor={row['expected_anchor_len']})"
+        )
+        print(
+            f"  TTFT ms              : "
+            f"cold={row['cold_ttft_ms']}  upstream={row['upstream_ttft_ms']}  "
+            f"anchor={row['anchor_ttft_ms']}"
+        )
+        print(
+            f"  next-token equiv     : "
+            f"upstream={row['upstream_next_equiv']}  anchor={row['anchor_next_equiv']}  "
+            f"(cold_tok={row['cold_next_token']})"
+        )
+    verdict = "PASS" if not failures else "FAIL"
+    print(f"\nverdict: {verdict}")
+    if failures:
+        print(f"failures: {json.dumps(failures)}")
+    else:
+        print(
+            "  upstream reuses 0 across the divergent tail (non-trimmable cache);\n"
+            "  anchor mode reuses the nearest-anchor prefix;\n"
+            "  the anchor-reused continuation is next-token-identical to cold."
+        )
+
+
+def main():
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument("--stride", type=int, default=128, help="anchor stride (tokens)")
+    ap.add_argument(
+        "--target", type=int, default=600, help="shared-prefix length (tokens)"
+    )
+    ap.add_argument("--model", default=None, help="real model path (optional)")
+    ap.add_argument("--output", default=None, help="JSONL output path (append)")
+    # synthetic-model knobs (kept small so it runs instantly on CPU)
+    ap.add_argument("--vocab", type=int, default=256)
+    ap.add_argument("--dim", type=int, default=32)
+    ap.add_argument("--layers", type=int, default=2)
+    ap.add_argument("--tail", type=int, default=64, help="divergent tail length")
+    ap.add_argument("--seed", type=int, default=0)
+    args = ap.parse_args()
+
+    if args.stride <= 0:
+        print(json.dumps({"error": f"--stride must be positive, got {args.stride}"}))
+        raise SystemExit(2)
+    if args.target <= args.stride:
+        print(
+            json.dumps(
+                {
+                    "error": f"--target ({args.target}) must exceed --stride ({args.stride})"
+                }
+            )
+        )
+        raise SystemExit(2)
+
+    if args.model:
+        rows = run_real(args.model, args.target, args.stride)
+    else:
+        rows = run_synthetic(
+            args.target,
+            args.stride,
+            args.vocab,
+            args.dim,
+            args.layers,
+            args.tail,
+            args.seed,
+        )
+
+    for row in rows:
+        print(json.dumps(row, sort_keys=True), flush=True)
+        if args.output:
+            with open(args.output, "a") as f:
+                f.write(json.dumps(row, sort_keys=True) + "\n")
+
+    failures = aggregate_failures(rows)
+    print_summary(rows, failures)
+    if failures:
+        raise SystemExit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/mlx_lm/generate.py
+++ b/mlx_lm/generate.py
@@ -10,7 +10,17 @@ import time
 from collections import deque
 from dataclasses import dataclass
 from functools import partial
-from typing import Any, Callable, Generator, List, Optional, Sequence, Tuple, Union
+from typing import (
+    Any,
+    Callable,
+    Dict,
+    Generator,
+    List,
+    Optional,
+    Sequence,
+    Tuple,
+    Union,
+)
 
 import mlx.core as mx
 import mlx.nn as nn
@@ -24,9 +34,11 @@ from .models.cache import (
     BatchRotatingKVCache,
     CacheList,
     KVCache,
+    PrefixAnchor,
     QuantizedKVCache,
     RotatingKVCache,
     TokenBuffer,
+    can_trim_prompt_cache,
     load_prompt_cache,
 )
 from .sample_utils import make_sampler
@@ -1114,6 +1126,7 @@ class PromptProcessingBatch:
         ] = None,
         stop_matchers: Optional[List[StopSequenceMatcher]] = None,
         max_tokens: Optional[List[int]] = None,
+        anchor_stride: int = 0,
     ):
         self.model = model
         self.uids = uids
@@ -1121,6 +1134,10 @@ class PromptProcessingBatch:
         self.tokens = tokens if tokens is not None else [[] for _ in uids]
 
         self.prefill_step_size = prefill_step_size
+        # Anchor-stride prefix reuse: exact per-request prompt-prefix snapshots
+        # captured during prefill, keyed by uid, drained by the scheduler.
+        self.anchor_stride = anchor_stride
+        self.anchors: Dict[int, List[PrefixAnchor]] = {}
         self.samplers = samplers if samplers is not None else []
         self.fallback_sampler = fallback_sampler or (lambda x: mx.argmax(x, axis=-1))
         self.logits_processors = (
@@ -1175,6 +1192,10 @@ class PromptProcessingBatch:
         new_batch.logits_processors = list(self.logits_processors)
         new_batch.stop_matchers = list(self.stop_matchers)
         new_batch.max_tokens = list(self.max_tokens)
+        new_batch.anchor_stride = self.anchor_stride
+        # Anchors are drained by the scheduler right after each prompt() call,
+        # so they are empty at split/copy time; start the copy clean.
+        new_batch.anchors = {}
         return new_batch
 
     def split(self, indices: List[int]):
@@ -1229,6 +1250,20 @@ class PromptProcessingBatch:
         padding = [max_length - l for l in lengths]
         max_padding = max(padding)
 
+        # Anchor capture is only well-defined for an unpadded batch: with right
+        # padding, a request's cache state past its real length is polluted by
+        # padding until finalize(), so mid-prefill snapshots there would be
+        # wrong. Skip capture for padded (mixed-length) batches and for
+        # trimmable caches (which already reuse the full prefix via trim).
+        capture = (
+            self.anchor_stride > 0
+            and max_padding == 0
+            and not can_trim_prompt_cache(self.prompt_cache)
+        )
+        # Absolute prefix length already in each request's cache before this
+        # call (a prompt may be prefilled across several prompt() calls).
+        bases = [len(self.tokens[i]) - lengths[i] for i in range(len(lengths))]
+
         # Prepare the caches and inputs. Right pad if needed otherwise just
         # cast to array.
         if max_padding > 0:
@@ -1239,12 +1274,16 @@ class PromptProcessingBatch:
             tokens = mx.array(tokens)
 
         # Actual prompt processing loop
+        processed = 0
         while tokens.shape[1] > 0:
             n_to_process = min(self.prefill_step_size, tokens.shape[1])
             self.model(tokens[:, :n_to_process], cache=self.prompt_cache)
             mx.eval([c.state for c in self.prompt_cache])
             mx.clear_cache()
             tokens = tokens[:, n_to_process:]
+            processed += n_to_process
+            if capture:
+                self._capture_anchors(bases, lengths, processed)
 
         # Finalize the cache if there was any padding
         if max_padding > 0:
@@ -1252,6 +1291,30 @@ class PromptProcessingBatch:
                 c.finalize()
             mx.eval([c.state for c in self.prompt_cache])
             mx.clear_cache()
+
+    def _capture_anchors(self, bases, lengths, processed):
+        # Snapshot each request's exact prefix at stride boundaries as prefill
+        # advances. A prompt is fed to the model in prefill_step_size chunks
+        # (possibly across several prompt() calls), so we capture at chunk
+        # boundaries spaced at least anchor_stride apart; the caller keeps
+        # prefill_step_size <= anchor_stride so boundaries are stride-granular.
+        # An anchor equal to the full stored prompt is dropped later by
+        # LRUPromptCache.insert_anchors. Called only for an unpadded,
+        # non-trimmable batch.
+        for i, uid in enumerate(self.uids):
+            abs_len = bases[i] + processed
+            captured = self.anchors.get(uid)
+            last = captured[-1].length if captured else bases[i]
+            if abs_len < last + self.anchor_stride:
+                continue
+            snapshot = [c.extract(i) for c in self.prompt_cache]
+            mx.eval([c.state for c in snapshot])
+            self.anchors.setdefault(uid, []).append(PrefixAnchor(abs_len, snapshot))
+
+    def drain_anchors(self) -> Dict[int, List[PrefixAnchor]]:
+        """Return captured anchors keyed by uid and clear them."""
+        anchors, self.anchors = self.anchors, {}
+        return anchors
 
     def generate(self, tokens: List[List[int]]):
         """
@@ -1295,6 +1358,7 @@ class PromptProcessingBatch:
         model: nn.Module,
         fallback_sampler: Callable[[mx.array], mx.array],
         prefill_step_size: int = 2048,
+        anchor_stride: int = 0,
     ):
         return cls(
             model=model,
@@ -1307,6 +1371,7 @@ class PromptProcessingBatch:
             logits_processors=[],
             max_tokens=[],
             stop_matchers=[],
+            anchor_stride=anchor_stride,
         )
 
 
@@ -1587,6 +1652,7 @@ class BatchGenerator:
         prefill_batch_size: int = 8,
         prefill_step_size: int = 2048,
         max_kv_size: Optional[int] = None,
+        prompt_cache_anchor_stride: int = 0,
         stream=None,
     ):
         self.model = model
@@ -1598,6 +1664,12 @@ class BatchGenerator:
         self.prefill_batch_size = prefill_batch_size
         self.completion_batch_size = max(completion_batch_size, prefill_batch_size)
         self.max_kv_size = max_kv_size
+        self.prompt_cache_anchor_stride = prompt_cache_anchor_stride
+        # Anchors can only be snapshotted at prefill chunk boundaries, so keep
+        # chunks no larger than the stride when capture is on.
+        if prompt_cache_anchor_stride > 0:
+            self.prefill_step_size = min(prefill_step_size, prompt_cache_anchor_stride)
+            prefill_step_size = self.prefill_step_size
 
         self._stream = stream or generation_stream
 
@@ -1609,7 +1681,11 @@ class BatchGenerator:
             self.model,
             self.sampler,
             prefill_step_size=prefill_step_size,
+            anchor_stride=prompt_cache_anchor_stride,
         )
+        # Anchors captured during prompt prefill, keyed by uid, until the
+        # caller extracts the finished cache.
+        self._anchors: Dict[int, List[PrefixAnchor]] = {}
         self._generation_batch = GenerationBatch.empty(self.model, self.sampler)
         self._unprocessed_sequences = deque()
         self._currently_processing = []
@@ -1774,10 +1850,23 @@ class BatchGenerator:
                 )
         return results
 
+    def pop_anchors(self, uids):
+        """Take (and clear) the anchor snapshots captured for the given uids.
+
+        Returns ``{uid: [PrefixAnchor, ...]}`` (empty list if none) and removes
+        them, so the caller drains them once when a request finishes. Only
+        populated when the generator was created with
+        ``prompt_cache_anchor_stride > 0`` and the model's cache is
+        non-trimmable; see ``LRUPromptCache.insert_anchors``.
+        """
+        return {uid: self._anchors.pop(uid, []) for uid in uids}
+
     def remove(self, uids, return_prompt_caches=False):
         caches = {}
         if return_prompt_caches:
             caches = self.extract_cache(uids)
+        for uid in uids:
+            self._anchors.pop(uid, None)
 
         keep = (
             set(range(len(self._unprocessed_sequences))),
@@ -1917,6 +2006,11 @@ class BatchGenerator:
         self._prompt_batch.prompt(prompts)
         toc = time.perf_counter()
         self._prompt_time_counter += toc - tic
+
+        # Collect anchors captured during this prefill, keyed by uid, so they
+        # survive the split/generate lifecycle until the cache is extracted.
+        for uid, anchors in self._prompt_batch.drain_anchors().items():
+            self._anchors.setdefault(uid, []).extend(anchors)
 
         return prompt_responses, generation_responses
 

--- a/mlx_lm/models/cache.py
+++ b/mlx_lm/models/cache.py
@@ -1736,6 +1736,40 @@ class LRUPromptCache:
             self._n_bytes -= entry.nbytes
             self._n_bytes_by_type[entry.cache_type] -= entry.nbytes
 
+    def insert_anchors(
+        self,
+        model: Any,
+        tokens: List[int],
+        anchors: List["PrefixAnchor"],
+        *,
+        cache_type: str = "assistant",
+    ):
+        """Insert exact shorter-prefix anchor snapshots for a prompt.
+
+        For a non-trimmable cache (recurrent/hybrid models, or a sliding-window
+        cache outside its window) ``fetch_nearest_cache`` cannot reuse a longer
+        stored prompt across a divergent tail, because that path needs
+        ``can_trim_prompt_cache``. Storing exact snapshots captured at stride
+        boundaries of this prompt (see ``PrefixAnchorCapture``) gives a later,
+        divergent prompt a reuse point at the nearest anchor below the shared
+        prefix. Each anchor is inserted as a normal shorter entry, so the
+        existing trie ``shorter`` lookup finds it with no change to retrieval.
+
+        Anchors whose cache is trimmable are skipped: for those the full-prefix
+        trim path already covers reuse and the anchors would only take space.
+        """
+        for anchor in anchors:
+            if anchor.length <= 0 or anchor.length >= len(tokens):
+                continue
+            if can_trim_prompt_cache(anchor.prompt_cache):
+                continue
+            self.insert_cache(
+                model,
+                tokens[: anchor.length],
+                anchor.prompt_cache,
+                cache_type=cache_type,
+            )
+
     def trim_to(
         self, *, n_sequences: Optional[int] = None, n_bytes: Optional[int] = None
     ):
@@ -1761,3 +1795,54 @@ class LRUPromptCache:
                 "n_bytes": self._n_bytes_by_type[cache_type],
             }
         return result
+
+
+@dataclass
+class PrefixAnchor:
+    length: int  # number of prompt tokens this snapshot covers
+    prompt_cache: List[Any]  # deep-copied cache state at that prefix length
+
+
+class PrefixAnchorCapture:
+    """Capture exact prompt-cache snapshots at stride boundaries during prefill.
+
+    Wire an instance as (part of) the ``prompt_progress_callback`` passed to
+    ``generate_step``/``stream_generate``. On each call it deep-copies the live
+    cache once its processed length has advanced at least ``stride`` tokens past
+    the previous anchor, recording a ``PrefixAnchor`` at the true processed
+    prefix. The snapshots are amortized into the prefill the caller is doing
+    anyway; ``insert_anchors`` then stores them in an ``LRUPromptCache`` so a
+    later, divergent prompt can reuse up to the nearest anchor.
+
+    Capture is a no-op for trimmable caches -- those already get full-prefix
+    reuse through ``trim_prompt_cache`` -- so enabling it is safe regardless of
+    model architecture; it only does work for non-trimmable caches.
+
+    Args:
+        cache: the prompt cache being filled (the same object generation uses).
+        stride: minimum token spacing between anchors. ``<= 0`` disables capture.
+        max_anchors: cap on stored anchors per prompt (oldest kept first).
+    """
+
+    def __init__(self, cache: List[Any], stride: int, max_anchors: int = 32):
+        self.cache = cache
+        self.stride = stride
+        self.max_anchors = max_anchors
+        self.anchors: List[PrefixAnchor] = []
+        self._enabled = stride > 0 and not can_trim_prompt_cache(cache)
+        self._next = stride
+
+    @property
+    def enabled(self) -> bool:
+        return self._enabled
+
+    def __call__(self, processed: int, total: int):
+        # Signature matches prompt_progress_callback(processed, total).
+        if not self._enabled or len(self.anchors) >= self.max_anchors:
+            return
+        # Only snapshot strictly-shorter prefixes: the full prompt is stored
+        # separately by the caller via insert_cache.
+        if processed <= 0 or processed >= total or processed < self._next:
+            return
+        self.anchors.append(PrefixAnchor(processed, copy.deepcopy(self.cache)))
+        self._next = processed + self.stride

--- a/mlx_lm/server.py
+++ b/mlx_lm/server.py
@@ -359,15 +359,11 @@ class ModelProvider:
         is_batchable = is_batchable and all(
             hasattr(c, "merge") for c in make_prompt_cache(model)
         )
-        # Anchor-stride prefix reuse captures per-request prefill snapshots via
-        # the single-request generation path's progress callback, which the
-        # batched path does not expose. Trimmable models already reuse the full
-        # prefix via trim_prompt_cache (anchor-stride is a no-op for them), so
-        # only route non-trimmable models off the batched path when it is on.
-        if self.cli_args.prompt_cache_anchor_stride > 0 and not can_trim_prompt_cache(
-            make_prompt_cache(model)
-        ):
-            is_batchable = False
+        # Anchor-stride prefix reuse only does work for non-trimmable caches
+        # (recurrent/hybrid models); trimmable models already reuse the full
+        # prefix via trim_prompt_cache. Both the batched and single-request
+        # paths capture anchors, so batchability is unaffected.
+        non_trimmable = not can_trim_prompt_cache(make_prompt_cache(model))
 
         # Update the member variables
         self.model_key = (model_path, adapter_path, draft_model_path)
@@ -375,6 +371,7 @@ class ModelProvider:
         self.tokenizer = tokenizer
         self.draft_model = draft_model
         self.is_batchable = is_batchable
+        self.non_trimmable = non_trimmable
 
     def load_default(self):
         if self._model_map["default_model"] is not None:
@@ -776,6 +773,11 @@ class ResponseGenerator:
                         completion_batch_size=self.cli_args.decode_concurrency,
                         prefill_batch_size=self.cli_args.prompt_concurrency,
                         prefill_step_size=self.cli_args.prefill_step_size,
+                        prompt_cache_anchor_stride=(
+                            self.cli_args.prompt_cache_anchor_stride
+                            if self.model_provider.non_trimmable
+                            else 0
+                        ),
                         stream=generation_stream,
                     )
                     unprocessed_requests.append((rqueue, request, args))
@@ -869,6 +871,17 @@ class ResponseGenerator:
                                 r.prompt_cache,
                                 cache_type="assistant",
                             )
+                            # Store anchors captured during this request's
+                            # prefill (non-trimmable models only; empty
+                            # otherwise). Drained here so they cannot leak.
+                            anchors = batch_generator.pop_anchors([r.uid])[r.uid]
+                            if anchors:
+                                self.prompt_cache.insert_anchors(
+                                    current_model_key,
+                                    r.all_tokens[:],
+                                    anchors,
+                                    cache_type="assistant",
+                                )
                             del batch_results[r.uid]
 
                         if result["ctx"]._should_stop:

--- a/mlx_lm/server.py
+++ b/mlx_lm/server.py
@@ -40,7 +40,12 @@ from .generate import (
     make_text_state_machine,
     stream_generate,
 )
-from .models.cache import LRUPromptCache, make_prompt_cache
+from .models.cache import (
+    LRUPromptCache,
+    PrefixAnchorCapture,
+    can_trim_prompt_cache,
+    make_prompt_cache,
+)
 from .sample_utils import make_logits_processors, make_sampler
 from .utils import _parse_size, load, sharded_load
 
@@ -354,6 +359,15 @@ class ModelProvider:
         is_batchable = is_batchable and all(
             hasattr(c, "merge") for c in make_prompt_cache(model)
         )
+        # Anchor-stride prefix reuse captures per-request prefill snapshots via
+        # the single-request generation path's progress callback, which the
+        # batched path does not expose. Trimmable models already reuse the full
+        # prefix via trim_prompt_cache (anchor-stride is a no-op for them), so
+        # only route non-trimmable models off the batched path when it is on.
+        if self.cli_args.prompt_cache_anchor_stride > 0 and not can_trim_prompt_cache(
+            make_prompt_cache(model)
+        ):
+            is_batchable = False
 
         # Update the member variables
         self.model_key = (model_path, adapter_path, draft_model_path)
@@ -915,10 +929,28 @@ class ResponseGenerator:
             )
             ctx.prompt_cache_count = len(prompt) - len(rest)
             cache_key = prompt[:]
+            made_fresh = cache is None
             if cache is None:
                 cache = make_prompt_cache(self.model_provider.model)
                 if self.model_provider.draft_model is not None:
                     cache += make_prompt_cache(self.model_provider.draft_model)
+
+            # Capture anchor snapshots during this prefill for a non-trimmable
+            # cache, so a later divergent request can reuse up to the nearest
+            # anchor. Only on a full miss, where processed prefill length equals
+            # the absolute prompt prefix length. No-op for trimmable caches.
+            anchor_stride = self.cli_args.prompt_cache_anchor_stride
+            anchor_capture = None
+            progress_callback = progress
+            prefill_step_size = self.cli_args.prefill_step_size
+            if anchor_stride > 0 and made_fresh:
+                anchor_capture = PrefixAnchorCapture(cache, anchor_stride)
+                if anchor_capture.enabled:
+                    prefill_step_size = min(prefill_step_size, anchor_stride)
+
+                    def progress_callback(processed, total, _cap=anchor_capture):
+                        _cap(processed, total)
+                        progress(processed, total)
 
             # Process the prompt and generate tokens
             stop_state = stop_matcher.make_state()
@@ -932,8 +964,8 @@ class ResponseGenerator:
                 prompt_cache=cache,
                 draft_model=draft_model,
                 num_draft_tokens=args.num_draft_tokens,
-                prompt_progress_callback=progress,
-                prefill_step_size=self.cli_args.prefill_step_size,
+                prompt_progress_callback=progress_callback,
+                prefill_step_size=prefill_step_size,
             ):
                 finish_reason = gen.finish_reason
 
@@ -971,6 +1003,10 @@ class ResponseGenerator:
             self.prompt_cache.insert_cache(
                 self.model_provider.model_key, cache_key, cache
             )
+            if anchor_capture is not None:
+                self.prompt_cache.insert_anchors(
+                    self.model_provider.model_key, cache_key, anchor_capture.anchors
+                )
 
         except Exception as e:
             rqueue.put(e)
@@ -1847,6 +1883,19 @@ def main():
         "--prompt-cache-bytes",
         type=_parse_size,
         help="Maximum size in bytes of the KV caches",
+    )
+    parser.add_argument(
+        "--prompt-cache-anchor-stride",
+        type=int,
+        default=0,
+        help=(
+            "Enable anchor-stride prefix reuse for non-trimmable caches "
+            "(recurrent/hybrid models). Captures exact prompt-prefix snapshots "
+            "every N tokens so a later divergent request reuses up to the "
+            "nearest anchor. 0 disables it (default). No effect on trimmable "
+            "models. Enabling it routes non-trimmable models through the "
+            "single-request generation path."
+        ),
     )
     parser.add_argument(
         "--pipeline",

--- a/tests/test_prompt_cache.py
+++ b/tests/test_prompt_cache.py
@@ -6,6 +6,7 @@ import tempfile
 import unittest
 
 import mlx.core as mx
+import mlx.nn as nn
 
 from mlx_lm.generate import generate_step
 from mlx_lm.models.base import create_attention_mask, create_causal_mask
@@ -20,6 +21,7 @@ from mlx_lm.models.cache import (
     PrefixAnchorCapture,
     QuantizedKVCache,
     RotatingKVCache,
+    can_trim_prompt_cache,
     load_prompt_cache,
     make_prompt_cache,
     save_prompt_cache,
@@ -28,6 +30,43 @@ from mlx_lm.models.cache import (
 from mlx_lm.utils import load
 
 HF_MODEL_PATH = "mlx-community/Qwen1.5-0.5B-Chat-4bit"
+
+
+class _TinyRecurrentModel(nn.Module):
+    """A tiny non-trimmable recurrent LM for anchor-capture tests.
+
+    ``make_cache`` returns one single-slot ``ArraysCache`` per layer
+    (``can_trim_prompt_cache`` is False), and the final hidden state is a pure
+    function of the entire processed prefix, so continuing from a shorter-prefix
+    snapshot is identical to a cold full prefill regardless of prefill chunking.
+    """
+
+    def __init__(self, vocab=64, dim=16, n_layers=2):
+        super().__init__()
+        self.embed = nn.Embedding(vocab, dim)
+        self.wx = [nn.Linear(dim, dim, bias=False) for _ in range(n_layers)]
+        self.wh = [nn.Linear(dim, dim, bias=False) for _ in range(n_layers)]
+        self.out = nn.Linear(dim, vocab, bias=False)
+        self.n_layers = n_layers
+
+    def make_cache(self):
+        return [ArraysCache(1) for _ in range(self.n_layers)]
+
+    def __call__(self, inputs, cache=None):
+        x = self.embed(inputs)
+        if cache is None:
+            cache = [None] * self.n_layers
+        for wx, wh, c in zip(self.wx, self.wh, cache):
+            B, T, D = x.shape
+            h = c[0] if (c is not None and c[0] is not None) else mx.zeros((B, D))
+            outs = []
+            for t in range(T):
+                h = mx.tanh(wx(x[:, t]) + wh(h))
+                outs.append(h)
+            if c is not None:
+                c[0] = h
+            x = mx.stack(outs, axis=1)
+        return self.out(x)
 
 
 class TestPromptCache(unittest.TestCase):
@@ -335,6 +374,55 @@ class TestPromptCache(unittest.TestCase):
         self.assertEqual(rest, req_b[12:])
         # The reused prefix is an exact prefix of req_b (next-token-safe).
         self.assertEqual(req_b[:reused], req_a[:reused])
+
+    def test_anchor_capture_during_real_prefill_enables_exact_reuse(self):
+        # End-to-end: capture anchors during a real generate_step prefill (the
+        # path the server uses), then reuse from an anchor for a divergent
+        # request and confirm the continuation is next-token-identical to cold.
+        mx.random.seed(0)
+        model = _TinyRecurrentModel(vocab=64, dim=16, n_layers=2)
+        mx.eval(model.parameters())
+
+        import random
+
+        rng = random.Random(0)
+        shared = [rng.randrange(64) for _ in range(40)]
+        req_a = shared + [rng.randrange(64) for _ in range(6)]
+        req_b = shared + [63, 0, 62]  # diverges right after the 40-token prefix
+        stride = 8
+
+        # Serve req_a, capturing anchors as a byproduct of its prefill.
+        cache = make_prompt_cache(model)
+        self.assertFalse(can_trim_prompt_cache(cache))
+        capture = PrefixAnchorCapture(cache, stride)
+        self.assertTrue(capture.enabled)
+        gen = generate_step(
+            mx.array(req_a),
+            model,
+            max_tokens=1,
+            prompt_cache=cache,
+            prompt_progress_callback=capture,
+            prefill_step_size=stride,
+        )
+        next(gen)
+        mx.eval([c.state for c in cache])
+        self.assertEqual([a.length for a in capture.anchors], [8, 16, 24, 32, 40])
+
+        store = LRUPromptCache(max_size=8)
+        store.insert_cache("m", req_a, cache)
+        store.insert_anchors("m", req_a, capture.anchors)
+
+        reuse_cache, rest = store.fetch_nearest_cache("m", req_b)
+        self.assertIsNotNone(reuse_cache)
+        reused = len(req_b) - len(rest)
+        self.assertEqual(reused, 40)  # nearest anchor <= the 40-token prefix
+        self.assertEqual(rest, req_b[40:])
+
+        # Next token from the reused cache must equal a cold full prefill.
+        warm_tok = int(mx.argmax(model(mx.array([rest]), cache=reuse_cache)[0, -1]))
+        cold_cache = make_prompt_cache(model)
+        cold_tok = int(mx.argmax(model(mx.array([req_b]), cache=cold_cache)[0, -1]))
+        self.assertEqual(warm_tok, cold_tok)
 
     def test_insert_anchors_skips_trimmable_snapshots(self):
         from mlx_lm.models.cache import PrefixAnchor

--- a/tests/test_prompt_cache.py
+++ b/tests/test_prompt_cache.py
@@ -8,7 +8,7 @@ import unittest
 import mlx.core as mx
 import mlx.nn as nn
 
-from mlx_lm.generate import generate_step
+from mlx_lm.generate import PromptProcessingBatch, generate_step
 from mlx_lm.models.base import create_attention_mask, create_causal_mask
 from mlx_lm.models.cache import (
     ArraysCache,
@@ -423,6 +423,104 @@ class TestPromptCache(unittest.TestCase):
         cold_cache = make_prompt_cache(model)
         cold_tok = int(mx.argmax(model(mx.array([req_b]), cache=cold_cache)[0, -1]))
         self.assertEqual(warm_tok, cold_tok)
+
+    def test_batched_prompt_captures_anchors_unpadded(self):
+        # PromptProcessingBatch captures per-request anchors during a batched,
+        # unpadded prefill; offsets track prompts prefilled across calls; padded
+        # (mixed-length) batches skip capture.
+        mx.random.seed(0)
+        model = _TinyRecurrentModel(vocab=64, dim=16, n_layers=2)
+        mx.eval(model.parameters())
+
+        # Batch of one, stride 4, 20-token prompt -> anchors at 4,8,12,16.
+        batch = PromptProcessingBatch(
+            model, [7], [model.make_cache()], prefill_step_size=4, anchor_stride=4
+        )
+        prompt = list(range(1, 21))
+        batch.prompt([prompt])
+        mx.eval([c.state for c in batch.prompt_cache])
+        anchors = batch.drain_anchors()
+        # Boundaries at every stride; the length-20 anchor equals the full
+        # prompt and is dropped by insert_anchors below.
+        self.assertEqual([a.length for a in anchors[7]], [4, 8, 12, 16, 20])
+        self.assertEqual(batch.drain_anchors(), {})  # drained
+
+        # Those anchors give a divergent request reuse up to the nearest anchor.
+        store = LRUPromptCache(max_size=8)
+        store.insert_cache("m", prompt, batch.extract_cache(0))
+        store.insert_anchors("m", prompt, anchors[7])
+        req_b = prompt[:13] + [63, 0, 62]
+        _, rest = store.fetch_nearest_cache("m", req_b)
+        self.assertEqual(len(req_b) - len(rest), 12)
+
+        # A prompt prefilled across two calls: absolute offsets are honored.
+        split = PromptProcessingBatch(
+            model, [9], [model.make_cache()], prefill_step_size=4, anchor_stride=4
+        )
+        split.prompt([list(range(1, 9))])
+        first = split.drain_anchors()
+        split.prompt([list(range(9, 17))])
+        second = split.drain_anchors()
+        self.assertEqual([a.length for a in first[9]], [4, 8])
+        self.assertEqual([a.length for a in second[9]], [12, 16])
+
+        # Mixed-length (padded) batch: capture is skipped.
+        padded = PromptProcessingBatch(
+            model,
+            [1, 2],
+            [model.make_cache(), model.make_cache()],
+            prefill_step_size=4,
+            anchor_stride=4,
+        )
+        padded.prompt([list(range(1, 21)), list(range(1, 9))])
+        self.assertEqual(padded.drain_anchors(), {})
+
+    def test_batch_generator_captures_and_reuses_anchors(self):
+        # End-to-end through the continuous-batching scheduler: a request is
+        # prefilled and generated; its captured anchors are available at the
+        # finish response (before removal) and give a divergent request reuse.
+        from mlx_lm.generate import BatchGenerator
+
+        mx.random.seed(0)
+        model = _TinyRecurrentModel(vocab=64, dim=16, n_layers=2)
+        mx.eval(model.parameters())
+
+        gen = BatchGenerator(
+            model,
+            max_tokens=2,
+            prefill_step_size=2048,
+            prompt_cache_anchor_stride=4,
+        )
+        # prefill step is clamped down to the stride so anchors are captured.
+        self.assertEqual(gen.prefill_step_size, 4)
+
+        prompt = list(range(1, 21))
+        (uid,) = gen.insert_segments([[prompt]])
+        finish = None
+        for _ in range(40):
+            _, gen_responses = gen.next()
+            for r in gen_responses:
+                if r.finish_reason is not None:
+                    # Mirror the server: drain anchors + cache at finish.
+                    finish = (
+                        gen.pop_anchors([r.uid])[r.uid],
+                        r.prompt_cache,
+                        r.all_tokens,
+                    )
+            if finish is not None:
+                break
+        self.assertIsNotNone(finish)
+        anchors, cache, all_tokens = finish
+        self.assertEqual([a.length for a in anchors], [4, 8, 12, 16])
+        # Draining is one-shot: no leak after the request finishes.
+        self.assertEqual(gen.pop_anchors([uid])[uid], [])
+
+        store = LRUPromptCache(max_size=8)
+        store.insert_cache("m", all_tokens, cache)
+        store.insert_anchors("m", all_tokens, anchors)
+        req_b = prompt[:13] + [63, 0, 62]
+        _, rest = store.fetch_nearest_cache("m", req_b)
+        self.assertEqual(len(req_b) - len(rest), 12)
 
     def test_insert_anchors_skips_trimmable_snapshots(self):
         from mlx_lm.models.cache import PrefixAnchor

--- a/tests/test_prompt_cache.py
+++ b/tests/test_prompt_cache.py
@@ -16,6 +16,8 @@ from mlx_lm.models.cache import (
     CacheList,
     ChunkedKVCache,
     KVCache,
+    LRUPromptCache,
+    PrefixAnchorCapture,
     QuantizedKVCache,
     RotatingKVCache,
     load_prompt_cache,
@@ -261,6 +263,91 @@ class TestPromptCache(unittest.TestCase):
         # Trim more tokens than remain
         num_trimmed = trim_prompt_cache(cache, 4)
         self.assertEqual(num_trimmed, 3)
+
+    def _arrays_cache(self, tag):
+        # A minimal non-trimmable cache (as recurrent/hybrid models produce).
+        c = ArraysCache(size=1)
+        c[0] = mx.array([float(tag)])
+        return [c]
+
+    def test_prefix_anchor_capture_boundaries(self):
+        cache = self._arrays_cache(0)
+        cap = PrefixAnchorCapture(cache, stride=4)
+        self.assertTrue(cap.enabled)
+
+        total = 20
+        # Simulate a prefill that processes 4 tokens per step and mutates the
+        # cache each step; the capture should snapshot at each stride boundary.
+        for processed in range(0, total, 4):
+            cache[0][0] = mx.array([float(processed)])
+            cap(processed, total)
+
+        lengths = [a.length for a in cap.anchors]
+        self.assertEqual(lengths, [4, 8, 12, 16])
+        # Snapshots are independent copies frozen at capture time.
+        self.assertEqual(float(cap.anchors[0].prompt_cache[0][0].item()), 4.0)
+        self.assertEqual(float(cap.anchors[2].prompt_cache[0][0].item()), 12.0)
+        # The full length is never captured as an anchor.
+        self.assertTrue(all(a.length < total for a in cap.anchors))
+
+    def test_prefix_anchor_capture_noop_for_trimmable(self):
+        # Trimmable caches already reuse the full prefix via trim; capture off.
+        cache = [KVCache()]
+        x = mx.random.uniform(shape=(1, 8, 4, 4))
+        cache[0].update_and_fetch(x, x)
+        cap = PrefixAnchorCapture(cache, stride=4)
+        self.assertFalse(cap.enabled)
+        for processed in range(0, 20, 4):
+            cap(processed, 20)
+        self.assertEqual(cap.anchors, [])
+
+        # stride <= 0 disables capture regardless of cache type.
+        cap = PrefixAnchorCapture(self._arrays_cache(0), stride=0)
+        self.assertFalse(cap.enabled)
+
+    def test_anchor_stride_enables_reuse_for_non_trimmable(self):
+        model = "m"
+        req_a = list(range(1, 21))  # 20 tokens
+        # req_b shares a 13-token prefix with req_a, then diverges.
+        req_b = req_a[:13] + [900, 901, 902]
+
+        # Baseline: upstream store with only the full prompt -> no reuse across
+        # the divergent tail for a non-trimmable cache.
+        base = LRUPromptCache(max_size=8)
+        base.insert_cache(model, req_a, self._arrays_cache(1))
+        cache, rest = base.fetch_nearest_cache(model, req_b)
+        self.assertIsNone(cache)
+        self.assertEqual(rest, req_b)  # reused 0 tokens
+
+        # With anchors captured at stride 4 (lengths 4, 8, 12, 16), req_b reuses
+        # up to the nearest anchor <= its 13-token shared prefix, i.e. 12.
+        store = LRUPromptCache(max_size=8)
+        cap = PrefixAnchorCapture(self._arrays_cache(1), stride=4)
+        for processed in range(0, 20, 4):
+            cap(processed, 20)
+        store.insert_cache(model, req_a, self._arrays_cache(1))
+        store.insert_anchors(model, req_a, cap.anchors)
+
+        cache, rest = store.fetch_nearest_cache(model, req_b)
+        self.assertIsNotNone(cache)
+        reused = len(req_b) - len(rest)
+        self.assertEqual(reused, 12)
+        self.assertEqual(rest, req_b[12:])
+        # The reused prefix is an exact prefix of req_b (next-token-safe).
+        self.assertEqual(req_b[:reused], req_a[:reused])
+
+    def test_insert_anchors_skips_trimmable_snapshots(self):
+        from mlx_lm.models.cache import PrefixAnchor
+
+        model = "m"
+        tokens = list(range(1, 21))
+        kv = [KVCache()]
+        x = mx.random.uniform(shape=(1, 8, 8, 4))
+        kv[0].update_and_fetch(x, x)
+        store = LRUPromptCache(max_size=8)
+        store.insert_anchors(model, tokens, [PrefixAnchor(8, kv)])
+        # Trimmable anchor was skipped: nothing stored.
+        self.assertEqual(len(store), 0)
 
     def test_trim_cache_with_generate(self):
         model, tokenizer = self.model, self.tokenizer


### PR DESCRIPTION
### What

Extends anchor-stride prefix reuse to the **continuous-batching path**, so non-trimmable models (recurrent/hybrid — `ArraysCache` + Mamba/GDN state) capture anchors **while staying batched**, and removes the single-request routing workaround from #1516.

> **Stacked on #1516 → #1515.** Until those merge, the diff here also shows their commits. The batched work is the last two commits (`generate.py`, `server.py`, `test_prompt_cache.py`).

### Why

#1516 made the feature work by routing non-trimmable models to the single-request generation path (the only path that then exposed a prefill hook), trading away request batching. This PR captures anchors inside `BatchGenerator` instead, so those models keep continuous batching **and** get prefix reuse.

### How

- **`PromptProcessingBatch`** snapshots each request's exact prefix at prefill chunk boundaries during an **unpadded** batched prefill, keyed by uid, with correct absolute offsets when a prompt is fed across several `prompt()` calls (segmented/continuous batching). It **skips padded (mixed-length) batches** — a right-padded request's state past its real length is polluted until `finalize()`, so mid-prefill snapshots there would be wrong — and skips trimmable caches. `drain_anchors()` hands them off.
- **`BatchGenerator`** threads `prompt_cache_anchor_stride` through, **clamps the prefill step to ≤ stride** so snapshots are stride-granular (snapshots can only be taken at chunk boundaries), accumulates drained anchors by uid, exposes `pop_anchors(uids)` (drained once when a request finishes, so nothing leaks), and drops anchors on `remove()`.
- **Server**: passes the stride to `BatchGenerator` (only for non-trimmable models, so trimmable models keep full-size prefill steps); on a finished generation, drains the request's anchors and stores them via `insert_anchors` alongside the full cache. The `is_batchable` override from #1516 is removed.

### Coverage & limits

- **Unpadded batches only.** Single-request batches (the common interactive/multi-turn case) are always unpadded and fully covered; equal-length concurrent batches too. Mixed-length concurrent batches skip capture that round (the full cache is still stored; only anchors are skipped) — documented, not incorrect.
- **Batch numerics.** A batched prefill produces state that differs from a solo prefill at the float level (batched matmuls), so a batched-captured anchor carries the capture-time batch context — exactly as upstream's existing prompt cache already does for any stored cache. Reuse is exact-prefix (same tokens); it is not bitwise-identical to a *solo* cold prefill, same as the existing cache.

### Tests

`tests/test_prompt_cache.py`:
- `test_batched_prompt_captures_anchors_unpadded` — capture boundaries, absolute offsets across split prefills, and the padded-batch skip, driving `PromptProcessingBatch` directly with a tiny non-trimmable recurrent model.
- `test_batch_generator_captures_and_reuses_anchors` — **end to end through the scheduler**: a request is prefilled and generated via `BatchGenerator`, its anchors are drained at the finish response, a divergent request reuses up to the nearest anchor, and `pop_anchors` is one-shot (no leak).

`black` / `isort --profile black` clean. Full served multi-request concurrency isn't exercised in CI (needs a live HTTP server); the scheduler-level mechanism is integration-tested as above and the mixed-length skip is unit-tested.
