### PR TITLE
utils: validate custom model_file stays inside the model directory

### DIFF
--- a/mlx_lm/utils.py
+++ b/mlx_lm/utils.py
@@ -349,9 +349,24 @@ def load_model(
                 "is disabled by default. Pass trust_remote_code=True if you "
                 "trust this model."
             )
+        model_file_path = Path(model_file)
+        if model_file_path.is_absolute() or model_file_path.suffix != ".py":
+            raise ValueError(
+                "The custom model_file must be a relative Python file inside "
+                f"the model directory (got {model_file!r})."
+            )
+        model_path_resolved = model_path.resolve()
+        custom_model_path = (model_path_resolved / model_file_path).resolve()
+        if custom_model_path == model_path_resolved or (
+            model_path_resolved not in custom_model_path.parents
+        ):
+            raise ValueError(
+                "The custom model_file must stay inside the model directory "
+                f"(got {model_file!r})."
+            )
         spec = importlib.util.spec_from_file_location(
             "custom_model",
-            model_path / model_file,
+            custom_model_path,
         )
         arch = importlib.util.module_from_spec(spec)
         spec.loader.exec_module(arch)

--- a/tests/test_load_model_file_guard.py
+++ b/tests/test_load_model_file_guard.py
@@ -1,0 +1,89 @@
+# Copyright © 2024 Apple Inc.
+
+import json
+import unittest
+from pathlib import Path
+from tempfile import TemporaryDirectory
+
+import mlx.core as mx
+
+from mlx_lm.utils import load_model
+
+# A minimal, valid custom architecture module. When dropped inside the model
+# directory and referenced by ``model_file``, ``load_model`` should import and
+# instantiate it.
+CUSTOM_ARCH_SOURCE = """
+from dataclasses import dataclass
+
+import mlx.core as mx
+import mlx.nn as nn
+
+
+@dataclass
+class ModelArgs:
+    hidden_size: int = 4
+
+    @classmethod
+    def from_dict(cls, config):
+        return cls(hidden_size=config.get("hidden_size", 4))
+
+
+class Model(nn.Module):
+    def __init__(self, args):
+        super().__init__()
+        self.args = args
+        self.linear = nn.Linear(args.hidden_size, args.hidden_size)
+
+    def __call__(self, x):
+        return self.linear(x)
+"""
+
+
+class TestLoadModelFileGuard(unittest.TestCase):
+    def _make_model_dir(self, model_file):
+        """Create a temp model dir whose config points at ``model_file``."""
+        tmp = TemporaryDirectory()
+        self.addCleanup(tmp.cleanup)
+        model_path = Path(tmp.name)
+        config = {
+            "model_type": "custom",
+            "model_file": model_file,
+            "hidden_size": 4,
+        }
+        with open(model_path / "config.json", "w") as f:
+            json.dump(config, f)
+        # A valid custom architecture living inside the model directory.
+        with open(model_path / "arch.py", "w") as f:
+            f.write(CUSTOM_ARCH_SOURCE)
+        # Fake weights so the "strict" weight-file check is satisfied.
+        mx.save_safetensors(
+            str(model_path / "model.safetensors"),
+            {"linear.weight": mx.zeros((4, 4)), "linear.bias": mx.zeros((4,))},
+        )
+        return model_path
+
+    def test_absolute_model_file_rejected(self):
+        model_path = self._make_model_dir("/etc/passwd_arch.py")
+        with self.assertRaises(ValueError):
+            load_model(model_path, trust_remote_code=True)
+
+    def test_escaping_model_file_rejected(self):
+        model_path = self._make_model_dir("../evil_arch.py")
+        with self.assertRaises(ValueError):
+            load_model(model_path, trust_remote_code=True)
+
+    def test_non_python_model_file_rejected(self):
+        model_path = self._make_model_dir("arch.txt")
+        with self.assertRaises(ValueError):
+            load_model(model_path, trust_remote_code=True)
+
+    def test_legit_relative_model_file_loads(self):
+        model_path = self._make_model_dir("arch.py")
+        model, config = load_model(model_path, trust_remote_code=True)
+        self.assertEqual(config["model_file"], "arch.py")
+        # The custom Model was imported and instantiated.
+        self.assertTrue(hasattr(model, "linear"))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
# utils: validate custom `model_file` stays inside the model directory

## What

`load_model` in `mlx_lm/utils.py` supports loading a custom model architecture
from a config's `model_file` key when `trust_remote_code=True`. This change adds
validation of that value before it is imported and executed: the `model_file`
must be a **relative** path with a `.py` suffix that resolves to a location
**inside the model directory**. Absolute paths, non-`.py` files, and any path
that `../`-escapes the model directory now raise `ValueError`.

## Why

Previously the code did:

```python
spec = importlib.util.spec_from_file_location("custom_model", model_path / model_file)
arch = importlib.util.module_from_spec(spec)
spec.loader.exec_module(arch)   # executes arbitrary Python
```

`model_file` came straight from the (untrusted) model config with no validation.
Because `Path(base) / other` returns `other` unchanged when `other` is absolute,
and because `../` segments escape the model directory, a crafted config could
point `model_file` at an absolute path (e.g. `/tmp/evil.py`) or a relative
`../../evil.py` and cause `exec_module` to run an arbitrary `.py` file anywhere
on disk — an arbitrary-file-execution primitive.

Loading a `trust_remote_code` model already implies trusting its *bundled* code,
but a user who inspected the shipped `arch.py` should not be silently made to
execute a *different* file elsewhere on their machine. Constraining execution to
the model directory keeps the trust boundary where the user expects it.

## Test

New `tests/test_load_model_file_guard.py` builds a temp model directory
(minimal `config.json`, a valid custom `arch.py` defining `Model`/`ModelArgs`,
and fake safetensors weights) and asserts, under `trust_remote_code=True`:

- an absolute `model_file` raises `ValueError`
- a `../`-escaping `model_file` raises `ValueError`
- a non-`.py` `model_file` raises `ValueError`
- a legit relative `arch.py` imports and instantiates the custom `Model`

The three rejection cases fail on `upstream/main` (no guard) and pass with the
fix; the legit-load case passes on both.

`black` and `isort --profile black` are clean on both files; `utils.py`
`py_compile`s.

## Note

This is an independent change branched off `upstream/main`. It touches only the
`model_file` path guard in `load_model` and the new test — no other changes.
