### PR TITLE
deepseek_v3: strip MTP layers by depth, not a hardcoded layer index

### DIFF
--- a/mlx_lm/models/deepseek_v3.py
+++ b/mlx_lm/models/deepseek_v3.py
@@ -470,11 +470,17 @@ class Model(nn.Module):
                 weights[f"{prefix}.embed_q.weight"] = wk
                 weights[f"{prefix}.unembed_out.weight"] = wv
 
-        # Remove multi-token prediction layer and any unused precomputed rotary freqs
+        # Remove multi-token prediction layer(s) — any layer index at or above
+        # num_hidden_layers — and any unused precomputed rotary freqs.
+        def is_mtp_layer(k):
+            if not k.startswith("model.layers."):
+                return False
+            return int(k.split(".")[2]) >= self.args.num_hidden_layers
+
         return {
             k: v
             for k, v in weights.items()
-            if not k.startswith("model.layers.61") and "rotary_emb.inv_freq" not in k
+            if not is_mtp_layer(k) and "rotary_emb.inv_freq" not in k
         }
 
     def shard(self, group: Optional[mx.distributed.Group] = None):

--- a/tests/test_deepseek_v3_sanitize.py
+++ b/tests/test_deepseek_v3_sanitize.py
@@ -1,0 +1,71 @@
+# Copyright © 2024 Apple Inc.
+import unittest
+
+import mlx.core as mx
+
+from mlx_lm.models import deepseek_v3
+
+
+class TestDeepseekV3Sanitize(unittest.TestCase):
+    def _make_model(self, num_hidden_layers=4):
+        # A small deepseek_v3-arch config. Keep every layer dense
+        # (first_k_dense_replace >= num_hidden_layers) so we don't need a
+        # routed-expert config, and shrink the dims so construction is cheap.
+        args = deepseek_v3.ModelArgs(
+            vocab_size=128,
+            hidden_size=32,
+            intermediate_size=64,
+            moe_intermediate_size=32,
+            num_hidden_layers=num_hidden_layers,
+            num_attention_heads=4,
+            num_key_value_heads=4,
+            n_routed_experts=None,
+            first_k_dense_replace=num_hidden_layers,
+            q_lora_rank=16,
+            kv_lora_rank=16,
+            qk_rope_head_dim=8,
+            qk_nope_head_dim=8,
+            v_head_dim=8,
+            max_position_embeddings=64,
+        )
+        return deepseek_v3.Model(args)
+
+    def test_strips_mtp_layer_by_depth(self):
+        num_hidden_layers = 4
+        model = self._make_model(num_hidden_layers)
+
+        weights = {
+            "model.embed_tokens.weight": mx.zeros((1,)),
+            "lm_head.weight": mx.zeros((1,)),
+            # An unused precomputed rotary-freq tensor that must be dropped too.
+            "model.layers.0.self_attn.rotary_emb.inv_freq": mx.zeros((1,)),
+        }
+        # In-range decoder layers 0..num_hidden_layers-1.
+        for l in range(num_hidden_layers):
+            weights[f"model.layers.{l}.input_layernorm.weight"] = mx.zeros((1,))
+            weights[f"model.layers.{l}.mlp.gate_proj.weight"] = mx.zeros((1,))
+        # The multi-token-prediction layer lives at index == num_hidden_layers.
+        mtp = num_hidden_layers
+        weights[f"model.layers.{mtp}.embed_tokens.weight"] = mx.zeros((1,))
+        weights[f"model.layers.{mtp}.enorm.weight"] = mx.zeros((1,))
+        weights[f"model.layers.{mtp}.shared_head.head.weight"] = mx.zeros((1,))
+
+        out = model.sanitize(dict(weights))
+        out_keys = set(out.keys())
+
+        # MTP-layer keys are dropped.
+        for k in weights:
+            if k.startswith(f"model.layers.{mtp}."):
+                self.assertNotIn(k, out_keys)
+        # In-range decoder-layer keys are kept.
+        for l in range(num_hidden_layers):
+            self.assertIn(f"model.layers.{l}.input_layernorm.weight", out_keys)
+            self.assertIn(f"model.layers.{l}.mlp.gate_proj.weight", out_keys)
+        # Non-layer weights are kept; the rotary inv_freq is dropped.
+        self.assertIn("model.embed_tokens.weight", out_keys)
+        self.assertIn("lm_head.weight", out_keys)
+        self.assertNotIn("model.layers.0.self_attn.rotary_emb.inv_freq", out_keys)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
# deepseek_v3: strip MTP layers by depth, not a hardcoded layer index

## What

`Model.sanitize()` in `mlx_lm/models/deepseek_v3.py` dropped the multi-token
prediction (MTP) head with a hardcoded check:

```python
if not k.startswith("model.layers.61") and "rotary_emb.inv_freq" not in k
```

The literal `61` is only correct for DeepSeek-V3-671B, whose MTP module sits at
`model.layers.61` (`num_hidden_layers == 61`). This replaces the string match
with a depth-based test that drops *any* layer whose index is `>=
self.args.num_hidden_layers`.

## Why

The MTP module in a deepseek_v3-arch checkpoint always lives at layer index
`num_hidden_layers` (one past the last real decoder layer). Any deepseek_v3-arch
checkpoint with a depth other than 61 — V2-Lite-style configs, distills, custom
configs — mis-loads under the old code:

- The real MTP layer (at `num_hidden_layers`, not 61) is **not** stripped, so
  extra `model.layers.<N>.*` weights leak into the state dict.
- Conversely, for a 61-layer model the check is fine, but the coupling to a
  magic number is fragile and silently wrong off the happy path.

## How

The `startswith("model.layers.61")` string test becomes a small helper:

```python
def is_mtp_layer(k):
    if not k.startswith("model.layers."):
        return False
    return int(k.split(".")[2]) >= self.args.num_hidden_layers
```

- Guarded to only parse the layer index for `model.layers.` keys, so non-layer
  weights (`model.embed_tokens`, `lm_head`, norms, …) are untouched.
- For DeepSeek-V3-671B this is behavior-identical to the old `61` literal.
- The existing `rotary_emb.inv_freq` drop is preserved verbatim.

## Test

Adds `tests/test_deepseek_v3_sanitize.py`: constructs a small deepseek_v3 `Model`
(`num_hidden_layers=4`, all-dense so no routed-expert config needed), builds a
fake `weights` dict with keys for layers `0..3` plus an MTP layer at index `4`
(`model.layers.4.*`), calls `model.sanitize(...)`, and asserts:

- the `model.layers.4.*` MTP keys are dropped,
- the in-range layer `0..3` keys are kept,
- non-layer weights are kept and `rotary_emb.inv_freq` is dropped.

The test **fails on `main`** (the hardcoded `61` keeps the layer-4 MTP weights)
and **passes** with this change.
