### PR TITLE
mistral3: load transformers v5 nested-model. checkpoints

### DIFF
--- a/mlx_lm/models/mistral3.py
+++ b/mlx_lm/models/mistral3.py
@@ -46,6 +46,26 @@ class Model(nn.Module):
         )
 
     def sanitize(self, weights):
+        # transformers >= 5 checkpoints nest everything under a top-level
+        # "model." (model.language_model.*, model.vision_tower.*) with
+        # lm_head.weight at the root. Remap to the older layout
+        # (language_model.model.*, language_model.lm_head.*) expected below.
+        if any(k.startswith("model.language_model.") for k in weights):
+            remapped = {}
+            for k, v in weights.items():
+                if k.startswith("model.language_model."):
+                    remapped[
+                        "language_model.model." + k[len("model.language_model.") :]
+                    ] = v
+                elif k.startswith(
+                    ("model.vision_tower.", "model.multi_modal_projector.")
+                ):
+                    continue
+                elif k.startswith("lm_head."):
+                    remapped["language_model." + k] = v
+                else:
+                    remapped[k] = v
+            weights = remapped
         weights = tree_unflatten(list(weights.items()))
         weights.pop("vision_tower", None)
         weights.pop("multi_modal_projector", None)

--- a/tests/test_mistral3_sanitize.py
+++ b/tests/test_mistral3_sanitize.py
@@ -1,0 +1,62 @@
+# Copyright © 2025 Apple Inc.
+
+import unittest
+
+from mlx_lm.models import mistral3
+
+
+def _minimal_args():
+    text_config = {
+        "model_type": "llama",
+        "hidden_size": 8,
+        "num_hidden_layers": 1,
+        "intermediate_size": 16,
+        "num_attention_heads": 2,
+        "rms_norm_eps": 1e-5,
+        "vocab_size": 32,
+    }
+    return mistral3.ModelArgs(model_type="mistral3", text_config=text_config)
+
+
+class TestMistral3Sanitize(unittest.TestCase):
+    def test_transformers_v5_nested_layout(self):
+        model = mistral3.Model(_minimal_args())
+
+        # transformers >= 5 nested "model." layout: the text backbone lives
+        # directly under "model.language_model.", lm_head at the root.
+        weights = {
+            "model.language_model.embed_tokens.weight": 0,
+            "model.language_model.layers.0.self_attn.q_proj.weight": 1,
+            "model.language_model.layers.0.mlp.gate_proj.weight": 2,
+            "lm_head.weight": 3,
+            "model.vision_tower.foo": 4,
+            "model.multi_modal_projector.bar": 5,
+        }
+
+        out = model.sanitize(weights)
+
+        # language_model.* remapped, vision/projector dropped.
+        self.assertIn("language_model.model.embed_tokens.weight", out)
+        self.assertIn("language_model.model.layers.0.self_attn.q_proj.weight", out)
+        self.assertIn("language_model.model.layers.0.mlp.gate_proj.weight", out)
+        self.assertIn("language_model.lm_head.weight", out)
+
+        for k in out:
+            self.assertFalse(k.startswith("model."))
+            self.assertNotIn("vision_tower", k)
+            self.assertNotIn("multi_modal_projector", k)
+
+    def test_nested_branch_triggers(self):
+        # A key in the nested layout should route through the remap branch.
+        model = mistral3.Model(_minimal_args())
+        weights = {
+            "model.language_model.embed_tokens.weight": 0,
+            "model.vision_tower.foo": 1,
+        }
+        out = model.sanitize(weights)
+        self.assertIn("language_model.model.embed_tokens.weight", out)
+        self.assertTrue(all(not k.startswith("model.") for k in out))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
# mistral3: load transformers v5 nested-`model.` checkpoints

## Summary

transformers >= 5 exports Mistral3 (and other VLM) checkpoints with everything
nested under a top-level `model.` prefix:

- text backbone under `model.language_model.*`
- vision tower under `model.vision_tower.*`
- multimodal projector under `model.multi_modal_projector.*`
- `lm_head.weight` at the root

This differs from the older layout `mistral3.Model` expects, where the text
weights live under `language_model.model.*` and the head under
`language_model.lm_head.*`. Without a remap, newer Mistral3 checkpoints fail to
load (missing/unexpected keys).

## Fix

`Model.sanitize` now detects the nested layout (any key starting with
`model.language_model.`) and remaps it back to the expected form before the
existing tree-unflatten logic runs:

- `model.language_model.*` -> `language_model.model.*`
- `lm_head.*` -> `language_model.lm_head.*`
- `model.vision_tower.*` and `model.multi_modal_projector.*` are dropped

The branch is a no-op for older checkpoints, so existing weights continue to
load unchanged.

## Test

`tests/test_mistral3_sanitize.py` builds a fake `weights` dict in the
transformers-5 nested layout, runs `Model(args).sanitize(weights)` on a minimal
`ModelArgs`, and asserts the keys are remapped to the `language_model.*` layout
and the vision/projector keys are dropped. A second case confirms the
nested-layout branch actually triggers.

```
$ python -m pytest tests/test_mistral3_sanitize.py -q
2 passed
```

Formatting: `black` and `isort --profile black` clean.
