### PR TITLE
cache: forward max_kv_size to models that define make_cache

### DIFF
--- a/mlx_lm/models/cache.py
+++ b/mlx_lm/models/cache.py
@@ -1,6 +1,7 @@
 # Copyright © 2023-2024 Apple Inc.
 
 import copy
+import inspect
 from collections import deque
 from dataclasses import dataclass
 from typing import Any, Dict, List, Optional
@@ -24,11 +25,17 @@ def make_prompt_cache(
 
     Args:
         model (nn.Module): The language model.
-        max_kv_size (Optional[int]): If provided and the model does not have a
-            ``make_cache`` method, a ``RotatingKVCache`` is used with a maximum
-            size of ``max_kv_size``
+        max_kv_size (Optional[int]): If provided, the attention KV cache is
+            bounded to ``max_kv_size`` tokens via a ``RotatingKVCache``. Models
+            with a ``make_cache`` method honor this only if their ``make_cache``
+            accepts a ``max_kv_size`` argument (e.g. hybrid models cap their
+            full-attention layers and leave recurrent layers unbounded);
+            otherwise the model's own cache policy is used unchanged.
     """
     if hasattr(model, "make_cache"):
+        params = inspect.signature(model.make_cache).parameters
+        if max_kv_size is not None and "max_kv_size" in params:
+            return model.make_cache(max_kv_size=max_kv_size)
         return model.make_cache()
 
     num_layers = len(model.layers)

--- a/mlx_lm/models/qwen3_next.py
+++ b/mlx_lm/models/qwen3_next.py
@@ -17,7 +17,7 @@ from .base import (
     create_ssm_mask,
     scaled_dot_product_attention,
 )
-from .cache import ArraysCache, KVCache
+from .cache import ArraysCache, KVCache, RotatingKVCache
 from .gated_delta import gated_delta_update
 from .rope_utils import initialize_rope
 from .switch_layers import SwitchGLU
@@ -446,8 +446,21 @@ class Model(nn.Module):
     def layers(self):
         return self.model.layers
 
-    def make_cache(self):
-        return [ArraysCache(size=2) if l.is_linear else KVCache() for l in self.layers]
+    def make_cache(self, max_kv_size: Optional[int] = None):
+        # Recurrent (GDN) layers keep a fixed-size ArraysCache regardless. Only
+        # the full-attention layers grow unbounded, so cap just those with a
+        # RotatingKVCache when a budget is given (keep=4 preserves the sink
+        # tokens). Quantized KV is not compatible with RotatingKVCache
+        # (toQuantized NYI), so callers must not combine --max-kv-size with
+        # --kv-bits on this model.
+        def attn_cache():
+            if max_kv_size is not None:
+                return RotatingKVCache(max_size=max_kv_size, keep=4)
+            return KVCache()
+
+        return [
+            ArraysCache(size=2) if l.is_linear else attn_cache() for l in self.layers
+        ]
 
     def sanitize(self, weights):
         if "model.layers.0.mlp.experts.0.up_proj.weight" not in weights:

--- a/tests/test_make_prompt_cache_max_kv.py
+++ b/tests/test_make_prompt_cache_max_kv.py
@@ -1,0 +1,101 @@
+# Copyright © 2024 Apple Inc.
+
+import unittest
+
+import mlx.nn as nn
+
+from mlx_lm.models.cache import KVCache, RotatingKVCache, make_prompt_cache
+
+
+class MakeCacheAcceptsMaxKV(nn.Module):
+    """Stub model whose make_cache accepts max_kv_size (hybrid-style)."""
+
+    def __init__(self):
+        super().__init__()
+        self.received = "unset"
+
+    def make_cache(self, max_kv_size=None):
+        self.received = max_kv_size
+        return [KVCache()]
+
+
+class MakeCacheNoMaxKV(nn.Module):
+    """Stub model whose make_cache does not accept max_kv_size (legacy)."""
+
+    def __init__(self):
+        super().__init__()
+        self.called = False
+
+    def make_cache(self):
+        self.called = True
+        return [KVCache()]
+
+
+class TestMakePromptCacheMaxKV(unittest.TestCase):
+    def test_forwards_max_kv_size_when_accepted(self):
+        model = MakeCacheAcceptsMaxKV()
+        make_prompt_cache(model, max_kv_size=128)
+        # The fix must forward the budget to models that accept it.
+        self.assertEqual(model.received, 128)
+
+    def test_no_forward_when_not_accepted(self):
+        model = MakeCacheNoMaxKV()
+        # Legacy models without a max_kv_size parameter must still work and be
+        # called with no arguments (backward compatible).
+        cache = make_prompt_cache(model, max_kv_size=128)
+        self.assertTrue(model.called)
+        self.assertEqual(len(cache), 1)
+
+    def test_no_forward_when_budget_is_none(self):
+        model = MakeCacheAcceptsMaxKV()
+        make_prompt_cache(model)
+        self.assertIsNone(model.received)
+
+    def test_qwen3_next_caps_attention_layers(self):
+        from mlx_lm.models import qwen3_next
+
+        args = qwen3_next.ModelArgs(
+            model_type="qwen3_next",
+            hidden_size=32,
+            num_hidden_layers=4,
+            intermediate_size=64,
+            num_attention_heads=4,
+            linear_num_value_heads=2,
+            linear_num_key_heads=2,
+            linear_key_head_dim=16,
+            linear_value_head_dim=16,
+            linear_conv_kernel_dim=4,
+            num_experts=2,
+            num_experts_per_tok=1,
+            decoder_sparse_step=1,
+            shared_expert_intermediate_size=64,
+            mlp_only_layers=[],
+            moe_intermediate_size=64,
+            rms_norm_eps=1e-6,
+            vocab_size=128,
+            num_key_value_heads=2,
+            rope_theta=10000.0,
+            partial_rotary_factor=0.25,
+            max_position_embeddings=64,
+            head_dim=16,
+            full_attention_interval=2,
+        )
+        model = qwen3_next.Model(args)
+
+        capped = make_prompt_cache(model, max_kv_size=128)
+        uncapped = make_prompt_cache(model)
+
+        linear_flags = [l.is_linear for l in model.layers]
+        # Attention (non-linear) layers must be rotating when a budget is set,
+        # recurrent (linear) layers stay unbounded either way.
+        self.assertTrue(any(not f for f in linear_flags))
+        for layer_cache, is_linear in zip(capped, linear_flags):
+            if not is_linear:
+                self.assertIsInstance(layer_cache, RotatingKVCache)
+        for layer_cache, is_linear in zip(uncapped, linear_flags):
+            if not is_linear:
+                self.assertIsInstance(layer_cache, KVCache)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Forward `max_kv_size` to models that define `make_cache`

### Problem

`make_prompt_cache(model, max_kv_size=...)` silently drops `max_kv_size`
whenever the model defines its own `make_cache` method:

```python
if hasattr(model, "make_cache"):
    return model.make_cache()   # max_kv_size ignored
```

This means sliding-window / hybrid models that implement `make_cache` (to mix
recurrent and full-attention layers) cannot honor `--max-kv-size` at all. The
budget is only ever applied to plain models that fall through to the default
`KVCache` / `RotatingKVCache` path.

### Fix

Inspect the model's `make_cache` signature and forward `max_kv_size` only when
the parameter is accepted; otherwise call `make_cache()` as before. This is
fully backward compatible — existing `make_cache(self)` implementations are
untouched.

```python
if hasattr(model, "make_cache"):
    params = inspect.signature(model.make_cache).parameters
    if max_kv_size is not None and "max_kv_size" in params:
        return model.make_cache(max_kv_size=max_kv_size)
    return model.make_cache()
```

### Paired model change: `qwen3_next`

`Qwen3Next` is a hybrid GDN + full-attention model. Its `make_cache` now
accepts an optional `max_kv_size` and caps only the full-attention layers with
a `RotatingKVCache(max_size=max_kv_size, keep=4)`, leaving the recurrent
(GDN) `ArraysCache` layers fixed. Without a budget, behavior is unchanged
(plain `KVCache` for the attention layers).

Note: `RotatingKVCache` is not compatible with quantized KV (`toQuantized`
NYI), so `--max-kv-size` should not be combined with `--kv-bits` on this model.

### Tests

`tests/test_make_prompt_cache_max_kv.py`:

- forwards `max_kv_size` to a model whose `make_cache` accepts it;
- still calls (with no args) a legacy `make_cache(self)` that does not accept it;
- does not forward when no budget is given;
- `qwen3_next.make_cache(max_kv_size=...)` produces `RotatingKVCache` for the
  attention layers and `KVCache` when no budget is set.

The two behavioral assertions fail on `main` (budget dropped) and pass with the
fix.
