### PR TITLE
server: return JSON 400 for malformed logit_bias and invalid params

### DIFF
--- a/mlx_lm/server.py
+++ b/mlx_lm/server.py
@@ -3,6 +3,7 @@
 import argparse
 import json
 import logging
+import math
 import pickle
 import platform
 import socket
@@ -1142,7 +1143,16 @@ class APIHandler(BaseHTTPRequestHandler):
         self.top_logprobs = self.body.get("top_logprobs", -1)
         self.seed = self.body.get("seed", None)
         self.chat_template_kwargs = self.body.get("chat_template_kwargs")
-        self.validate_model_parameters()
+        try:
+            self.validate_model_parameters()
+        except ValueError as e:
+            # Parameter validation happens before completion/stream headers are
+            # emitted, so malformed requests receive a normal JSON 400 instead
+            # of a dropped connection after a streaming response has begun.
+            self._set_completion_headers(400)
+            self.end_headers()
+            self.wfile.write(json.dumps({"error": str(e)}).encode())
+            return
 
         # Get stop sequences
         stop_words = self.body.get("stop")
@@ -1203,10 +1213,23 @@ class APIHandler(BaseHTTPRequestHandler):
         self._validate("logit_bias", dict, optional=True)
 
         if self.logit_bias is not None:
-            try:
-                self.logit_bias = {int(k): float(v) for k, v in self.logit_bias.items()}
-            except ValueError:
-                raise ValueError("logit_bias must be a dict of int to float")
+            # Normalize into {int: float}. Malformed entries (null / non-numeric
+            # values, bool values, non-integer keys) and non-finite values must
+            # all surface as ValueError so the request gets the JSON 400 path,
+            # never an uncaught TypeError.
+            normalized = {}
+            for k, v in self.logit_bias.items():
+                if isinstance(v, bool) or not isinstance(v, (int, float)):
+                    raise ValueError("logit_bias must be a dict of int to float")
+                try:
+                    key = int(str(k))
+                    value = float(v)
+                except (ValueError, TypeError):
+                    raise ValueError("logit_bias must be a dict of int to float")
+                if not math.isfinite(value):
+                    raise ValueError("logit_bias values must be finite")
+                normalized[key] = value
+            self.logit_bias = normalized
 
     def generate_response(
         self,

--- a/tests/test_server_param_validation.py
+++ b/tests/test_server_param_validation.py
@@ -1,0 +1,107 @@
+# Copyright © 2024 Apple Inc.
+
+import math
+import unittest
+
+from mlx_lm.server import APIHandler
+
+
+def _make_handler(**overrides):
+    """Build an APIHandler without running BaseHTTPRequestHandler.__init__.
+
+    validate_model_parameters() only reads plain attributes off ``self`` and
+    does not touch the socket or the loaded model, so we can exercise it in
+    isolation by populating a bare instance with valid defaults and overriding
+    the field(s) under test.
+    """
+    handler = APIHandler.__new__(APIHandler)
+    defaults = {
+        "stream": False,
+        "max_tokens": 16,
+        "temperature": 1.0,
+        "top_p": 1.0,
+        "top_k": 0,
+        "min_p": 0.0,
+        "num_draft_tokens": 3,
+        "repetition_penalty": 1.0,
+        "repetition_context_size": 20,
+        "presence_penalty": 0.0,
+        "presence_context_size": 20,
+        "frequency_penalty": 0.0,
+        "frequency_context_size": 20,
+        "logprobs": False,
+        "top_logprobs": -1,
+        "xtc_probability": 0.0,
+        "xtc_threshold": 0.0,
+        "requested_model": "default_model",
+        "adapter": None,
+        "seed": None,
+        "logit_bias": None,
+    }
+    defaults.update(overrides)
+    for key, value in defaults.items():
+        setattr(handler, key, value)
+    return handler
+
+
+class TestLogitBiasValidation(unittest.TestCase):
+    def test_valid_logit_bias_is_normalized(self):
+        handler = _make_handler(logit_bias={"1": 2, "3": -1.5})
+        handler.validate_model_parameters()
+        self.assertEqual(handler.logit_bias, {1: 2.0, 3: -1.5})
+        for v in handler.logit_bias.values():
+            self.assertIsInstance(v, float)
+
+    def test_null_value_raises_valueerror_not_typeerror(self):
+        # Upstream did `float(None)` inside a `except ValueError` guard, so a
+        # null bias value raised an uncaught TypeError (500 / dropped socket).
+        handler = _make_handler(logit_bias={"1": None})
+        with self.assertRaises(ValueError):
+            handler.validate_model_parameters()
+
+    def test_non_finite_value_rejected(self):
+        for bad in (float("inf"), float("-inf"), float("nan")):
+            handler = _make_handler(logit_bias={"1": bad})
+            with self.assertRaises(ValueError):
+                handler.validate_model_parameters()
+
+    def test_bool_value_rejected(self):
+        # bool is a subclass of int; upstream let it pass silently.
+        handler = _make_handler(logit_bias={"1": True})
+        with self.assertRaises(ValueError):
+            handler.validate_model_parameters()
+
+    def test_non_integer_key_rejected(self):
+        handler = _make_handler(logit_bias={"x": 2})
+        with self.assertRaises(ValueError):
+            handler.validate_model_parameters()
+
+    def test_non_numeric_string_value_rejected(self):
+        handler = _make_handler(logit_bias={"1": "nope"})
+        with self.assertRaises(ValueError):
+            handler.validate_model_parameters()
+
+    def test_none_logit_bias_passes(self):
+        handler = _make_handler(logit_bias=None)
+        handler.validate_model_parameters()
+        self.assertIsNone(handler.logit_bias)
+
+
+class TestModelParameterValidation(unittest.TestCase):
+    def test_top_p_out_of_range_raises(self):
+        handler = _make_handler(top_p=5)
+        with self.assertRaises(ValueError):
+            handler.validate_model_parameters()
+
+    def test_temperature_wrong_type_raises(self):
+        handler = _make_handler(temperature="x")
+        with self.assertRaises(ValueError):
+            handler.validate_model_parameters()
+
+    def test_valid_params_pass(self):
+        handler = _make_handler(top_p=0.9, temperature=0.7)
+        handler.validate_model_parameters()
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Return JSON 400 for malformed `logit_bias` and invalid params

Two robustness fixes to `mlx_lm/server.py` so malformed requests get a clean
JSON `400` instead of a `500` / dropped socket.

### 1. `logit_bias` hardening

The previous normalization was:

```python
self.logit_bias = {int(k): float(v) for k, v in self.logit_bias.items()}
```

wrapped in `except ValueError`. This had three problems:

- **Null / non-numeric values raise an uncaught `TypeError`.** `float(None)`
  raises `TypeError`, which the `except ValueError` guard does not catch — so a
  body like `{"logit_bias": {"1": null}}` crashed the handler (500 / dropped
  connection) instead of returning a `400`.
- **Bool values passed silently.** `bool` is a subclass of `int`/`float`, so
  `{"1": true}` slipped through and biased sampling by `1.0`.
- **Non-finite values poisoned sampling.** `inf` / `nan` were accepted and
  corrupted the logits.

The fix explicitly rejects bool, rejects non-numeric / null values, rejects
non-integer keys, and rejects non-finite values — all via `ValueError`, so they
all take the documented JSON `400` path. Adds `import math` for `math.isfinite`.

### 2. Param-validation `400`

`do_POST` called `self.validate_model_parameters()` bare, so any invalid
parameter (`top_p=5`, `temperature="x"`, …) propagated as an uncaught
`ValueError` after request parsing — dropping the connection. The call is now
wrapped to emit a JSON `400` with an error body **before** any
completion/stream headers are sent.

### Tests

`tests/test_server_param_validation.py` exercises `validate_model_parameters`
directly (built via `APIHandler.__new__`, no socket / model needed):

- valid `logit_bias` normalizes to `{int: float}`
- `{"1": null}` raises `ValueError` (previously an uncaught `TypeError`)
- `inf` / `-inf` / `nan` rejected
- bool value rejected
- non-integer key rejected
- non-numeric string value rejected
- `None` passes through
- `top_p=5` and `temperature="x"` raise `ValueError`

Verified the malformed-`logit_bias` case raises an uncaught `TypeError` on
current `main` and a `ValueError` (JSON-400 path) with this change.
`tests/test_server.py` continues to pass with no regression.
