### PR TITLE
Add sarvam_mla (Sarvam-105B) model

### DIFF
--- a/mlx_lm/models/sarvam_mla.py
+++ b/mlx_lm/models/sarvam_mla.py
@@ -1,0 +1,63 @@
+# Copyright © 2026 Apple Inc.
+
+# Sarvam-105B (`sarvam_mla` / SarvamMLAForCausalLM). Architecturally this is
+# DeepSeek-V3: MLA attention (kv_lora_rank 512, q_head_dim 192, no q_lora_rank →
+# direct q_proj) + sigmoid `noaux_tc` group-topk MoE with expert-bias correction +
+# a shared expert + `first_k_dense_replace`. The reference `use_qk_norm` flag is a
+# no-op in Sarvam's own attention forward (standard MLA, no per-head q/k norm), so
+# we reuse the DeepSeek-V3 implementation wholesale — it already caches the 512-dim
+# latent and does absorbed-decode / materialized-prefill, and its `sanitize` folds
+# `kv_b_proj` into those.
+#
+# This module only remaps Sarvam's config key names onto the V3 ModelArgs.
+
+from dataclasses import dataclass
+from typing import Optional
+
+from .deepseek_v3 import Model as DeepseekV3ForCausalLM
+from .deepseek_v3 import ModelArgs as _V3Args
+
+
+@dataclass
+class ModelArgs(_V3Args):
+    model_type: str = "sarvam_mla"
+    # Sarvam uses different key names for the MoE cardinalities:
+    num_experts: Optional[int] = None  # -> n_routed_experts
+    num_shared_experts: Optional[int] = None  # -> n_shared_experts
+    # Sarvam has no q_lora_rank -> direct q_proj path (V3 default is 1536).
+    q_lora_rank: Optional[int] = None
+    # Default to None (not the V3 base's 1) so __post_init__ can tell a
+    # truly-absent key apart from an explicit n_group=1/topk_group=1
+    # ("no group restriction"), which must be honored as-is.
+    n_group: Optional[int] = None
+    topk_group: Optional[int] = None
+    # present in Sarvam config; unused by the V3 attention math but kept so
+    # BaseModelArgs.from_dict doesn't choke and for documentation.
+    q_head_dim: int = 192
+    head_dim: int = 576
+    use_qk_norm: bool = False
+    moe_router_enable_expert_bias: bool = True
+    default_theta: float = 10000.0
+
+    def __post_init__(self):
+        # Map Sarvam cardinalities onto the DeepSeek-V3 field names.
+        if self.num_experts is not None:
+            self.n_routed_experts = self.num_experts
+        if self.num_shared_experts is not None:
+            self.n_shared_experts = self.num_shared_experts
+        # Sarvam omits the group-routing dims; its gate defaults to
+        # n_group = n_routed_experts // 8, topk_group = 2 (see modeling MoEGate).
+        # Only fill in defaults when the config truly omits the keys — an
+        # explicit n_group=1/topk_group=1 means "no group restriction" and
+        # must be honored as-is.
+        n_routed = self.n_routed_experts or self.num_experts or 128
+        if self.n_group is None:
+            self.n_group = n_routed // 8
+        if self.topk_group is None:
+            self.topk_group = 2
+
+
+class Model(DeepseekV3ForCausalLM):
+    def __init__(self, config: ModelArgs):
+        super().__init__(config)
+        self.model_type = config.model_type

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -1453,6 +1453,39 @@ class TestModels(unittest.TestCase):
             model, args.model_type, args.vocab_size, args.num_hidden_layers
         )
 
+    def test_sarvam_mla(self):
+        from mlx_lm.models import sarvam_mla
+
+        # Sarvam-105B config-name remap onto DeepSeek-V3: Sarvam-style keys
+        # (num_experts / num_shared_experts, no q_lora_rank -> direct q_proj).
+        args = sarvam_mla.ModelArgs(
+            model_type="sarvam_mla",
+            vocab_size=1024,
+            hidden_size=128,
+            intermediate_size=256,
+            moe_intermediate_size=256,
+            num_hidden_layers=4,
+            num_attention_heads=4,
+            num_key_value_heads=2,
+            num_experts=4,
+            num_shared_experts=1,
+            n_group=2,
+            topk_group=1,
+            num_experts_per_tok=2,
+            first_k_dense_replace=1,
+            kv_lora_rank=4,
+            q_lora_rank=None,
+            qk_rope_head_dim=32,
+            v_head_dim=16,
+            qk_nope_head_dim=32,
+        )
+        model = sarvam_mla.Model(args)
+        self.assertEqual(args.n_routed_experts, 4)
+        self.assertEqual(args.n_shared_experts, 1)
+        self.model_test_runner(
+            model, args.model_type, args.vocab_size, args.num_hidden_layers
+        )
+
     def test_gemma2(self):
         from mlx_lm.models import gemma2
 


### PR DESCRIPTION
# Add `sarvam_mla` (Sarvam-105B) model

This adds support for Sarvam-105B (`SarvamMLAForCausalLM`, `model_type: "sarvam_mla"`).

## What it is

Architecturally Sarvam-105B is DeepSeek-V3:

- MLA attention (`kv_lora_rank=512`, `q_head_dim=192`), with **no `q_lora_rank`**
  (direct `q_proj` path).
- Sigmoid `noaux_tc` group-topk MoE with expert-bias correction.
- A shared expert plus `first_k_dense_replace` leading dense layers.

The reference `use_qk_norm` flag is a no-op in Sarvam's attention forward
(standard MLA, no per-head q/k norm), so the existing `deepseek_v3`
implementation is reused wholesale.

## Implementation

`mlx_lm/models/sarvam_mla.py` is a thin subclass of the existing
`deepseek_v3` model — it only remaps Sarvam's config key names onto the V3
`ModelArgs`:

- `num_experts` → `n_routed_experts`
- `num_shared_experts` → `n_shared_experts`
- `q_lora_rank` defaults to `None` (direct `q_proj`).
- `n_group` / `topk_group` default to `None` so a truly-absent key is
  distinguishable from an explicit `1` ("no group restriction"); when omitted
  they fall back to Sarvam's gate defaults (`n_routed_experts // 8`, `2`).

No new architecture code — `Model`/`ModelArgs`/`DeepseekV3Model` are inherited
from `deepseek_v3`.

## Registration

The HF `model_type` is `sarvam_mla`, which maps directly to the module
filename, so **no `MODEL_REMAPPING` entry is needed**.

## Testing

Adds `test_sarvam_mla` to `tests/test_models.py`, building a small
Sarvam-keyed config and running the standard `model_test_runner`
(instantiation + forward + cache). Passes.
