### PR TITLE
nemotron_h: load in-checkpoint MTP head for self-speculation

### DIFF
--- a/mlx_lm/generate.py
+++ b/mlx_lm/generate.py
@@ -526,7 +526,9 @@ def speculative_generate_step(
         model_cache = prompt_cache[: len(model.layers)]
         draft_cache = prompt_cache[len(model.layers) :]
 
-    if not cache.can_trim_prompt_cache(model_cache):
+    if not cache.can_trim_prompt_cache(model_cache) and not getattr(
+        model, "supports_speculative_rollback", False
+    ):
         types = {type(c).__name__ for c in model_cache if not c.is_trimmable()}
         raise ValueError(
             f"Speculative decoding requires a trimmable prompt cache " f"(got {types})."
@@ -604,6 +606,12 @@ def speculative_generate_step(
         draft_y = _prefill(draft_model, draft_cache, y)
         y = _prefill(model, model_cache, y)
 
+    # After prefill (recording a rollback for the whole prompt would hold on to
+    # prompt-sized tensors), let rollback-capable caches start recording so
+    # verify steps can be trimmed exactly (no-op for regular KV caches).
+    for c in model_cache:
+        c.start_speculation()
+
     ntoks = 0
     # Set these so the finally block doesn't raise
     num_draft = 0
@@ -652,6 +660,8 @@ def speculative_generate_step(
             _rewind_cache(num_draft, n)
     finally:
         _rewind_cache(num_draft, n)
+        for c in model_cache:
+            c.stop_speculation()
 
 
 def stream_generate(

--- a/mlx_lm/generate.py
+++ b/mlx_lm/generate.py
@@ -526,10 +526,17 @@ def speculative_generate_step(
         model_cache = prompt_cache[: len(model.layers)]
         draft_cache = prompt_cache[len(model.layers) :]
 
-    if not cache.can_trim_prompt_cache(model_cache) and not getattr(
-        model, "supports_speculative_rollback", False
-    ):
-        types = {type(c).__name__ for c in model_cache if not c.is_trimmable()}
+    def _can_speculate(c):
+        # Trimmable directly, or able to record an exact rollback while
+        # speculating (see ArraysCache.record_rollback). The model must also
+        # declare support: recording is done by its recurrent layers.
+        return c.is_trimmable() or (
+            hasattr(c, "record_rollback")
+            and getattr(model, "supports_speculative_rollback", False)
+        )
+
+    if not all(_can_speculate(c) for c in model_cache):
+        types = {type(c).__name__ for c in model_cache if not _can_speculate(c)}
         raise ValueError(
             f"Speculative decoding requires a trimmable prompt cache " f"(got {types})."
         )
@@ -608,8 +615,10 @@ def speculative_generate_step(
 
     # After prefill (recording a rollback for the whole prompt would hold on to
     # prompt-sized tensors), let rollback-capable caches start recording so
-    # verify steps can be trimmed exactly (no-op for regular KV caches).
-    for c in model_cache:
+    # verify steps can be trimmed exactly (no-op for regular KV caches). The
+    # draft cache records too: hybrid draft models (e.g. a small Qwen3.5) need
+    # their recurrent state rewound just like the target's.
+    for c in model_cache + draft_cache:
         c.start_speculation()
 
     ntoks = 0
@@ -619,6 +628,11 @@ def speculative_generate_step(
     try:
         while True:
             num_draft = min(max_tokens - ntoks, num_draft_tokens)
+            # Until this round's verify step has advanced the caches there is
+            # nothing to rewind; keep n == num_draft so an exception here (or a
+            # generator close) makes the finally-block rewind a no-op instead
+            # of trimming with values from a previous round.
+            n = num_draft
             draft_tokens = _draft_generate(draft_y, num_draft)
             if prev_tokens is not None:
                 prev_tokens = prev_tokens[: prev_tokens.size - y.size - num_draft + 1]

--- a/mlx_lm/models/cache.py
+++ b/mlx_lm/models/cache.py
@@ -146,6 +146,19 @@ class _BaseCache:
     def is_trimmable(self):
         return False
 
+    def start_speculation(self):
+        """Called by speculative decoding before draft/verify steps begin.
+
+        Caches that cannot trim directly but support an exact rollback (e.g.
+        recurrent-state caches, see ``ArraysCache``) use this to start recording
+        the information needed to roll a verify step back. No-op by default.
+        """
+        pass
+
+    def stop_speculation(self):
+        """Called by speculative decoding when it finishes. No-op by default."""
+        pass
+
     def size(self):
         """
         Return the size (i.e. sequence length) of the cache.
@@ -596,12 +609,57 @@ class ArraysCache(_BaseCache):
         instance = super().__new__(cls)
         instance.left_padding = None
         instance.lengths = None
+        instance.speculating = False
+        instance._rollback = None
         return instance
 
     def __init__(self, size, left_padding: Optional[List[int]] = None):
         self.cache = [None] * size
         if left_padding:
             self.left_padding = mx.array(left_padding)
+
+    def start_speculation(self):
+        self.speculating = True
+        self._rollback = None
+
+    def stop_speculation(self):
+        self.speculating = False
+        self._rollback = None
+
+    def record_rollback(self, num_tokens, fn, snapshot):
+        """Recorded by the owning layer during a forward while ``speculating``.
+
+        Args:
+            num_tokens (int): Sequence length of the forward being recorded.
+            fn (callable): ``fn(m) -> list`` returning the cache entries as they
+                would be had only the first ``m`` of ``num_tokens`` tokens been
+                processed. Must be exact (e.g. replay the recurrence from the
+                pre-forward state over the stashed per-token inputs).
+            snapshot (list): The cache entries from before the forward (returned
+                for a full rollback, ``m == 0``).
+        """
+        self._rollback = (num_tokens, fn, snapshot)
+
+    def is_trimmable(self):
+        # While speculating, every forward records an exact rollback, so the
+        # cache is trimmable within the last forward's window.
+        return self.speculating
+
+    def trim(self, n):
+        if n <= 0:
+            return 0
+        if self._rollback is None:
+            raise RuntimeError(
+                "ArraysCache.trim requires a rollback recorded by the model's "
+                "recurrent layers; this model does not support speculative "
+                "rollback."
+            )
+        num_tokens, fn, snapshot = self._rollback
+        n = min(n, num_tokens)
+        m = num_tokens - n
+        self.cache = list(snapshot) if m == 0 else fn(m)
+        self._rollback = None
+        return n
 
     @property
     def batch_size(self):

--- a/mlx_lm/models/cache.py
+++ b/mlx_lm/models/cache.py
@@ -422,6 +422,17 @@ class KVCache(_BaseCache):
 
 class RotatingKVCache(_BaseCache):
     step = 256
+    # Tokens of exact-rollback history kept while speculating (mirrors
+    # ArraysCache; a speculative trim never exceeds the last verify window).
+    _ROLLBACK_WINDOW = 64
+
+    def __new__(cls, *args, **kwargs):
+        # Set on __new__ (not __init__) so caches reconstructed by
+        # load_prompt_cache (which bypasses __init__) still have them.
+        instance = super().__new__(cls)
+        instance.speculating = False
+        instance._rollbacks = deque()
+        return instance
 
     def __init__(self, max_size, keep=0):
         self.keep = keep
@@ -430,6 +441,32 @@ class RotatingKVCache(_BaseCache):
         self.offset = 0
         self.max_size = max_size
         self._idx = 0
+
+    def start_speculation(self):
+        self.speculating = True
+        self._rollbacks.clear()
+
+    def stop_speculation(self):
+        self.speculating = False
+        self._rollbacks.clear()
+
+    def record_rollback(self, num_tokens, snapshot, keys, values):
+        """Recorded by ``update_and_fetch`` during a forward while
+        ``speculating``. A sliding-window KV cache is not directly trimmable
+        once it has wrapped (``offset >= max_size``): the tokens a verify step
+        pushes out of the window are gone. So we stash the pre-forward window
+        (``snapshot``) plus this forward's new K/V; ``trim`` rebuilds the exact
+        window for any accepted prefix by restoring the snapshot and
+        re-appending the first ``m`` tokens. The verify path uses
+        ``_update_concat`` which reallocates (never mutates in place), so
+        holding references in ``snapshot`` is safe."""
+        self._rollbacks.append((num_tokens, snapshot, keys, values))
+        total = sum(r[0] for r in self._rollbacks)
+        while (
+            len(self._rollbacks) > 1
+            and total - self._rollbacks[0][0] >= self._ROLLBACK_WINDOW
+        ):
+            total -= self._rollbacks.popleft()[0]
 
     def _trim(self, trim_size, v, append=None):
         to_cat = []
@@ -523,6 +560,13 @@ class RotatingKVCache(_BaseCache):
         return self.keys, self.values
 
     def update_and_fetch(self, keys, values):
+        if self.speculating:
+            self.record_rollback(
+                keys.shape[2],
+                [self.keys, self.values, self._idx, self.offset],
+                keys,
+                values,
+            )
         if keys.shape[2] == 1:
             return self._update_in_place(keys, values)
         return self._update_concat(keys, values)
@@ -553,12 +597,43 @@ class RotatingKVCache(_BaseCache):
         )
 
     def is_trimmable(self):
-        return self.offset < self.max_size
+        # While speculating every forward records an exact rollback, so the
+        # cache is trimmable within the recorded window even after it wraps.
+        return self.speculating or self.offset < self.max_size
 
     def trim(self, n):
-        n = min(self.offset, n)
-        self.offset -= n
-        self._idx -= n
+        if not self.speculating:
+            n = min(self.offset, n)
+            self.offset -= n
+            self._idx -= n
+            return n
+        recorded = sum(r[0] for r in self._rollbacks)
+        if recorded < n:
+            raise RuntimeError(
+                f"Cannot trim {n} tokens from RotatingKVCache: only {recorded} "
+                "tokens of exact rollback are recorded (speculative window)."
+            )
+        trimmed = 0
+        while trimmed < n:
+            num_tokens, snap, keys, values = self._rollbacks.pop()
+            take = min(n - trimmed, num_tokens)
+            m = num_tokens - take
+            # Restore the pre-forward window, then re-append the first m tokens
+            # of this chunk to reconstruct the exact accepted-prefix window.
+            self.keys, self.values, self._idx, self.offset = (
+                snap[0],
+                snap[1],
+                snap[2],
+                snap[3],
+            )
+            if m > 0:
+                if m == 1:
+                    self._update_in_place(keys[..., :1, :], values[..., :1, :])
+                else:
+                    self._update_concat(keys[..., :m, :], values[..., :m, :])
+                # The record still describes its first m tokens; keep it.
+                self._rollbacks.append((m, snap, keys, values))
+            trimmed += take
         return n
 
     def to_quantized(self, group_size: int = 64, bits: int = 4) -> QuantizedKVCache:

--- a/mlx_lm/models/cache.py
+++ b/mlx_lm/models/cache.py
@@ -605,12 +605,18 @@ class RotatingKVCache(_BaseCache):
 
 
 class ArraysCache(_BaseCache):
+    # Tokens of exact-rollback history kept while speculating — records beyond
+    # this window are dropped (speculative trims never exceed the last verify
+    # window, so 64 tokens is far more than any round needs). Bounding by
+    # tokens keeps the retained per-token stashes small.
+    _ROLLBACK_WINDOW = 64
+
     def __new__(cls, *args, **kwargs):
         instance = super().__new__(cls)
         instance.left_padding = None
         instance.lengths = None
         instance.speculating = False
-        instance._rollback = None
+        instance._rollbacks = deque()
         return instance
 
     def __init__(self, size, left_padding: Optional[List[int]] = None):
@@ -620,11 +626,11 @@ class ArraysCache(_BaseCache):
 
     def start_speculation(self):
         self.speculating = True
-        self._rollback = None
+        self._rollbacks.clear()
 
     def stop_speculation(self):
         self.speculating = False
-        self._rollback = None
+        self._rollbacks.clear()
 
     def record_rollback(self, num_tokens, fn, snapshot):
         """Recorded by the owning layer during a forward while ``speculating``.
@@ -638,27 +644,40 @@ class ArraysCache(_BaseCache):
             snapshot (list): The cache entries from before the forward (returned
                 for a full rollback, ``m == 0``).
         """
-        self._rollback = (num_tokens, fn, snapshot)
+        self._rollbacks.append((num_tokens, fn, snapshot))
+        total = sum(r[0] for r in self._rollbacks)
+        while (
+            len(self._rollbacks) > 1
+            and total - self._rollbacks[0][0] >= self._ROLLBACK_WINDOW
+        ):
+            total -= self._rollbacks.popleft()[0]
 
     def is_trimmable(self):
         # While speculating, every forward records an exact rollback, so the
-        # cache is trimmable within the last forward's window.
+        # cache is trimmable within the recorded window.
         return self.speculating
 
     def trim(self, n):
         if n <= 0:
             return 0
-        if self._rollback is None:
+        if sum(r[0] for r in self._rollbacks) < n:
             raise RuntimeError(
-                "ArraysCache.trim requires a rollback recorded by the model's "
-                "recurrent layers; this model does not support speculative "
-                "rollback."
+                f"Cannot trim {n} tokens from ArraysCache: only "
+                f"{sum(r[0] for r in self._rollbacks)} tokens of exact rollback "
+                "are recorded. Recurrent state cannot be trimmed beyond the "
+                "speculative window."
             )
-        num_tokens, fn, snapshot = self._rollback
-        n = min(n, num_tokens)
-        m = num_tokens - n
-        self.cache = list(snapshot) if m == 0 else fn(m)
-        self._rollback = None
+        trimmed = 0
+        while trimmed < n:
+            num_tokens, fn, snapshot = self._rollbacks.pop()
+            take = min(n - trimmed, num_tokens)
+            m = num_tokens - take
+            self.cache = list(snapshot) if m == 0 else fn(m)
+            trimmed += take
+            if m > 0:
+                # The record still describes the first m tokens of its chunk
+                # (fn(m') is valid for any m' <= m), so keep it for further trims.
+                self._rollbacks.append((m, fn, snapshot))
         return n
 
     @property

--- a/mlx_lm/models/gpt_oss.py
+++ b/mlx_lm/models/gpt_oss.py
@@ -230,6 +230,11 @@ class GptOssMoeModel(nn.Module):
 
 
 class Model(nn.Module):
+    # Sliding-window (RotatingKVCache) layers record an exact rollback while
+    # speculating, so the cache is trimmable within the verify window (see
+    # RotatingKVCache.record_rollback) — enables --draft-model speculation.
+    supports_speculative_rollback = True
+
     def __init__(self, args: ModelArgs):
         super().__init__()
         self.args = args

--- a/mlx_lm/models/nemotron_h.py
+++ b/mlx_lm/models/nemotron_h.py
@@ -56,6 +56,12 @@ class ModelArgs(BaseModelArgs):
     time_step_limit: Optional[Tuple[float, float]] = None
     time_step_min: Optional[float] = None
     time_step_max: Optional[float] = None
+    # Multi-token-prediction head (Nemotron 3 Super checkpoints). The module
+    # is built when num_nextn_predict_layers > 0 and dropped again in
+    # sanitize() if the checkpoint carries no mtp.* tensors.
+    num_nextn_predict_layers: int = 0
+    mtp_layers_block_type: Optional[List[str]] = None
+    mtp_hybrid_override_pattern: Optional[List[str]] = None
 
     # Map from layers_block_type names to single-char pattern codes
     _block_type_to_char = {"mamba": "M", "attention": "*", "moe": "E", "mlp": "-"}
@@ -71,6 +77,16 @@ class ModelArgs(BaseModelArgs):
             ]
         if self.hybrid_override_pattern is not None:
             self.num_hidden_layers = len(self.hybrid_override_pattern)
+
+        if (
+            self.mtp_hybrid_override_pattern is None
+            and self.mtp_layers_block_type is not None
+        ):
+            self.mtp_hybrid_override_pattern = [
+                self._block_type_to_char[t] for t in self.mtp_layers_block_type
+            ]
+        if isinstance(self.mtp_hybrid_override_pattern, str):
+            self.mtp_hybrid_override_pattern = list(self.mtp_hybrid_override_pattern)
 
 
 class MambaRMSNormGated(nn.Module):
@@ -136,7 +152,7 @@ class NemotronHMamba2Mixer(nn.Module):
         conv_input: mx.array,
         cache: Optional[ArraysCache],
         mask: Optional[mx.array],
-    ) -> mx.array:
+    ) -> Tuple[mx.array, mx.array]:
         if mask is not None:
             conv_input = mx.where(mask[..., None], conv_input, 0)
 
@@ -163,7 +179,7 @@ class NemotronHMamba2Mixer(nn.Module):
             )
 
         conv_output = self.conv1d(padded_input)
-        return nn.silu(conv_output)
+        return nn.silu(conv_output), padded_input
 
     def _ssm(
         self,
@@ -209,6 +225,7 @@ class NemotronHMamba2Mixer(nn.Module):
         hidden_states: mx.array,
         mask: Optional[mx.array],
         cache: Optional[ArraysCache] = None,
+        ssm_sink: Optional[list] = None,
     ) -> mx.array:
 
         projected = self.in_proj(hidden_states)
@@ -218,7 +235,7 @@ class NemotronHMamba2Mixer(nn.Module):
             [self.intermediate_size, self.intermediate_size + self.conv_dim],
             axis=-1,
         )
-        conv_output = self._conv(conv_input, cache, mask)
+        conv_output, padded_input = self._conv(conv_input, cache, mask)
         hidden_states_ssm, B, C = mx.split(
             conv_output,
             [
@@ -227,6 +244,28 @@ class NemotronHMamba2Mixer(nn.Module):
             ],
             axis=-1,
         )
+        if ssm_sink is not None:
+            # Everything needed to replay this update on an accepted prefix
+            # during speculative rollback; tuple layout consumed by
+            # Model.rollback_speculative_cache. Captured pre-_ssm so `state`
+            # is the value before this update overwrites cache[1].
+            bsz, S, _ = hidden_states_ssm.shape
+            ssm_sink.append(
+                (
+                    hidden_states_ssm.reshape(bsz, S, self.num_heads, self.head_dim),
+                    B.reshape(bsz, S, self.n_groups, self.ssm_state_size),
+                    C.reshape(bsz, S, self.n_groups, self.ssm_state_size),
+                    dt,
+                    self.A_log,
+                    self.D,
+                    self.dt_bias,
+                    self.time_step_limit,
+                    cache[1] if cache else None,
+                    mask,
+                    padded_input,
+                    self.conv_kernel_size,
+                )
+            )
         y = self._ssm(hidden_states_ssm, B, C, dt, cache, mask)
         if cache:
             cache.advance(y.shape[1])
@@ -445,14 +484,48 @@ class NemotronHBlock(nn.Module):
         x,
         mask: Optional[mx.array] = None,
         cache: Optional[Any] = None,
+        ssm_sink: Optional[list] = None,
     ):
         hidden_states = self.norm(x)
-        if self.block_type == "M" or self.block_type == "*":
+        if self.block_type == "M":
+            hidden_states = self.mixer(
+                hidden_states, mask=mask, cache=cache, ssm_sink=ssm_sink
+            )
+        elif self.block_type == "*":
             hidden_states = self.mixer(hidden_states, mask=mask, cache=cache)
         else:
             hidden_states = self.mixer(hidden_states)
 
         return x + hidden_states
+
+
+class NemotronHMTPBlock(NemotronHBlock):
+    """One layer of the DeepSeek-style multi-token-prediction head shipped
+    in Nemotron 3 Super checkpoints (config: num_nextn_predict_layers,
+    mtp_layers_block_type). The first layer carries the embed/hidden fusion
+    (eh_proj / enorm / hnorm), the last carries final_layernorm; the block
+    itself is a standard NemotronHBlock."""
+
+    def __init__(self, args: ModelArgs, block_type: str, is_first: bool, is_last: bool):
+        super().__init__(args, block_type)
+        eps = args.layer_norm_epsilon
+        if is_first:
+            self.eh_proj = nn.Linear(2 * args.hidden_size, args.hidden_size, bias=False)
+            self.enorm = nn.RMSNorm(args.hidden_size, eps=eps)
+            self.hnorm = nn.RMSNorm(args.hidden_size, eps=eps)
+        if is_last:
+            self.final_layernorm = nn.RMSNorm(args.hidden_size, eps=eps)
+
+
+class NemotronHMTP(nn.Module):
+    def __init__(self, args: ModelArgs):
+        super().__init__()
+        pattern = args.mtp_hybrid_override_pattern
+        n = len(pattern)
+        self.layers = [
+            NemotronHMTPBlock(args, bt, i == 0, i == n - 1)
+            for i, bt in enumerate(pattern)
+        ]
 
 
 class NemotronHModel(nn.Module):
@@ -481,6 +554,7 @@ class NemotronHModel(nn.Module):
         self,
         inputs,
         cache: Optional[Any] = None,
+        ssm_sink: Optional[list] = None,
     ):
         hidden_states = self.embeddings(inputs)
 
@@ -501,7 +575,7 @@ class NemotronHModel(nn.Module):
                 mask = attn_mask
             else:
                 mask = ssm_mask
-            hidden_states = layer(hidden_states, mask=mask, cache=c)
+            hidden_states = layer(hidden_states, mask=mask, cache=c, ssm_sink=ssm_sink)
 
         return self.norm_f(hidden_states)
 
@@ -513,6 +587,8 @@ class Model(nn.Module):
         self.backbone = NemotronHModel(args)
         self.lm_head = nn.Linear(args.hidden_size, args.vocab_size, bias=False)
         self.model_type = args.model_type
+        if args.num_nextn_predict_layers > 0 and args.mtp_hybrid_override_pattern:
+            self.mtp = NemotronHMTP(args)
 
     def __call__(
         self,
@@ -535,15 +611,116 @@ class Model(nn.Module):
                 caches.append(KVCache())
         return caches
 
+    def logits(self, hidden: mx.array) -> mx.array:
+        return self.lm_head(hidden)
+
+    def make_mtp_cache(self):
+        caches = []
+        for l in self.mtp.layers:
+            if l.block_type == "M":
+                caches.append(ArraysCache(size=2))
+            elif l.block_type == "*":
+                caches.append(KVCache())
+            else:
+                caches.append(None)
+        return caches
+
+    def mtp_step(self, hidden, tokens, mtp_cache):
+        """One MTP forward over S positions.
+
+        hidden: [B, S, H] post-norm_f hiddens at positions p..p+S-1 (from
+        the backbone, or from a previous mtp_step when chaining draft
+        depth). tokens: [B, S] the tokens at positions p+1..p+S (the
+        committed or drafted token FOLLOWING each hidden's position).
+        Returns (logits [B, S, V], post_final_layernorm hidden [B, S, H]).
+
+        The MTP KV cache offset counts pairs fed, i.e. positions are
+        uniformly shifted by -1 vs absolute; the attention layer only
+        attends within its own cache so the shift is harmless (NemotronH
+        attention uses no rope)."""
+        first = self.mtp.layers[0]
+        e = first.enorm(self.backbone.embeddings(tokens))
+        h = first.hnorm(hidden)
+        x = first.eh_proj(mx.concatenate([e, h], axis=-1))
+        fa_cache = next((c for c in mtp_cache if isinstance(c, KVCache)), None)
+        mask = create_attention_mask(x, fa_cache)
+        for layer, c in zip(self.mtp.layers, mtp_cache):
+            x = layer(x, mask=mask, cache=c)
+        post = self.mtp.layers[-1].final_layernorm(x)
+        return self.lm_head(post), post
+
+    def rollback_speculative_cache(self, caches, ssm_states, keep, block_size):
+        """Rewind target caches after a speculative verify forward of
+        `block_size` tokens of which the first `keep` are kept.
+
+        KV caches trim normally. Mamba2 caches (ArraysCache) hold a
+        recurrent state that cannot trim, so they are rebuilt by replaying
+        the captured verify inputs (`ssm_states`, from an `ssm_sink` passed
+        to the verify forward) on the kept prefix — one ssm_update per
+        Mamba layer since A_log/D/dt_bias are per-layer vectors.
+        Single-sequence (B=1, unpadded) only."""
+        trim = block_size - keep
+        ssm_caches = []
+        for c in caches:
+            if c is None:
+                continue
+            if c.is_trimmable():
+                if trim > 0:
+                    c.trim(trim)
+            else:
+                if c.lengths is not None or c.left_padding is not None:
+                    raise ValueError(
+                        "rollback_speculative_cache supports single-sequence "
+                        "caches only (lengths/left_padding must be None)"
+                    )
+                ssm_caches.append(c)
+        if not ssm_caches or trim == 0:
+            return
+        if len(ssm_caches) != len(ssm_states):
+            raise ValueError(
+                f"ssm_states has {len(ssm_states)} entries for "
+                f"{len(ssm_caches)} Mamba caches"
+            )
+
+        for c, st in zip(ssm_caches, ssm_states):
+            x, B, C, dt, A_log, D, dt_bias, tsl, state, mask, padded, K = st
+            if keep == 0:
+                # Nothing kept: restore the pre-verify state verbatim.
+                c[1] = state
+                c[0] = padded[:, : K - 1]
+                continue
+            _, new_state = ssm_update(
+                x[:, :keep],
+                A_log,
+                B[:, :keep],
+                C[:, :keep],
+                D.astype(x.dtype),
+                dt[:, :keep],
+                dt_bias,
+                state,
+                tsl,
+                None if mask is None else mask[:, :keep],
+            )
+            c[1] = new_state
+            c[0] = mx.contiguous(padded[:, keep : keep + K - 1])
+
     def sanitize(self, weights):
-        weights = {k: v for (k, v) in weights.items() if not k.startswith("mtp.")}
+        has_mtp_weights = any(k.startswith("mtp.") for k in weights)
+        if not (has_mtp_weights and hasattr(self, "mtp")):
+            # Checkpoint has no MTP tensors (or config declared no MTP
+            # layers): drop both the weights and the module so strict
+            # loading stays consistent.
+            weights = {k: v for (k, v) in weights.items() if not k.startswith("mtp.")}
+            if hasattr(self, "mtp"):
+                self.mtp = None
+
         for k, v in weights.items():
             if "conv1d.weight" in k and v.shape[-1] != 1:
                 weights[k] = v.moveaxis(2, 1)
 
-        # Stack experts
-        for l in range(self.args.num_hidden_layers):
-            prefix = f"backbone.layers.{l}.mixer"
+        # Stack experts (backbone and mtp layers alike)
+        prefixes = {k.rsplit(".experts.", 1)[0] for k in weights if ".experts." in k}
+        for prefix in prefixes:
             for m, n in [("down_proj", "fc2"), ("up_proj", "fc1")]:
                 if f"{prefix}.experts.0.{m}.weight" in weights:
                     to_join = [

--- a/mlx_lm/models/qwen3_5.py
+++ b/mlx_lm/models/qwen3_5.py
@@ -536,6 +536,22 @@ class Model(nn.Module):
     def model(self):
         return self.language_model.model
 
+    # Expose the MTP (nextn) self-speculation interface through the wrapper so
+    # self_mtp_generate_step works on the top-level model (the head lives on the
+    # inner language_model / TextModel, e.g. qwen3_5_moe's language_model.mtp).
+    @property
+    def mtp(self):
+        return self.language_model.mtp
+
+    def logits(self, hidden: mx.array) -> mx.array:
+        return self.language_model.logits(hidden)
+
+    def make_mtp_cache(self):
+        return self.language_model.make_mtp_cache()
+
+    def mtp_step(self, hidden, tokens, mtp_cache):
+        return self.language_model.mtp_step(hidden, tokens, mtp_cache)
+
     def sanitize(self, weights):
         sanitized = {}
         for key, value in weights.items():

--- a/mlx_lm/models/qwen3_5.py
+++ b/mlx_lm/models/qwen3_5.py
@@ -181,6 +181,40 @@ class GatedDeltaNet(nn.Module):
         q = (inv_scale**2) * mx.fast.rms_norm(q, None, 1e-6)
         k = inv_scale * mx.fast.rms_norm(k, None, 1e-6)
 
+        if (
+            cache is not None
+            and getattr(cache, "speculating", False)
+            and mask is None
+            and cache.lengths is None
+            and cache.left_padding is None
+        ):
+            # Record an exact rollback for speculative decoding: replaying the
+            # recurrence from the pre-forward state over the first m of the
+            # exact per-token inputs the kernel consumes reproduces the state
+            # after m tokens bit-for-bit; the conv state after m tokens is a
+            # slice of conv_input. See ArraysCache.record_rollback.
+            n_keep = self.conv_kernel_size - 1
+            use_kernel = not self.training
+
+            def _rollback(
+                m, q=q, k=k, v=v, a=a, b=b, S0=state, ci=conv_input, nk=n_keep
+            ):
+                _, s_m = gated_delta_update(
+                    q[:, :m],
+                    k[:, :m],
+                    v[:, :m],
+                    a[:, :m],
+                    b[:, :m],
+                    self.A_log,
+                    self.dt_bias,
+                    S0,
+                    None,
+                    use_kernel,
+                )
+                return [mx.contiguous(ci[:, m : m + nk, :]), s_m]
+
+            cache.record_rollback(S, _rollback, [conv_state, state])
+
         out, state = gated_delta_update(
             q,
             k,
@@ -406,6 +440,11 @@ class ModelArgs(BaseModelArgs):
 
 
 class Model(nn.Module):
+    # The GDN layers record exact rollbacks on their ArraysCache during
+    # speculative decoding, making the hybrid cache trimmable (see
+    # GatedDeltaNet.__call__ and ArraysCache.record_rollback).
+    supports_speculative_rollback = True
+
     def __init__(self, args: ModelArgs):
         super().__init__()
         self.args = args

--- a/mlx_lm/models/qwen3_5.py
+++ b/mlx_lm/models/qwen3_5.py
@@ -42,6 +42,10 @@ class TextModelArgs(BaseModelArgs):
     attention_bias: bool = False
     head_dim: Optional[int] = None
     full_attention_interval: int = 4
+    # Multi-token-prediction head (Qwen3.5 "-mtp" checkpoints). The module
+    # is built when this is > 0 and dropped again in sanitize() if the
+    # checkpoint carries no mtp.* tensors.
+    mtp_num_hidden_layers: int = 0
 
     # MoE fields (optional, for Qwen3_5MoeForConditionalGeneration)
     num_experts: int = 0
@@ -135,6 +139,7 @@ class GatedDeltaNet(nn.Module):
         inputs: mx.array,
         mask: Optional[mx.array] = None,
         cache: Optional[Any] = None,
+        gdn_sink: Optional[list] = None,
     ) -> mx.array:
         B, S, _ = inputs.shape
 
@@ -180,6 +185,26 @@ class GatedDeltaNet(nn.Module):
         inv_scale = k.shape[-1] ** -0.5
         q = (inv_scale**2) * mx.fast.rms_norm(q, None, 1e-6)
         k = inv_scale * mx.fast.rms_norm(k, None, 1e-6)
+
+        if gdn_sink is not None:
+            # Everything needed to replay this update on an accepted prefix
+            # during speculative rollback; tuple layout consumed by
+            # TextModel.rollback_speculative_cache.
+            gdn_sink.append(
+                (
+                    q,
+                    k,
+                    v,
+                    a,
+                    b,
+                    self.A_log,
+                    self.dt_bias,
+                    state,
+                    mask,
+                    conv_input,
+                    self.conv_kernel_size,
+                )
+            )
 
         out, state = gated_delta_update(
             q,
@@ -231,9 +256,10 @@ class DecoderLayer(nn.Module):
         x: mx.array,
         mask: Optional[mx.array] = None,
         cache: Optional[Any] = None,
+        gdn_sink: Optional[list] = None,
     ) -> mx.array:
         if self.is_linear:
-            r = self.linear_attn(self.input_layernorm(x), mask, cache)
+            r = self.linear_attn(self.input_layernorm(x), mask, cache, gdn_sink)
         else:
             r = self.self_attn(self.input_layernorm(x), mask, cache)
         h = x + r
@@ -269,6 +295,7 @@ class Qwen3_5TextModel(PipelineMixin, nn.Module):
         inputs: mx.array,
         cache: Optional[Any] = None,
         input_embeddings: Optional[mx.array] = None,
+        gdn_sink: Optional[list] = None,
     ) -> mx.array:
         if input_embeddings is not None:
             hidden_states = input_embeddings
@@ -294,7 +321,7 @@ class Qwen3_5TextModel(PipelineMixin, nn.Module):
 
         for layer, c in zip(self.pipeline_layers, cache):
             mask = ssm_mask if layer.is_linear else fa_mask
-            hidden_states = layer(hidden_states, mask=mask, cache=c)
+            hidden_states = layer(hidden_states, mask=mask, cache=c, gdn_sink=gdn_sink)
 
         # Send to the next process in the pipeline
         if pipeline_rank != 0:
@@ -316,12 +343,35 @@ class Qwen3_5TextModel(PipelineMixin, nn.Module):
         return self.norm(hidden_states)
 
 
+class MTPModule(nn.Module):
+    """Qwen3.5 multi-token-prediction head, present in "-mtp" checkpoints:
+    fc([norm(embed(t_{p+1})); norm(hidden_p)]) -> full-attention decoder
+    layer (own KV cache) -> norm -> the target's own lm_head. Enables
+    self-speculative decoding with no external draft model."""
+
+    def __init__(self, args: TextModelArgs):
+        super().__init__()
+        self.fc = nn.Linear(2 * args.hidden_size, args.hidden_size, bias=False)
+        self.pre_fc_norm_embedding = nn.RMSNorm(
+            args.hidden_size, eps=args.rms_norm_eps
+        )
+        self.pre_fc_norm_hidden = nn.RMSNorm(args.hidden_size, eps=args.rms_norm_eps)
+        # layer_idx chosen so is_linear=False: the MTP block is full attention.
+        self.layers = [
+            DecoderLayer(args, layer_idx=args.full_attention_interval - 1)
+            for _ in range(args.mtp_num_hidden_layers)
+        ]
+        self.norm = nn.RMSNorm(args.hidden_size, eps=args.rms_norm_eps)
+
+
 class TextModel(nn.Module):
     def __init__(self, args: TextModelArgs):
         super().__init__()
         self.args = args
         self.model_type = args.model_type
         self.model = Qwen3_5TextModel(args)
+        if args.mtp_num_hidden_layers > 0:
+            self.mtp = MTPModule(args)
         if not args.tie_word_embeddings:
             self.lm_head = nn.Linear(args.hidden_size, args.vocab_size, bias=False)
 
@@ -345,13 +395,143 @@ class TextModel(nn.Module):
     def make_cache(self):
         return [ArraysCache(size=2) if l.is_linear else KVCache() for l in self.layers]
 
+    def logits(self, hidden: mx.array) -> mx.array:
+        if self.args.tie_word_embeddings:
+            return self.model.embed_tokens.as_linear(hidden)
+        return self.lm_head(hidden)
+
+    def make_mtp_cache(self):
+        return [KVCache() for _ in self.mtp.layers]
+
+    def mtp_step(self, hidden, tokens, mtp_cache):
+        """One MTP forward over S positions.
+
+        hidden: [B, S, H] post-final-norm hiddens at positions p..p+S-1
+        (from the trunk, or from a previous mtp_step when chaining draft
+        depth). tokens: [B, S] the tokens at positions p+1..p+S (the
+        committed or drafted token FOLLOWING each hidden's position).
+        Returns (logits [B, S, V], post_norm_hidden [B, S, H]).
+
+        The MTP KV cache offset counts pairs fed, i.e. rope positions are
+        uniformly shifted by -1 vs absolute; the shift cancels in q·k
+        since the MTP layer only attends within its own cache.
+        """
+        e = self.mtp.pre_fc_norm_embedding(self.model.embed_tokens(tokens))
+        h = self.mtp.pre_fc_norm_hidden(hidden)
+        x = self.mtp.fc(mx.concatenate([e, h], axis=-1))
+        mask = create_attention_mask(x, mtp_cache[0])
+        x = self.mtp.layers[0](x, mask=mask, cache=mtp_cache[0])
+        post = self.mtp.norm(x)
+        return self.logits(post), post
+
+    def rollback_speculative_cache(self, caches, gdn_states, keep, block_size):
+        """Rewind target caches after a speculative verify forward of
+        `block_size` tokens of which the first `keep` are kept.
+
+        KV caches trim normally. GatedDeltaNet caches (ArraysCache) hold a
+        recurrent state that cannot trim, so they are rebuilt by replaying
+        the captured verify inputs (`gdn_states`, from a `gdn_sink` passed
+        to the verify forward) on the kept prefix — all linear layers
+        batched into one gated_delta_update call. Single-sequence (B=1,
+        unpadded) only."""
+        trim = block_size - keep
+        ssm_caches = []
+        for c in caches:
+            if c is None:
+                continue
+            if c.is_trimmable():
+                if trim > 0:
+                    c.trim(trim)
+            else:
+                if c.lengths is not None or c.left_padding is not None:
+                    raise ValueError(
+                        "rollback_speculative_cache supports single-sequence "
+                        "caches only (lengths/left_padding must be None)"
+                    )
+                ssm_caches.append(c)
+        if not ssm_caches or trim == 0:
+            return
+        if len(ssm_caches) != len(gdn_states):
+            raise ValueError(
+                f"gdn_states has {len(gdn_states)} entries for "
+                f"{len(ssm_caches)} linear-attention caches"
+            )
+
+        if keep == 0:
+            # Nothing kept: restore the pre-verify state verbatim.
+            for c, st in zip(ssm_caches, gdn_states):
+                _, _, _, _, _, _, _, state, _, conv_input, K = st
+                c[1] = state
+                c[0] = conv_input[:, : K - 1]
+            return
+
+        q_l, k_l, v_l, a_l, b_l, al_l, dt_l, st_l = [], [], [], [], [], [], [], []
+        conv_data = []
+        replay_mask = None
+        for st in gdn_states:
+            q, k, v, a, b, A_log, dt_bias, state, mask, conv_input, K = st
+            rows = q.shape[0]
+            q_l.append(q[:, :keep])
+            k_l.append(k[:, :keep])
+            v_l.append(v[:, :keep])
+            a_l.append(a[:, :keep])
+            b_l.append(b[:, :keep])
+            al_l.append(
+                mx.broadcast_to(A_log[None, None, :], (rows, 1, A_log.shape[0]))
+            )
+            dt_l.append(
+                mx.broadcast_to(dt_bias[None, None, :], (rows, 1, dt_bias.shape[0]))
+            )
+            if state is None:
+                state = mx.zeros(
+                    (rows, v.shape[-2], v.shape[-1], k.shape[-1]),
+                    dtype=mx.float32,
+                )
+            st_l.append(state)
+            conv_data.append((conv_input, K))
+            if replay_mask is None and mask is not None:
+                replay_mask = mask[:, :keep]
+
+        if replay_mask is not None and replay_mask.shape[0] != len(gdn_states):
+            replay_mask = mx.concatenate([replay_mask] * len(gdn_states), axis=0)
+
+        _, states_out = gated_delta_update(
+            mx.concatenate(q_l, axis=0),
+            mx.concatenate(k_l, axis=0),
+            mx.concatenate(v_l, axis=0),
+            mx.concatenate(a_l, axis=0),
+            mx.concatenate(b_l, axis=0),
+            mx.concatenate(al_l, axis=0),
+            mx.concatenate(dt_l, axis=0),
+            mx.concatenate(st_l, axis=0),
+            replay_mask,
+            use_kernel=True,
+        )
+
+        for j, c in enumerate(ssm_caches):
+            c[1] = states_out[j : j + 1]
+            conv_input, K = conv_data[j]
+            c[0] = mx.contiguous(conv_input[:, keep : keep + K - 1])
+
     def sanitize(self, weights):
-        has_mtp_weights = any("mtp." in k for k in weights)
         has_unsanitized_conv1d = any(
             "conv1d.weight" in k and v.shape[-1] != 1 for k, v in weights.items()
         )
-        should_shift_norm_weights = has_mtp_weights or has_unsanitized_conv1d
-        weights = {k: v for k, v in weights.items() if "mtp." not in k}
+        # Raw HF checkpoints store zero-centered norms AND raw conv1d
+        # shapes. mtp.* presence is NOT a raw-checkpoint signal:
+        # mlx-community "-mtp" conversions keep mtp tensors but already
+        # have shifted norms and sanitized conv1d — shifting again
+        # double-shifts every RMSNorm and produces garbage output.
+        should_shift_norm_weights = has_unsanitized_conv1d
+
+        has_mtp_weights = any("mtp." in k for k in weights)
+        if not (has_mtp_weights and hasattr(self, "mtp")):
+            # Checkpoint has no MTP tensors (or config declared no MTP
+            # layers): drop both the weights and the module so strict
+            # loading stays consistent.
+            weights = {k: v for k, v in weights.items() if "mtp." not in k}
+            if hasattr(self, "mtp"):
+                self.mtp = None
 
         if self.args.tie_word_embeddings:
             weights.pop("lm_head.weight", None)
@@ -360,6 +540,9 @@ class TextModel(nn.Module):
             ".input_layernorm.weight",
             ".post_attention_layernorm.weight",
             "model.norm.weight",
+            "mtp.norm.weight",
+            ".pre_fc_norm_embedding.weight",
+            ".pre_fc_norm_hidden.weight",
             ".q_norm.weight",
             ".k_norm.weight",
         )

--- a/mlx_lm/models/qwen3_next.py
+++ b/mlx_lm/models/qwen3_next.py
@@ -284,6 +284,40 @@ class Qwen3NextGatedDeltaNet(nn.Module):
         q = (inv_scale**2) * mx.fast.rms_norm(q, None, 1e-6)
         k = inv_scale * mx.fast.rms_norm(k, None, 1e-6)
 
+        if (
+            cache is not None
+            and getattr(cache, "speculating", False)
+            and mask is None
+            and cache.lengths is None
+            and cache.left_padding is None
+        ):
+            # Record an exact rollback for speculative decoding: replaying the
+            # recurrence from the pre-forward state over the first m of the
+            # exact per-token inputs the kernel consumes reproduces the state
+            # after m tokens bit-for-bit; the conv state after m tokens is a
+            # slice of conv_input. See ArraysCache.record_rollback.
+            n_keep = self.conv_kernel_size - 1
+            use_kernel = not self.training
+
+            def _rollback(
+                m, q=q, k=k, v=v, a=a, b=b, S0=state, ci=conv_input, nk=n_keep
+            ):
+                _, s_m = gated_delta_update(
+                    q[:, :m],
+                    k[:, :m],
+                    v[:, :m],
+                    a[:, :m],
+                    b[:, :m],
+                    self.A_log,
+                    self.dt_bias,
+                    S0,
+                    None,
+                    use_kernel,
+                )
+                return [mx.contiguous(ci[:, m : m + nk, :]), s_m]
+
+            cache.record_rollback(S, _rollback, [conv_state, state])
+
         out, state = gated_delta_update(
             q,
             k,
@@ -422,6 +456,11 @@ class Qwen3NextModel(nn.Module):
 
 
 class Model(nn.Module):
+    # The GDN layers record exact rollbacks on their ArraysCache during
+    # speculative decoding, making the hybrid cache trimmable (see
+    # Qwen3NextGatedDeltaNet.__call__ and ArraysCache.record_rollback).
+    supports_speculative_rollback = True
+
     def __init__(self, args: ModelArgs):
         super().__init__()
         self.args = args

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -609,13 +609,18 @@ class TestModels(unittest.TestCase):
             "linear_num_key_heads": 1,
             "linear_key_head_dim": 4,
             "linear_value_head_dim": 4,
-            "linear_conv_kernel_dim": 1,
-            "full_attention_interval": 1,
+            "linear_conv_kernel_dim": 4,
+            "full_attention_interval": 2,
             "tie_word_embeddings": False,
             "max_position_embeddings": 64,
         }
         hf_norm_key = "model.language_model.layers.0.input_layernorm.weight"
         mlx_norm_key = "language_model.model.layers.0.input_layernorm.weight"
+        # Raw HF checkpoints are identified by their unsanitized conv1d
+        # layout (mtp.* presence is NOT a raw signal: converted "-mtp"
+        # checkpoints keep mtp tensors with already-shifted norms).
+        hf_conv_key = "model.language_model.layers.0.linear_attn.conv1d.weight"
+        mlx_conv_key = "language_model.model.layers.0.linear_attn.conv1d.weight"
 
         for model_type, hf_mtp_key in (
             ("qwen3_5", "mtp.fc.weights"),
@@ -632,21 +637,34 @@ class TestModels(unittest.TestCase):
 
             base = mx.arange(8, dtype=mx.float32)
 
-            # Simulate convert sanitize on HF-style keys.
+            # Simulate convert sanitize on HF-style keys (raw layout:
+            # unsanitized conv1d, zero-centered norms, mtp present).
             converted = model.sanitize(
                 {
                     hf_norm_key: base,
+                    hf_conv_key: mx.zeros((12, 1, 4), dtype=mx.float32),
                     hf_mtp_key: mx.zeros((1,), dtype=mx.float32),
                 }
             )
             self.assertIn(mlx_norm_key, converted)
             self.assertTrue(mx.array_equal(converted[mlx_norm_key], base + 1.0))
+            self.assertEqual(converted[mlx_conv_key].shape, (12, 4, 1))
             self.assertFalse(any("mtp." in k for k in converted))
 
-            # Simulate load sanitize on already-converted keys.
+            # Simulate load sanitize on already-converted keys: sanitized
+            # conv1d means no second norm shift — even if a conversion
+            # kept mtp.* tensors (mlx-community "-mtp" checkpoints).
             loaded = model.sanitize(converted)
             self.assertTrue(
                 mx.array_equal(loaded[mlx_norm_key], converted[mlx_norm_key])
+            )
+            with_mtp = dict(converted)
+            with_mtp[hf_mtp_key.replace("mtp.", "language_model.mtp.")] = mx.zeros(
+                (1,), dtype=mx.float32
+            )
+            loaded2 = model.sanitize(with_mtp)
+            self.assertTrue(
+                mx.array_equal(loaded2[mlx_norm_key], converted[mlx_norm_key])
             )
 
     def test_gemma4_convert_then_load_keeps_language_model_prefix(self):

--- a/tests/test_nemotron_h_mtp.py
+++ b/tests/test_nemotron_h_mtp.py
@@ -1,0 +1,122 @@
+# Copyright © 2026 Apple Inc.
+
+import unittest
+
+import mlx.core as mx
+
+from mlx_lm.models.nemotron_h import Model, ModelArgs, NemotronHMTP
+
+
+def tiny_args(**overrides):
+    kwargs = dict(
+        model_type="nemotron_h",
+        vocab_size=64,
+        hidden_size=32,
+        intermediate_size=64,
+        num_hidden_layers=4,
+        max_position_embeddings=1000,
+        num_attention_heads=4,
+        num_key_value_heads=2,
+        attention_bias=False,
+        mamba_num_heads=4,
+        mamba_head_dim=16,
+        mamba_proj_bias=False,
+        ssm_state_size=16,
+        conv_kernel=3,
+        n_groups=2,
+        time_step_limit=(0.0, float("inf")),
+        mlp_bias=False,
+        layer_norm_epsilon=1e-4,
+        use_bias=True,
+        use_conv_bias=True,
+        # attention + mamba backbone
+        hybrid_override_pattern=["*", "M", "*", "M"],
+        # DeepSeek-style MTP head: first layer fuses embed/hidden (eh_proj /
+        # enorm / hnorm), last carries final_layernorm. The shipped Nemotron-3
+        # Super head is transformer (attention) blocks; mtp_step builds the
+        # attention mask accordingly.
+        num_nextn_predict_layers=2,
+        mtp_layers_block_type=["attention", "attention"],
+    )
+    kwargs.update(overrides)
+    return ModelArgs(**kwargs)
+
+
+def _kv_offset(mtp_cache):
+    from mlx_lm.models.cache import KVCache
+
+    return next(c.offset for c in mtp_cache if isinstance(c, KVCache))
+
+
+class TestNemotronHMTP(unittest.TestCase):
+    def test_mtp_step_shapes_and_chaining(self):
+        mx.random.seed(0)
+        model = Model(tiny_args())
+        self.assertIsInstance(model.mtp, NemotronHMTP)
+        cache = model.make_cache()
+        mtp_cache = model.make_mtp_cache()
+        prompt = mx.random.randint(0, 64, (1, 8))
+        hidden = model.backbone(prompt, cache=cache)
+        logits, post = model.mtp_step(hidden[:, :-1], prompt[:, 1:], mtp_cache)
+        self.assertEqual(logits.shape, (1, 7, 64))
+        self.assertEqual(post.shape, (1, 7, 32))
+        self.assertEqual(_kv_offset(mtp_cache), 7)
+        # The head produces a real next-token prediction.
+        tok = mx.argmax(logits[:, -1:, :], axis=-1)
+        self.assertEqual(tok.shape, (1, 1))
+        self.assertTrue((0 <= tok).all().item() and (tok < 64).all().item())
+        # Recursive chaining on the MTP's own hidden.
+        logits2, _ = model.mtp_step(post[:, -1:], tok, mtp_cache)
+        self.assertEqual(logits2.shape, (1, 1, 64))
+        self.assertEqual(_kv_offset(mtp_cache), 8)
+
+    def test_mtp_module_dropped_without_weights(self):
+        model = Model(tiny_args())
+        # A checkpoint without mtp tensors: module must drop so strict loading
+        # stays consistent.
+        weights = {"backbone.norm_f.weight": mx.ones((32,))}
+        model.sanitize(dict(weights))
+        self.assertIsNone(model.mtp)
+
+    def test_rollback_speculative_cache_matches_fresh_forward(self):
+        """A verify forward of `block_size` tokens, of which `keep` are
+        accepted, must leave the (KV + Mamba) caches identical to a fresh
+        forward over just the committed prefix + kept tokens. Exercises the
+        ssm_sink capture and rollback_speculative_cache replay."""
+        mx.random.seed(0)
+        model = Model(tiny_args())
+        tokens = mx.random.randint(0, 64, (1, 12))
+        prefix, block_size, keep = 6, 4, 2
+
+        # Ground truth: fresh forward over prefix + kept tokens.
+        ref = model.make_cache()
+        model.backbone(tokens[:, : prefix + keep], cache=ref)
+
+        # Speculative: commit prefix, verify a block, then roll back.
+        spec = model.make_cache()
+        model.backbone(tokens[:, :prefix], cache=spec)
+        sink = []
+        model.backbone(
+            tokens[:, prefix : prefix + block_size], cache=spec, ssm_sink=sink
+        )
+        # One ssm capture per Mamba layer in the backbone.
+        n_mamba = sum(1 for l in model.layers if l.block_type == "M")
+        self.assertEqual(len(sink), n_mamba)
+        model.rollback_speculative_cache(spec, sink, keep, block_size)
+
+        for cr, cs in zip(ref, spec):
+            if cr.is_trimmable():  # KV cache
+                self.assertEqual(cr.offset, cs.offset)
+                self.assertTrue(
+                    mx.allclose(
+                        cr.keys[..., : cr.offset, :],
+                        cs.keys[..., : cs.offset, :],
+                        atol=1e-4,
+                    ).item()
+                )
+            else:  # Mamba ArraysCache: compare recurrent state
+                self.assertTrue(mx.allclose(cr[1], cs[1], atol=1e-4).item())
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_qwen3_5_mtp.py
+++ b/tests/test_qwen3_5_mtp.py
@@ -1,0 +1,157 @@
+# Copyright © 2026 Apple Inc.
+
+import unittest
+
+import mlx.core as mx
+
+from mlx_lm.models.qwen3_5 import MTPModule, TextModel, TextModelArgs
+
+
+def tiny_args(**overrides):
+    kwargs = dict(
+        model_type="qwen3_5_moe_text",
+        hidden_size=32,
+        intermediate_size=64,
+        num_hidden_layers=4,
+        num_attention_heads=4,
+        num_key_value_heads=2,
+        head_dim=8,
+        vocab_size=64,
+        full_attention_interval=4,
+        linear_num_value_heads=4,
+        linear_num_key_heads=2,
+        # >= 64 so the fused gated-delta step kernel's tiling stays valid
+        linear_key_head_dim=64,
+        linear_value_head_dim=64,
+        linear_conv_kernel_dim=4,
+        num_experts=4,
+        num_experts_per_tok=2,
+        moe_intermediate_size=16,
+        shared_expert_intermediate_size=16,
+        mtp_num_hidden_layers=1,
+        rope_parameters={
+            "type": "default",
+            "rope_theta": 10000,
+            "partial_rotary_factor": 0.25,
+        },
+    )
+    kwargs.update(overrides)
+    return TextModelArgs(**kwargs)
+
+
+def gdn_states_of(cache_list):
+    return [
+        (c[0], c[1])
+        for c in cache_list
+        if c is not None and not c.is_trimmable()
+    ]
+
+
+class TestQwen35MTP(unittest.TestCase):
+    def test_rollback_replay_matches_sequential(self):
+        """After a speculative verify forward of `block` tokens,
+        rollback(keep=j) must leave GDN caches in the same state as a
+        model that only ever saw the first j block tokens."""
+        mx.random.seed(0)
+        model = TextModel(tiny_args())
+        prompt = mx.random.randint(0, 64, (1, 8))
+        block = mx.random.randint(0, 64, (1, 4))
+
+        for keep in range(0, 5):
+            # Ground truth: sequential path that never saw rejected tokens.
+            ref_cache = model.make_cache()
+            model(prompt, cache=ref_cache)
+            if keep > 0:
+                model(block[:, :keep], cache=ref_cache)
+            ref_states = gdn_states_of(ref_cache)
+
+            # Speculative path: full-width verify, then rollback.
+            cache = model.make_cache()
+            model(prompt, cache=cache)
+            sink = []
+            model.model(block, cache=cache, gdn_sink=sink)
+            model.rollback_speculative_cache(cache, sink, keep, block.shape[1])
+            got_states = gdn_states_of(cache)
+
+            for (rc, rs), (gc, gs) in zip(ref_states, got_states):
+                if keep == 0 and gs is None:
+                    self.assertIsNone(rs) if rs is None else self.assertTrue(
+                        mx.allclose(rs, mx.zeros_like(rs)).item()
+                    )
+                    continue
+                # Batched (verify-width) vs sequential matmuls differ by
+                # kernel-scheduling numerics (~1e-3 fp32); a wrong slice or
+                # stale state is orders of magnitude larger.
+                self.assertTrue(
+                    mx.allclose(rc, gc, atol=5e-3).item(),
+                    f"conv state mismatch at keep={keep}",
+                )
+                self.assertTrue(
+                    mx.allclose(rs, gs, atol=5e-3).item(),
+                    f"ssm state mismatch at keep={keep}",
+                )
+            # KV caches must hold prompt + keep tokens.
+            kv = next(c for c in cache if c.is_trimmable())
+            self.assertEqual(kv.offset, 8 + keep)
+
+    def test_mtp_step_shapes_and_chaining(self):
+        mx.random.seed(0)
+        model = TextModel(tiny_args())
+        self.assertIsInstance(model.mtp, MTPModule)
+        cache = model.make_cache()
+        mtp_cache = model.make_mtp_cache()
+        prompt = mx.random.randint(0, 64, (1, 8))
+        hidden = model.model(prompt, cache=cache)
+        logits, post = model.mtp_step(hidden[:, :-1], prompt[:, 1:], mtp_cache)
+        self.assertEqual(logits.shape, (1, 7, 64))
+        self.assertEqual(post.shape, (1, 7, 32))
+        self.assertEqual(mtp_cache[0].offset, 7)
+        # Recursive chaining on the MTP's own hidden.
+        tok = mx.argmax(logits[:, -1:, :], axis=-1)
+        logits2, _ = model.mtp_step(post[:, -1:], tok, mtp_cache)
+        self.assertEqual(logits2.shape, (1, 1, 64))
+        self.assertEqual(mtp_cache[0].offset, 8)
+        mtp_cache[0].trim(1)
+        self.assertEqual(mtp_cache[0].offset, 7)
+
+    def test_mtp_module_dropped_without_weights(self):
+        model = TextModel(tiny_args())
+        # A converted checkpoint without mtp tensors: module must drop so
+        # strict loading stays consistent.
+        weights = {"model.norm.weight": mx.ones((32,))}
+        model.sanitize(dict(weights))
+        self.assertIsNone(model.mtp)
+
+    def test_no_norm_shift_for_converted_mtp_checkpoints(self):
+        """mtp.* presence alone must NOT trigger the raw-checkpoint norm
+        shift: converted '-mtp' checkpoints have sanitized conv1d and
+        already-shifted norms."""
+        model = TextModel(tiny_args())
+        norm = mx.ones((32,))
+        weights = {
+            "model.norm.weight": norm,
+            "mtp.norm.weight": norm,
+            # sanitized conv1d (last dim 1) => not a raw checkpoint
+            "model.layers.0.linear_attn.conv1d.weight": mx.zeros((24, 4, 1)),
+        }
+        out = model.sanitize(weights)
+        self.assertTrue(mx.array_equal(out["model.norm.weight"], norm).item())
+        self.assertTrue(mx.array_equal(out["mtp.norm.weight"], norm).item())
+        # Raw checkpoint (unsanitized conv1d) still shifts.
+        model2 = TextModel(tiny_args())
+        weights2 = {
+            "model.norm.weight": norm,
+            "mtp.norm.weight": norm,
+            "model.layers.0.linear_attn.conv1d.weight": mx.zeros((24, 1, 4)),
+        }
+        out2 = model2.sanitize(weights2)
+        self.assertTrue(
+            mx.array_equal(out2["model.norm.weight"], norm + 1.0).item()
+        )
+        self.assertTrue(
+            mx.array_equal(out2["mtp.norm.weight"], norm + 1.0).item()
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_rotating_rollback.py
+++ b/tests/test_rotating_rollback.py
@@ -1,0 +1,118 @@
+# Copyright © 2026 Apple Inc.
+
+"""Exact speculative rollback for RotatingKVCache (sliding-window KV).
+
+The sibling of the ArraysCache (GDN) exact-replay rollback: once a rotating
+cache wraps (offset >= max_size) it is not directly trimmable, so speculative
+decoding needs an exact rollback. These tests pin the key property —
+bit-exact tail-independence: two verify chunks that share an m-token prefix
+but have different tails must leave IDENTICAL windows after rolling back to m
+(any off-by-one in the restore/re-append leaks the tail).
+"""
+import unittest
+
+import mlx.core as mx
+from mlx_lm.models.cache import RotatingKVCache
+
+W = 4  # tiny window so the cache wraps
+H, D = 2, 8
+
+
+def _kv(n, seed):
+    mx.random.seed(seed)
+    return (mx.random.normal((1, H, n, D)), mx.random.normal((1, H, n, D)))
+
+
+def _prefill(cache, n, seed=0):
+    k, v = _kv(n, seed)
+    cache.update_and_fetch(k, v)
+    return k, v
+
+
+def _window(cache):
+    return (
+        mx.contiguous(cache._temporal_order(cache.keys)),
+        mx.contiguous(cache._temporal_order(cache.values)),
+    )
+
+
+class TestRotatingRollback(unittest.TestCase):
+    def test_tail_independence(self):
+        # Reference: prefill P (wraps), then append only the shared prefix m.
+        P, m, tail = 6, 3, 3
+        pk, pv = _kv(m, seed=1)  # shared prefix K/V
+
+        ref = RotatingKVCache(max_size=W)
+        _prefill(ref, P, seed=9)
+        ref.update_and_fetch(pk, pv)
+        rk, rv = _window(ref)
+
+        for tail_seed in (2, 3):  # two DIFFERENT tails
+            tk, tv = _kv(tail, seed=tail_seed)
+            c = RotatingKVCache(max_size=W)
+            _prefill(c, P, seed=9)
+            c.start_speculation()
+            # one verify forward of [prefix ++ tail]
+            c.update_and_fetch(
+                mx.concatenate([pk, tk], axis=2),
+                mx.concatenate([pv, tv], axis=2),
+            )
+            c.trim(tail)  # roll back to the m-token prefix
+            wk, wv = _window(c)
+            self.assertTrue(mx.allclose(wk, rk, atol=1e-5).item(),
+                            f"keys leak tail (seed {tail_seed})")
+            self.assertTrue(mx.allclose(wv, rv, atol=1e-5).item(),
+                            f"values leak tail (seed {tail_seed})")
+            self.assertEqual(c.offset, ref.offset)
+
+    def test_trim_to_various_prefixes(self):
+        P, block = 5, 4
+        c = RotatingKVCache(max_size=W)
+        _prefill(c, P, seed=7)
+        bk, bv = _kv(block, seed=8)
+        for keep in range(block + 1):
+            ref = RotatingKVCache(max_size=W)
+            _prefill(ref, P, seed=7)
+            if keep > 0:
+                ref.update_and_fetch(bk[..., :keep, :], bv[..., :keep, :])
+            rk, rv = _window(ref)
+
+            t = RotatingKVCache(max_size=W)
+            _prefill(t, P, seed=7)
+            t.start_speculation()
+            t.update_and_fetch(bk, bv)
+            t.trim(block - keep)
+            wk, wv = _window(t)
+            self.assertTrue(mx.allclose(wk, rk, atol=1e-5).item(),
+                            f"keys mismatch at keep={keep}")
+            self.assertTrue(mx.allclose(wv, rv, atol=1e-5).item(),
+                            f"values mismatch at keep={keep}")
+            self.assertEqual(t.offset, ref.offset, f"offset at keep={keep}")
+
+    def test_stacked_draft_records(self):
+        # Mimic a draft: several single-token forwards, then roll them all back.
+        P = 5
+        c = RotatingKVCache(max_size=W)
+        _prefill(c, P, seed=4)
+        base_k, base_v = _window(c)
+        base_off = c.offset
+        c.start_speculation()
+        for i in range(3):
+            k, v = _kv(1, seed=100 + i)
+            c.update_and_fetch(k, v)
+        c.trim(3)  # rewind all three draft tokens
+        wk, wv = _window(c)
+        self.assertTrue(mx.allclose(wk, base_k, atol=1e-5).item())
+        self.assertTrue(mx.allclose(wv, base_v, atol=1e-5).item())
+        self.assertEqual(c.offset, base_off)
+
+    def test_not_speculating_uses_plain_trim(self):
+        c = RotatingKVCache(max_size=64)
+        _prefill(c, 10, seed=0)  # offset < max_size -> directly trimmable
+        self.assertTrue(c.is_trimmable())
+        c.trim(3)
+        self.assertEqual(c.offset, 7)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_speculative_rollback.py
+++ b/tests/test_speculative_rollback.py
@@ -1,0 +1,133 @@
+# Copyright © 2026 Apple Inc.
+
+import unittest
+
+import mlx.core as mx
+
+from mlx_lm.generate import generate_step, speculative_generate_step
+from mlx_lm.models import cache, llama, qwen3_next
+
+QWEN3_NEXT_ARGS = {
+    "model_type": "qwen3_next",
+    "hidden_size": 128,
+    "num_hidden_layers": 4,
+    "intermediate_size": 128,
+    "num_attention_heads": 8,
+    "num_key_value_heads": 4,
+    "vocab_size": 1000,
+    "linear_num_value_heads": 4,
+    "linear_num_key_heads": 4,
+    "linear_key_head_dim": 32,
+    "linear_value_head_dim": 32,
+    "linear_conv_kernel_dim": 3,
+    "num_experts": 4,
+    "num_experts_per_tok": 2,
+    "decoder_sparse_step": 1,
+    "shared_expert_intermediate_size": 128,
+    "mlp_only_layers": [0],
+    "moe_intermediate_size": 128,
+    "rms_norm_eps": 1e-5,
+    "head_dim": 64,
+    "rope_theta": 1000.0,
+    "partial_rotary_factor": 0.5,
+    "max_position_embeddings": 1000,
+}
+
+LLAMA_ARGS = {
+    "model_type": "llama",
+    "hidden_size": 64,
+    "num_hidden_layers": 2,
+    "intermediate_size": 128,
+    "num_attention_heads": 4,
+    "rms_norm_eps": 1e-5,
+    "vocab_size": 1000,
+}
+
+
+def make_hybrid(seed=0):
+    mx.random.seed(seed)
+    return qwen3_next.Model(qwen3_next.ModelArgs.from_dict(QWEN3_NEXT_ARGS))
+
+
+class TestSpeculativeRollback(unittest.TestCase):
+
+    def test_rollback_is_exact(self):
+        # Tail independence: feed two verify chunks sharing the first m tokens
+        # but with different tails, roll both back to m — every cache entry and
+        # the next-token logits must be IDENTICAL (no numeric tolerance: same
+        # starting state, same shapes, deterministic kernels). Any off-by-one
+        # in the recorded rollback leaks the divergent tail.
+        model = make_hybrid()
+        prompt = mx.random.randint(0, 1000, (32,), dtype=mx.uint32)
+        T = 8
+        xs = mx.random.randint(0, 1000, (T,), dtype=mx.uint32)
+        zs = mx.random.randint(0, 1000, (T,), dtype=mx.uint32)
+        probe = mx.array([7], mx.uint32)
+
+        def run(chunk, m):
+            c = model.make_cache()
+            model(prompt[None], cache=c)
+            mx.eval([x.state for x in c])
+            for x in c:
+                x.start_speculation()
+            model(chunk[None], cache=c)
+            self.assertEqual(cache.trim_prompt_cache(c, chunk.size - m),
+                             chunk.size - m)
+            logits = model(probe[None], cache=c)
+            mx.eval(logits, [x.state for x in c])
+            return c, logits
+
+        for m in (1, 3, T - 1):
+            cA, lA = run(xs, m)
+            chunk_b = mx.concatenate([xs[:m], zs[: T - m]])
+            cB, lB = run(chunk_b, m)
+            self.assertTrue(mx.array_equal(lA, lB))
+            for a, b in zip(cA, cB):
+                if isinstance(a, cache.ArraysCache):
+                    for ea, eb in zip(a.cache, b.cache):
+                        self.assertTrue(mx.array_equal(ea, eb))
+                else:
+                    self.assertEqual(a.offset, b.offset)
+                    self.assertTrue(
+                        mx.array_equal(a.keys[..., : a.offset, :],
+                                       b.keys[..., : b.offset, :]))
+                    self.assertTrue(
+                        mx.array_equal(a.values[..., : a.offset, :],
+                                       b.values[..., : b.offset, :]))
+
+    def test_speculative_matches_vanilla(self):
+        # With an unrelated (random) draft model the acceptance rate is ~0, so
+        # every round exercises the rollback path; greedy speculative decoding
+        # must still reproduce the vanilla greedy generation exactly.
+        model = make_hybrid()
+        mx.random.seed(1)
+        draft = llama.Model(llama.ModelArgs.from_dict(LLAMA_ARGS))
+        prompt = mx.random.randint(0, 1000, (16,), dtype=mx.uint32)
+        n = 24
+
+        vanilla = [
+            int(tok) for tok, _ in generate_step(prompt, model, max_tokens=n)
+        ]
+        spec = [
+            int(tok)
+            for tok, _, _ in speculative_generate_step(
+                prompt, model, draft, num_draft_tokens=3, max_tokens=n
+            )
+        ]
+        self.assertEqual(vanilla, spec)
+
+    def test_unsupported_hybrid_still_raises(self):
+        # An ArraysCache whose layers never record a rollback must not be
+        # silently trimmable outside of speculation.
+        c = cache.ArraysCache(size=2)
+        self.assertFalse(c.is_trimmable())
+        c.start_speculation()
+        self.assertTrue(c.is_trimmable())
+        with self.assertRaises(RuntimeError):
+            c.trim(1)
+        c.stop_speculation()
+        self.assertFalse(c.is_trimmable())
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_speculative_rollback.py
+++ b/tests/test_speculative_rollback.py
@@ -71,8 +71,7 @@ class TestSpeculativeRollback(unittest.TestCase):
             for x in c:
                 x.start_speculation()
             model(chunk[None], cache=c)
-            self.assertEqual(cache.trim_prompt_cache(c, chunk.size - m),
-                             chunk.size - m)
+            self.assertEqual(cache.trim_prompt_cache(c, chunk.size - m), chunk.size - m)
             logits = model(probe[None], cache=c)
             mx.eval(logits, [x.state for x in c])
             return c, logits
@@ -89,11 +88,15 @@ class TestSpeculativeRollback(unittest.TestCase):
                 else:
                     self.assertEqual(a.offset, b.offset)
                     self.assertTrue(
-                        mx.array_equal(a.keys[..., : a.offset, :],
-                                       b.keys[..., : b.offset, :]))
+                        mx.array_equal(
+                            a.keys[..., : a.offset, :], b.keys[..., : b.offset, :]
+                        )
+                    )
                     self.assertTrue(
-                        mx.array_equal(a.values[..., : a.offset, :],
-                                       b.values[..., : b.offset, :]))
+                        mx.array_equal(
+                            a.values[..., : a.offset, :], b.values[..., : b.offset, :]
+                        )
+                    )
 
     def test_speculative_matches_vanilla(self):
         # With an unrelated (random) draft model the acceptance rate is ~0, so
@@ -105,9 +108,7 @@ class TestSpeculativeRollback(unittest.TestCase):
         prompt = mx.random.randint(0, 1000, (16,), dtype=mx.uint32)
         n = 24
 
-        vanilla = [
-            int(tok) for tok, _ in generate_step(prompt, model, max_tokens=n)
-        ]
+        vanilla = [int(tok) for tok, _ in generate_step(prompt, model, max_tokens=n)]
         spec = [
             int(tok)
             for tok, _, _ in speculative_generate_step(
@@ -115,6 +116,62 @@ class TestSpeculativeRollback(unittest.TestCase):
             )
         ]
         self.assertEqual(vanilla, spec)
+
+    def test_cache_reusable_after_speculation(self):
+        # A prompt cache used for speculative decoding must come back clean:
+        # not trimmable, no dangling rollback, and usable for plain decoding
+        # that matches a never-speculated run.
+        model = make_hybrid()
+        mx.random.seed(2)
+        draft = llama.Model(llama.ModelArgs.from_dict(LLAMA_ARGS))
+        prompt = mx.random.randint(0, 1000, (16,), dtype=mx.uint32)
+
+        c = cache.make_prompt_cache(model) + cache.make_prompt_cache(draft)
+        spec = [
+            int(tok)
+            for tok, _, _ in speculative_generate_step(
+                prompt, model, draft, num_draft_tokens=3, max_tokens=8, prompt_cache=c
+            )
+        ]
+        model_cache = c[: len(model.layers)]
+        self.assertFalse(cache.can_trim_prompt_cache(model_cache))
+        for x in model_cache:
+            if isinstance(x, cache.ArraysCache):
+                self.assertFalse(x.speculating)
+                self.assertIsNone(x._rollback)
+
+        # continue decoding on the same cache with plain steps
+        cont = [
+            int(tok)
+            for tok, _ in generate_step(
+                mx.array(spec[-1:], mx.uint32),
+                model,
+                max_tokens=8,
+                prompt_cache=model_cache,
+            )
+        ]
+
+        # reference: one uninterrupted vanilla run over the same tokens
+        ref = [
+            int(tok)
+            for tok, _ in generate_step(prompt, model, max_tokens=8 + len(spec))
+        ]
+        self.assertEqual(ref, spec + cont)
+
+    def test_early_generator_close(self):
+        # Closing the speculative generator mid-stream must roll the cache back
+        # cleanly (the finally path) without raising.
+        model = make_hybrid()
+        mx.random.seed(3)
+        draft = llama.Model(llama.ModelArgs.from_dict(LLAMA_ARGS))
+        prompt = mx.random.randint(0, 1000, (16,), dtype=mx.uint32)
+
+        gen = speculative_generate_step(
+            prompt, model, draft, num_draft_tokens=3, max_tokens=64
+        )
+        took = [next(gen) for _ in range(3)]
+        gen.close()  # must not raise (double-rewind / consumed-rollback bugs)
+        self.assertEqual(len(took), 3)
 
     def test_unsupported_hybrid_still_raises(self):
         # An ArraysCache whose layers never record a rollback must not be

--- a/tests/test_speculative_rollback.py
+++ b/tests/test_speculative_rollback.py
@@ -138,7 +138,7 @@ class TestSpeculativeRollback(unittest.TestCase):
         for x in model_cache:
             if isinstance(x, cache.ArraysCache):
                 self.assertFalse(x.speculating)
-                self.assertIsNone(x._rollback)
+                self.assertEqual(len(x._rollbacks), 0)
 
         # continue decoding on the same cache with plain steps
         cont = [
@@ -184,6 +184,72 @@ class TestSpeculativeRollback(unittest.TestCase):
             c.trim(1)
         c.stop_speculation()
         self.assertFalse(c.is_trimmable())
+
+    def test_hybrid_draft_model(self):
+        # Target AND draft are hybrid GDN models (the setup reported in #1446:
+        # Qwen3.6 target + Qwen3.5 draft). The draft cache is rewound exactly
+        # too — its rollback spans several T=1 records per round — and the
+        # output must still equal vanilla greedy.
+        model = make_hybrid(seed=0)
+        draft = make_hybrid(seed=7)  # different weights, same arch
+        prompt = mx.random.randint(0, 1000, (16,), dtype=mx.uint32)
+        n = 24
+
+        vanilla = [int(tok) for tok, _ in generate_step(prompt, model, max_tokens=n)]
+        spec = [
+            int(tok)
+            for tok, _, _ in speculative_generate_step(
+                prompt, model, draft, num_draft_tokens=3, max_tokens=n
+            )
+        ]
+        self.assertEqual(vanilla, spec)
+
+    def test_draft_exception_not_masked(self):
+        # An exception raised mid-round (e.g. inside the draft model) must
+        # surface as itself: the finally-block cache rewind must not replace it
+        # with a rollback RuntimeError.
+        model = make_hybrid()
+        mx.random.seed(4)
+        draft = llama.Model(llama.ModelArgs.from_dict(LLAMA_ARGS))
+        prompt = mx.random.randint(0, 1000, (16,), dtype=mx.uint32)
+
+        boom = ValueError("draft exploded")
+        calls = {"n": 0}
+
+        class Flaky:
+            def __call__(self, *args, **kwargs):
+                calls["n"] += 1
+                if calls["n"] > 4:  # fail during the second round's draft steps
+                    raise boom
+                return draft(*args, **kwargs)
+
+            def __getattr__(self, name):
+                return getattr(draft, name)
+
+        gen = speculative_generate_step(
+            prompt, model, Flaky(), num_draft_tokens=3, max_tokens=32
+        )
+        with self.assertRaises(ValueError) as ctx:
+            for _ in gen:
+                pass
+        self.assertIs(ctx.exception, boom)
+
+    def test_trim_beyond_window_raises(self):
+        # Trimming more than the recorded rollback window must fail loudly and
+        # consistently rather than silently clamping (which would desync the
+        # ArraysCache layers from the KVCache layers).
+        model = make_hybrid()
+        prompt = mx.random.randint(0, 1000, (32,), dtype=mx.uint32)
+        c = model.make_cache()
+        model(prompt[None], cache=c)
+        mx.eval([x.state for x in c])
+        for x in c:
+            x.start_speculation()
+        chunk = mx.random.randint(0, 1000, (4,), dtype=mx.uint32)
+        model(chunk[None], cache=c)
+        arrays = next(x for x in c if isinstance(x, cache.ArraysCache))
+        with self.assertRaises(RuntimeError):
+            arrays.trim(10)  # only 4 tokens of rollback recorded
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
# nemotron_h: load in-checkpoint MTP head for self-speculation

**Stacked on #1456** (MTP self-speculation machinery + qwen3_5 MTP-head
template). Please review/merge #1456 first.

## What

Nemotron 3 Super checkpoints ship a DeepSeek-style multi-token-prediction
(MTP) head alongside the main backbone. This wires that head into
`nemotron_h.py` so it loads from the checkpoint and drives self-speculative
decoding through the same interface #1456 established for `qwen3_5`
(`logits` / `make_mtp_cache` / `mtp_step`, plus `sanitize` that drops the
module when a checkpoint carries no `mtp.*` tensors).

Because the backbone is a hybrid Mamba-2/attention stack, the recurrent
(SSM) layers cannot be trimmed the way a KV cache can. Rolling back a
rejected speculative block therefore needs to *replay* the accepted prefix
through the SSM update rather than truncate it. This PR adds that support:

- **`ssm_sink`** — an optional list threaded through the Mamba mixer / block
  / model forwards. When present, each Mamba layer appends the exact inputs
  (`hidden_states`, `B`, `C`, `dt`, per-layer `A_log`/`D`/`dt_bias`, the
  pre-update state, mask, and padded conv input) needed to replay its update.
  When `None` (the default, i.e. normal decoding) there is zero overhead.
- **`Model.rollback_speculative_cache(caches, ssm_states, keep, block_size)`**
  — trims the KV caches normally and rebuilds each Mamba `ArraysCache` by
  re-running `ssm_update` on the kept prefix (or restoring the captured
  pre-verify state verbatim when `keep == 0`). Single-sequence (B=1,
  unpadded) only; raises on padded/batched caches.
- **`NemotronHMTPBlock` / `NemotronHMTP`** — the head itself. The first MTP
  layer carries the embed/hidden fusion (`eh_proj` / `enorm` / `hnorm`), the
  last carries `final_layernorm`; each block is otherwise a standard
  `NemotronHBlock`. The shipped head is transformer (attention) blocks, so
  `mtp_step` builds the attention mask.
- **`ModelArgs`** gains `num_nextn_predict_layers`, `mtp_layers_block_type`,
  and `mtp_hybrid_override_pattern` (the block-type list is normalized to
  single-char pattern codes in `__post_init__`, mirroring the backbone's
  `hybrid_override_pattern`). The MTP module is built only when the config
  declares MTP layers and dropped again in `sanitize` if the checkpoint has
  no `mtp.*` tensors, so strict loading stays consistent for plain
  (non-MTP) Nemotron-H checkpoints.

## How it wires to the self-spec machinery

Identical head interface to #1456's `qwen3_5` template:

- `logits(hidden)` projects a hidden through `lm_head`.
- `make_mtp_cache()` builds the head's own per-layer cache (KV for
  attention layers).
- `mtp_step(hidden, tokens, mtp_cache)` runs one MTP forward: fuses the
  backbone hidden with the next token's embedding via
  `enorm`/`hnorm`/`eh_proj`, runs the head layers, applies `final_layernorm`,
  and returns `(logits, post_hidden)` so draft depth can be chained.
- `sanitize` uses the same "drop the module when the checkpoint has no
  `mtp.*` tensors" logic (and only stacks experts for prefixes actually
  present, covering both backbone and MTP layers).

The one Nemotron-specific addition over the qwen template is the SSM
rollback path (`ssm_sink` + `rollback_speculative_cache`). Nemotron's
recurrent state does **not** use the base's `ArraysCache.record_rollback`
hook — it is self-contained: the verify forward captures replay inputs via
`ssm_sink`, and `rollback_speculative_cache` rebuilds the state directly. No
new cache hook was required; all helpers it needs (`ssm_update`,
`create_attention_mask`, `ArraysCache`, `KVCache`) already exist on the
#1456 base.

## Test

`tests/test_nemotron_h_mtp.py` (mirrors `tests/test_qwen3_5_mtp.py`):

- **`test_mtp_step_shapes_and_chaining`** — tiny hybrid config with a
  2-layer attention MTP head; real backbone forward, then `mtp_step`
  produces a valid next-token prediction with correct shapes and cache
  offsets, and chaining on the head's own hidden advances the cache.
- **`test_mtp_module_dropped_without_weights`** — a checkpoint with no
  `mtp.*` tensors drops the module (`model.mtp is None`).
- **`test_rollback_speculative_cache_matches_fresh_forward`** — exercises
  `ssm_sink` capture + `rollback_speculative_cache`: after a `block_size`-4
  verify forward with `keep`-2 accepted, both the KV caches and the Mamba
  recurrent states match a fresh forward over just the committed prefix plus
  kept tokens.

All pass; `test_qwen3_5_mtp.py` and the existing `nemotron_h` model test are
unaffected. `black` + `isort --profile black` clean.
