### PR TITLE
Support Nemotron Puzzle heterogeneous MoE (nemotron_h_puzzle)

### DIFF
--- a/mlx_lm/models/nemotron_h.py
+++ b/mlx_lm/models/nemotron_h.py
@@ -561,6 +561,16 @@ class Model(nn.Module):
                 caches.append(KVCache())
         return caches
 
+    @property
+    def quant_predicate(self):
+        if self.model_type != "nemotron_h_puzzle":
+            return lambda _path, _module: True
+        # Puzzle's 131k-token output projection is unusually sensitive to
+        # low-bit affine quantization. Quantizing it at 4 bits produced
+        # unrelated and repetitive generations while the same checkpoint
+        # generated correctly with the BF16 head restored.
+        return lambda path, _: path != "lm_head"
+
     def sanitize(self, weights):
         weights = {k: v for (k, v) in weights.items() if not k.startswith("mtp.")}
         for k, v in weights.items():

--- a/mlx_lm/models/nemotron_h.py
+++ b/mlx_lm/models/nemotron_h.py
@@ -1,5 +1,6 @@
-# Copyright © 2025 Apple Inc.
+# Copyright © 2025-2026 Apple Inc.
 
+import copy
 from dataclasses import dataclass
 from functools import partial
 from typing import Any, List, Optional, Tuple
@@ -42,6 +43,10 @@ class ModelArgs(BaseModelArgs):
     use_conv_bias: bool
     hybrid_override_pattern: Optional[List[str]] = None
     layers_block_type: Optional[List[str]] = None
+    # nemotron_h_puzzle (Puzzle-NAS): heterogeneous MoE. Per-layer list aligned
+    # with layers_block_type; MoE entries carry their own `moe_intermediate_size`
+    # and `num_experts_per_tok`. Absent (plain nemotron_h) => uniform dims.
+    block_configs: Optional[List[dict]] = None
     head_dim: Optional[int] = None
     moe_intermediate_size: Optional[int] = None
     moe_shared_expert_intermediate_size: Optional[int] = None
@@ -351,9 +356,12 @@ class MoEGate(nn.Module):
         self.top_k = config.num_experts_per_tok
         self.norm_topk_prob = config.norm_topk_prob
         self.n_routed_experts = config.n_routed_experts
-        self.routed_scaling_factor = config.routed_scaling_factor
-        self.n_group = config.n_group
-        self.topk_group = config.topk_group
+        # Puzzle configs omit group routing / scaling; default to the identity
+        # (no grouping, unit scale) so group_expert_select's `n_group > 1`
+        # guard doesn't hit a `None > 1` TypeError.
+        self.routed_scaling_factor = config.routed_scaling_factor or 1.0
+        self.n_group = config.n_group or 1
+        self.topk_group = config.topk_group or 1
         self.weight = mx.zeros((self.n_routed_experts, config.hidden_size))
         self.e_score_correction_bias = mx.zeros((self.n_routed_experts,))
 
@@ -455,13 +463,31 @@ class NemotronHBlock(nn.Module):
         return x + hidden_states
 
 
+def _moe_layer_args(args: ModelArgs, block_cfg: Optional[dict]) -> ModelArgs:
+    """Shallow per-layer view overriding this MoE layer's heterogeneous dims
+    (nemotron_h_puzzle). `n_routed_experts` / `moe_latent_size` stay global;
+    only `moe_intermediate_size` and `num_experts_per_tok` vary per layer."""
+    if not block_cfg:
+        return args
+    lc = copy.copy(args)
+    if block_cfg.get("moe_intermediate_size") is not None:
+        lc.moe_intermediate_size = block_cfg["moe_intermediate_size"]
+    if block_cfg.get("num_experts_per_tok") is not None:
+        lc.num_experts_per_tok = block_cfg["num_experts_per_tok"]
+    return lc
+
+
 class NemotronHModel(nn.Module):
     def __init__(self, args: ModelArgs):
         super().__init__()
         self.embeddings = nn.Embedding(args.vocab_size, args.hidden_size)
+        pattern = args.hybrid_override_pattern
+        block_configs = args.block_configs or [None] * len(pattern)
         self.layers = [
-            NemotronHBlock(args, block_type)
-            for block_type in args.hybrid_override_pattern
+            NemotronHBlock(
+                _moe_layer_args(args, bc) if bt == "E" else args, bt
+            )
+            for bt, bc in zip(pattern, block_configs)
         ]
         self.norm_f = nn.RMSNorm(args.hidden_size, eps=args.layer_norm_epsilon)
         self.fa_idx = 0

--- a/mlx_lm/utils.py
+++ b/mlx_lm/utils.py
@@ -53,6 +53,7 @@ MODEL_REMAPPING = {
     "minimax_m2": "minimax",
     "iquestcoder": "llama",
     "gemma4_unified": "gemma4",  # encoder-free multimodal variant; vision/audio weights stripped by sanitize()
+    "nemotron_h_puzzle": "nemotron_h",  # Puzzle-NAS heterogeneous MoE on the Nemotron-H hybrid; per-layer dims via block_configs
 }
 
 MAX_FILE_SIZE_GB = 5

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -1727,6 +1727,56 @@ class TestModels(unittest.TestCase):
             model, args.model_type, args.vocab_size, args.num_hidden_layers
         )
 
+    def test_nemotron_h_puzzle(self):
+        from mlx_lm.models import nemotron_h
+
+        # Puzzle-NAS heterogeneous MoE: two "moe" layers with different
+        # moe_intermediate_size / num_experts_per_tok, and no group-routing
+        # or scaling keys (which the Puzzle checkpoints omit).
+        args = nemotron_h.ModelArgs(
+            model_type="nemotron_h_puzzle",
+            vocab_size=1000,
+            hidden_size=128,
+            intermediate_size=128,
+            num_hidden_layers=5,
+            max_position_embeddings=1000,
+            num_attention_heads=8,
+            num_key_value_heads=4,
+            attention_bias=False,
+            mamba_num_heads=8,
+            mamba_head_dim=64,
+            mamba_proj_bias=False,
+            ssm_state_size=128,
+            conv_kernel=3,
+            n_groups=4,
+            mlp_bias=False,
+            layer_norm_epsilon=1e-4,
+            use_bias=True,
+            use_conv_bias=True,
+            n_routed_experts=4,
+            n_shared_experts=1,
+            moe_latent_size=32,
+            moe_shared_expert_intermediate_size=64,
+            norm_topk_prob=True,
+            layers_block_type=["mamba", "moe", "attention", "moe", "mamba"],
+            block_configs=[
+                {"block_type": "mamba"},
+                {"block_type": "moe", "moe_intermediate_size": 48, "num_experts_per_tok": 2},
+                {"block_type": "attention"},
+                {"block_type": "moe", "moe_intermediate_size": 96, "num_experts_per_tok": 4},
+                {"block_type": "mamba"},
+            ],
+        )
+        model = nemotron_h.Model(args)
+        moe = [l for l in model.layers if l.block_type == "E"]
+        self.assertEqual(moe[0].mixer.switch_mlp.fc1.weight.shape, (4, 48, 32))
+        self.assertEqual(moe[1].mixer.switch_mlp.fc1.weight.shape, (4, 96, 32))
+        self.assertEqual(moe[0].mixer.gate.top_k, 2)
+        self.assertEqual(moe[1].mixer.gate.top_k, 4)
+        self.model_test_runner(
+            model, args.model_type, args.vocab_size, args.num_hidden_layers
+        )
+
     def test_phi3small(self):
         from mlx_lm.models import phi3small
 

--- a/tests/test_nemotron_h_puzzle.py
+++ b/tests/test_nemotron_h_puzzle.py
@@ -1,0 +1,30 @@
+# Copyright © 2025-2026 Apple Inc.
+
+import unittest
+
+from mlx_lm.models.nemotron_h import Model
+
+
+class _Stub:
+    """Minimal stand-in carrying only the attribute quant_predicate reads."""
+
+    def __init__(self, model_type):
+        self.model_type = model_type
+
+
+class TestNemotronHPuzzleQuantPredicate(unittest.TestCase):
+    def test_puzzle_excludes_lm_head_from_quantization(self):
+        pred = Model.quant_predicate.fget(_Stub("nemotron_h_puzzle"))
+        # The 131k-token output projection must stay out of low-bit quant.
+        self.assertFalse(pred("lm_head", object()))
+        # Every other module is still eligible for quantization.
+        self.assertTrue(pred("backbone.layers.0.mixer.fc1", object()))
+
+    def test_non_puzzle_quantizes_everything(self):
+        pred = Model.quant_predicate.fget(_Stub("nemotron_h"))
+        self.assertTrue(pred("lm_head", object()))
+        self.assertTrue(pred("backbone.layers.0.mixer.fc1", object()))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Closes #1506.

NVIDIA's Nemotron Puzzle checkpoints (`model_type: nemotron_h_puzzle`, e.g. `NVIDIA-Nemotron-Labs-3-Puzzle-75B-A9B`) run Puzzle-NAS over the existing Nemotron-H hybrid backbone. Unlike plain `nemotron_h`, each MoE layer has its own `moe_intermediate_size` and `num_experts_per_tok`, listed in a per-layer `block_configs` array. The loader assumed uniform MoE dims, so conversion failed with `uniform(): incompatible function arguments` and the model type was unsupported.

**Changes**
- `ModelArgs` gains `block_configs`; a shallow per-layer `_moe_layer_args` view sizes each MoE block from its own entry. Non-MoE layers and the uniform path are unaffected (`block_configs=None` -> identity).
- `MoEGate` defaults `n_group`/`topk_group`/`routed_scaling_factor` to the identity when absent -- Puzzle configs carry no group routing, which otherwise tripped `None > 1` in `group_expert_select`.
- Remap `nemotron_h_puzzle -> nemotron_h`.

The rest of the architecture (latent MoE projections, `e_score_correction_bias` routing, shared expert, Mamba/attention hybrid) is already handled by `nemotron_h`. Experts are stored pre-stacked, so `sanitize()` is unchanged.

**Testing** -- added `test_nemotron_h_puzzle` (heterogeneous dims + forward/decode); verified end-to-end on a 6-bit conversion of the 75B checkpoint (88 layers, all 1471 tensors load, coherent generation); confirmed the uniform `nemotron_h` path is unchanged.
