### PR TITLE
Add persistent runtime-quantized LoRA adapters

### DIFF
--- a/benchmarks/quantized_lora.py
+++ b/benchmarks/quantized_lora.py
@@ -1,0 +1,229 @@
+# Copyright © 2026 Apple Inc.
+
+import argparse
+import json
+import platform
+import statistics
+import time
+from pathlib import Path
+
+import mlx.core as mx
+import mlx.nn as nn
+from mlx.utils import tree_flatten
+
+from mlx_lm.tuner.lora import LoRALinear
+
+DTYPES = {
+    "float16": mx.float16,
+    "bfloat16": mx.bfloat16,
+    "float32": mx.float32,
+}
+
+
+def comma_separated_ints(value):
+    return tuple(int(item) for item in value.split(",") if item)
+
+
+def configure_parser():
+    parser = argparse.ArgumentParser(
+        description="Benchmark quantized LoRA precision, memory, and latency."
+    )
+    parser.add_argument("--input-dims", type=int, default=4096)
+    parser.add_argument("--output-dims", type=int, default=4096)
+    parser.add_argument("--tokens", type=int, default=32)
+    parser.add_argument("--ranks", type=comma_separated_ints, default=(8, 16, 32, 64))
+    parser.add_argument("--bits", type=comma_separated_ints, default=(8, 6, 5, 4))
+    parser.add_argument("--group-size", type=int, default=64)
+    parser.add_argument("--rank-group-size", type=int, default=32)
+    parser.add_argument("--base-bits", type=int, choices=(0, 4, 8), default=8)
+    parser.add_argument("--dtype", choices=DTYPES, default="float16")
+    parser.add_argument("--warmup", type=int, default=10)
+    parser.add_argument("--iterations", type=int, default=50)
+    parser.add_argument("--seed", type=int, default=7)
+    parser.add_argument("--output", type=Path)
+    return parser
+
+
+def percentile(values, quantile):
+    values = sorted(values)
+    index = round((len(values) - 1) * quantile)
+    return values[index]
+
+
+def measure(function, warmup, iterations):
+    for _ in range(warmup):
+        mx.eval(function())
+    mx.synchronize()
+
+    timings = []
+    for _ in range(iterations):
+        started = time.perf_counter()
+        mx.eval(function())
+        mx.synchronize()
+        timings.append((time.perf_counter() - started) * 1000)
+    return {
+        "mean_ms": statistics.mean(timings),
+        "median_ms": statistics.median(timings),
+        "p90_ms": percentile(timings, 0.9),
+    }
+
+
+def adapter_bytes(module):
+    return sum(
+        value.nbytes
+        for name, value in tree_flatten(module.parameters())
+        if name.startswith("lora_")
+    )
+
+
+def compare(reference, candidate):
+    reference = reference.astype(mx.float32)
+    candidate = candidate.astype(mx.float32)
+    difference = candidate - reference
+    mx.eval(reference, candidate, difference)
+    reference_norm = float(mx.linalg.norm(reference))
+    difference_norm = float(mx.linalg.norm(difference))
+    return {
+        "relative_l2": difference_norm / (reference_norm + 1e-12),
+        "cosine": float(
+            mx.sum(reference * candidate)
+            / (mx.linalg.norm(reference) * mx.linalg.norm(candidate) + 1e-12)
+        ),
+        "max_abs": float(mx.max(mx.abs(difference))),
+    }
+
+
+def benchmark_rank(args, rank, dtype):
+    linear = nn.Linear(args.input_dims, args.output_dims, bias=False)
+    linear.weight = linear.weight.astype(dtype)
+    base = (
+        nn.QuantizedLinear.from_linear(
+            linear,
+            group_size=args.group_size,
+            bits=args.base_bits,
+        )
+        if args.base_bits
+        else linear
+    )
+    lora = LoRALinear.from_base(base, r=rank, dropout=0.0, scale=1.0)
+    lora.lora_a = (0.02 * mx.random.normal(lora.lora_a.shape)).astype(dtype)
+    lora.lora_b = (0.02 * mx.random.normal(lora.lora_b.shape)).astype(dtype)
+    x = mx.random.normal((args.tokens, args.input_dims)).astype(dtype)
+
+    reference = (x @ lora.lora_a) @ lora.lora_b
+    mx.eval(reference)
+    fp_bytes = lora.lora_a.nbytes + lora.lora_b.nbytes
+    fp_latency = measure(
+        lambda: (x @ lora.lora_a) @ lora.lora_b,
+        args.warmup,
+        args.iterations,
+    )
+    fp_layer_latency = measure(
+        lambda: lora(x),
+        args.warmup,
+        args.iterations,
+    )
+    result = {
+        "rank": rank,
+        "fp_adapter_bytes": fp_bytes,
+        "fp_latency": fp_latency,
+        "fp_layer_latency": fp_layer_latency,
+        "quantized": {},
+    }
+
+    for bits in args.bits:
+        quantized = lora.to_quantized(
+            group_size=args.group_size,
+            bits=bits,
+            rank_group_size=args.rank_group_size,
+        )
+        candidate = quantized.lora_delta(x)
+        mx.eval(candidate)
+        size = adapter_bytes(quantized)
+        latency = measure(
+            lambda quantized=quantized: quantized.lora_delta(x),
+            args.warmup,
+            args.iterations,
+        )
+        layer_latency = measure(
+            lambda quantized=quantized: quantized(x),
+            args.warmup,
+            args.iterations,
+        )
+        result["quantized"][str(bits)] = {
+            **compare(reference, candidate),
+            "adapter_bytes": size,
+            "memory_reduction": 1 - size / fp_bytes,
+            "latency": latency,
+            "latency_ratio_vs_fp": latency["median_ms"] / fp_latency["median_ms"],
+            "layer_latency": layer_latency,
+            "layer_latency_ratio_vs_fp": (
+                layer_latency["median_ms"] / fp_layer_latency["median_ms"]
+            ),
+        }
+    return result
+
+
+def print_table(results):
+    header = (
+        "rank bits size_KiB reduction rel_L2 cosine "
+        "branch_ms branch_x layer_ms layer_x"
+    )
+    print(header)
+    for result in results:
+        rank = result["rank"]
+        fp_size = result["fp_adapter_bytes"] / 1024
+        fp_latency = result["fp_latency"]["median_ms"]
+        fp_layer_latency = result["fp_layer_latency"]["median_ms"]
+        print(
+            f"{rank:>4} {'fp':>4} {fp_size:>8.1f} {'-':>9} {'-':>8} "
+            f"{'-':>8} {fp_latency:>9.4f} {'1.00x':>8} "
+            f"{fp_layer_latency:>8.4f} {'1.00x':>7}"
+        )
+        for bits, item in result["quantized"].items():
+            print(
+                f"{rank:>4} {bits:>4} {item['adapter_bytes'] / 1024:>8.1f} "
+                f"{item['memory_reduction']:>8.1%} {item['relative_l2']:>8.4f} "
+                f"{item['cosine']:>8.5f} "
+                f"{item['latency']['median_ms']:>9.4f} "
+                f"{item['latency_ratio_vs_fp']:>7.2f}x "
+                f"{item['layer_latency']['median_ms']:>8.4f} "
+                f"{item['layer_latency_ratio_vs_fp']:>6.2f}x"
+            )
+
+
+def main():
+    args = configure_parser().parse_args()
+    mx.random.seed(args.seed)
+    dtype = DTYPES[args.dtype]
+    results = [benchmark_rank(args, rank, dtype) for rank in args.ranks]
+    payload = {
+        "environment": {
+            "platform": platform.platform(),
+            "machine": platform.machine(),
+            "mlx_version": mx.__version__,
+        },
+        "config": {
+            "input_dims": args.input_dims,
+            "output_dims": args.output_dims,
+            "tokens": args.tokens,
+            "ranks": args.ranks,
+            "bits": args.bits,
+            "group_size": args.group_size,
+            "rank_group_size": args.rank_group_size,
+            "base_bits": args.base_bits,
+            "dtype": args.dtype,
+            "warmup": args.warmup,
+            "iterations": args.iterations,
+            "seed": args.seed,
+        },
+        "results": results,
+    }
+    print_table(results)
+    if args.output is not None:
+        args.output.parent.mkdir(parents=True, exist_ok=True)
+        args.output.write_text(json.dumps(payload, indent=2) + "\n")
+
+
+if __name__ == "__main__":
+    main()

--- a/mlx_lm/LORA.md
+++ b/mlx_lm/LORA.md
@@ -20,6 +20,7 @@ LoRA (QLoRA).[^qlora] LoRA fine-tuning works with the following model families:
   - [Fine-tune](#Fine-tune)
   - [Evaluate](#Evaluate)
   - [Generate](#Generate)
+  - [Quantize adapters](#Quantize-adapters)
 - [Fuse](#Fuse)
 - [Data](#Data)
 - [Memory Issues](#Memory-Issues)
@@ -123,6 +124,63 @@ mlx_lm.generate \
     --model <path_to_model> \
     --adapter-path <path_to_adapters> \
     --prompt "<your_model_prompt>"
+```
+
+### Quantize adapters
+
+LoRA matrices on linear layers can be quantized after loading to reduce their
+inference-time memory footprint. The base model is left unchanged, so it may
+be either a floating-point or quantized model. LoRA embedding and
+switch-linear layers remain in their original precision.
+
+To create a directly loadable quantized adapter, run:
+
+```shell
+mlx_lm.quantize_adapter \
+    --model <path_to_model> \
+    --adapter-path <path_to_adapters> \
+    --output-path <path_to_quantized_adapters> \
+    --bits 8
+```
+
+The output contains packed quantized adapter weights and quantization metadata.
+It can be loaded through the normal adapter interface without materializing a
+floating-point copy of the saved LoRA matrices:
+
+```shell
+mlx_lm.generate \
+    --model <path_to_model> \
+    --adapter-path <path_to_quantized_adapters> \
+    --prompt "<your_model_prompt>"
+```
+
+You can also quantize an already loaded adapter in memory:
+
+```python
+from mlx_lm import load
+from mlx_lm.tuner import quantize_lora_layers
+
+model, tokenizer = load(
+    "<path_to_model>",
+    adapter_path="<path_to_adapters>",
+)
+quantize_lora_layers(model, bits=8)
+```
+
+Quantized adapters are inference-only. Their dimensions are padded when
+needed to satisfy MLX quantization group-size requirements. The default uses
+8-bit affine quantization with group size 64 for the input dimension and 32
+for the LoRA rank dimension. You can select lower precision with `bits`, for
+example `quantize_lora_layers(model, bits=4)`.
+
+Padding and quantization metadata can outweigh the packed-weight savings for
+small ranks. The conversion command rejects adapters whose parameter memory
+would increase unless `--allow-larger` is supplied.
+
+The generic benchmark can be run from a source checkout with:
+
+```shell
+PYTHONPATH=. python benchmarks/quantized_lora.py
 ```
 
 ## Fuse

--- a/mlx_lm/cli.py
+++ b/mlx_lm/cli.py
@@ -16,6 +16,7 @@ def main():
         "lora",
         "manage",
         "perplexity",
+        "quantize_adapter",
         "awq",
         "dwq",
         "dynamic_quant",

--- a/mlx_lm/quantize_adapter.py
+++ b/mlx_lm/quantize_adapter.py
@@ -1,0 +1,118 @@
+# Copyright © 2026 Apple Inc.
+
+import argparse
+from pathlib import Path
+
+from mlx.utils import tree_flatten
+
+from .tuner.utils import quantize_lora_layers, save_quantized_adapter
+from .utils import load
+
+
+def configure_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description="Quantize LoRA adapter matrices for direct MLX inference."
+    )
+    parser.add_argument(
+        "--model",
+        required=True,
+        help="Base model path or Hugging Face repository.",
+    )
+    parser.add_argument(
+        "--adapter-path",
+        required=True,
+        help="Path to an MLX LoRA adapter.",
+    )
+    parser.add_argument(
+        "--output-path",
+        required=True,
+        help="Directory for the quantized adapter.",
+    )
+    parser.add_argument(
+        "--bits",
+        type=int,
+        choices=(2, 3, 4, 5, 6, 8),
+        default=8,
+        help="Bits per LoRA weight. Default: 8.",
+    )
+    parser.add_argument(
+        "--group-size",
+        type=int,
+        default=64,
+        help="Quantization group size for LoRA A. Default: 64.",
+    )
+    parser.add_argument(
+        "--rank-group-size",
+        type=int,
+        default=32,
+        help="Quantization group size for LoRA B. Default: 32.",
+    )
+    parser.add_argument(
+        "--trust-remote-code",
+        action="store_true",
+        help="Allow custom model code from the model repository.",
+    )
+    parser.add_argument(
+        "--allow-larger",
+        action="store_true",
+        help="Save even if quantization increases adapter parameter memory.",
+    )
+    return parser
+
+
+def adapter_parameter_bytes(model) -> int:
+    return sum(
+        value.nbytes
+        for name, value in tree_flatten(model.parameters())
+        if any(part.startswith("lora_") for part in name.split("."))
+    )
+
+
+def main() -> None:
+    args = configure_parser().parse_args()
+    adapter_path = Path(args.adapter_path)
+    output_path = Path(args.output_path)
+    if not adapter_path.exists():
+        raise FileNotFoundError(f"Adapter path does not exist: {adapter_path}")
+    if output_path.exists():
+        raise FileExistsError(f"Output path already exists: {output_path}")
+
+    model, _ = load(
+        args.model,
+        adapter_path=str(adapter_path),
+        trust_remote_code=args.trust_remote_code,
+    )
+    float_parameter_bytes = adapter_parameter_bytes(model)
+    quantize_lora_layers(
+        model,
+        group_size=args.group_size,
+        bits=args.bits,
+        rank_group_size=args.rank_group_size,
+    )
+    quantized_parameter_bytes = adapter_parameter_bytes(model)
+    if quantized_parameter_bytes >= float_parameter_bytes and not args.allow_larger:
+        raise ValueError(
+            "Quantization does not reduce adapter parameter memory "
+            f"({float_parameter_bytes} -> {quantized_parameter_bytes} bytes). "
+            "Use a lower bit width, a smaller rank group size, or "
+            "--allow-larger to override."
+        )
+    save_quantized_adapter(model, str(adapter_path), str(output_path))
+
+    source_size = (adapter_path / "adapters.safetensors").stat().st_size
+    output_size = (output_path / "adapters.safetensors").stat().st_size
+    reduction = 1 - output_size / source_size
+    parameter_reduction = 1 - quantized_parameter_bytes / float_parameter_bytes
+    print(f"Saved quantized adapter to {output_path}")
+    print(
+        "Adapter parameter memory: "
+        f"{float_parameter_bytes / 1e6:.2f} MB -> "
+        f"{quantized_parameter_bytes / 1e6:.2f} MB "
+        f"({parameter_reduction:.2%} reduction)"
+    )
+    print(f"Adapter size: {source_size / 1e6:.2f} MB -> {output_size / 1e6:.2f} MB")
+    print(f"Size reduction: {reduction:.2%}")
+
+
+if __name__ == "__main__":
+    main()

--- a/mlx_lm/tuner/__init__.py
+++ b/mlx_lm/tuner/__init__.py
@@ -1,2 +1,6 @@
 from .trainer import TrainingArgs, evaluate, train
-from .utils import linear_to_lora_layers
+from .utils import (
+    linear_to_lora_layers,
+    quantize_lora_layers,
+    save_quantized_adapter,
+)

--- a/mlx_lm/tuner/lora.py
+++ b/mlx_lm/tuner/lora.py
@@ -8,6 +8,22 @@ import mlx.nn as nn
 from ..models.switch_layers import QuantizedSwitchLinear, SwitchLinear
 
 
+def _pad_last_dim(x, size):
+    padding = size - x.shape[-1]
+    if padding == 0:
+        return x
+    return mx.pad(x, [(0, 0)] * (x.ndim - 1) + [(0, padding)])
+
+
+def _padded_size(size, group_size):
+    return ((size + group_size - 1) // group_size) * group_size
+
+
+def _quantize_matrix(weight, group_size, bits, mode):
+    values = mx.quantize(weight, group_size=group_size, bits=bits, mode=mode)
+    return values if len(values) == 3 else (*values, None)
+
+
 class LoRALinear(nn.Module):
     @staticmethod
     def from_base(
@@ -95,6 +111,146 @@ class LoRALinear(nn.Module):
     def __call__(self, x):
         y = self.linear(x)
         z = (self.dropout(x) @ self.lora_a) @ self.lora_b
+        return y + (self.scale * z).astype(x.dtype)
+
+    def to_quantized(
+        self,
+        group_size: int = 64,
+        bits: int = 8,
+        rank_group_size: int = 32,
+        mode: str = "affine",
+    ):
+        """Quantize this linear layer's LoRA matrices for inference."""
+        return QuantizedLoRALinear.from_lora(
+            self,
+            group_size=group_size,
+            bits=bits,
+            rank_group_size=rank_group_size,
+            mode=mode,
+        )
+
+
+class QuantizedLoRALinear(nn.Module):
+    """A linear layer with quantized low-rank adapter matrices.
+
+    The base linear layer is left unchanged. Adapter dimensions are padded as
+    needed because MLX quantization requires the final matrix dimension to be
+    divisible by the quantization group size.
+    """
+
+    @staticmethod
+    def from_lora(
+        lora: LoRALinear,
+        group_size: int = 64,
+        bits: int = 8,
+        rank_group_size: int = 32,
+        mode: str = "affine",
+    ):
+        input_dims, rank = lora.lora_a.shape
+        rank_b, output_dims = lora.lora_b.shape
+        if rank != rank_b:
+            raise ValueError(f"LoRA rank mismatch between A ({rank}) and B ({rank_b})")
+
+        quantized = QuantizedLoRALinear()
+        quantized.linear = lora.linear
+        quantized.dropout = lora.dropout
+        quantized.scale = lora.scale
+        quantized.bits = bits
+        quantized.group_size = group_size
+        quantized.rank_group_size = rank_group_size
+        quantized.mode = mode
+        quantized.input_dims = input_dims
+        quantized.output_dims = output_dims
+        quantized.rank = rank
+        quantized.padded_input_dims = _padded_size(input_dims, group_size)
+        quantized.padded_rank = _padded_size(rank, rank_group_size)
+
+        lora_a = _pad_last_dim(lora.lora_a.T, quantized.padded_input_dims)
+        lora_b = _pad_last_dim(lora.lora_b.T, quantized.padded_rank)
+        (
+            quantized.lora_a,
+            quantized.lora_a_scales,
+            quantized.lora_a_biases,
+        ) = _quantize_matrix(lora_a, group_size, bits, mode)
+        (
+            quantized.lora_b,
+            quantized.lora_b_scales,
+            quantized.lora_b_biases,
+        ) = _quantize_matrix(lora_b, rank_group_size, bits, mode)
+        quantized.freeze()
+        return quantized
+
+    def lora_delta(self, x):
+        x = _pad_last_dim(self.dropout(x), self.padded_input_dims)
+        z = mx.quantized_matmul(
+            x,
+            self.lora_a,
+            self.lora_a_scales,
+            self.lora_a_biases,
+            transpose=True,
+            group_size=self.group_size,
+            bits=self.bits,
+            mode=self.mode,
+        )
+        z = _pad_last_dim(z, self.padded_rank)
+        return mx.quantized_matmul(
+            z,
+            self.lora_b,
+            self.lora_b_scales,
+            self.lora_b_biases,
+            transpose=True,
+            group_size=self.rank_group_size,
+            bits=self.bits,
+            mode=self.mode,
+        )
+
+    def fuse(self, dequantize: bool = False):
+        linear = self.linear
+        weight = linear.weight
+        is_quantized = isinstance(linear, nn.QuantizedLinear)
+        if is_quantized:
+            weight = mx.dequantize(
+                weight,
+                linear.scales,
+                linear.biases,
+                group_size=linear.group_size,
+                bits=linear.bits,
+                mode=linear.mode,
+            )
+
+        lora_a = mx.dequantize(
+            self.lora_a,
+            self.lora_a_scales,
+            self.lora_a_biases,
+            group_size=self.group_size,
+            bits=self.bits,
+            mode=self.mode,
+        )[: self.rank, : self.input_dims]
+        lora_b = mx.dequantize(
+            self.lora_b,
+            self.lora_b_scales,
+            self.lora_b_biases,
+            group_size=self.rank_group_size,
+            bits=self.bits,
+            mode=self.mode,
+        )[:, : self.rank]
+
+        fused = nn.Linear(self.input_dims, self.output_dims, bias="bias" in linear)
+        fused.weight = weight + (self.scale * lora_b @ lora_a).astype(weight.dtype)
+        if "bias" in linear:
+            fused.bias = linear.bias
+        if is_quantized and not dequantize:
+            fused = nn.QuantizedLinear.from_linear(
+                fused,
+                group_size=linear.group_size,
+                bits=linear.bits,
+                mode=linear.mode,
+            )
+        return fused
+
+    def __call__(self, x):
+        y = self.linear(x)
+        z = self.lora_delta(x)
         return y + (self.scale * z).astype(x.dtype)
 
 

--- a/mlx_lm/tuner/utils.py
+++ b/mlx_lm/tuner/utils.py
@@ -1,9 +1,12 @@
 # Copyright © 2024 Apple Inc.
 import json
+import shutil
+import tempfile
 import types
 from pathlib import Path
-from typing import Dict
+from typing import Dict, Optional
 
+import mlx.core as mx
 import mlx.nn as nn
 import mlx.optimizers as opt
 from mlx.utils import tree_flatten, tree_unflatten
@@ -12,7 +15,72 @@ from ..cli_ui import rprint
 from ..models.switch_layers import QuantizedSwitchLinear, SwitchLinear
 from ..utils import get_total_parameters
 from .dora import DoRAEmbedding, DoRALinear
-from .lora import LoRAEmbedding, LoRALinear, LoRASwitchLinear
+from .lora import LoRAEmbedding, LoRALinear, LoRASwitchLinear, QuantizedLoRALinear
+
+QUANTIZED_LORA_FORMAT = "mlx_lm.quantized_lora"
+QUANTIZED_LORA_VERSION = 1
+
+
+def _parse_quantized_lora_layers(quantization: Dict) -> Dict[str, Dict[str, int]]:
+    try:
+        group_size = int(quantization["group_size"])
+        rank_group_size = int(quantization["rank_group_size"])
+    except (KeyError, TypeError, ValueError) as error:
+        raise ValueError("Quantized LoRA adapter has invalid group sizes") from error
+    if group_size not in (32, 64, 128):
+        raise ValueError(f"Unsupported LoRA group size: {group_size}")
+    if rank_group_size not in (32, 64, 128):
+        raise ValueError(f"Unsupported LoRA rank group size: {rank_group_size}")
+
+    layers = quantization.get("layers")
+    if not isinstance(layers, dict) or not layers:
+        raise ValueError("Quantized LoRA adapter has no layer metadata")
+
+    required = {
+        "bits",
+        "input_dims",
+        "output_dims",
+        "rank",
+        "padded_input_dims",
+        "padded_rank",
+    }
+    parsed = {}
+    for name, metadata in layers.items():
+        if not isinstance(metadata, dict):
+            raise ValueError(f"Quantized LoRA layer '{name}' has invalid metadata")
+        missing = sorted(required - set(metadata))
+        if missing:
+            raise ValueError(
+                f"Quantized LoRA layer '{name}' is missing metadata: "
+                + ", ".join(missing)
+            )
+        values = {key: int(metadata[key]) for key in required}
+        if any(value <= 0 for value in values.values()):
+            raise ValueError(f"Quantized LoRA layer '{name}' metadata must be positive")
+        if values["padded_input_dims"] < values["input_dims"]:
+            raise ValueError(f"Quantized LoRA layer '{name}' has invalid input padding")
+        if values["padded_rank"] < values["rank"]:
+            raise ValueError(f"Quantized LoRA layer '{name}' has invalid rank padding")
+        if values["bits"] not in (2, 3, 4, 5, 6, 8):
+            raise ValueError(f"Quantized LoRA layer '{name}' has unsupported bit width")
+        expected_input = (
+            (values["input_dims"] + group_size - 1) // group_size * group_size
+        )
+        expected_rank = (
+            (values["rank"] + rank_group_size - 1) // rank_group_size * rank_group_size
+        )
+        if values["padded_input_dims"] != expected_input:
+            raise ValueError(
+                f"Quantized LoRA layer '{name}' input padding does not match "
+                "the group size"
+            )
+        if values["padded_rank"] != expected_rank:
+            raise ValueError(
+                f"Quantized LoRA layer '{name}' rank padding does not match "
+                "the rank group size"
+            )
+        parsed[name] = values
+    return parsed
 
 
 def build_schedule(schedule_config: Dict):
@@ -110,6 +178,138 @@ def linear_to_lora_layers(
         model.update_modules(tree_unflatten(lora_modules))
 
 
+def quantize_lora_layers(
+    model: nn.Module,
+    group_size: int = 64,
+    bits: int = 8,
+    rank_group_size: int = 32,
+    mode: str = "affine",
+    layer_bits: Optional[Dict[str, int]] = None,
+):
+    """Replace all LoRA linear layers with quantized inference layers.
+
+    LoRA embedding and switch-linear layers are left unchanged.
+    """
+    lora_layers = {
+        name: module
+        for name, module in model.named_modules()
+        if isinstance(module, LoRALinear)
+    }
+    if layer_bits is None:
+        selected_layers = {name: bits for name in lora_layers}
+    else:
+        missing = sorted(set(layer_bits) - set(lora_layers))
+        if missing:
+            raise ValueError(
+                "Quantized LoRA metadata references missing linear layers: "
+                + ", ".join(missing)
+            )
+        selected_layers = layer_bits
+
+    replacements = []
+    for name, layer_bits_value in selected_layers.items():
+        replacements.append(
+            (
+                name,
+                lora_layers[name].to_quantized(
+                    group_size=group_size,
+                    bits=layer_bits_value,
+                    rank_group_size=rank_group_size,
+                    mode=mode,
+                ),
+            )
+        )
+    if replacements:
+        model.update_modules(tree_unflatten(replacements))
+    return model
+
+
+def save_quantized_adapter(
+    model: nn.Module,
+    source_adapter_path: str,
+    output_path: str,
+) -> Path:
+    """Save a model's quantized LoRA layers as a directly loadable adapter."""
+    source_adapter_path = Path(source_adapter_path)
+    output_path = Path(output_path)
+    if output_path.exists():
+        raise FileExistsError(f"Output path already exists: {output_path}")
+
+    config_path = source_adapter_path / "adapter_config.json"
+    with open(config_path, "r", encoding="utf-8") as fid:
+        config = json.load(fid)
+    if config.get("fine_tune_type", "lora") != "lora":
+        raise ValueError("Only LoRA adapters can be quantized")
+    if "adapter_quantization" in config:
+        raise ValueError("The source adapter is already quantized")
+
+    quantized_layers = {
+        name: module
+        for name, module in model.named_modules()
+        if isinstance(module, QuantizedLoRALinear)
+    }
+    if not quantized_layers:
+        raise ValueError("The model has no quantized LoRA linear layers")
+
+    settings = {
+        (module.group_size, module.rank_group_size, module.mode)
+        for module in quantized_layers.values()
+    }
+    if len(settings) != 1:
+        raise ValueError(
+            "All persisted LoRA layers must use the same group sizes and mode"
+        )
+    group_size, rank_group_size, mode = settings.pop()
+    if mode != "affine":
+        raise ValueError("Persisted quantized LoRA currently supports affine mode")
+
+    adapter_weights = {
+        name: value
+        for name, value in tree_flatten(model.parameters())
+        if any(part.startswith("lora_") for part in name.split("."))
+    }
+    if not adapter_weights:
+        raise ValueError("No LoRA adapter parameters were found")
+
+    config["adapter_quantization"] = {
+        "format": QUANTIZED_LORA_FORMAT,
+        "version": QUANTIZED_LORA_VERSION,
+        "group_size": group_size,
+        "rank_group_size": rank_group_size,
+        "mode": mode,
+        "layers": {
+            name: {
+                "bits": module.bits,
+                "input_dims": module.input_dims,
+                "output_dims": module.output_dims,
+                "rank": module.rank,
+                "padded_input_dims": module.padded_input_dims,
+                "padded_rank": module.padded_rank,
+            }
+            for name, module in sorted(quantized_layers.items())
+        },
+    }
+
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    temporary_path = Path(
+        tempfile.mkdtemp(prefix=f".{output_path.name}.", dir=output_path.parent)
+    )
+    try:
+        mx.save_safetensors(
+            str(temporary_path / "adapters.safetensors"),
+            adapter_weights,
+        )
+        (temporary_path / "adapter_config.json").write_text(
+            json.dumps(config, indent=2, sort_keys=True) + "\n",
+            encoding="utf-8",
+        )
+        temporary_path.replace(output_path)
+    except Exception:
+        shutil.rmtree(temporary_path, ignore_errors=True)
+        raise
+    return output_path
+
+
 def load_adapters(model: nn.Module, adapter_path: str) -> nn.Module:
     """
     Load any fine-tuned adapters / layers.
@@ -124,8 +324,9 @@ def load_adapters(model: nn.Module, adapter_path: str) -> nn.Module:
     adapter_path = Path(adapter_path)
     if not adapter_path.exists():
         raise FileNotFoundError(f"The adapter path does not exist: {adapter_path}")
-    with open(adapter_path / "adapter_config.json", "r") as fid:
-        config = types.SimpleNamespace(**json.load(fid))
+    with open(adapter_path / "adapter_config.json", "r", encoding="utf-8") as fid:
+        config_dict = json.load(fid)
+    config = types.SimpleNamespace(**config_dict)
     fine_tune_type = getattr(config, "fine_tune_type", "lora")
     if fine_tune_type != "full":
         linear_to_lora_layers(
@@ -134,7 +335,63 @@ def load_adapters(model: nn.Module, adapter_path: str) -> nn.Module:
             config.lora_parameters,
             use_dora=(fine_tune_type == "dora"),
         )
-    model.load_weights(str(adapter_path / "adapters.safetensors"), strict=False)
+    quantization = config_dict.get("adapter_quantization")
+    adapter_file = adapter_path / "adapters.safetensors"
+    if quantization is not None:
+        if quantization.get("format") != QUANTIZED_LORA_FORMAT:
+            raise ValueError("Unsupported quantized LoRA adapter format")
+        if quantization.get("version") != QUANTIZED_LORA_VERSION:
+            raise ValueError("Unsupported quantized LoRA adapter version")
+        if quantization.get("mode") != "affine":
+            raise ValueError("Persisted quantized LoRA currently supports affine mode")
+        layers = _parse_quantized_lora_layers(quantization)
+        layer_bits = {name: metadata["bits"] for name, metadata in layers.items()}
+        quantize_lora_layers(
+            model,
+            group_size=int(quantization["group_size"]),
+            rank_group_size=int(quantization["rank_group_size"]),
+            mode=quantization["mode"],
+            layer_bits=layer_bits,
+        )
+        model_layers = dict(model.named_modules())
+        for name, metadata in layers.items():
+            layer = model_layers[name]
+            actual = {
+                "bits": layer.bits,
+                "input_dims": layer.input_dims,
+                "output_dims": layer.output_dims,
+                "rank": layer.rank,
+                "padded_input_dims": layer.padded_input_dims,
+                "padded_rank": layer.padded_rank,
+            }
+            if actual != metadata:
+                raise ValueError(
+                    f"Quantized LoRA layer '{name}' metadata does not match "
+                    "the base model"
+                )
+        adapter_weights = mx.load(str(adapter_file))
+        suffixes = (
+            "lora_a",
+            "lora_a_scales",
+            "lora_a_biases",
+            "lora_b",
+            "lora_b_scales",
+            "lora_b_biases",
+        )
+        missing_weights = [
+            f"{name}.{suffix}"
+            for name in layer_bits
+            for suffix in suffixes
+            if f"{name}.{suffix}" not in adapter_weights
+        ]
+        if missing_weights:
+            raise ValueError(
+                "Quantized LoRA adapter is missing weights: "
+                + ", ".join(missing_weights)
+            )
+        model.load_weights(list(adapter_weights.items()), strict=False)
+    else:
+        model.load_weights(str(adapter_file), strict=False)
     return model
 
 
@@ -150,7 +407,7 @@ def remove_lora_layers(model: nn.Module) -> nn.Module:
     """
     reset_layers = []
     for name, module in model.named_modules():
-        if isinstance(module, LoRALinear):
+        if isinstance(module, (LoRALinear, QuantizedLoRALinear)):
             reset_layers.append((name, module.linear))
     if len(reset_layers) > 0:
         model.update_modules(tree_unflatten(reset_layers))

--- a/setup.py
+++ b/setup.py
@@ -65,6 +65,7 @@ setup(
             "mlx_lm.generate = mlx_lm.generate:main",
             "mlx_lm.lora = mlx_lm.lora:main",
             "mlx_lm.perplexity = mlx_lm.perplexity:main",
+            "mlx_lm.quantize_adapter = mlx_lm.quantize_adapter:main",
             "mlx_lm.server = mlx_lm.server:main",
             "mlx_lm.share = mlx_lm.share:main",
             "mlx_lm.manage = mlx_lm.manage:main",

--- a/tests/test_finetune.py
+++ b/tests/test_finetune.py
@@ -14,9 +14,9 @@ from mlx.utils import tree_flatten
 
 from mlx_lm import lora, tuner
 from mlx_lm.tuner.dora import DoRAEmbedding, DoRALinear
-from mlx_lm.tuner.lora import LoRAEmbedding, LoRALinear
+from mlx_lm.tuner.lora import LoRAEmbedding, LoRALinear, QuantizedLoRALinear
 from mlx_lm.tuner.trainer import evaluate
-from mlx_lm.tuner.utils import build_schedule
+from mlx_lm.tuner.utils import build_schedule, quantize_lora_layers, remove_lora_layers
 
 
 @contextmanager
@@ -28,6 +28,85 @@ def swapped_with_identity(obj, func):
 
 
 class TestLora(unittest.TestCase):
+    def test_quantize_and_remove_lora_layers(self):
+        class Model(nn.Module):
+            def __init__(self):
+                super().__init__()
+                self.proj = LoRALinear.from_base(
+                    nn.Linear(64, 32),
+                    r=8,
+                    dropout=0.0,
+                    scale=2.0,
+                )
+
+        model = Model()
+        base = model.proj.linear
+        quantize_lora_layers(
+            model,
+            group_size=32,
+            bits=8,
+            rank_group_size=32,
+        )
+        self.assertIsInstance(model.proj, QuantizedLoRALinear)
+        self.assertIs(model.proj.linear, base)
+
+        remove_lora_layers(model)
+        self.assertIs(model.proj, base)
+
+    def test_quantized_lora_linear(self):
+        mx.random.seed(7)
+        linear = nn.Linear(70, 45, bias=False)
+        linear.weight = mx.zeros_like(linear.weight)
+        lora = LoRALinear.from_base(linear, r=7, dropout=0.0, scale=2.0)
+        lora.lora_a = mx.random.normal(lora.lora_a.shape)
+        lora.lora_b = mx.random.normal(lora.lora_b.shape)
+        x = mx.random.normal((2, 3, 70))
+
+        reference = lora(x)
+        thresholds = {8: 0.999, 6: 0.999, 5: 0.995, 4: 0.99}
+        for bits, threshold in thresholds.items():
+            with self.subTest(bits=bits):
+                quantized = lora.to_quantized(
+                    group_size=32,
+                    bits=bits,
+                    rank_group_size=32,
+                )
+                candidate = quantized(x)
+                mx.eval(reference, candidate)
+
+                self.assertIsInstance(quantized, QuantizedLoRALinear)
+                self.assertEqual(candidate.shape, reference.shape)
+                self.assertEqual(quantized.padded_input_dims, 96)
+                self.assertEqual(quantized.padded_rank, 32)
+                cosine = mx.sum(reference * candidate) / (
+                    mx.linalg.norm(reference) * mx.linalg.norm(candidate)
+                )
+                self.assertGreater(float(cosine), threshold)
+
+    def test_quantized_lora_with_quantized_base(self):
+        mx.random.seed(11)
+        linear = nn.Linear(64, 32, bias=False)
+        base = nn.QuantizedLinear.from_linear(linear, group_size=32, bits=8)
+        lora = LoRALinear.from_base(base, r=8, dropout=0.0, scale=2.0)
+        lora.lora_a = mx.random.normal(lora.lora_a.shape)
+        lora.lora_b = mx.random.normal(lora.lora_b.shape)
+        quantized = lora.to_quantized(group_size=32, bits=4, rank_group_size=32)
+        x = mx.random.normal((2, 64))
+        output = quantized(x)
+        mx.eval(output)
+
+        self.assertEqual(output.shape, (2, 32))
+        self.assertIsInstance(quantized.linear, nn.QuantizedLinear)
+
+        fused = quantized.fuse(dequantize=True)
+        fused_output = fused(x)
+        mx.eval(fused_output)
+        self.assertEqual(fused_output.shape, (2, 32))
+        cosine = mx.sum(output * fused_output) / (
+            mx.linalg.norm(output) * mx.linalg.norm(fused_output)
+        )
+        self.assertGreater(float(cosine), 0.999)
+
     def test_llama(self):
         from mlx_lm.models import llama
 

--- a/tests/test_quantized_lora.py
+++ b/tests/test_quantized_lora.py
@@ -1,0 +1,205 @@
+# Copyright © 2026 Apple Inc.
+
+import json
+import tempfile
+import unittest
+from pathlib import Path
+
+import mlx.core as mx
+import mlx.nn as nn
+from mlx.utils import tree_flatten
+
+from mlx_lm.models import llama
+from mlx_lm.tuner.lora import LoRALinear, QuantizedLoRALinear
+from mlx_lm.tuner.utils import (
+    linear_to_lora_layers,
+    load_adapters,
+    quantize_lora_layers,
+    save_quantized_adapter,
+)
+
+
+class Block(nn.Module):
+    def __init__(self):
+        super().__init__()
+        self.proj = nn.Linear(70, 45)
+
+
+class Model(nn.Module):
+    def __init__(self):
+        super().__init__()
+        self.layers = [Block(), Block(), Block()]
+
+    def __call__(self, x):
+        return sum(layer.proj(x) for layer in self.layers)
+
+
+LORA_CONFIG = {
+    "rank": 7,
+    "dropout": 0.0,
+    "scale": 2.0,
+    "keys": ["proj"],
+}
+
+
+def make_lora_model(seed=19):
+    mx.random.seed(seed)
+    model = Model()
+    model.freeze()
+    linear_to_lora_layers(model, 3, LORA_CONFIG)
+    for _, module in model.named_modules():
+        if hasattr(module, "lora_b"):
+            module.lora_b = mx.random.normal(module.lora_b.shape)
+    model.eval()
+    return model
+
+
+def save_float_adapter(model, path: Path):
+    path.mkdir()
+    config = {
+        "fine_tune_type": "lora",
+        "num_layers": 3,
+        "lora_parameters": LORA_CONFIG,
+    }
+    (path / "adapter_config.json").write_text(json.dumps(config))
+    mx.save_safetensors(
+        str(path / "adapters.safetensors"),
+        dict(tree_flatten(model.trainable_parameters())),
+    )
+
+
+class TestQuantizedLoraAdapter(unittest.TestCase):
+    def test_q8_adapter_preserves_tiny_transformer_logits(self):
+        args = llama.ModelArgs(
+            model_type="llama",
+            hidden_size=64,
+            num_hidden_layers=2,
+            intermediate_size=128,
+            num_attention_heads=4,
+            num_key_value_heads=4,
+            rms_norm_eps=1e-5,
+            vocab_size=128,
+            tie_word_embeddings=False,
+        )
+        mx.random.seed(47)
+        model = llama.Model(args)
+        model.freeze()
+        linear_to_lora_layers(
+            model,
+            2,
+            {
+                "rank": 8,
+                "dropout": 0.0,
+                "scale": 2.0,
+                "keys": ["self_attn.q_proj", "self_attn.v_proj"],
+            },
+        )
+        for _, module in model.named_modules():
+            if hasattr(module, "lora_b"):
+                module.lora_b = 0.02 * mx.random.normal(module.lora_b.shape)
+        model.eval()
+
+        tokens = mx.array([[1, 7, 13, 21, 34]], dtype=mx.int32)
+        reference = model(tokens).astype(mx.float32)
+        mx.eval(reference)
+        quantize_lora_layers(
+            model,
+            group_size=32,
+            bits=8,
+            rank_group_size=32,
+        )
+        candidate = model(tokens).astype(mx.float32)
+        difference = candidate - reference
+        mx.eval(candidate, difference)
+
+        relative_l2 = float(mx.linalg.norm(difference)) / float(
+            mx.linalg.norm(reference)
+        )
+        cosine = float(
+            mx.sum(reference * candidate)
+            / (mx.linalg.norm(reference) * mx.linalg.norm(candidate))
+        )
+        self.assertLess(relative_l2, 0.002)
+        self.assertGreater(cosine, 0.99999)
+        self.assertLess(float(mx.max(mx.abs(difference))), 0.005)
+
+    def test_persist_and_directly_load_mixed_bits(self):
+        with tempfile.TemporaryDirectory() as directory:
+            directory = Path(directory)
+            source_path = directory / "source"
+            output_path = directory / "quantized"
+            model = make_lora_model()
+            save_float_adapter(model, source_path)
+
+            layer_bits = {
+                "layers.0.proj": 8,
+                "layers.1.proj": 4,
+            }
+            quantize_lora_layers(
+                model,
+                group_size=32,
+                rank_group_size=32,
+                layer_bits=layer_bits,
+            )
+            x = mx.random.normal((2, 3, 70))
+            reference = model(x)
+            mx.eval(reference)
+            save_quantized_adapter(model, source_path, output_path)
+
+            mx.random.seed(19)
+            loaded = Model()
+            loaded.freeze()
+            load_adapters(loaded, output_path)
+            loaded.eval()
+            candidate = loaded(x)
+            mx.eval(candidate)
+
+            self.assertTrue(mx.array_equal(reference, candidate))
+            self.assertIsInstance(loaded.layers[0].proj, QuantizedLoRALinear)
+            self.assertIsInstance(loaded.layers[1].proj, QuantizedLoRALinear)
+            self.assertIsInstance(loaded.layers[2].proj, LoRALinear)
+            self.assertEqual(loaded.layers[0].proj.bits, 8)
+            self.assertEqual(loaded.layers[1].proj.bits, 4)
+
+            saved_config = json.loads((output_path / "adapter_config.json").read_text())
+            self.assertEqual(
+                {
+                    name: metadata["bits"]
+                    for name, metadata in saved_config["adapter_quantization"][
+                        "layers"
+                    ].items()
+                },
+                layer_bits,
+            )
+            saved_weights = mx.load(str(output_path / "adapters.safetensors"))
+            self.assertEqual(saved_weights["layers.0.proj.lora_a"].dtype, mx.uint32)
+            self.assertEqual(saved_weights["layers.1.proj.lora_b"].dtype, mx.uint32)
+
+            source_size = (source_path / "adapters.safetensors").stat().st_size
+            output_size = (output_path / "adapters.safetensors").stat().st_size
+            self.assertLess(output_size, source_size)
+
+    def test_missing_quantized_weight_is_rejected(self):
+        with tempfile.TemporaryDirectory() as directory:
+            directory = Path(directory)
+            source_path = directory / "source"
+            output_path = directory / "quantized"
+            model = make_lora_model()
+            save_float_adapter(model, source_path)
+            quantize_lora_layers(model, group_size=32, bits=8)
+            save_quantized_adapter(model, source_path, output_path)
+
+            adapter_file = output_path / "adapters.safetensors"
+            weights = mx.load(str(adapter_file))
+            del weights["layers.0.proj.lora_a_scales"]
+            mx.save_safetensors(str(adapter_file), weights)
+
+            mx.random.seed(19)
+            loaded = Model()
+            loaded.freeze()
+            with self.assertRaisesRegex(ValueError, "missing weights"):
+                load_adapters(loaded, output_path)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- Add `QuantizedLoRALinear`, which keeps LoRA A and B matrices packed at runtime and evaluates both projections with `mx.quantized_matmul`.
- Add a versioned persistent adapter format with packed weights, scales, biases, dimensions, rank, padding, and per-layer bit-width metadata.
- Load quantized adapters through the existing `adapter_path` interface without materializing the saved LoRA matrices as full floating-point weights.
- Add `mlx_lm.quantize_adapter`, documentation, numerical tests, and a reproducible benchmark.

## Motivation

MLX-LM already supports a quantized base model with floating-point LoRA weights. This PR adds inference-time quantization for the adapter matrices themselves. The primary goal is adapter memory reduction, especially when adapters are kept separate for dynamic deployment. This PR does not claim a general end-to-end latency improvement.

## Design

- The base `Linear` or `QuantizedLinear` module is unchanged.
- LoRA A and B are independently padded to supported group sizes and stored as packed `uint32` tensors plus affine scales and biases.
- Normal inference remains on the quantized path. Full adapter dequantization occurs only when explicitly fusing the adapter.
- Persistence is atomic and validates format version, layer dimensions, rank, padding, bit width, and every required packed tensor before loading.
- Conversion rejects configurations that increase adapter parameter memory unless `--allow-larger` is specified.
- Linear LoRA layers support 2, 3, 4, 5, 6, and 8-bit affine quantization.

## Validation

- 21 focused unit tests pass.
- A two-layer randomly initialized Llama test compares final logits after Q8 adapter quantization and requires cosine similarity above 0.99999, relative L2 below 0.002, and maximum absolute error below 0.005.
- Direct persistence round trips reproduce the packed runtime output exactly.
- Missing packed tensors and incompatible metadata are rejected before inference.

For a 4096 x 4096 rank-16 FP16 adapter in the included synthetic benchmark:

| Format | Adapter memory | Reduction | Delta cosine | Relative L2 |
|---|---:|---:|---:|---:|
| FP16 | 256 KiB | - | 1.0 | 0 |
| Q8 | 212 KiB | 17.2% | 0.99998 | 0.0066 |
| Q4 | 116 KiB | 54.7% | 0.99376 | 0.1116 |

The benchmark also makes the padding tradeoff visible: low-rank adapters can become larger at higher bit widths, which is why the CLI checks actual packed parameter bytes instead of assuming savings from bit width alone.

## Limitations

- Quantized adapters are inference-only.
- This PR quantizes `LoRALinear` matrices; LoRA embedding and switch-linear layers remain in their original precision.
- Persistent quantized adapters currently use affine quantization.
- Multi-adapter banks and dynamic routing are intentionally proposed in a follow-up stacked PR so that this format and runtime path can be reviewed independently.

## Test commands

```bash
PYTHONPATH=. python -m unittest tests.test_finetune tests.test_quantized_lora
PYTHONPATH=. python benchmarks/quantized_lora.py
python -m mlx_lm.quantize_adapter --help
```