### PR TITLE
Add quantized LoRA adapter banks and dynamic routing

### DIFF
--- a/benchmarks/quantized_lora.py
+++ b/benchmarks/quantized_lora.py
@@ -1,0 +1,229 @@
+# Copyright © 2026 Apple Inc.
+
+import argparse
+import json
+import platform
+import statistics
+import time
+from pathlib import Path
+
+import mlx.core as mx
+import mlx.nn as nn
+from mlx.utils import tree_flatten
+
+from mlx_lm.tuner.lora import LoRALinear
+
+DTYPES = {
+    "float16": mx.float16,
+    "bfloat16": mx.bfloat16,
+    "float32": mx.float32,
+}
+
+
+def comma_separated_ints(value):
+    return tuple(int(item) for item in value.split(",") if item)
+
+
+def configure_parser():
+    parser = argparse.ArgumentParser(
+        description="Benchmark quantized LoRA precision, memory, and latency."
+    )
+    parser.add_argument("--input-dims", type=int, default=4096)
+    parser.add_argument("--output-dims", type=int, default=4096)
+    parser.add_argument("--tokens", type=int, default=32)
+    parser.add_argument("--ranks", type=comma_separated_ints, default=(8, 16, 32, 64))
+    parser.add_argument("--bits", type=comma_separated_ints, default=(8, 6, 5, 4))
+    parser.add_argument("--group-size", type=int, default=64)
+    parser.add_argument("--rank-group-size", type=int, default=32)
+    parser.add_argument("--base-bits", type=int, choices=(0, 4, 8), default=8)
+    parser.add_argument("--dtype", choices=DTYPES, default="float16")
+    parser.add_argument("--warmup", type=int, default=10)
+    parser.add_argument("--iterations", type=int, default=50)
+    parser.add_argument("--seed", type=int, default=7)
+    parser.add_argument("--output", type=Path)
+    return parser
+
+
+def percentile(values, quantile):
+    values = sorted(values)
+    index = round((len(values) - 1) * quantile)
+    return values[index]
+
+
+def measure(function, warmup, iterations):
+    for _ in range(warmup):
+        mx.eval(function())
+    mx.synchronize()
+
+    timings = []
+    for _ in range(iterations):
+        started = time.perf_counter()
+        mx.eval(function())
+        mx.synchronize()
+        timings.append((time.perf_counter() - started) * 1000)
+    return {
+        "mean_ms": statistics.mean(timings),
+        "median_ms": statistics.median(timings),
+        "p90_ms": percentile(timings, 0.9),
+    }
+
+
+def adapter_bytes(module):
+    return sum(
+        value.nbytes
+        for name, value in tree_flatten(module.parameters())
+        if name.startswith("lora_")
+    )
+
+
+def compare(reference, candidate):
+    reference = reference.astype(mx.float32)
+    candidate = candidate.astype(mx.float32)
+    difference = candidate - reference
+    mx.eval(reference, candidate, difference)
+    reference_norm = float(mx.linalg.norm(reference))
+    difference_norm = float(mx.linalg.norm(difference))
+    return {
+        "relative_l2": difference_norm / (reference_norm + 1e-12),
+        "cosine": float(
+            mx.sum(reference * candidate)
+            / (mx.linalg.norm(reference) * mx.linalg.norm(candidate) + 1e-12)
+        ),
+        "max_abs": float(mx.max(mx.abs(difference))),
+    }
+
+
+def benchmark_rank(args, rank, dtype):
+    linear = nn.Linear(args.input_dims, args.output_dims, bias=False)
+    linear.weight = linear.weight.astype(dtype)
+    base = (
+        nn.QuantizedLinear.from_linear(
+            linear,
+            group_size=args.group_size,
+            bits=args.base_bits,
+        )
+        if args.base_bits
+        else linear
+    )
+    lora = LoRALinear.from_base(base, r=rank, dropout=0.0, scale=1.0)
+    lora.lora_a = (0.02 * mx.random.normal(lora.lora_a.shape)).astype(dtype)
+    lora.lora_b = (0.02 * mx.random.normal(lora.lora_b.shape)).astype(dtype)
+    x = mx.random.normal((args.tokens, args.input_dims)).astype(dtype)
+
+    reference = (x @ lora.lora_a) @ lora.lora_b
+    mx.eval(reference)
+    fp_bytes = lora.lora_a.nbytes + lora.lora_b.nbytes
+    fp_latency = measure(
+        lambda: (x @ lora.lora_a) @ lora.lora_b,
+        args.warmup,
+        args.iterations,
+    )
+    fp_layer_latency = measure(
+        lambda: lora(x),
+        args.warmup,
+        args.iterations,
+    )
+    result = {
+        "rank": rank,
+        "fp_adapter_bytes": fp_bytes,
+        "fp_latency": fp_latency,
+        "fp_layer_latency": fp_layer_latency,
+        "quantized": {},
+    }
+
+    for bits in args.bits:
+        quantized = lora.to_quantized(
+            group_size=args.group_size,
+            bits=bits,
+            rank_group_size=args.rank_group_size,
+        )
+        candidate = quantized.lora_delta(x)
+        mx.eval(candidate)
+        size = adapter_bytes(quantized)
+        latency = measure(
+            lambda quantized=quantized: quantized.lora_delta(x),
+            args.warmup,
+            args.iterations,
+        )
+        layer_latency = measure(
+            lambda quantized=quantized: quantized(x),
+            args.warmup,
+            args.iterations,
+        )
+        result["quantized"][str(bits)] = {
+            **compare(reference, candidate),
+            "adapter_bytes": size,
+            "memory_reduction": 1 - size / fp_bytes,
+            "latency": latency,
+            "latency_ratio_vs_fp": latency["median_ms"] / fp_latency["median_ms"],
+            "layer_latency": layer_latency,
+            "layer_latency_ratio_vs_fp": (
+                layer_latency["median_ms"] / fp_layer_latency["median_ms"]
+            ),
+        }
+    return result
+
+
+def print_table(results):
+    header = (
+        "rank bits size_KiB reduction rel_L2 cosine "
+        "branch_ms branch_x layer_ms layer_x"
+    )
+    print(header)
+    for result in results:
+        rank = result["rank"]
+        fp_size = result["fp_adapter_bytes"] / 1024
+        fp_latency = result["fp_latency"]["median_ms"]
+        fp_layer_latency = result["fp_layer_latency"]["median_ms"]
+        print(
+            f"{rank:>4} {'fp':>4} {fp_size:>8.1f} {'-':>9} {'-':>8} "
+            f"{'-':>8} {fp_latency:>9.4f} {'1.00x':>8} "
+            f"{fp_layer_latency:>8.4f} {'1.00x':>7}"
+        )
+        for bits, item in result["quantized"].items():
+            print(
+                f"{rank:>4} {bits:>4} {item['adapter_bytes'] / 1024:>8.1f} "
+                f"{item['memory_reduction']:>8.1%} {item['relative_l2']:>8.4f} "
+                f"{item['cosine']:>8.5f} "
+                f"{item['latency']['median_ms']:>9.4f} "
+                f"{item['latency_ratio_vs_fp']:>7.2f}x "
+                f"{item['layer_latency']['median_ms']:>8.4f} "
+                f"{item['layer_latency_ratio_vs_fp']:>6.2f}x"
+            )
+
+
+def main():
+    args = configure_parser().parse_args()
+    mx.random.seed(args.seed)
+    dtype = DTYPES[args.dtype]
+    results = [benchmark_rank(args, rank, dtype) for rank in args.ranks]
+    payload = {
+        "environment": {
+            "platform": platform.platform(),
+            "machine": platform.machine(),
+            "mlx_version": mx.__version__,
+        },
+        "config": {
+            "input_dims": args.input_dims,
+            "output_dims": args.output_dims,
+            "tokens": args.tokens,
+            "ranks": args.ranks,
+            "bits": args.bits,
+            "group_size": args.group_size,
+            "rank_group_size": args.rank_group_size,
+            "base_bits": args.base_bits,
+            "dtype": args.dtype,
+            "warmup": args.warmup,
+            "iterations": args.iterations,
+            "seed": args.seed,
+        },
+        "results": results,
+    }
+    print_table(results)
+    if args.output is not None:
+        args.output.parent.mkdir(parents=True, exist_ok=True)
+        args.output.write_text(json.dumps(payload, indent=2) + "\n")
+
+
+if __name__ == "__main__":
+    main()

--- a/benchmarks/quantized_lora.py
+++ b/benchmarks/quantized_lora.py
@@ -33,6 +33,11 @@ def configure_parser():
     parser.add_argument("--tokens", type=int, default=32)
     parser.add_argument("--ranks", type=comma_separated_ints, default=(8, 16, 32, 64))
     parser.add_argument("--bits", type=comma_separated_ints, default=(8, 6, 5, 4))
+    parser.add_argument(
+        "--adapter-counts",
+        type=comma_separated_ints,
+        default=(1, 8, 32, 64),
+    )
     parser.add_argument("--group-size", type=int, default=64)
     parser.add_argument("--rank-group-size", type=int, default=32)
     parser.add_argument("--base-bits", type=int, choices=(0, 4, 8), default=8)
@@ -160,6 +165,9 @@ def benchmark_rank(args, rank, dtype):
             "layer_latency_ratio_vs_fp": (
                 layer_latency["median_ms"] / fp_layer_latency["median_ms"]
             ),
+            "multi_adapter_bytes": {
+                str(count): count * size for count in args.adapter_counts
+            },
         }
     return result
 
@@ -209,6 +217,7 @@ def main():
             "tokens": args.tokens,
             "ranks": args.ranks,
             "bits": args.bits,
+            "adapter_counts": args.adapter_counts,
             "group_size": args.group_size,
             "rank_group_size": args.rank_group_size,
             "base_bits": args.base_bits,

--- a/benchmarks/quantized_lora_bank.py
+++ b/benchmarks/quantized_lora_bank.py
@@ -1,0 +1,253 @@
+# Copyright © 2026 Apple Inc.
+
+import argparse
+import json
+import statistics
+import time
+from pathlib import Path
+
+import mlx.core as mx
+import mlx.nn as nn
+
+from mlx_lm.tuner.lora import LoRALinear
+from mlx_lm.tuner.lora_pack import QuantizedLoRAAdapterPack
+
+
+def comma_separated_ints(value):
+    return tuple(int(item) for item in value.split(",") if item)
+
+
+def configure_parser():
+    parser = argparse.ArgumentParser(
+        description="Benchmark resident memory and routing for a LoRA adapter bank."
+    )
+    parser.add_argument("--input-dims", type=int, default=4096)
+    parser.add_argument("--output-dims", type=int, default=4096)
+    parser.add_argument("--rank", type=int, default=16)
+    parser.add_argument("--bits", type=comma_separated_ints, default=(8, 4))
+    parser.add_argument(
+        "--adapter-counts", type=comma_separated_ints, default=(10, 50, 100)
+    )
+    parser.add_argument("--mixed-rows", type=int, default=64)
+    parser.add_argument("--group-size", type=int, default=64)
+    parser.add_argument("--rank-group-size", type=int, default=32)
+    parser.add_argument("--warmup", type=int, default=10)
+    parser.add_argument("--iterations", type=int, default=50)
+    parser.add_argument("--seed", type=int, default=7)
+    parser.add_argument("--output", type=Path)
+    return parser
+
+
+def percentile(values, quantile):
+    values = sorted(values)
+    return values[round((len(values) - 1) * quantile)]
+
+
+def measure(function, warmup, iterations):
+    for index in range(warmup):
+        mx.eval(function(index))
+    mx.synchronize()
+    timings = []
+    for index in range(iterations):
+        started = time.perf_counter()
+        mx.eval(function(index))
+        mx.synchronize()
+        timings.append((time.perf_counter() - started) * 1000)
+    return {
+        "mean_ms": statistics.mean(timings),
+        "median_ms": statistics.median(timings),
+        "p90_ms": percentile(timings, 0.9),
+    }
+
+
+def compare(reference, candidate):
+    reference = reference.astype(mx.float32)
+    candidate = candidate.astype(mx.float32)
+    difference = candidate - reference
+    mx.eval(reference, candidate, difference)
+    return {
+        "relative_l2": float(mx.linalg.norm(difference))
+        / (float(mx.linalg.norm(reference)) + 1e-12),
+        "cosine": float(
+            mx.sum(reference * candidate)
+            / (mx.linalg.norm(reference) * mx.linalg.norm(candidate) + 1e-12)
+        ),
+        "max_abs": float(mx.max(mx.abs(difference))),
+    }
+
+
+def fp_mixed_delta(x, lora_a, lora_b, indices):
+    z = mx.gather_mm(
+        mx.expand_dims(x, -2),
+        lora_a,
+        rhs_indices=indices,
+        sorted_indices=False,
+    )
+    return mx.gather_mm(
+        z,
+        lora_b,
+        rhs_indices=indices,
+        sorted_indices=False,
+    ).squeeze(-2)
+
+
+def make_adapters(args):
+    maximum = max(args.adapter_counts)
+    base = nn.Linear(args.input_dims, args.output_dims, bias=False)
+    template = LoRALinear.from_base(
+        base,
+        r=args.rank,
+        dropout=0.0,
+        scale=1.0,
+    )
+    float_weights = []
+    quantized = {bits: [] for bits in args.bits}
+    for _ in range(maximum):
+        lora_a = (0.02 * mx.random.normal(template.lora_a.shape)).astype(mx.float16)
+        lora_b = (0.02 * mx.random.normal(template.lora_b.shape)).astype(mx.float16)
+        float_weights.append((lora_a, lora_b))
+        template.lora_a = lora_a
+        template.lora_b = lora_b
+        for bits in args.bits:
+            quantized[bits].append(
+                template.to_quantized(
+                    group_size=args.group_size,
+                    bits=bits,
+                    rank_group_size=args.rank_group_size,
+                )
+            )
+    return float_weights, quantized
+
+
+def benchmark_count(args, count, float_weights, quantized_layers):
+    lora_a = mx.stack([weights[0] for weights in float_weights[:count]])
+    lora_b = mx.stack([weights[1] for weights in float_weights[:count]])
+    fp_bytes = lora_a.nbytes + lora_b.nbytes
+    request_x = mx.random.normal((1, args.input_dims)).astype(mx.float16)
+    mixed_x = mx.random.normal((args.mixed_rows, args.input_dims)).astype(mx.float16)
+    indices = mx.sort(
+        (mx.arange(args.mixed_rows, dtype=mx.int32) % count).astype(mx.int32)
+    )
+
+    fp_request = measure(
+        lambda iteration: (request_x @ lora_a[iteration % count])
+        @ lora_b[iteration % count],
+        args.warmup,
+        args.iterations,
+    )
+    fp_mixed = measure(
+        lambda _: fp_mixed_delta(
+            mixed_x,
+            lora_a,
+            lora_b,
+            indices,
+        ),
+        args.warmup,
+        args.iterations,
+    )
+    reference = fp_mixed_delta(
+        mixed_x,
+        lora_a,
+        lora_b,
+        indices,
+    )
+    mx.eval(reference)
+    result = {
+        "adapter_count": count,
+        "fp16": {
+            "adapter_bytes": fp_bytes,
+            "request_switch_latency": fp_request,
+            "mixed_batch_latency": fp_mixed,
+        },
+        "quantized": {},
+    }
+
+    for bits in args.bits:
+        pack = QuantizedLoRAAdapterPack.from_layers(quantized_layers[bits][:count])
+        candidate = pack.delta(mixed_x, indices)
+        mx.eval(candidate)
+        request_latency = measure(
+            lambda iteration, pack=pack: pack.delta_for_adapter(
+                request_x, iteration % count
+            ),
+            args.warmup,
+            args.iterations,
+        )
+        mixed_latency = measure(
+            lambda _, pack=pack: pack.delta(mixed_x, indices),
+            args.warmup,
+            args.iterations,
+        )
+        result["quantized"][str(bits)] = {
+            **compare(reference, candidate),
+            "adapter_bytes": pack.adapter_bytes,
+            "memory_reduction": 1 - pack.adapter_bytes / fp_bytes,
+            "request_switch_latency": request_latency,
+            "request_latency_ratio_vs_fp": request_latency["median_ms"]
+            / fp_request["median_ms"],
+            "mixed_batch_latency": mixed_latency,
+            "mixed_latency_ratio_vs_fp": mixed_latency["median_ms"]
+            / fp_mixed["median_ms"],
+        }
+    return result
+
+
+def print_table(results):
+    print(
+        "count format memory_MiB reduction request_ms request_x "
+        "mixed_ms mixed_x rel_L2 cosine"
+    )
+    for result in results:
+        count = result["adapter_count"]
+        fp = result["fp16"]
+        print(
+            f"{count:>5} {'fp16':>6} {fp['adapter_bytes'] / 2**20:>10.2f} "
+            f"{'-':>9} {fp['request_switch_latency']['median_ms']:>10.4f} "
+            f"{'1.00x':>9} {fp['mixed_batch_latency']['median_ms']:>8.4f} "
+            f"{'1.00x':>7} {'-':>8} {'-':>8}"
+        )
+        for bits, item in result["quantized"].items():
+            print(
+                f"{count:>5} {('q' + bits):>6} "
+                f"{item['adapter_bytes'] / 2**20:>10.2f} "
+                f"{item['memory_reduction']:>8.1%} "
+                f"{item['request_switch_latency']['median_ms']:>10.4f} "
+                f"{item['request_latency_ratio_vs_fp']:>8.2f}x "
+                f"{item['mixed_batch_latency']['median_ms']:>8.4f} "
+                f"{item['mixed_latency_ratio_vs_fp']:>6.2f}x "
+                f"{item['relative_l2']:>8.4f} {item['cosine']:>8.5f}"
+            )
+
+
+def main():
+    args = configure_parser().parse_args()
+    mx.random.seed(args.seed)
+    float_weights, quantized_layers = make_adapters(args)
+    results = [
+        benchmark_count(args, count, float_weights, quantized_layers)
+        for count in args.adapter_counts
+    ]
+    payload = {
+        "config": {
+            "input_dims": args.input_dims,
+            "output_dims": args.output_dims,
+            "rank": args.rank,
+            "bits": args.bits,
+            "adapter_counts": args.adapter_counts,
+            "mixed_rows": args.mixed_rows,
+            "group_size": args.group_size,
+            "rank_group_size": args.rank_group_size,
+            "warmup": args.warmup,
+            "iterations": args.iterations,
+            "seed": args.seed,
+        },
+        "results": results,
+    }
+    print_table(results)
+    if args.output is not None:
+        args.output.parent.mkdir(parents=True, exist_ok=True)
+        args.output.write_text(json.dumps(payload, indent=2) + "\n")
+
+
+if __name__ == "__main__":
+    main()

--- a/mlx_lm/LORA.md
+++ b/mlx_lm/LORA.md
@@ -20,6 +20,7 @@ LoRA (QLoRA).[^qlora] LoRA fine-tuning works with the following model families:
   - [Fine-tune](#Fine-tune)
   - [Evaluate](#Evaluate)
   - [Generate](#Generate)
+  - [Quantize adapters](#Quantize-adapters)
 - [Fuse](#Fuse)
 - [Data](#Data)
 - [Memory Issues](#Memory-Issues)
@@ -123,6 +124,63 @@ mlx_lm.generate \
     --model <path_to_model> \
     --adapter-path <path_to_adapters> \
     --prompt "<your_model_prompt>"
+```
+
+### Quantize adapters
+
+LoRA matrices on linear layers can be quantized after loading to reduce their
+inference-time memory footprint. The base model is left unchanged, so it may
+be either a floating-point or quantized model. LoRA embedding and
+switch-linear layers remain in their original precision.
+
+To create a directly loadable quantized adapter, run:
+
+```shell
+mlx_lm.quantize_adapter \
+    --model <path_to_model> \
+    --adapter-path <path_to_adapters> \
+    --output-path <path_to_quantized_adapters> \
+    --bits 8
+```
+
+The output contains packed quantized adapter weights and quantization metadata.
+It can be loaded through the normal adapter interface without materializing a
+floating-point copy of the saved LoRA matrices:
+
+```shell
+mlx_lm.generate \
+    --model <path_to_model> \
+    --adapter-path <path_to_quantized_adapters> \
+    --prompt "<your_model_prompt>"
+```
+
+You can also quantize an already loaded adapter in memory:
+
+```python
+from mlx_lm import load
+from mlx_lm.tuner import quantize_lora_layers
+
+model, tokenizer = load(
+    "<path_to_model>",
+    adapter_path="<path_to_adapters>",
+)
+quantize_lora_layers(model, bits=8)
+```
+
+Quantized adapters are inference-only. Their dimensions are padded when
+needed to satisfy MLX quantization group-size requirements. The default uses
+8-bit affine quantization with group size 64 for the input dimension and 32
+for the LoRA rank dimension. You can select lower precision with `bits`, for
+example `quantize_lora_layers(model, bits=4)`.
+
+Padding and quantization metadata can outweigh the packed-weight savings for
+small ranks. The conversion command rejects adapters whose parameter memory
+would increase unless `--allow-larger` is supplied.
+
+The generic benchmark can be run from a source checkout with:
+
+```shell
+PYTHONPATH=. python benchmarks/quantized_lora.py
 ```
 
 ## Fuse

--- a/mlx_lm/LORA.md
+++ b/mlx_lm/LORA.md
@@ -177,10 +177,57 @@ Padding and quantization metadata can outweigh the packed-weight savings for
 small ranks. The conversion command rejects adapters whose parameter memory
 would increase unless `--allow-larger` is supplied.
 
-The generic benchmark can be run from a source checkout with:
+For mixed-precision adapters, select per-layer bit widths from representative
+layer inputs, then quantize only the layers that satisfy both the numerical
+error and memory-reduction thresholds:
+
+```python
+from mlx_lm.tuner import select_lora_layer_bits
+
+layer_bits, report = select_lora_layer_bits(
+    model,
+    layer_inputs,
+    candidate_bits=(4, 5, 6, 8),
+    max_relative_l2=0.01,
+    min_cosine=0.9999,
+)
+quantize_lora_layers(model, layer_bits=layer_bits)
+```
+
+Layers omitted from `layer_bits` stay in their original floating-point
+precision. Saved adapters preserve this per-layer precision configuration.
+
+Quantized adapters with the same layer and quantization configuration can be
+loaded into a shared adapter bank without loading or duplicating the base
+model:
+
+```python
+from mlx_lm.tuner import load_quantized_lora_adapter_bank
+
+bank = load_quantized_lora_adapter_bank(
+    {
+        "adapter-a": "<path_to_quantized_adapter_a>",
+        "adapter-b": "<path_to_quantized_adapter_b>",
+    }
+)
+pack = bank.packs["model.layers.0.self_attn.q_proj"]
+
+# One adapter for all token rows in a request.
+delta = pack.delta_for_adapter(x, bank.adapter_index("adapter-a"))
+
+# A different adapter index for each flattened token row.
+delta = pack.delta(x, adapter_indices)
+```
+
+The mixed-row path uses `mx.gather_qmm`; packed weights remain quantized for
+both request-level switching and token-level routing. Adapter banks currently
+require affine quantization and a common per-layer bit configuration.
+
+The generic benchmarks can be run from a source checkout with:
 
 ```shell
 PYTHONPATH=. python benchmarks/quantized_lora.py
+PYTHONPATH=. python benchmarks/quantized_lora_bank.py
 ```
 
 ## Fuse

--- a/mlx_lm/cli.py
+++ b/mlx_lm/cli.py
@@ -16,6 +16,7 @@ def main():
         "lora",
         "manage",
         "perplexity",
+        "quantize_adapter",
         "awq",
         "dwq",
         "dynamic_quant",

--- a/mlx_lm/quantize_adapter.py
+++ b/mlx_lm/quantize_adapter.py
@@ -1,0 +1,118 @@
+# Copyright © 2026 Apple Inc.
+
+import argparse
+from pathlib import Path
+
+from mlx.utils import tree_flatten
+
+from .tuner.utils import quantize_lora_layers, save_quantized_adapter
+from .utils import load
+
+
+def configure_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description="Quantize LoRA adapter matrices for direct MLX inference."
+    )
+    parser.add_argument(
+        "--model",
+        required=True,
+        help="Base model path or Hugging Face repository.",
+    )
+    parser.add_argument(
+        "--adapter-path",
+        required=True,
+        help="Path to an MLX LoRA adapter.",
+    )
+    parser.add_argument(
+        "--output-path",
+        required=True,
+        help="Directory for the quantized adapter.",
+    )
+    parser.add_argument(
+        "--bits",
+        type=int,
+        choices=(2, 3, 4, 5, 6, 8),
+        default=8,
+        help="Bits per LoRA weight. Default: 8.",
+    )
+    parser.add_argument(
+        "--group-size",
+        type=int,
+        default=64,
+        help="Quantization group size for LoRA A. Default: 64.",
+    )
+    parser.add_argument(
+        "--rank-group-size",
+        type=int,
+        default=32,
+        help="Quantization group size for LoRA B. Default: 32.",
+    )
+    parser.add_argument(
+        "--trust-remote-code",
+        action="store_true",
+        help="Allow custom model code from the model repository.",
+    )
+    parser.add_argument(
+        "--allow-larger",
+        action="store_true",
+        help="Save even if quantization increases adapter parameter memory.",
+    )
+    return parser
+
+
+def adapter_parameter_bytes(model) -> int:
+    return sum(
+        value.nbytes
+        for name, value in tree_flatten(model.parameters())
+        if any(part.startswith("lora_") for part in name.split("."))
+    )
+
+
+def main() -> None:
+    args = configure_parser().parse_args()
+    adapter_path = Path(args.adapter_path)
+    output_path = Path(args.output_path)
+    if not adapter_path.exists():
+        raise FileNotFoundError(f"Adapter path does not exist: {adapter_path}")
+    if output_path.exists():
+        raise FileExistsError(f"Output path already exists: {output_path}")
+
+    model, _ = load(
+        args.model,
+        adapter_path=str(adapter_path),
+        trust_remote_code=args.trust_remote_code,
+    )
+    float_parameter_bytes = adapter_parameter_bytes(model)
+    quantize_lora_layers(
+        model,
+        group_size=args.group_size,
+        bits=args.bits,
+        rank_group_size=args.rank_group_size,
+    )
+    quantized_parameter_bytes = adapter_parameter_bytes(model)
+    if quantized_parameter_bytes >= float_parameter_bytes and not args.allow_larger:
+        raise ValueError(
+            "Quantization does not reduce adapter parameter memory "
+            f"({float_parameter_bytes} -> {quantized_parameter_bytes} bytes). "
+            "Use a lower bit width, a smaller rank group size, or "
+            "--allow-larger to override."
+        )
+    save_quantized_adapter(model, str(adapter_path), str(output_path))
+
+    source_size = (adapter_path / "adapters.safetensors").stat().st_size
+    output_size = (output_path / "adapters.safetensors").stat().st_size
+    reduction = 1 - output_size / source_size
+    parameter_reduction = 1 - quantized_parameter_bytes / float_parameter_bytes
+    print(f"Saved quantized adapter to {output_path}")
+    print(
+        "Adapter parameter memory: "
+        f"{float_parameter_bytes / 1e6:.2f} MB -> "
+        f"{quantized_parameter_bytes / 1e6:.2f} MB "
+        f"({parameter_reduction:.2%} reduction)"
+    )
+    print(f"Adapter size: {source_size / 1e6:.2f} MB -> {output_size / 1e6:.2f} MB")
+    print(f"Size reduction: {reduction:.2%}")
+
+
+if __name__ == "__main__":
+    main()

--- a/mlx_lm/tuner/__init__.py
+++ b/mlx_lm/tuner/__init__.py
@@ -1,2 +1,6 @@
 from .trainer import TrainingArgs, evaluate, train
-from .utils import linear_to_lora_layers
+from .utils import (
+    linear_to_lora_layers,
+    quantize_lora_layers,
+    save_quantized_adapter,
+)

--- a/mlx_lm/tuner/__init__.py
+++ b/mlx_lm/tuner/__init__.py
@@ -1,6 +1,12 @@
+from .lora_pack import (
+    QuantizedLoRAAdapterBank,
+    QuantizedLoRAAdapterPack,
+    load_quantized_lora_adapter_bank,
+)
 from .trainer import TrainingArgs, evaluate, train
 from .utils import (
     linear_to_lora_layers,
     quantize_lora_layers,
     save_quantized_adapter,
+    select_lora_layer_bits,
 )

--- a/mlx_lm/tuner/lora.py
+++ b/mlx_lm/tuner/lora.py
@@ -8,6 +8,22 @@ import mlx.nn as nn
 from ..models.switch_layers import QuantizedSwitchLinear, SwitchLinear
 
 
+def _pad_last_dim(x, size):
+    padding = size - x.shape[-1]
+    if padding == 0:
+        return x
+    return mx.pad(x, [(0, 0)] * (x.ndim - 1) + [(0, padding)])
+
+
+def _padded_size(size, group_size):
+    return ((size + group_size - 1) // group_size) * group_size
+
+
+def _quantize_matrix(weight, group_size, bits, mode):
+    values = mx.quantize(weight, group_size=group_size, bits=bits, mode=mode)
+    return values if len(values) == 3 else (*values, None)
+
+
 class LoRALinear(nn.Module):
     @staticmethod
     def from_base(
@@ -95,6 +111,146 @@ class LoRALinear(nn.Module):
     def __call__(self, x):
         y = self.linear(x)
         z = (self.dropout(x) @ self.lora_a) @ self.lora_b
+        return y + (self.scale * z).astype(x.dtype)
+
+    def to_quantized(
+        self,
+        group_size: int = 64,
+        bits: int = 8,
+        rank_group_size: int = 32,
+        mode: str = "affine",
+    ):
+        """Quantize this linear layer's LoRA matrices for inference."""
+        return QuantizedLoRALinear.from_lora(
+            self,
+            group_size=group_size,
+            bits=bits,
+            rank_group_size=rank_group_size,
+            mode=mode,
+        )
+
+
+class QuantizedLoRALinear(nn.Module):
+    """A linear layer with quantized low-rank adapter matrices.
+
+    The base linear layer is left unchanged. Adapter dimensions are padded as
+    needed because MLX quantization requires the final matrix dimension to be
+    divisible by the quantization group size.
+    """
+
+    @staticmethod
+    def from_lora(
+        lora: LoRALinear,
+        group_size: int = 64,
+        bits: int = 8,
+        rank_group_size: int = 32,
+        mode: str = "affine",
+    ):
+        input_dims, rank = lora.lora_a.shape
+        rank_b, output_dims = lora.lora_b.shape
+        if rank != rank_b:
+            raise ValueError(f"LoRA rank mismatch between A ({rank}) and B ({rank_b})")
+
+        quantized = QuantizedLoRALinear()
+        quantized.linear = lora.linear
+        quantized.dropout = lora.dropout
+        quantized.scale = lora.scale
+        quantized.bits = bits
+        quantized.group_size = group_size
+        quantized.rank_group_size = rank_group_size
+        quantized.mode = mode
+        quantized.input_dims = input_dims
+        quantized.output_dims = output_dims
+        quantized.rank = rank
+        quantized.padded_input_dims = _padded_size(input_dims, group_size)
+        quantized.padded_rank = _padded_size(rank, rank_group_size)
+
+        lora_a = _pad_last_dim(lora.lora_a.T, quantized.padded_input_dims)
+        lora_b = _pad_last_dim(lora.lora_b.T, quantized.padded_rank)
+        (
+            quantized.lora_a,
+            quantized.lora_a_scales,
+            quantized.lora_a_biases,
+        ) = _quantize_matrix(lora_a, group_size, bits, mode)
+        (
+            quantized.lora_b,
+            quantized.lora_b_scales,
+            quantized.lora_b_biases,
+        ) = _quantize_matrix(lora_b, rank_group_size, bits, mode)
+        quantized.freeze()
+        return quantized
+
+    def lora_delta(self, x):
+        x = _pad_last_dim(self.dropout(x), self.padded_input_dims)
+        z = mx.quantized_matmul(
+            x,
+            self.lora_a,
+            self.lora_a_scales,
+            self.lora_a_biases,
+            transpose=True,
+            group_size=self.group_size,
+            bits=self.bits,
+            mode=self.mode,
+        )
+        z = _pad_last_dim(z, self.padded_rank)
+        return mx.quantized_matmul(
+            z,
+            self.lora_b,
+            self.lora_b_scales,
+            self.lora_b_biases,
+            transpose=True,
+            group_size=self.rank_group_size,
+            bits=self.bits,
+            mode=self.mode,
+        )
+
+    def fuse(self, dequantize: bool = False):
+        linear = self.linear
+        weight = linear.weight
+        is_quantized = isinstance(linear, nn.QuantizedLinear)
+        if is_quantized:
+            weight = mx.dequantize(
+                weight,
+                linear.scales,
+                linear.biases,
+                group_size=linear.group_size,
+                bits=linear.bits,
+                mode=linear.mode,
+            )
+
+        lora_a = mx.dequantize(
+            self.lora_a,
+            self.lora_a_scales,
+            self.lora_a_biases,
+            group_size=self.group_size,
+            bits=self.bits,
+            mode=self.mode,
+        )[: self.rank, : self.input_dims]
+        lora_b = mx.dequantize(
+            self.lora_b,
+            self.lora_b_scales,
+            self.lora_b_biases,
+            group_size=self.rank_group_size,
+            bits=self.bits,
+            mode=self.mode,
+        )[:, : self.rank]
+
+        fused = nn.Linear(self.input_dims, self.output_dims, bias="bias" in linear)
+        fused.weight = weight + (self.scale * lora_b @ lora_a).astype(weight.dtype)
+        if "bias" in linear:
+            fused.bias = linear.bias
+        if is_quantized and not dequantize:
+            fused = nn.QuantizedLinear.from_linear(
+                fused,
+                group_size=linear.group_size,
+                bits=linear.bits,
+                mode=linear.mode,
+            )
+        return fused
+
+    def __call__(self, x):
+        y = self.linear(x)
+        z = self.lora_delta(x)
         return y + (self.scale * z).astype(x.dtype)
 
 

--- a/mlx_lm/tuner/lora_pack.py
+++ b/mlx_lm/tuner/lora_pack.py
@@ -1,0 +1,381 @@
+# Copyright © 2026 Apple Inc.
+
+from __future__ import annotations
+
+import json
+from collections.abc import Mapping, Sequence
+from dataclasses import dataclass
+from pathlib import Path
+
+import mlx.core as mx
+import mlx.nn as nn
+
+from .lora import QuantizedLoRALinear
+
+
+def _pad_last_dim(x, size):
+    padding = size - x.shape[-1]
+    if padding < 0:
+        raise ValueError(
+            f"Input dimension {x.shape[-1]} exceeds packed dimension {size}"
+        )
+    if padding == 0:
+        return x
+    return mx.pad(x, [(0, 0)] * (x.ndim - 1) + [(0, padding)])
+
+
+class QuantizedLoRAAdapterPack(nn.Module):
+    """Packed quantized LoRA weights for one target layer and many adapters.
+
+    All adapters must use the same dimensions and quantization settings. The
+    pack supports both homogeneous request-level selection and token-level
+    mixed-adapter routing without materializing floating-point LoRA matrices.
+    """
+
+    @classmethod
+    def from_weight_sets(
+        cls,
+        weight_sets: Sequence[Mapping[str, mx.array]],
+        scales: Sequence[float],
+        *,
+        group_size: int,
+        rank_group_size: int,
+        bits: int,
+        input_dims: int,
+        output_dims: int,
+        rank: int,
+        padded_input_dims: int,
+        padded_rank: int,
+        mode: str = "affine",
+    ):
+        if not weight_sets:
+            raise ValueError("Quantized LoRA adapter pack must not be empty")
+        if len(scales) != len(weight_sets):
+            raise ValueError("Expected one LoRA scale per packed adapter")
+        if mode != "affine":
+            raise ValueError("Adapter packs currently support affine mode")
+
+        names = (
+            "lora_a",
+            "lora_a_scales",
+            "lora_a_biases",
+            "lora_b",
+            "lora_b_scales",
+            "lora_b_biases",
+        )
+        expected_shapes = {
+            "lora_a": (rank, padded_input_dims * bits // 32),
+            "lora_a_scales": (rank, padded_input_dims // group_size),
+            "lora_a_biases": (rank, padded_input_dims // group_size),
+            "lora_b": (output_dims, padded_rank * bits // 32),
+            "lora_b_scales": (output_dims, padded_rank // rank_group_size),
+            "lora_b_biases": (output_dims, padded_rank // rank_group_size),
+        }
+        missing = [name for name in names if name not in weight_sets[0]]
+        if missing:
+            raise ValueError("Packed adapter is missing weights: " + ", ".join(missing))
+        reference_shapes = {name: weight_sets[0][name].shape for name in names}
+        if reference_shapes != expected_shapes:
+            raise ValueError("Packed adapter weight shapes do not match metadata")
+        for weights in weight_sets[1:]:
+            missing = [name for name in names if name not in weights]
+            if missing:
+                raise ValueError(
+                    "Packed adapter is missing weights: " + ", ".join(missing)
+                )
+            shapes = {name: weights[name].shape for name in names}
+            if shapes != reference_shapes:
+                raise ValueError("Packed adapter weight shapes must match")
+
+        pack = cls()
+        pack.input_dims = input_dims
+        pack.output_dims = output_dims
+        pack.rank = rank
+        pack.padded_input_dims = padded_input_dims
+        pack.padded_rank = padded_rank
+        if input_dims > pack.padded_input_dims or rank > pack.padded_rank:
+            raise ValueError("Packed adapter padding does not match metadata")
+        pack.group_size = group_size
+        pack.rank_group_size = rank_group_size
+        pack.bits = bits
+        pack.mode = mode
+        for name in names:
+            setattr(pack, name, mx.stack([weights[name] for weights in weight_sets]))
+        pack.scales = mx.array(scales)
+        pack.freeze()
+        mx.eval(pack.parameters())
+        return pack
+
+    @classmethod
+    def from_layers(
+        cls,
+        layers: Sequence[QuantizedLoRALinear],
+        scales: Sequence[float] | None = None,
+    ):
+        if not layers:
+            raise ValueError("Quantized LoRA adapter pack must not be empty")
+        if any(not isinstance(layer, QuantizedLoRALinear) for layer in layers):
+            raise TypeError("All adapter pack layers must be QuantizedLoRALinear")
+
+        first = layers[0]
+        settings = (
+            first.input_dims,
+            first.output_dims,
+            first.rank,
+            first.padded_input_dims,
+            first.padded_rank,
+            first.group_size,
+            first.rank_group_size,
+            first.bits,
+            first.mode,
+        )
+        for layer in layers[1:]:
+            candidate = (
+                layer.input_dims,
+                layer.output_dims,
+                layer.rank,
+                layer.padded_input_dims,
+                layer.padded_rank,
+                layer.group_size,
+                layer.rank_group_size,
+                layer.bits,
+                layer.mode,
+            )
+            if candidate != settings:
+                raise ValueError(
+                    "All packed adapters must share dimensions, rank, and "
+                    "quantization settings"
+                )
+        if first.mode != "affine":
+            raise ValueError("Adapter packs currently support affine mode")
+
+        if scales is None:
+            scales = [layer.scale for layer in layers]
+        if len(scales) != len(layers):
+            raise ValueError("Expected one LoRA scale per packed adapter")
+
+        pack = cls()
+        pack.input_dims = first.input_dims
+        pack.output_dims = first.output_dims
+        pack.rank = first.rank
+        pack.padded_input_dims = first.padded_input_dims
+        pack.padded_rank = first.padded_rank
+        pack.group_size = first.group_size
+        pack.rank_group_size = first.rank_group_size
+        pack.bits = first.bits
+        pack.mode = first.mode
+        pack.lora_a = mx.stack([layer.lora_a for layer in layers])
+        pack.lora_a_scales = mx.stack([layer.lora_a_scales for layer in layers])
+        pack.lora_a_biases = mx.stack([layer.lora_a_biases for layer in layers])
+        pack.lora_b = mx.stack([layer.lora_b for layer in layers])
+        pack.lora_b_scales = mx.stack([layer.lora_b_scales for layer in layers])
+        pack.lora_b_biases = mx.stack([layer.lora_b_biases for layer in layers])
+        pack.scales = mx.array(scales)
+        pack.freeze()
+        return pack
+
+    @property
+    def num_adapters(self):
+        return self.lora_a.shape[0]
+
+    @property
+    def adapter_bytes(self):
+        arrays = (
+            self.lora_a,
+            self.lora_a_scales,
+            self.lora_a_biases,
+            self.lora_b,
+            self.lora_b_scales,
+            self.lora_b_biases,
+            self.scales,
+        )
+        return sum(array.nbytes for array in arrays)
+
+    def _first_projection(self, x, lora_a, scales, biases):
+        x = _pad_last_dim(x, self.padded_input_dims)
+        return mx.quantized_matmul(
+            x,
+            lora_a,
+            scales,
+            biases,
+            transpose=True,
+            group_size=self.group_size,
+            bits=self.bits,
+            mode=self.mode,
+        )
+
+    def delta_for_adapter(self, x, adapter_index: int):
+        """Return the scaled LoRA delta for one adapter and arbitrary rows."""
+        if adapter_index < 0 or adapter_index >= self.num_adapters:
+            raise IndexError(f"Adapter index out of range: {adapter_index}")
+        z = self._first_projection(
+            x,
+            self.lora_a[adapter_index],
+            self.lora_a_scales[adapter_index],
+            self.lora_a_biases[adapter_index],
+        )
+        z = _pad_last_dim(z, self.padded_rank)
+        delta = mx.quantized_matmul(
+            z,
+            self.lora_b[adapter_index],
+            self.lora_b_scales[adapter_index],
+            self.lora_b_biases[adapter_index],
+            transpose=True,
+            group_size=self.rank_group_size,
+            bits=self.bits,
+            mode=self.mode,
+        )
+        return self.scales[adapter_index].astype(delta.dtype) * delta
+
+    def delta(self, x, adapter_indices):
+        """Return scaled LoRA deltas routed by flattened token-row indices."""
+        original_shape = tuple(x.shape)
+        flat_x = x.reshape((-1, original_shape[-1]))
+        adapter_indices = mx.array(adapter_indices, dtype=mx.int32).reshape(-1)
+        if adapter_indices.size != flat_x.shape[0]:
+            raise ValueError(
+                f"Expected {flat_x.shape[0]} adapter indices, "
+                f"received {adapter_indices.size}"
+            )
+
+        flat_x = _pad_last_dim(flat_x, self.padded_input_dims)
+        z = mx.gather_qmm(
+            mx.expand_dims(flat_x, -2),
+            self.lora_a,
+            self.lora_a_scales,
+            self.lora_a_biases,
+            rhs_indices=adapter_indices,
+            transpose=True,
+            group_size=self.group_size,
+            bits=self.bits,
+            mode=self.mode,
+            sorted_indices=False,
+        ).squeeze(-2)
+        z = _pad_last_dim(z, self.padded_rank)
+        delta = mx.gather_qmm(
+            mx.expand_dims(z, -2),
+            self.lora_b,
+            self.lora_b_scales,
+            self.lora_b_biases,
+            rhs_indices=adapter_indices,
+            transpose=True,
+            group_size=self.rank_group_size,
+            bits=self.bits,
+            mode=self.mode,
+            sorted_indices=False,
+        ).squeeze(-2)
+        scales = self.scales[adapter_indices].astype(delta.dtype).reshape((-1, 1))
+        delta = scales * delta
+        return delta.reshape(original_shape[:-1] + (self.output_dims,))
+
+
+@dataclass(frozen=True)
+class QuantizedLoRAAdapterBank:
+    adapter_names: tuple[str, ...]
+    packs: dict[str, QuantizedLoRAAdapterPack]
+
+    @property
+    def adapter_bytes(self):
+        return sum(pack.adapter_bytes for pack in self.packs.values())
+
+    def adapter_index(self, name: str):
+        try:
+            return self.adapter_names.index(name)
+        except ValueError as error:
+            raise KeyError(f"Unknown adapter: {name}") from error
+
+
+def load_quantized_lora_adapter_bank(
+    adapters: Mapping[str, str | Path],
+) -> QuantizedLoRAAdapterBank:
+    """Load packed adapter files into layer-wise banks without a base model."""
+    from .utils import (
+        QUANTIZED_LORA_FORMAT,
+        QUANTIZED_LORA_VERSION,
+        _parse_quantized_lora_layers,
+    )
+
+    if not adapters:
+        raise ValueError("Adapter bank must not be empty")
+
+    adapter_names = tuple(adapters)
+    loaded = []
+    reference_quantization = None
+    reference_layers = None
+    for name, path in adapters.items():
+        path = Path(path)
+        config = json.loads((path / "adapter_config.json").read_text(encoding="utf-8"))
+        quantization = config.get("adapter_quantization")
+        if quantization is None:
+            raise ValueError(f"Adapter '{name}' is not a quantized LoRA adapter")
+        if quantization.get("format") != QUANTIZED_LORA_FORMAT:
+            raise ValueError(f"Adapter '{name}' uses an unsupported format")
+        if quantization.get("version") != QUANTIZED_LORA_VERSION:
+            raise ValueError(f"Adapter '{name}' uses an unsupported version")
+        if quantization.get("mode") != "affine":
+            raise ValueError("Adapter banks currently support affine mode")
+
+        settings = {
+            "group_size": int(quantization["group_size"]),
+            "rank_group_size": int(quantization["rank_group_size"]),
+            "mode": quantization["mode"],
+        }
+        layers = _parse_quantized_lora_layers(quantization)
+        if reference_quantization is None:
+            reference_quantization = settings
+            reference_layers = layers
+        elif settings != reference_quantization or layers != reference_layers:
+            raise ValueError(
+                "All adapter-bank entries must share layer and quantization metadata"
+            )
+
+        lora_parameters = config.get("lora_parameters", {})
+        scale = float(lora_parameters.get("scale", 1.0))
+        weights = mx.load(str(path / "adapters.safetensors"))
+        weight_layers = {
+            key[: -len(".lora_a")] for key in weights if key.endswith(".lora_a")
+        }
+        if weight_layers != set(layers):
+            raise ValueError(
+                "Adapter banks require every LoRA layer to use packed "
+                f"quantization; adapter '{name}' has incompatible layers"
+            )
+        loaded.append((scale, weights))
+
+    suffixes = (
+        "lora_a",
+        "lora_a_scales",
+        "lora_a_biases",
+        "lora_b",
+        "lora_b_scales",
+        "lora_b_biases",
+    )
+    packs = {}
+    for layer_name, metadata in reference_layers.items():
+        weight_sets = []
+        for adapter_name, (_, weights) in zip(adapter_names, loaded):
+            missing = [
+                suffix for suffix in suffixes if f"{layer_name}.{suffix}" not in weights
+            ]
+            if missing:
+                raise ValueError(
+                    f"Adapter '{adapter_name}' layer '{layer_name}' is missing: "
+                    + ", ".join(missing)
+                )
+            weight_sets.append(
+                {suffix: weights[f"{layer_name}.{suffix}"] for suffix in suffixes}
+            )
+        packs[layer_name] = QuantizedLoRAAdapterPack.from_weight_sets(
+            weight_sets,
+            [scale for scale, _ in loaded],
+            group_size=reference_quantization["group_size"],
+            rank_group_size=reference_quantization["rank_group_size"],
+            bits=metadata["bits"],
+            input_dims=metadata["input_dims"],
+            output_dims=metadata["output_dims"],
+            rank=metadata["rank"],
+            padded_input_dims=metadata["padded_input_dims"],
+            padded_rank=metadata["padded_rank"],
+            mode=reference_quantization["mode"],
+        )
+    return QuantizedLoRAAdapterBank(adapter_names=adapter_names, packs=packs)

--- a/mlx_lm/tuner/utils.py
+++ b/mlx_lm/tuner/utils.py
@@ -4,7 +4,7 @@ import shutil
 import tempfile
 import types
 from pathlib import Path
-from typing import Dict, Optional
+from typing import Dict, Optional, Sequence, Tuple
 
 import mlx.core as mx
 import mlx.nn as nn
@@ -222,6 +222,105 @@ def quantize_lora_layers(
     if replacements:
         model.update_modules(tree_unflatten(replacements))
     return model
+
+
+def select_lora_layer_bits(
+    model: nn.Module,
+    layer_inputs: Dict[str, mx.array],
+    candidate_bits: Sequence[int] = (4, 5, 6, 8),
+    group_size: int = 64,
+    rank_group_size: int = 32,
+    mode: str = "affine",
+    max_relative_l2: float = 0.01,
+    min_cosine: float = 0.9999,
+    min_memory_reduction: float = 0.0,
+) -> Tuple[Dict[str, int], Dict[str, Dict]]:
+    """Select the lowest acceptable precision from real layer activations.
+
+    Layers that do not satisfy both error thresholds remain unquantized and
+    are omitted from the returned bit mapping.
+    """
+    candidate_bits = tuple(sorted(set(candidate_bits)))
+    if not candidate_bits:
+        raise ValueError("candidate_bits must not be empty")
+
+    lora_layers = {
+        name: module
+        for name, module in model.named_modules()
+        if isinstance(module, LoRALinear)
+    }
+    missing = sorted(set(layer_inputs) - set(lora_layers))
+    if missing:
+        raise ValueError(
+            "Calibration inputs reference missing LoRA linear layers: "
+            + ", ".join(missing)
+        )
+
+    selected = {}
+    report = {}
+    for name, x in layer_inputs.items():
+        layer = lora_layers[name]
+        if x.shape[-1] != layer.lora_a.shape[0]:
+            raise ValueError(
+                f"Calibration input for {name} has dimension {x.shape[-1]}, "
+                f"expected {layer.lora_a.shape[0]}"
+            )
+
+        reference = ((x @ layer.lora_a) @ layer.lora_b).astype(mx.float32)
+        mx.eval(reference)
+        reference_norm = float(mx.linalg.norm(reference))
+        float_bytes = layer.lora_a.nbytes + layer.lora_b.nbytes
+        candidates = {}
+        selected_bits = None
+        for bits in candidate_bits:
+            quantized = layer.to_quantized(
+                group_size=group_size,
+                bits=bits,
+                rank_group_size=rank_group_size,
+                mode=mode,
+            )
+            candidate = quantized.lora_delta(x).astype(mx.float32)
+            difference = candidate - reference
+            mx.eval(candidate, difference)
+            candidate_norm = float(mx.linalg.norm(candidate))
+            difference_norm = float(mx.linalg.norm(difference))
+            quantized_bytes = sum(
+                value.nbytes
+                for parameter_name, value in tree_flatten(quantized.parameters())
+                if parameter_name.startswith("lora_")
+            )
+            memory_reduction = 1 - quantized_bytes / float_bytes
+            if reference_norm == 0.0:
+                relative_l2 = 0.0 if difference_norm == 0.0 else float("inf")
+                cosine = 1.0 if candidate_norm == 0.0 else 0.0
+            else:
+                relative_l2 = difference_norm / reference_norm
+                cosine = float(
+                    mx.sum(reference * candidate)
+                    / (mx.linalg.norm(reference) * mx.linalg.norm(candidate) + 1e-12)
+                )
+            candidates[str(bits)] = {
+                "relative_l2": relative_l2,
+                "cosine": cosine,
+                "adapter_bytes": quantized_bytes,
+                "memory_reduction": memory_reduction,
+            }
+            if (
+                selected_bits is None
+                and relative_l2 <= max_relative_l2
+                and cosine >= min_cosine
+                and memory_reduction >= min_memory_reduction
+            ):
+                selected_bits = bits
+
+        if selected_bits is not None:
+            selected[name] = selected_bits
+        report[name] = {
+            "selected_bits": selected_bits,
+            "float_adapter_bytes": float_bytes,
+            "candidates": candidates,
+        }
+    return selected, report
 
 
 def save_quantized_adapter(

--- a/mlx_lm/tuner/utils.py
+++ b/mlx_lm/tuner/utils.py
@@ -1,9 +1,12 @@
 # Copyright © 2024 Apple Inc.
 import json
+import shutil
+import tempfile
 import types
 from pathlib import Path
-from typing import Dict
+from typing import Dict, Optional
 
+import mlx.core as mx
 import mlx.nn as nn
 import mlx.optimizers as opt
 from mlx.utils import tree_flatten, tree_unflatten
@@ -12,7 +15,72 @@ from ..cli_ui import rprint
 from ..models.switch_layers import QuantizedSwitchLinear, SwitchLinear
 from ..utils import get_total_parameters
 from .dora import DoRAEmbedding, DoRALinear
-from .lora import LoRAEmbedding, LoRALinear, LoRASwitchLinear
+from .lora import LoRAEmbedding, LoRALinear, LoRASwitchLinear, QuantizedLoRALinear
+
+QUANTIZED_LORA_FORMAT = "mlx_lm.quantized_lora"
+QUANTIZED_LORA_VERSION = 1
+
+
+def _parse_quantized_lora_layers(quantization: Dict) -> Dict[str, Dict[str, int]]:
+    try:
+        group_size = int(quantization["group_size"])
+        rank_group_size = int(quantization["rank_group_size"])
+    except (KeyError, TypeError, ValueError) as error:
+        raise ValueError("Quantized LoRA adapter has invalid group sizes") from error
+    if group_size not in (32, 64, 128):
+        raise ValueError(f"Unsupported LoRA group size: {group_size}")
+    if rank_group_size not in (32, 64, 128):
+        raise ValueError(f"Unsupported LoRA rank group size: {rank_group_size}")
+
+    layers = quantization.get("layers")
+    if not isinstance(layers, dict) or not layers:
+        raise ValueError("Quantized LoRA adapter has no layer metadata")
+
+    required = {
+        "bits",
+        "input_dims",
+        "output_dims",
+        "rank",
+        "padded_input_dims",
+        "padded_rank",
+    }
+    parsed = {}
+    for name, metadata in layers.items():
+        if not isinstance(metadata, dict):
+            raise ValueError(f"Quantized LoRA layer '{name}' has invalid metadata")
+        missing = sorted(required - set(metadata))
+        if missing:
+            raise ValueError(
+                f"Quantized LoRA layer '{name}' is missing metadata: "
+                + ", ".join(missing)
+            )
+        values = {key: int(metadata[key]) for key in required}
+        if any(value <= 0 for value in values.values()):
+            raise ValueError(f"Quantized LoRA layer '{name}' metadata must be positive")
+        if values["padded_input_dims"] < values["input_dims"]:
+            raise ValueError(f"Quantized LoRA layer '{name}' has invalid input padding")
+        if values["padded_rank"] < values["rank"]:
+            raise ValueError(f"Quantized LoRA layer '{name}' has invalid rank padding")
+        if values["bits"] not in (2, 3, 4, 5, 6, 8):
+            raise ValueError(f"Quantized LoRA layer '{name}' has unsupported bit width")
+        expected_input = (
+            (values["input_dims"] + group_size - 1) // group_size * group_size
+        )
+        expected_rank = (
+            (values["rank"] + rank_group_size - 1) // rank_group_size * rank_group_size
+        )
+        if values["padded_input_dims"] != expected_input:
+            raise ValueError(
+                f"Quantized LoRA layer '{name}' input padding does not match "
+                "the group size"
+            )
+        if values["padded_rank"] != expected_rank:
+            raise ValueError(
+                f"Quantized LoRA layer '{name}' rank padding does not match "
+                "the rank group size"
+            )
+        parsed[name] = values
+    return parsed
 
 
 def build_schedule(schedule_config: Dict):
@@ -110,6 +178,138 @@ def linear_to_lora_layers(
         model.update_modules(tree_unflatten(lora_modules))
 
 
+def quantize_lora_layers(
+    model: nn.Module,
+    group_size: int = 64,
+    bits: int = 8,
+    rank_group_size: int = 32,
+    mode: str = "affine",
+    layer_bits: Optional[Dict[str, int]] = None,
+):
+    """Replace all LoRA linear layers with quantized inference layers.
+
+    LoRA embedding and switch-linear layers are left unchanged.
+    """
+    lora_layers = {
+        name: module
+        for name, module in model.named_modules()
+        if isinstance(module, LoRALinear)
+    }
+    if layer_bits is None:
+        selected_layers = {name: bits for name in lora_layers}
+    else:
+        missing = sorted(set(layer_bits) - set(lora_layers))
+        if missing:
+            raise ValueError(
+                "Quantized LoRA metadata references missing linear layers: "
+                + ", ".join(missing)
+            )
+        selected_layers = layer_bits
+
+    replacements = []
+    for name, layer_bits_value in selected_layers.items():
+        replacements.append(
+            (
+                name,
+                lora_layers[name].to_quantized(
+                    group_size=group_size,
+                    bits=layer_bits_value,
+                    rank_group_size=rank_group_size,
+                    mode=mode,
+                ),
+            )
+        )
+    if replacements:
+        model.update_modules(tree_unflatten(replacements))
+    return model
+
+
+def save_quantized_adapter(
+    model: nn.Module,
+    source_adapter_path: str,
+    output_path: str,
+) -> Path:
+    """Save a model's quantized LoRA layers as a directly loadable adapter."""
+    source_adapter_path = Path(source_adapter_path)
+    output_path = Path(output_path)
+    if output_path.exists():
+        raise FileExistsError(f"Output path already exists: {output_path}")
+
+    config_path = source_adapter_path / "adapter_config.json"
+    with open(config_path, "r", encoding="utf-8") as fid:
+        config = json.load(fid)
+    if config.get("fine_tune_type", "lora") != "lora":
+        raise ValueError("Only LoRA adapters can be quantized")
+    if "adapter_quantization" in config:
+        raise ValueError("The source adapter is already quantized")
+
+    quantized_layers = {
+        name: module
+        for name, module in model.named_modules()
+        if isinstance(module, QuantizedLoRALinear)
+    }
+    if not quantized_layers:
+        raise ValueError("The model has no quantized LoRA linear layers")
+
+    settings = {
+        (module.group_size, module.rank_group_size, module.mode)
+        for module in quantized_layers.values()
+    }
+    if len(settings) != 1:
+        raise ValueError(
+            "All persisted LoRA layers must use the same group sizes and mode"
+        )
+    group_size, rank_group_size, mode = settings.pop()
+    if mode != "affine":
+        raise ValueError("Persisted quantized LoRA currently supports affine mode")
+
+    adapter_weights = {
+        name: value
+        for name, value in tree_flatten(model.parameters())
+        if any(part.startswith("lora_") for part in name.split("."))
+    }
+    if not adapter_weights:
+        raise ValueError("No LoRA adapter parameters were found")
+
+    config["adapter_quantization"] = {
+        "format": QUANTIZED_LORA_FORMAT,
+        "version": QUANTIZED_LORA_VERSION,
+        "group_size": group_size,
+        "rank_group_size": rank_group_size,
+        "mode": mode,
+        "layers": {
+            name: {
+                "bits": module.bits,
+                "input_dims": module.input_dims,
+                "output_dims": module.output_dims,
+                "rank": module.rank,
+                "padded_input_dims": module.padded_input_dims,
+                "padded_rank": module.padded_rank,
+            }
+            for name, module in sorted(quantized_layers.items())
+        },
+    }
+
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    temporary_path = Path(
+        tempfile.mkdtemp(prefix=f".{output_path.name}.", dir=output_path.parent)
+    )
+    try:
+        mx.save_safetensors(
+            str(temporary_path / "adapters.safetensors"),
+            adapter_weights,
+        )
+        (temporary_path / "adapter_config.json").write_text(
+            json.dumps(config, indent=2, sort_keys=True) + "\n",
+            encoding="utf-8",
+        )
+        temporary_path.replace(output_path)
+    except Exception:
+        shutil.rmtree(temporary_path, ignore_errors=True)
+        raise
+    return output_path
+
+
 def load_adapters(model: nn.Module, adapter_path: str) -> nn.Module:
     """
     Load any fine-tuned adapters / layers.
@@ -124,8 +324,9 @@ def load_adapters(model: nn.Module, adapter_path: str) -> nn.Module:
     adapter_path = Path(adapter_path)
     if not adapter_path.exists():
         raise FileNotFoundError(f"The adapter path does not exist: {adapter_path}")
-    with open(adapter_path / "adapter_config.json", "r") as fid:
-        config = types.SimpleNamespace(**json.load(fid))
+    with open(adapter_path / "adapter_config.json", "r", encoding="utf-8") as fid:
+        config_dict = json.load(fid)
+    config = types.SimpleNamespace(**config_dict)
     fine_tune_type = getattr(config, "fine_tune_type", "lora")
     if fine_tune_type != "full":
         linear_to_lora_layers(
@@ -134,7 +335,63 @@ def load_adapters(model: nn.Module, adapter_path: str) -> nn.Module:
             config.lora_parameters,
             use_dora=(fine_tune_type == "dora"),
         )
-    model.load_weights(str(adapter_path / "adapters.safetensors"), strict=False)
+    quantization = config_dict.get("adapter_quantization")
+    adapter_file = adapter_path / "adapters.safetensors"
+    if quantization is not None:
+        if quantization.get("format") != QUANTIZED_LORA_FORMAT:
+            raise ValueError("Unsupported quantized LoRA adapter format")
+        if quantization.get("version") != QUANTIZED_LORA_VERSION:
+            raise ValueError("Unsupported quantized LoRA adapter version")
+        if quantization.get("mode") != "affine":
+            raise ValueError("Persisted quantized LoRA currently supports affine mode")
+        layers = _parse_quantized_lora_layers(quantization)
+        layer_bits = {name: metadata["bits"] for name, metadata in layers.items()}
+        quantize_lora_layers(
+            model,
+            group_size=int(quantization["group_size"]),
+            rank_group_size=int(quantization["rank_group_size"]),
+            mode=quantization["mode"],
+            layer_bits=layer_bits,
+        )
+        model_layers = dict(model.named_modules())
+        for name, metadata in layers.items():
+            layer = model_layers[name]
+            actual = {
+                "bits": layer.bits,
+                "input_dims": layer.input_dims,
+                "output_dims": layer.output_dims,
+                "rank": layer.rank,
+                "padded_input_dims": layer.padded_input_dims,
+                "padded_rank": layer.padded_rank,
+            }
+            if actual != metadata:
+                raise ValueError(
+                    f"Quantized LoRA layer '{name}' metadata does not match "
+                    "the base model"
+                )
+        adapter_weights = mx.load(str(adapter_file))
+        suffixes = (
+            "lora_a",
+            "lora_a_scales",
+            "lora_a_biases",
+            "lora_b",
+            "lora_b_scales",
+            "lora_b_biases",
+        )
+        missing_weights = [
+            f"{name}.{suffix}"
+            for name in layer_bits
+            for suffix in suffixes
+            if f"{name}.{suffix}" not in adapter_weights
+        ]
+        if missing_weights:
+            raise ValueError(
+                "Quantized LoRA adapter is missing weights: "
+                + ", ".join(missing_weights)
+            )
+        model.load_weights(list(adapter_weights.items()), strict=False)
+    else:
+        model.load_weights(str(adapter_file), strict=False)
     return model
 
 
@@ -150,7 +407,7 @@ def remove_lora_layers(model: nn.Module) -> nn.Module:
     """
     reset_layers = []
     for name, module in model.named_modules():
-        if isinstance(module, LoRALinear):
+        if isinstance(module, (LoRALinear, QuantizedLoRALinear)):
             reset_layers.append((name, module.linear))
     if len(reset_layers) > 0:
         model.update_modules(tree_unflatten(reset_layers))

--- a/setup.py
+++ b/setup.py
@@ -65,6 +65,7 @@ setup(
             "mlx_lm.generate = mlx_lm.generate:main",
             "mlx_lm.lora = mlx_lm.lora:main",
             "mlx_lm.perplexity = mlx_lm.perplexity:main",
+            "mlx_lm.quantize_adapter = mlx_lm.quantize_adapter:main",
             "mlx_lm.server = mlx_lm.server:main",
             "mlx_lm.share = mlx_lm.share:main",
             "mlx_lm.manage = mlx_lm.manage:main",

--- a/tests/test_finetune.py
+++ b/tests/test_finetune.py
@@ -14,9 +14,9 @@ from mlx.utils import tree_flatten
 
 from mlx_lm import lora, tuner
 from mlx_lm.tuner.dora import DoRAEmbedding, DoRALinear
-from mlx_lm.tuner.lora import LoRAEmbedding, LoRALinear
+from mlx_lm.tuner.lora import LoRAEmbedding, LoRALinear, QuantizedLoRALinear
 from mlx_lm.tuner.trainer import evaluate
-from mlx_lm.tuner.utils import build_schedule
+from mlx_lm.tuner.utils import build_schedule, quantize_lora_layers, remove_lora_layers
 
 
 @contextmanager
@@ -28,6 +28,85 @@ def swapped_with_identity(obj, func):
 
 
 class TestLora(unittest.TestCase):
+    def test_quantize_and_remove_lora_layers(self):
+        class Model(nn.Module):
+            def __init__(self):
+                super().__init__()
+                self.proj = LoRALinear.from_base(
+                    nn.Linear(64, 32),
+                    r=8,
+                    dropout=0.0,
+                    scale=2.0,
+                )
+
+        model = Model()
+        base = model.proj.linear
+        quantize_lora_layers(
+            model,
+            group_size=32,
+            bits=8,
+            rank_group_size=32,
+        )
+        self.assertIsInstance(model.proj, QuantizedLoRALinear)
+        self.assertIs(model.proj.linear, base)
+
+        remove_lora_layers(model)
+        self.assertIs(model.proj, base)
+
+    def test_quantized_lora_linear(self):
+        mx.random.seed(7)
+        linear = nn.Linear(70, 45, bias=False)
+        linear.weight = mx.zeros_like(linear.weight)
+        lora = LoRALinear.from_base(linear, r=7, dropout=0.0, scale=2.0)
+        lora.lora_a = mx.random.normal(lora.lora_a.shape)
+        lora.lora_b = mx.random.normal(lora.lora_b.shape)
+        x = mx.random.normal((2, 3, 70))
+
+        reference = lora(x)
+        thresholds = {8: 0.999, 6: 0.999, 5: 0.995, 4: 0.99}
+        for bits, threshold in thresholds.items():
+            with self.subTest(bits=bits):
+                quantized = lora.to_quantized(
+                    group_size=32,
+                    bits=bits,
+                    rank_group_size=32,
+                )
+                candidate = quantized(x)
+                mx.eval(reference, candidate)
+
+                self.assertIsInstance(quantized, QuantizedLoRALinear)
+                self.assertEqual(candidate.shape, reference.shape)
+                self.assertEqual(quantized.padded_input_dims, 96)
+                self.assertEqual(quantized.padded_rank, 32)
+                cosine = mx.sum(reference * candidate) / (
+                    mx.linalg.norm(reference) * mx.linalg.norm(candidate)
+                )
+                self.assertGreater(float(cosine), threshold)
+
+    def test_quantized_lora_with_quantized_base(self):
+        mx.random.seed(11)
+        linear = nn.Linear(64, 32, bias=False)
+        base = nn.QuantizedLinear.from_linear(linear, group_size=32, bits=8)
+        lora = LoRALinear.from_base(base, r=8, dropout=0.0, scale=2.0)
+        lora.lora_a = mx.random.normal(lora.lora_a.shape)
+        lora.lora_b = mx.random.normal(lora.lora_b.shape)
+        quantized = lora.to_quantized(group_size=32, bits=4, rank_group_size=32)
+        x = mx.random.normal((2, 64))
+        output = quantized(x)
+        mx.eval(output)
+
+        self.assertEqual(output.shape, (2, 32))
+        self.assertIsInstance(quantized.linear, nn.QuantizedLinear)
+
+        fused = quantized.fuse(dequantize=True)
+        fused_output = fused(x)
+        mx.eval(fused_output)
+        self.assertEqual(fused_output.shape, (2, 32))
+        cosine = mx.sum(output * fused_output) / (
+            mx.linalg.norm(output) * mx.linalg.norm(fused_output)
+        )
+        self.assertGreater(float(cosine), 0.999)
+
     def test_llama(self):
         from mlx_lm.models import llama
 

--- a/tests/test_quantized_lora.py
+++ b/tests/test_quantized_lora.py
@@ -11,11 +11,16 @@ from mlx.utils import tree_flatten
 
 from mlx_lm.models import llama
 from mlx_lm.tuner.lora import LoRALinear, QuantizedLoRALinear
+from mlx_lm.tuner.lora_pack import (
+    QuantizedLoRAAdapterPack,
+    load_quantized_lora_adapter_bank,
+)
 from mlx_lm.tuner.utils import (
     linear_to_lora_layers,
     load_adapters,
     quantize_lora_layers,
     save_quantized_adapter,
+    select_lora_layer_bits,
 )
 
 
@@ -66,6 +71,27 @@ def save_float_adapter(model, path: Path):
         str(path / "adapters.safetensors"),
         dict(tree_flatten(model.trainable_parameters())),
     )
+
+
+def make_quantized_layers(count, bits=8):
+    layers = []
+    for index in range(count):
+        lora = LoRALinear.from_base(
+            nn.Linear(64, 32, bias=False),
+            r=8,
+            dropout=0.0,
+            scale=1.0 + index / 10,
+        )
+        lora.lora_a = mx.random.normal(lora.lora_a.shape)
+        lora.lora_b = mx.random.normal(lora.lora_b.shape)
+        layers.append(
+            lora.to_quantized(
+                group_size=32,
+                bits=bits,
+                rank_group_size=32,
+            )
+        )
+    return layers
 
 
 class TestQuantizedLoraAdapter(unittest.TestCase):
@@ -123,6 +149,83 @@ class TestQuantizedLoraAdapter(unittest.TestCase):
         self.assertGreater(cosine, 0.99999)
         self.assertLess(float(mx.max(mx.abs(difference))), 0.005)
 
+    def test_load_quantized_adapter_bank_without_base_models(self):
+        with tempfile.TemporaryDirectory() as directory:
+            directory = Path(directory)
+            adapter_paths = {}
+            models = []
+            for index, name in enumerate(("first", "second", "third")):
+                source_path = directory / f"source-{name}"
+                output_path = directory / f"quantized-{name}"
+                model = make_lora_model(seed=31 + index)
+                save_float_adapter(model, source_path)
+                quantize_lora_layers(model, group_size=32, bits=8)
+                save_quantized_adapter(model, source_path, output_path)
+                adapter_paths[name] = output_path
+                models.append(model)
+
+            bank = load_quantized_lora_adapter_bank(adapter_paths)
+            self.assertEqual(bank.adapter_names, ("first", "second", "third"))
+            self.assertEqual(bank.adapter_index("second"), 1)
+            self.assertGreater(bank.adapter_bytes, 0)
+            with self.assertRaises(KeyError):
+                bank.adapter_index("missing")
+
+            x = mx.random.normal((2, 70))
+            pack = bank.packs["layers.0.proj"]
+            self.assertEqual(pack.input_dims, 70)
+            self.assertEqual(pack.output_dims, 45)
+            self.assertEqual(pack.rank, 7)
+            for index, model in enumerate(models):
+                expected = model.layers[0].proj.scale * model.layers[0].proj.lora_delta(
+                    x
+                )
+                candidate = pack.delta_for_adapter(x, index)
+                mx.eval(expected, candidate)
+                self.assertTrue(mx.array_equal(expected, candidate))
+
+    def test_quantized_adapter_pack_routes_mixed_rows(self):
+        mx.random.seed(23)
+        layers = make_quantized_layers(3)
+        pack = QuantizedLoRAAdapterPack.from_layers(layers)
+        x = mx.random.normal((2, 3, 64))
+        indices = mx.array([[0, 1, 2], [2, 0, 1]], dtype=mx.int32)
+        candidate = pack.delta(x, indices)
+
+        flat_x = x.reshape((-1, 64))
+        flat_indices = indices.reshape(-1)
+        reference = mx.concatenate(
+            [
+                layers[int(flat_indices[row])].scale
+                * layers[int(flat_indices[row])].lora_delta(flat_x[row : row + 1])
+                for row in range(flat_x.shape[0])
+            ],
+            axis=0,
+        ).reshape((2, 3, 32))
+        mx.eval(candidate, reference)
+
+        self.assertTrue(mx.allclose(candidate, reference, rtol=1e-5, atol=5e-5))
+        self.assertEqual(candidate.shape, (2, 3, 32))
+        self.assertEqual(pack.num_adapters, 3)
+
+        homogeneous = pack.delta_for_adapter(x, 1)
+        expected = layers[1].scale * layers[1].lora_delta(x)
+        mx.eval(homogeneous, expected)
+        self.assertTrue(mx.array_equal(homogeneous, expected))
+
+    def test_quantized_adapter_pack_validates_its_contract(self):
+        mx.random.seed(29)
+        layers = make_quantized_layers(2)
+        mismatched = make_quantized_layers(1, bits=4)[0]
+        with self.assertRaisesRegex(ValueError, "share dimensions"):
+            QuantizedLoRAAdapterPack.from_layers([layers[0], mismatched])
+
+        pack = QuantizedLoRAAdapterPack.from_layers(layers)
+        with self.assertRaisesRegex(ValueError, "adapter indices"):
+            pack.delta(mx.zeros((3, 64)), [0, 1])
+        with self.assertRaises(IndexError):
+            pack.delta_for_adapter(mx.zeros((1, 64)), 2)
+
     def test_persist_and_directly_load_mixed_bits(self):
         with tempfile.TemporaryDirectory() as directory:
             directory = Path(directory)
@@ -179,6 +282,55 @@ class TestQuantizedLoraAdapter(unittest.TestCase):
             output_size = (output_path / "adapters.safetensors").stat().st_size
             self.assertLess(output_size, source_size)
 
+    def test_select_layer_bits_uses_error_thresholds(self):
+        model = make_lora_model()
+        layer_inputs = {
+            "layers.0.proj": mx.random.normal((2, 3, 70)),
+            "layers.1.proj": mx.random.normal((2, 3, 70)),
+        }
+        selected, report = select_lora_layer_bits(
+            model,
+            layer_inputs,
+            candidate_bits=(4, 8),
+            max_relative_l2=1.0,
+            min_cosine=0.0,
+            min_memory_reduction=-1.0,
+        )
+        self.assertEqual(
+            selected,
+            {
+                "layers.0.proj": 4,
+                "layers.1.proj": 4,
+            },
+        )
+        self.assertEqual(report["layers.0.proj"]["selected_bits"], 4)
+
+        selected, report = select_lora_layer_bits(
+            model,
+            layer_inputs,
+            candidate_bits=(4, 8),
+            max_relative_l2=0.0,
+            min_cosine=1.0,
+            min_memory_reduction=-1.0,
+        )
+        self.assertEqual(selected, {})
+        self.assertIsNone(report["layers.0.proj"]["selected_bits"])
+
+        model.layers[0].proj.lora_a = model.layers[0].proj.lora_a.astype(mx.float16)
+        model.layers[0].proj.lora_b = model.layers[0].proj.lora_b.astype(mx.float16)
+        selected, report = select_lora_layer_bits(
+            model,
+            {"layers.0.proj": layer_inputs["layers.0.proj"]},
+            candidate_bits=(8,),
+            max_relative_l2=1.0,
+            min_cosine=0.0,
+        )
+        self.assertEqual(selected, {})
+        self.assertLess(
+            report["layers.0.proj"]["candidates"]["8"]["memory_reduction"],
+            0.0,
+        )
+
     def test_missing_quantized_weight_is_rejected(self):
         with tempfile.TemporaryDirectory() as directory:
             directory = Path(directory)
@@ -199,6 +351,26 @@ class TestQuantizedLoraAdapter(unittest.TestCase):
             loaded.freeze()
             with self.assertRaisesRegex(ValueError, "missing weights"):
                 load_adapters(loaded, output_path)
+
+    def test_adapter_bank_rejects_shape_metadata_mismatch(self):
+        with tempfile.TemporaryDirectory() as directory:
+            directory = Path(directory)
+            source_path = directory / "source"
+            output_path = directory / "quantized"
+            model = make_lora_model()
+            save_float_adapter(model, source_path)
+            quantize_lora_layers(model, group_size=32, bits=8)
+            save_quantized_adapter(model, source_path, output_path)
+
+            config_path = output_path / "adapter_config.json"
+            config = json.loads(config_path.read_text())
+            config["adapter_quantization"]["layers"]["layers.0.proj"][
+                "output_dims"
+            ] += 1
+            config_path.write_text(json.dumps(config))
+
+            with self.assertRaisesRegex(ValueError, "shapes do not match metadata"):
+                load_quantized_lora_adapter_bank({"invalid": output_path})
 
 
 if __name__ == "__main__":

--- a/tests/test_quantized_lora.py
+++ b/tests/test_quantized_lora.py
@@ -1,0 +1,205 @@
+# Copyright © 2026 Apple Inc.
+
+import json
+import tempfile
+import unittest
+from pathlib import Path
+
+import mlx.core as mx
+import mlx.nn as nn
+from mlx.utils import tree_flatten
+
+from mlx_lm.models import llama
+from mlx_lm.tuner.lora import LoRALinear, QuantizedLoRALinear
+from mlx_lm.tuner.utils import (
+    linear_to_lora_layers,
+    load_adapters,
+    quantize_lora_layers,
+    save_quantized_adapter,
+)
+
+
+class Block(nn.Module):
+    def __init__(self):
+        super().__init__()
+        self.proj = nn.Linear(70, 45)
+
+
+class Model(nn.Module):
+    def __init__(self):
+        super().__init__()
+        self.layers = [Block(), Block(), Block()]
+
+    def __call__(self, x):
+        return sum(layer.proj(x) for layer in self.layers)
+
+
+LORA_CONFIG = {
+    "rank": 7,
+    "dropout": 0.0,
+    "scale": 2.0,
+    "keys": ["proj"],
+}
+
+
+def make_lora_model(seed=19):
+    mx.random.seed(seed)
+    model = Model()
+    model.freeze()
+    linear_to_lora_layers(model, 3, LORA_CONFIG)
+    for _, module in model.named_modules():
+        if hasattr(module, "lora_b"):
+            module.lora_b = mx.random.normal(module.lora_b.shape)
+    model.eval()
+    return model
+
+
+def save_float_adapter(model, path: Path):
+    path.mkdir()
+    config = {
+        "fine_tune_type": "lora",
+        "num_layers": 3,
+        "lora_parameters": LORA_CONFIG,
+    }
+    (path / "adapter_config.json").write_text(json.dumps(config))
+    mx.save_safetensors(
+        str(path / "adapters.safetensors"),
+        dict(tree_flatten(model.trainable_parameters())),
+    )
+
+
+class TestQuantizedLoraAdapter(unittest.TestCase):
+    def test_q8_adapter_preserves_tiny_transformer_logits(self):
+        args = llama.ModelArgs(
+            model_type="llama",
+            hidden_size=64,
+            num_hidden_layers=2,
+            intermediate_size=128,
+            num_attention_heads=4,
+            num_key_value_heads=4,
+            rms_norm_eps=1e-5,
+            vocab_size=128,
+            tie_word_embeddings=False,
+        )
+        mx.random.seed(47)
+        model = llama.Model(args)
+        model.freeze()
+        linear_to_lora_layers(
+            model,
+            2,
+            {
+                "rank": 8,
+                "dropout": 0.0,
+                "scale": 2.0,
+                "keys": ["self_attn.q_proj", "self_attn.v_proj"],
+            },
+        )
+        for _, module in model.named_modules():
+            if hasattr(module, "lora_b"):
+                module.lora_b = 0.02 * mx.random.normal(module.lora_b.shape)
+        model.eval()
+
+        tokens = mx.array([[1, 7, 13, 21, 34]], dtype=mx.int32)
+        reference = model(tokens).astype(mx.float32)
+        mx.eval(reference)
+        quantize_lora_layers(
+            model,
+            group_size=32,
+            bits=8,
+            rank_group_size=32,
+        )
+        candidate = model(tokens).astype(mx.float32)
+        difference = candidate - reference
+        mx.eval(candidate, difference)
+
+        relative_l2 = float(mx.linalg.norm(difference)) / float(
+            mx.linalg.norm(reference)
+        )
+        cosine = float(
+            mx.sum(reference * candidate)
+            / (mx.linalg.norm(reference) * mx.linalg.norm(candidate))
+        )
+        self.assertLess(relative_l2, 0.002)
+        self.assertGreater(cosine, 0.99999)
+        self.assertLess(float(mx.max(mx.abs(difference))), 0.005)
+
+    def test_persist_and_directly_load_mixed_bits(self):
+        with tempfile.TemporaryDirectory() as directory:
+            directory = Path(directory)
+            source_path = directory / "source"
+            output_path = directory / "quantized"
+            model = make_lora_model()
+            save_float_adapter(model, source_path)
+
+            layer_bits = {
+                "layers.0.proj": 8,
+                "layers.1.proj": 4,
+            }
+            quantize_lora_layers(
+                model,
+                group_size=32,
+                rank_group_size=32,
+                layer_bits=layer_bits,
+            )
+            x = mx.random.normal((2, 3, 70))
+            reference = model(x)
+            mx.eval(reference)
+            save_quantized_adapter(model, source_path, output_path)
+
+            mx.random.seed(19)
+            loaded = Model()
+            loaded.freeze()
+            load_adapters(loaded, output_path)
+            loaded.eval()
+            candidate = loaded(x)
+            mx.eval(candidate)
+
+            self.assertTrue(mx.array_equal(reference, candidate))
+            self.assertIsInstance(loaded.layers[0].proj, QuantizedLoRALinear)
+            self.assertIsInstance(loaded.layers[1].proj, QuantizedLoRALinear)
+            self.assertIsInstance(loaded.layers[2].proj, LoRALinear)
+            self.assertEqual(loaded.layers[0].proj.bits, 8)
+            self.assertEqual(loaded.layers[1].proj.bits, 4)
+
+            saved_config = json.loads((output_path / "adapter_config.json").read_text())
+            self.assertEqual(
+                {
+                    name: metadata["bits"]
+                    for name, metadata in saved_config["adapter_quantization"][
+                        "layers"
+                    ].items()
+                },
+                layer_bits,
+            )
+            saved_weights = mx.load(str(output_path / "adapters.safetensors"))
+            self.assertEqual(saved_weights["layers.0.proj.lora_a"].dtype, mx.uint32)
+            self.assertEqual(saved_weights["layers.1.proj.lora_b"].dtype, mx.uint32)
+
+            source_size = (source_path / "adapters.safetensors").stat().st_size
+            output_size = (output_path / "adapters.safetensors").stat().st_size
+            self.assertLess(output_size, source_size)
+
+    def test_missing_quantized_weight_is_rejected(self):
+        with tempfile.TemporaryDirectory() as directory:
+            directory = Path(directory)
+            source_path = directory / "source"
+            output_path = directory / "quantized"
+            model = make_lora_model()
+            save_float_adapter(model, source_path)
+            quantize_lora_layers(model, group_size=32, bits=8)
+            save_quantized_adapter(model, source_path, output_path)
+
+            adapter_file = output_path / "adapters.safetensors"
+            weights = mx.load(str(adapter_file))
+            del weights["layers.0.proj.lora_a_scales"]
+            mx.save_safetensors(str(adapter_file), weights)
+
+            mx.random.seed(19)
+            loaded = Model()
+            loaded.freeze()
+            with self.assertRaisesRegex(ValueError, "missing weights"):
+                load_adapters(loaded, output_path)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
> [!IMPORTANT]
> This is a stacked follow-up to #1538. PR #1538 introduces the persistent runtime-quantized LoRA format and must be reviewed and merged first. Until then, GitHub shows both commits in this pull request because the base branch lives in a fork. The incremental PR 2 diff is available here: https://github.com/HongyuChen0926/mlx-lm/compare/feature/runtime-quantized-lora...feature/quantized-lora-adapter-bank

## Relationship to PR #1538

PR #1538 provides the foundation used here:

- `QuantizedLoRALinear` with packed A and B matrices evaluated by `mx.quantized_matmul`.
- A versioned persistent adapter format containing packed weights and strict metadata.
- Direct loading through the normal `adapter_path` interface.
- The conversion CLI, numerical tests, and single-adapter benchmark.

This follow-up does not change that format. It builds a multi-adapter runtime on top of the packed files from PR #1538.

## Summary

- Add `QuantizedLoRAAdapterPack`, which stacks one target layer from multiple adapters while keeping all matrices packed.
- Add `QuantizedLoRAAdapterBank`, with stable name-to-index lookup and layer-wise packs that do not duplicate the base model.
- Load multiple persistent quantized adapters directly from disk without constructing a base model per adapter.
- Support request-level adapter selection with two `mx.quantized_matmul` operations.
- Support per-token-row adapter routing with two `mx.gather_qmm` operations.
- Add activation-based mixed-precision selection across Q4, Q5, Q6, and Q8 with numerical-error and actual-memory thresholds.
- Add 10, 50, and 100-adapter memory/routing benchmarks and focused contract tests.

## Motivation

The main use case is not accelerating one small LoRA branch. It is keeping more task- or user-specific adapters resident next to one shared base model while preserving dynamic selection. Packed runtime storage is particularly useful for endpoint deployments where fusing every adapter would duplicate the base model and loading adapters on demand would add switching latency.

## Design

- Adapter packs store stacked packed `uint32` weights, affine scales, affine biases, and one LoRA scale per adapter.
- Request-level selection indexes one packed adapter and uses `mx.quantized_matmul`; its lookup cost is independent of the number of resident adapters.
- Mixed-token routing uses `mx.gather_qmm` with an adapter index for every flattened token row. The implementation uses the regular gather path for correctness.
- Bank loading requires matching layer names, dimensions, rank, padding, group sizes, mode, and per-layer bit widths. Every required packed tensor is validated before stacking.
- Mixed-precision selection keeps a layer in floating point when no candidate satisfies both numerical and memory-reduction thresholds.

## Validation

The stacked branch passes 26 focused tests. PR 2 adds coverage for:

- Direct loading of three independently persisted adapters into one bank without base-model duplication.
- Exact request-level equality against the corresponding standalone quantized layer.
- Mixed-row routing against independently evaluated per-row quantized matmuls.
- Adapter index, shape, rank, metadata, and missing-weight validation.
- Mixed-precision selection and the low-rank padding memory gate.

For 100 resident 4096 x 4096 rank-16 adapters:

| Format | Packed adapter memory | Reduction | Request switching | Mixed-token routing | Delta cosine |
|---|---:|---:|---:|---:|---:|
| FP16 | 25.00 MiB | - | 0.208 ms | 0.310 ms | 1.0 |
| Q8 | 20.70 MiB | 17.2% | 0.216 ms | 0.776 ms | 0.99998 |
| Q4 | 11.33 MiB | 54.7% | 0.215 ms | 0.674 ms | 0.99342 |

These are synthetic microbenchmarks, not end-to-end generation results. Request-level switching remains in the same latency range at 100 adapters. Mixed-token quantized routing is currently about 2-3x slower than floating-point `gather_mm`, so this path should be considered memory-oriented rather than a throughput optimization.

## Limitations

- This PR depends on #1538 and should not merge first.
- All adapters in one bank must share the same target layers, dimensions, rank, and quantization configuration.
- Adapter banks currently require every target LoRA layer to be packed with affine quantization.
- This PR provides the packed bank and routing primitives, not a server or request-context API.
- Mixed-token routing prioritizes correctness and memory; further kernel work would be needed for a throughput-oriented path.
- Mixed-precision selection requires representative calibration activations supplied by the caller.

## Test commands

```bash
PYTHONPATH=. python -m unittest tests.test_finetune tests.test_quantized_lora
PYTHONPATH=. python benchmarks/quantized_lora.py
PYTHONPATH=. python benchmarks/quantized_lora_bank.py
```