### PR TITLE
Add `--preserve-mtp` to keep MTP weights during conversion

### DIFF
--- a/mlx_lm/convert.py
+++ b/mlx_lm/convert.py
@@ -1,6 +1,8 @@
 # Copyright © 2023-2024 Apple Inc.
 
 import argparse
+import glob
+import json
 from pathlib import Path
 from typing import Callable, Optional, Union
 
@@ -10,10 +12,32 @@ from mlx.utils import tree_map_with_path
 
 from .utils import (
     dequantize_model,
+    hf_repo_to_path,
     load,
+    make_shards,
     quantize_model,
     save,
     upload_to_hub,
+)
+
+# Weight-name substrings that mark multi-token-prediction ("next-n"/MTP)
+# modules, curated from the sanitize methods that drop them: qwen3_5,
+# qwen3_next, nemotron_h, exaone_moe (``mtp.``); mimo (``mtp_layers.``);
+# mimo_v2_flash, kimi_linear, longcat_flash (``model.mtp``); step3p5
+# (``.mtp``); and ernie4_5_moe (``mtp_block.`` / ``mtp_linear_proj.`` /
+# ``mtp_hidden_norm.`` / ``mtp_emb_norm.``).
+MTP_WEIGHT_PATTERNS = ("mtp.", ".mtp", "mtp_")
+
+# Architectures that carry the MTP module as decoder layers past
+# ``num_hidden_layers``, which sanitize drops by layer index. deepseek_v3's
+# sanitize hardcodes layer 61 (== num_hidden_layers for DeepSeek-V3
+# checkpoints), so the generic rule covers it.
+MTP_TRAILING_LAYER_MODEL_TYPES = (
+    "deepseek_v3",
+    "deepseek_v32",
+    "glm4_moe",
+    "glm4_moe_lite",
+    "step3p5",
 )
 
 
@@ -82,6 +106,78 @@ QUANT_RECIPES = ["mixed_2_6", "mixed_3_4", "mixed_3_6", "mixed_4_6"]
 MODEL_CONVERSION_DTYPES = ["float16", "bfloat16", "float32"]
 
 
+def _is_mtp_weight(
+    name: str, model_type: Optional[str], num_dense_layers: Optional[int]
+) -> bool:
+    """Whether ``name`` is a multi-token-prediction weight dropped by sanitize."""
+    if any(pattern in name for pattern in MTP_WEIGHT_PATTERNS):
+        return True
+    if model_type in MTP_TRAILING_LAYER_MODEL_TYPES and num_dense_layers is not None:
+        parts = name.split(".")
+        if "layers" in parts:
+            i = parts.index("layers")
+            if i + 1 < len(parts) and parts[i + 1].isdigit():
+                return int(parts[i + 1]) >= num_dense_layers
+    return False
+
+
+def _preserve_mtp_weights(mlx_path: Path, source_path: Path, config: dict) -> None:
+    """Copy the source MTP weights that sanitize would drop next to the model.
+
+    The multi-token-prediction weights are read from the raw source safetensors
+    and written unmodified (source dtype, never quantized) to
+    ``mtp*.safetensors`` with their own ``mtp.safetensors.index.json``;
+    ``model.safetensors.index.json`` is untouched. ``mlx_lm.load`` reads only
+    ``model*.safetensors``, so the converted model loads unchanged.
+    """
+    model_type = config.get("model_type")
+    num_dense_layers = config.get("num_hidden_layers")
+    if num_dense_layers is None:
+        num_dense_layers = (config.get("text_config") or {}).get("num_hidden_layers")
+
+    with open(mlx_path / "model.safetensors.index.json", "r") as f:
+        saved = set(json.load(f)["weight_map"])
+
+    preserved = {}
+    for wf in sorted(glob.glob(str(source_path / "model*.safetensors"))):
+        weights = mx.load(wf)
+        for name, weight in weights.items():
+            # Never shadow a weight the conversion already saved.
+            if name not in saved and _is_mtp_weight(name, model_type, num_dense_layers):
+                preserved[name] = weight
+
+    if not preserved:
+        print("[INFO] No MTP weights found to preserve.")
+        return
+
+    shards = make_shards(preserved)
+    shard_file_format = (
+        "mtp-{:05d}-of-{:05d}.safetensors" if len(shards) > 1 else "mtp.safetensors"
+    )
+    index = {
+        "metadata": {
+            "total_size": sum(v.nbytes for v in preserved.values()),
+            "total_parameters": sum(v.size for v in preserved.values()),
+        },
+        "weight_map": {},
+    }
+    for i, shard in enumerate(shards):
+        shard_name = shard_file_format.format(i + 1, len(shards))
+        mx.save_safetensors(
+            str(mlx_path / shard_name), shard, metadata={"format": "mlx"}
+        )
+        for name in shard:
+            index["weight_map"][name] = shard_name
+
+    index["weight_map"] = {
+        k: index["weight_map"][k] for k in sorted(index["weight_map"])
+    }
+    with open(mlx_path / "mtp.safetensors.index.json", "w") as f:
+        json.dump(index, f, indent=4)
+
+    print(f"[INFO] Preserved {len(preserved)} MTP weight(s) in {len(shards)} shard(s).")
+
+
 def convert(
     hf_path: str,
     mlx_path: str = "mlx_model",
@@ -97,6 +193,7 @@ def convert(
         Union[Callable[[str, nn.Module, dict], Union[bool, dict]], str]
     ] = None,
     trust_remote_code: bool = False,
+    preserve_mtp: bool = False,
 ):
     # Check the save path is empty
     if isinstance(mlx_path, str):
@@ -171,6 +268,12 @@ def convert(
         tokenizer,
         config,
     )
+
+    if preserve_mtp:
+        source_path = Path(hf_path)
+        if not source_path.exists():
+            source_path = hf_repo_to_path(hf_path, revision=revision)
+        _preserve_mtp_weights(mlx_path, source_path, config)
 
     if upload_repo is not None:
         upload_to_hub(mlx_path, upload_repo)
@@ -248,6 +351,13 @@ def configure_parser() -> argparse.ArgumentParser:
     parser.add_argument(
         "--trust-remote-code",
         help="Trust remote code when loading tokenizer.",
+        action="store_true",
+        default=False,
+    )
+    parser.add_argument(
+        "--preserve-mtp",
+        help="Also save the source multi-token-prediction (MTP) weights, which "
+        "are otherwise dropped on load, so external MTP tooling can use them.",
         action="store_true",
         default=False,
     )

--- a/mlx_lm/utils.py
+++ b/mlx_lm/utils.py
@@ -260,13 +260,14 @@ def _download(
     return model_path
 
 
-def hf_repo_to_path(hf_repo):
+def hf_repo_to_path(hf_repo, revision: Optional[str] = None):
     # Restrict to the same patterns that `_download` fetches so the snapshot
     # completeness check does not fail on files that were never downloaded
     # (e.g. `.gitattributes`), which would raise an IncompleteSnapshotError.
     return Path(
         snapshot_download(
             hf_repo,
+            revision=revision,
             local_files_only=True,
             allow_patterns=DEFAULT_ALLOW_PATTERNS,
         )

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,10 +1,12 @@
 # Copyright © 2024 Apple Inc.
 
+import hashlib
 import json
 import os
 import tempfile
 import unittest
 from pathlib import Path
+from unittest import mock
 
 import mlx.core as mx
 import mlx.nn as nn
@@ -182,6 +184,176 @@ class TestUtils(unittest.TestCase):
             logits = loaded(mx.array([[1, 2, 3]], dtype=mx.int32))
             mx.eval(logits)
             self.assertEqual(logits.shape, (1, 3, args.vocab_size))
+
+
+class TestPreserveMTP(unittest.TestCase):
+    def setUp(self):
+        self.test_dir_fid = tempfile.TemporaryDirectory()
+        self.test_dir = Path(self.test_dir_fid.name)
+
+    def tearDown(self):
+        self.test_dir_fid.cleanup()
+
+    def _write_source(self):
+        """Write a tiny model whose source weights include dropped MTP weights."""
+        from mlx_lm.models import mimo
+
+        config = {
+            "model_type": "mimo",
+            "hidden_size": 64,
+            "num_hidden_layers": 2,
+            "intermediate_size": 128,
+            "num_attention_heads": 4,
+            "num_key_value_heads": 2,
+            "rms_norm_eps": 1e-5,
+            "vocab_size": 320,
+            "tie_word_embeddings": False,
+            "num_nextn_predict_layers": 1,
+        }
+        model = mimo.Model(mimo.ModelArgs(**config))
+        weights = dict(tree_flatten(model.parameters()))
+        # MTP weights that `mimo.sanitize` drops, in mixed dtypes so the test
+        # also covers that preservation keeps the source dtype.
+        mtp_weights = {
+            "model.mtp_layers.0.input_layernorm.weight": mx.random.normal((64,)).astype(
+                mx.bfloat16
+            ),
+            "model.mtp_layers.0.token_layernorm.weight": mx.random.normal((64,)).astype(
+                mx.float32
+            ),
+        }
+        weights.update(mtp_weights)
+
+        source = self.test_dir / "source"
+        source.mkdir()
+        mx.save_safetensors(str(source / "model.safetensors"), weights)
+        with open(source / "config.json", "w") as f:
+            json.dump(config, f)
+        tokenizer = {
+            "version": "1.0",
+            "added_tokens": [],
+            "pre_tokenizer": {"type": "Whitespace"},
+            "model": {
+                "type": "WordLevel",
+                "vocab": {"<unk>": 0, "a": 1, "b": 2},
+                "unk_token": "<unk>",
+            },
+        }
+        with open(source / "tokenizer.json", "w") as f:
+            json.dump(tokenizer, f)
+        with open(source / "tokenizer_config.json", "w") as f:
+            json.dump(
+                {"tokenizer_class": "PreTrainedTokenizerFast", "unk_token": "<unk>"}, f
+            )
+        return source, mtp_weights
+
+    def test_mtp_weight_matcher(self):
+        """The MTP matcher covers each architecture's dropped weights."""
+        from mlx_lm.convert import _is_mtp_weight
+
+        mtp_names = [
+            "model.mtp.embed_tokens.weight",  # qwen3_5, qwen3_next
+            "mtp.layers.0.self_attn.q_proj.weight",  # nemotron_h, exaone_moe
+            "model.mtp_layers.0.input_layernorm.weight",  # mimo
+            "model.mtp.0.eh_proj.weight",  # mimo_v2_flash, kimi_linear, longcat_flash
+            "model.layers.30.mtp.enorm.weight",  # step3p5
+            "mtp_block.0.self_attn.qkv_proj.weight",  # ernie4_5_moe
+            "model.mtp_hidden_norm.weight",  # ernie4_5_moe
+        ]
+        for name in mtp_names:
+            self.assertTrue(_is_mtp_weight(name, None, None), name)
+
+        # Trailing decoder layers past the dense stack.
+        for model_type in [
+            "deepseek_v3",
+            "deepseek_v32",
+            "glm4_moe",
+            "glm4_moe_lite",
+            "step3p5",
+        ]:
+            self.assertTrue(
+                _is_mtp_weight(
+                    "model.layers.30.self_attn.kv_b_proj.weight", model_type, 30
+                ),
+                model_type,
+            )
+        self.assertTrue(
+            _is_mtp_weight("model.layers.61.eh_proj.weight", "deepseek_v3", 61)
+        )
+
+        # The trailing-layer rule only applies to the listed architectures.
+        self.assertFalse(
+            _is_mtp_weight("model.layers.30.self_attn.q_proj.weight", "llama", 30)
+        )
+
+        # Dense weights are never treated as MTP.
+        for name in [
+            "model.layers.29.self_attn.q_proj.weight",
+            "model.embed_tokens.weight",
+            "lm_head.weight",
+            "model.layers.0.self_attn.rotary_emb.inv_freq",
+        ]:
+            self.assertFalse(_is_mtp_weight(name, "glm4_moe_lite", 30), name)
+
+    def test_hf_repo_to_path_propagates_revision(self):
+        """The preservation path resolves the source at the converted revision."""
+        with mock.patch.object(
+            utils, "snapshot_download", return_value=str(self.test_dir)
+        ) as snapshot_download:
+            path = utils.hf_repo_to_path("some/repo", revision="abc123")
+        self.assertEqual(path, self.test_dir)
+        self.assertEqual(snapshot_download.call_args.kwargs["revision"], "abc123")
+
+    def test_convert_preserves_mtp_weights(self):
+        """`preserve_mtp` writes the dropped MTP weights byte-identically."""
+        source, mtp_weights = self._write_source()
+        mlx_path = self.test_dir / "mlx_model"
+        convert(str(source), mlx_path=str(mlx_path), dtype="float32", preserve_mtp=True)
+
+        preserved = mx.load(str(mlx_path / "mtp.safetensors"))
+        self.assertEqual(set(preserved), set(mtp_weights))
+        for name, value in mtp_weights.items():
+            self.assertEqual(preserved[name].dtype, value.dtype)  # source dtype kept
+            self.assertTrue(mx.array_equal(preserved[name], value))
+
+        # The sidecar has its own index covering exactly the preserved weights.
+        with open(mlx_path / "mtp.safetensors.index.json") as f:
+            index = json.load(f)
+        self.assertEqual(set(index["weight_map"]), set(mtp_weights))
+        for name in mtp_weights:
+            self.assertEqual(index["weight_map"][name], "mtp.safetensors")
+
+        # The converted model still loads and carries no MTP weights.
+        model, _ = utils.load(str(mlx_path))
+        loaded = dict(tree_flatten(model.parameters()))
+        self.assertFalse(any("mtp" in name for name in loaded))
+
+    def test_convert_without_flag_is_unchanged(self):
+        """The output directory is identical with and without `preserve_mtp`."""
+        source, _ = self._write_source()
+        with_mtp = self.test_dir / "with_mtp"
+        without_mtp = self.test_dir / "without_mtp"
+        convert(str(source), mlx_path=str(with_mtp), dtype="float32", preserve_mtp=True)
+        convert(
+            str(source), mlx_path=str(without_mtp), dtype="float32", preserve_mtp=False
+        )
+
+        def digests(path):
+            return {
+                f.name: hashlib.sha256(f.read_bytes()).hexdigest()
+                for f in path.iterdir()
+                if f.is_file()
+            }
+
+        with_digests = digests(with_mtp)
+        without_digests = digests(without_mtp)
+
+        # The flag only adds the mtp sidecar and its index; every other file,
+        # model.safetensors.index.json included, is byte-identical.
+        extra = set(with_digests) - set(without_digests)
+        self.assertEqual(extra, {"mtp.safetensors", "mtp.safetensors.index.json"})
+        for name, digest in without_digests.items():
+            self.assertEqual(with_digests[name], digest, name)
 
 
 CUSTOM_MODEL_FILE = """\


### PR DESCRIPTION
### Summary

For architectures whose `sanitize` implementation removes multi-token-prediction
(MTP / "next-n") tensors, `mlx_lm.convert` does not include those tensors in the
converted output, so downstream extraction currently needs access to the
original source checkpoint or another artifact that retained them. External MTP
tooling starts from exactly these tensors — the raw-weight extraction convention
used by mlx-vlm's MTP drafter split tools, vllm-metal, and MTPLX. In-checkpoint
MTP loading and runtime support are discussed in #872, #990, and #1456.

I added a `--preserve-mtp` flag to `convert` that keeps them. Convert-side only:
no `sanitize`, model, or runtime changes; the one utils change is an optional
`revision` argument on `hf_repo_to_path` so the preserved tensors are resolved
at the same revision as the converted weights.

### What it does

- Off by default. Without the flag the output directory is byte-for-byte
  identical — the test compares every file name and SHA-256 hash with and
  without the flag.
- With the flag, after the normal save the MTP tensors are read from the raw
  source safetensors and written to `mtp.safetensors` (sharded
  `mtp-XXXXX-of-YYYYY.safetensors` when large) with their own
  `mtp.safetensors.index.json`; `model.safetensors.index.json` is untouched.
- Preserved tensors are copied without applying mlx-lm's dtype conversion or
  quantization. Tests cover bf16 and fp32 source tensors; FP8 source layouts
  (e.g. weight + scale-inv pairs) are not yet validated.
- `mlx_lm.load` currently reads only `model*.safetensors`, so it does not load
  the sidecar; the sidecar and its index are for architecture-aware extraction
  tools.
- Exact key collisions with saved model parameters are skipped. Preserved
  tensors otherwise retain their raw source names, deliberately — extraction
  tools expect pre-sanitize names.

### Supported families

The MTP name patterns live in one constant (`MTP_WEIGHT_PATTERNS`), curated from
the sanitize implementations that drop them: qwen3_5, qwen3_next, nemotron_h,
exaone_moe, mimo, mimo_v2_flash, kimi_linear, longcat_flash, step3p5,
ernie4_5_moe. Architectures that instead carry the MTP module as decoder layers
past `num_hidden_layers` — deepseek_v3, deepseek_v32, glm4_moe, glm4_moe_lite,
step3p5 — are matched by layer index, gated on an explicit model-type list
(`MTP_TRAILING_LAYER_MODEL_TYPES`) so the layer-index rule cannot misfire on
other architectures. deepseek_v3's sanitize hardcodes layer 61, which equals
`num_hidden_layers` for DeepSeek-V3 checkpoints, so the generic rule covers it.

### Tests

`tests/test_utils.py::TestPreserveMTP`, no network:

- the matcher covers each family's dropped names and the trailing-layer list,
  and rejects dense weights and non-listed model types
- synthetic round-trip: preserved tensors survive byte-identical in their
  source dtype, the sidecar index maps every preserved key, and `load` of the
  output is unaffected
- without the flag, the entire output directory is identical (file names and
  hashes)
- `hf_repo_to_path` propagates `revision` (mocked `snapshot_download`)

Related: #1033 discussed keeping extra tensors on the load path
(`keep_prefixes` / exposing `strict=False`); this is the narrower convert-side
counterpart for tensors that never survive to load.
