### PR TITLE
Fix gradient accumulation to weight micro-batches by token count

### DIFF
--- a/mlx_lm/tuner/trainer.py
+++ b/mlx_lm/tuner/trainer.py
@@ -244,20 +244,37 @@ def train(
     state = [model.state, optimizer.state, mx.random.state]
 
     @partial(mx.compile, inputs=state, outputs=state)
-    def step(batch, prev_grad, do_update):
+    def step(batch, prev_grad, prev_ntoks, do_update):
         (lvalue, toks), grad = loss_value_and_grad(model, *batch)
 
-        if prev_grad is not None:
-            grad = tree_map(lambda x, y: x + y, grad, prev_grad)
+        # Token-weighted running mean of the gradient, so accumulation matches the
+        # token-mean loss over the full batch instead of a fixed 1/K average.
+        if prev_grad is None:
+            ntoks = toks
+        else:
+            ntoks = prev_ntoks + toks
+            denom = mx.maximum(ntoks, 1)
+            grad = tree_map(
+                lambda g, acc: (toks / denom) * g + (prev_ntoks / denom) * acc,
+                grad,
+                prev_grad,
+            )
 
         if do_update:
-            grad = average_gradients(grad)
-            if grad_accum_steps > 1:
-                grad = tree_map(lambda x: x / grad_accum_steps, grad)
+            # Single process: the running mean is already the gradient. Only
+            # multiple ranks need the token-weighted reduce.
+            if world_size > 1:
+                grad = average_gradients(tree_map(lambda g: g * ntoks, grad))
+                ntoks = (
+                    mx.maximum(mx.distributed.all_sum(ntoks, stream=mx.cpu), 1)
+                    / world_size
+                )
+                grad = tree_map(lambda g: g / ntoks, grad)
             optimizer.update(model, grad)
             grad = None
+            ntoks = None
 
-        return lvalue, toks, grad
+        return lvalue, toks, grad, ntoks
 
     model.train()
     losses = 0
@@ -266,6 +283,7 @@ def train(
     trained_tokens = 0
     train_time = 0
     grad_accum = None
+    ntoks_accum = None
 
     ui = TrainUI(args.iters, rank=rank)
     with ui:
@@ -318,16 +336,17 @@ def train(
 
                 tic = time.perf_counter()
 
-            lvalue, toks, grad_accum = step(
+            lvalue, toks, grad_accum, ntoks_accum = step(
                 batch,
                 grad_accum,
-                it % grad_accum_steps == 0,
+                ntoks_accum,
+                it % grad_accum_steps == 0 or it == args.iters,
             )
 
             losses += lvalue
             n_tokens += toks
             steps += 1
-            mx.eval(state, losses, n_tokens, grad_accum)
+            mx.eval(state, losses, n_tokens, grad_accum, ntoks_accum)
             _clear_cache(args.clear_cache_threshold)
             train_time += time.perf_counter() - tic
 

--- a/tests/test_finetune.py
+++ b/tests/test_finetune.py
@@ -341,7 +341,6 @@ class TestScheduleConfig(unittest.TestCase):
         self.assertAlmostEqual(optimizer.learning_rate.item(), expected_lr, delta=1e-1)
 
     def test_single_schedule(self):
-
         config = {
             "name": "cosine_decay",
             "arguments": [0.1, 10],
@@ -445,6 +444,169 @@ class TestScheduleConfig(unittest.TestCase):
             comm_group=ANY,
         )
         self.assertEqual(mock_default_loss.call_count, 3)
+
+
+class TestGradientAccumulation(unittest.TestCase):
+    def _build(self):
+        import numpy as np
+
+        vocab, dim = 64, 16
+
+        class TinyLM(nn.Module):
+            def __init__(self):
+                super().__init__()
+                self.embed = nn.Embedding(vocab, dim)
+                self.lm_head = nn.Linear(dim, vocab, bias=False)
+
+            def __call__(self, x):
+                return self.lm_head(self.embed(x))
+
+        def fresh_model():
+            mx.random.seed(0)
+            model = TinyLM()
+            mx.eval(model.parameters())
+            return model
+
+        def make_mb(ntok, seq_len=33):
+            np.random.seed(ntok)
+            arr = np.zeros((1, seq_len), np.int32)
+            arr[0, :ntok] = np.random.randint(1, vocab, ntok)
+            return mx.array(arr), ntok
+
+        def lengths(ls):
+            return mx.array([[0, n] for n in ls])
+
+        return fresh_model, make_mb, lengths
+
+    def _run(self, model, batches, iters, grad_accum, loss=None):
+        import contextlib
+        import os
+        import tempfile
+
+        from mlx_lm.tuner.trainer import TrainingArgs, default_loss, train
+
+        def batch_iterator(bs):
+            def iterate(
+                dataset, batch_size, max_seq_length, loop=False, comm_group=None
+            ):
+                while True:
+                    yield from bs
+                    if not loop:
+                        break
+
+            return iterate
+
+        with (
+            tempfile.TemporaryDirectory() as td,
+            contextlib.redirect_stdout(StringIO()),
+        ):
+            train(
+                model,
+                opt.SGD(learning_rate=0.1),
+                train_dataset=list(range(len(batches))),
+                args=TrainingArgs(
+                    iters=iters,
+                    batch_size=int(batches[0][0].shape[0]),
+                    grad_accumulation_steps=grad_accum,
+                    max_seq_length=64,
+                    steps_per_report=1000,
+                    steps_per_eval=1000,
+                    steps_per_save=1000,
+                    adapter_file=os.path.join(td, "adapters.safetensors"),
+                ),
+                loss=loss or default_loss,
+                iterate_batches=batch_iterator(batches),
+            )
+        return dict(tree_flatten(model.parameters()))
+
+    def _rel_diff(self, pa, pb):
+        diff = sum(mx.abs(pa[k] - pb[k]).sum().item() for k in pa)
+        norm = sum(mx.abs(pb[k]).sum().item() for k in pb)
+        return diff / norm
+
+    def test_unequal_token_microbatches_match_combined_batch(self):
+        # Unequal-token micro-batches must give the same update as one combined batch.
+        fresh_model, make_mb, lengths = self._build()
+        a1, n1 = make_mb(12)
+        a2, n2 = make_mb(4)
+        both = mx.concatenate([a1, a2], axis=0)
+        micro = [(a1, lengths([n1])), (a2, lengths([n2]))]
+        combined = [(both, lengths([n1, n2]))]
+        pa = self._run(fresh_model(), micro, iters=2, grad_accum=2)
+        pb = self._run(fresh_model(), combined, iters=1, grad_accum=1)
+        self.assertLess(self._rel_diff(pa, pb), 1e-4)
+
+    def test_final_partial_window_is_applied(self):
+        # A trailing partial window (iters not a multiple of grad_accum) must
+        # still be applied: 3 micro-batches at grad_accum=2 should match the two
+        # windows run explicitly.
+        fresh_model, make_mb, lengths = self._build()
+        a1, n1 = make_mb(12)
+        a2, n2 = make_mb(4)
+        a3, n3 = make_mb(7)
+        w1 = mx.concatenate([a1, a2], axis=0)
+        micro = [(a1, lengths([n1])), (a2, lengths([n2])), (a3, lengths([n3]))]
+        windows = [(w1, lengths([n1, n2])), (a3, lengths([n3]))]
+        pa = self._run(fresh_model(), micro, iters=3, grad_accum=2)
+        pb = self._run(fresh_model(), windows, iters=2, grad_accum=1)
+        self.assertLess(self._rel_diff(pa, pb), 1e-4)
+
+    def test_zero_token_window_keeps_params_finite(self):
+        # An all-zero-token window must not add a step-side divide-by-zero (the
+        # zero-token loss NaN itself lives in default_loss). Use a guarded loss.
+        fresh_model, make_mb, lengths = self._build()
+
+        def guarded_loss(model, batch, length):
+            inputs = batch[:, :-1]
+            targets = batch[:, 1:]
+            logits = model(inputs)
+            steps = mx.arange(1, targets.shape[1] + 1)
+            mask = mx.logical_and(steps >= length[:, 0:1], steps <= length[:, 1:])
+            ce = nn.losses.cross_entropy(logits, targets) * mask
+            ntoks = mask.sum()
+            ce = ce.astype(mx.float32).sum() / mx.maximum(ntoks, 1)
+            return ce, ntoks
+
+        a0, n0 = make_mb(0)
+        zero_window = [(a0, lengths([n0])), (a0, lengths([n0]))]
+        params = self._run(
+            fresh_model(), zero_window, iters=2, grad_accum=2, loss=guarded_loss
+        )
+        for name, p in params.items():
+            self.assertFalse(bool(mx.isnan(p.astype(mx.float32)).any().item()), name)
+
+    def test_mixed_zero_and_nonzero_window_ignores_zero_token(self):
+        # A zero-token micro-batch contributes nothing, so mixing it with a normal
+        # one (either order) must match the normal micro-batch alone.
+        fresh_model, make_mb, lengths = self._build()
+
+        def guarded_loss(model, batch, length):
+            inputs = batch[:, :-1]
+            targets = batch[:, 1:]
+            logits = model(inputs)
+            steps = mx.arange(1, targets.shape[1] + 1)
+            mask = mx.logical_and(steps >= length[:, 0:1], steps <= length[:, 1:])
+            ce = nn.losses.cross_entropy(logits, targets) * mask
+            ntoks = mask.sum()
+            ce = ce.astype(mx.float32).sum() / mx.maximum(ntoks, 1)
+            return ce, ntoks
+
+        a0, n0 = make_mb(0)
+        a1, n1 = make_mb(9)
+        zero_first = [(a0, lengths([n0])), (a1, lengths([n1]))]
+        nonzero_first = [(a1, lengths([n1])), (a0, lengths([n0]))]
+        only = [(a1, lengths([n1]))]
+        p_zero_first = self._run(
+            fresh_model(), zero_first, iters=2, grad_accum=2, loss=guarded_loss
+        )
+        p_nonzero_first = self._run(
+            fresh_model(), nonzero_first, iters=2, grad_accum=2, loss=guarded_loss
+        )
+        p_only = self._run(
+            fresh_model(), only, iters=1, grad_accum=1, loss=guarded_loss
+        )
+        self.assertLess(self._rel_diff(p_zero_first, p_only), 1e-4)
+        self.assertLess(self._rel_diff(p_nonzero_first, p_only), 1e-4)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
> This replaces #1413, which I accidentally closed when its source fork was detached. The change has been rebased onto current `main`.

`default_loss` returns a per-micro-batch token-mean (`ce.sum() / ntoks`). With gradient accumulation, `step()` summed the per-micro-batch gradients and divided by a fixed `grad_accumulation_steps`. Since each micro-batch gradient is already normalized by its own token count, dividing the sum by K does not equal the gradient of the token-mean loss over the combined effective batch unless every micro-batch has the same number of trained tokens. With variable-length completions the accumulated update is biased toward shorter examples and depends on how examples are partitioned into micro-batches. `evaluate()` already token-weights its average, so the trainer was internally inconsistent.

This keeps a running token-weighted mean of the gradient over the accumulation window. For single-process training that running mean is already the gradient the optimizer needs, so no extra normalization is applied at the update; only with multiple ranks is it reduced across ranks weighted by each rank's token count. The accumulation denominators are guarded so an all-zero-token window cannot divide by zero. The final partial window (when `iters` is not a multiple of `grad_accumulation_steps`) is now applied instead of dropped. Single-process behavior is unchanged; with multiple ranks, the reduction is now token-weighted, including when `grad_accumulation_steps == 1`. All-zero-token windows still call `optimizer.update` with a zero gradient. The underlying zero-token loss NaN in `default_loss` is tracked separately in open PR #1355.

Tests: unequal-token micro-batches now match a single combined batch, the final partial window matches explicit windows, and an all-zero-token window keeps parameters finite. The first two fail on the current code and pass with this change.

## Validation
- `pytest -q tests/test_finetune.py::TestGradientAccumulation` (4 passed)
