### PR TITLE
server: idle and on-demand eviction of MLX's pooled buffer memory

### DIFF
--- a/mlx_lm/server.py
+++ b/mlx_lm/server.py
@@ -1,4 +1,4 @@
-# Copyright © 2023-2024 Apple Inc.
+# Copyright © 2023-2026 Apple Inc.
 
 import argparse
 import json
@@ -271,6 +271,117 @@ class TimeBudget:
         raise StopIteration()
 
 
+class CacheEvictor:
+    """Release MLX's pooled buffer memory when the server is idle.
+
+    MLX's allocator pools freed buffers instead of returning them to the OS,
+    so the process keeps holding the memory of completed requests (KV caches,
+    prefill activations) indefinitely. This tracks generation-loop activity
+    and calls ``mx.clear_cache()`` once the server has been idle for
+    ``idle_s`` seconds (opt-in via ``--cache-idle-evict-s``). It also services
+    on-demand evictions coming from the ``POST /v1/cache/evict`` endpoint.
+
+    Evictions run on the generation thread (via :meth:`step`, called once per
+    generation-loop iteration) and only when the server is quiescent: no
+    incoming or queued requests and no active batch. Releasing the pool never
+    invalidates live arrays, so this gate is a safety margin ensuring an
+    eviction can never interleave with in-flight generation.
+    """
+
+    def __init__(
+        self,
+        prompt_cache: LRUPromptCache,
+        idle_s: float = 0.0,
+        clock: Callable[[], float] = time.monotonic,
+    ):
+        self._prompt_cache = prompt_cache
+        self._idle_s = idle_s
+        self._clock = clock
+        self._last_activity = clock()
+        self._idle_evicted = False
+        self._requests = Queue()
+
+    def stats(self) -> dict:
+        """Current memory stats. Byte counts throughout, as reported by MLX
+        (allocator pool and live arrays) and the prompt cache."""
+        return {
+            "cache_bytes": mx.get_cache_memory(),
+            "active_bytes": mx.get_active_memory(),
+            "prompt_cache_sequences": len(self._prompt_cache),
+            "prompt_cache_bytes": self._prompt_cache.nbytes,
+        }
+
+    def touch(self):
+        """Mark the server as active, re-arming the idle timer."""
+        self._last_activity = self._clock()
+        self._idle_evicted = False
+
+    def _evict(self, clear_prompt_cache: bool = False, reason: str = "") -> dict:
+        before = self.stats()
+        if clear_prompt_cache:
+            self._prompt_cache.trim_to(n_sequences=0, n_bytes=0)
+        mx.clear_cache()
+        after = self.stats()
+        self._idle_evicted = True
+        released_gb = (before["cache_bytes"] - after["cache_bytes"]) / 1e9
+        logging.info(
+            f"Cache eviction ({reason}): released {released_gb:.2f} GB of "
+            "pooled buffer memory"
+        )
+        return {"evicted": True, "reason": reason, "before": before, "after": after}
+
+    def request_evict(
+        self, clear_prompt_cache: bool = False, timeout: float = 10.0
+    ) -> dict:
+        """Ask the generation thread to evict now. Called from HTTP handler
+        threads; the eviction itself runs in :meth:`step` on the generation
+        thread. Returns ``{"evicted": False, ...}`` without evicting if the
+        server is busy (or stays busy past ``timeout``)."""
+        response_queue = Queue()
+        self._requests.put((response_queue, bool(clear_prompt_cache)))
+        try:
+            result = response_queue.get(timeout=timeout)
+        except QueueEmpty:
+            result = None
+            reason = "timeout"
+        else:
+            reason = "busy"
+        if result is None:
+            return {"evicted": False, "reason": reason, "stats": self.stats()}
+        return result
+
+    def step(self, busy: bool):
+        """Run once per generation-loop iteration, on the generation thread.
+
+        ``busy`` is True whenever there is any in-flight or queued work; it
+        re-arms the idle timer and blocks evictions for that iteration.
+        """
+        if busy:
+            self.touch()
+
+        # Service on-demand evictions from `POST /v1/cache/evict`. When busy,
+        # answer immediately with None (mapped to `evicted: false`) instead of
+        # deferring: an eviction must never run alongside active requests.
+        while True:
+            try:
+                response_queue, clear_prompt_cache = self._requests.get_nowait()
+            except QueueEmpty:
+                break
+            if busy:
+                response_queue.put(None)
+            else:
+                response_queue.put(self._evict(clear_prompt_cache, "on demand"))
+
+        # Idle timer: evict once per idle period after `idle_s` seconds.
+        if (
+            not busy
+            and self._idle_s > 0
+            and not self._idle_evicted
+            and self._clock() - self._last_activity >= self._idle_s
+        ):
+            self._evict(reason=f"idle for {self._idle_s:g}s")
+
+
 class ModelProvider:
     def __init__(self, cli_args: argparse.Namespace):
         """Load models on demand and persist them across the whole process."""
@@ -425,6 +536,12 @@ class ResponseGenerator:
         self.prompt_cache = prompt_cache
         self.requests = Queue()
         self._state_machine_cache = {}
+        self.cache_evictor = CacheEvictor(
+            prompt_cache,
+            idle_s=float(
+                getattr(model_provider.cli_args, "cache_idle_evict_s", 0) or 0
+            ),
+        )
 
         self._time_budget = TimeBudget()
         self._is_distributed = mx.distributed.init().size() > 1
@@ -663,6 +780,21 @@ class ResponseGenerator:
                 )
                 request = get_next_request(timeout=timeout)
 
+            # Idle/on-demand cache eviction. Evictions only run when the
+            # server is quiescent: no incoming request, no queued requests,
+            # and no active or draining batch.
+            busy = (
+                request is not None
+                or drain_batch
+                or bool(unprocessed_requests)
+                or (batch_generator is not None and len(batch_results) > 0)
+            )
+            try:
+                self.cache_evictor.step(busy)
+            except Exception:
+                # Fail-safe: eviction must never take down the generation loop
+                logging.exception("Cache eviction failed")
+
             # We got a request
             if request is not None:
                 rqueue, request, args = request
@@ -751,6 +883,9 @@ class ResponseGenerator:
 
                     if not self._is_batchable(args):
                         self._serve_single((rqueue, request, args))
+                        # Generation just finished; restart the idle clock so
+                        # long generations don't count toward the idle time.
+                        self.cache_evictor.touch()
                         continue
 
                     current_model = args.model
@@ -1054,6 +1189,10 @@ class APIHandler(BaseHTTPRequestHandler):
         """
         Respond to a POST request from a client.
         """
+        if self.path == "/v1/cache/evict":
+            self.handle_cache_evict()
+            return
+
         request_factories = {
             "/v1/completions": self.handle_text_completions,
             "/v1/chat/completions": self.handle_chat_completions,
@@ -1586,12 +1725,65 @@ class APIHandler(BaseHTTPRequestHandler):
             None,
         )
 
+    def handle_cache_evict(self):
+        """
+        Handle a POST request for the /v1/cache/evict endpoint.
+
+        Asks the generation thread to release MLX's pooled buffer memory
+        (``mx.clear_cache()``) now, without waiting for the idle timer. The
+        optional JSON body may set ``{"clear_prompt_cache": true}`` to also
+        drop all stored prompt (KV) caches first, so their memory is part of
+        what gets released. Responds with before/after byte stats, or with
+        ``{"evicted": false}`` if the server is busy — evictions only run
+        when no requests are queued or in flight.
+        """
+        content_length = int(self.headers.get("Content-Length") or 0)
+        body = {}
+        if content_length > 0:
+            try:
+                body = json.loads(self.rfile.read(content_length).decode())
+            except json.JSONDecodeError as e:
+                self._set_completion_headers(400)
+                self.end_headers()
+                self.wfile.write(
+                    json.dumps({"error": f"Invalid JSON in request body: {e}"}).encode()
+                )
+                return
+        if not isinstance(body, dict):
+            self._set_completion_headers(400)
+            self.end_headers()
+            self.wfile.write(
+                json.dumps({"error": "Request should be a JSON dictionary"}).encode()
+            )
+            return
+
+        result = self.response_generator.cache_evictor.request_evict(
+            clear_prompt_cache=bool(body.get("clear_prompt_cache", False))
+        )
+        self._set_completion_headers(200)
+        self.end_headers()
+        self.wfile.write(json.dumps(result).encode())
+        self.wfile.flush()
+
+    def handle_cache_stats(self):
+        """
+        Handle a GET request for the /v1/cache/stats endpoint.
+        """
+        self._set_completion_headers(200)
+        self.end_headers()
+        self.wfile.write(
+            json.dumps(self.response_generator.cache_evictor.stats()).encode()
+        )
+        self.wfile.flush()
+
     def do_GET(self):
         """
         Respond to a GET request from a client.
         """
         if self.path.startswith("/v1/models"):
             self.handle_models_request()
+        elif self.path == "/v1/cache/stats":
+            self.handle_cache_stats()
         elif self.path == "/health":
             self.handle_health_check()
         else:
@@ -1847,6 +2039,16 @@ def main():
         "--prompt-cache-bytes",
         type=_parse_size,
         help="Maximum size in bytes of the KV caches",
+    )
+    parser.add_argument(
+        "--cache-idle-evict-s",
+        type=float,
+        default=0.0,
+        help="Release MLX's pooled buffer memory (mx.clear_cache()) after the "
+        "server has been idle for this many seconds (default: 0, disabled). "
+        "MLX pools freed buffers instead of returning them to the OS, so the "
+        "process keeps holding the memory of completed requests; this returns "
+        "that memory once the server goes idle.",
     )
     parser.add_argument(
         "--pipeline",

--- a/mlx_lm/server.py
+++ b/mlx_lm/server.py
@@ -349,6 +349,18 @@ class CacheEvictor:
             "prompt_cache_bytes": self._prompt_cache.nbytes,
         }
 
+    def _safe_stats(self) -> dict:
+        """Best-effort stats for refusal/error replies.
+
+        Stats are useful diagnostics, but failure to collect them must not
+        turn a bounded refusal into an exception or strand a claimed request.
+        """
+        try:
+            return self.stats()
+        except Exception:
+            logging.exception("Cache stats collection failed")
+            return {}
+
     def touch(self):
         """Mark the server as active, re-arming the idle timer."""
         self._last_activity = self._clock()
@@ -396,7 +408,11 @@ class CacheEvictor:
         except QueueEmpty:
             if message.abandon():
                 # We won: the loop will discard the message unserviced.
-                return {"evicted": False, "reason": "timeout", "stats": self.stats()}
+                return {
+                    "evicted": False,
+                    "reason": "timeout",
+                    "stats": self._safe_stats(),
+                }
             # The loop claimed the message right at the boundary and a reply
             # is guaranteed (claim -> put, see step()). Wait it out; the long
             # backstop only guards against the generation thread dying
@@ -404,9 +420,13 @@ class CacheEvictor:
             try:
                 result = message.response_queue.get(timeout=60.0)
             except QueueEmpty:  # pragma: no cover
-                return {"evicted": False, "reason": "timeout", "stats": self.stats()}
+                return {
+                    "evicted": False,
+                    "reason": "timeout",
+                    "stats": self._safe_stats(),
+                }
         if result is None:
-            return {"evicted": False, "reason": "busy", "stats": self.stats()}
+            return {"evicted": False, "reason": "busy", "stats": self._safe_stats()}
         return result
 
     def step(self, busy: bool):
@@ -438,10 +458,16 @@ class CacheEvictor:
                     result = self._evict(message.clear_prompt_cache, "on demand")
                 except Exception:
                     logging.exception("Cache eviction failed")
+                    # The endpoint request is activity. Re-arm the idle timer
+                    # after a failed attempt so the idle path cannot retry in
+                    # this same step and evict just after reporting failure.
+                    self.touch()
                     result = {
                         "evicted": False,
                         "reason": "error",
-                        "stats": self.stats(),
+                        # A claimed message must always receive a reply, even
+                        # when the failure is in the stats backend itself.
+                        "stats": self._safe_stats(),
                     }
             message.response_queue.put(result)
 
@@ -452,7 +478,13 @@ class CacheEvictor:
             and not self._idle_evicted
             and self._clock() - self._last_activity >= self._idle_s
         ):
-            self._evict(reason=f"idle for {self._idle_s:g}s")
+            try:
+                self._evict(reason=f"idle for {self._idle_s:g}s")
+            except Exception:
+                logging.exception("Cache eviction failed")
+                # Back off for a full idle interval instead of retrying and
+                # logging on every generation-loop poll.
+                self.touch()
 
 
 class ModelProvider:
@@ -1810,8 +1842,8 @@ class APIHandler(BaseHTTPRequestHandler):
         ``{"evicted": false}`` if the server is busy — evictions only run
         when no requests are queued or in flight.
         """
-        content_length = self.headers.get("Content-Length")
-        if content_length is None:
+        content_lengths = self.headers.get_all("Content-Length", [])
+        if not content_lengths:
             # Mirror the completion endpoints: chunked or length-less bodies
             # are not read, and silently ignoring one could drop a
             # `clear_prompt_cache` the client asked for.
@@ -1821,20 +1853,42 @@ class APIHandler(BaseHTTPRequestHandler):
                 json.dumps({"error": "Content-Length header is required"}).encode()
             )
             return
-        try:
-            content_length = int(content_length)
-        except ValueError:
+        if len(content_lengths) != 1:
+            # Never choose one value from ambiguous request framing on a
+            # destructive endpoint, even when duplicate values agree.
+            self._set_completion_headers(400)
+            self.end_headers()
+            self.wfile.write(
+                json.dumps({"error": "Multiple Content-Length headers"}).encode()
+            )
+            return
+        content_length = content_lengths[0]
+        if self.headers.get("Transfer-Encoding") is not None:
+            # This server does not decode transfer codings. Reject an
+            # ambiguous CL+TE request instead of accepting Content-Length: 0
+            # and silently ignoring a chunked clear_prompt_cache option.
+            self._set_completion_headers(400)
+            self.end_headers()
+            self.wfile.write(
+                json.dumps({"error": "Transfer-Encoding is not supported"}).encode()
+            )
+            return
+        # Content-Length is one or more ASCII decimal digits (RFC 9110).
+        # Python's int() also accepts signs and underscores, which would make
+        # malformed framing look valid.
+        if not content_length.isascii() or not content_length.isdigit():
             self._set_completion_headers(400)
             self.end_headers()
             self.wfile.write(
                 json.dumps({"error": "Invalid Content-Length header"}).encode()
             )
             return
+        content_length = int(content_length)
         body = {}
         if content_length > 0:
             try:
                 body = json.loads(self.rfile.read(content_length).decode())
-            except json.JSONDecodeError as e:
+            except (UnicodeDecodeError, json.JSONDecodeError) as e:
                 self._set_completion_headers(400)
                 self.end_headers()
                 self.wfile.write(
@@ -1849,8 +1903,19 @@ class APIHandler(BaseHTTPRequestHandler):
             )
             return
 
+        clear_prompt_cache = body.get("clear_prompt_cache", False)
+        if not isinstance(clear_prompt_cache, bool):
+            self._set_completion_headers(400)
+            self.end_headers()
+            self.wfile.write(
+                json.dumps(
+                    {"error": "clear_prompt_cache must be a JSON boolean"}
+                ).encode()
+            )
+            return
+
         result = self.response_generator.cache_evictor.request_evict(
-            clear_prompt_cache=bool(body.get("clear_prompt_cache", False))
+            clear_prompt_cache=clear_prompt_cache
         )
         self._set_completion_headers(200)
         self.end_headers()

--- a/mlx_lm/server.py
+++ b/mlx_lm/server.py
@@ -362,6 +362,9 @@ class CacheEvictor:
         mx.clear_cache()
         if clear_prompt_cache:
             self._prompt_cache.trim_to(n_sequences=0, n_bytes=0)
+            # Trimmed entries free their arrays INTO the pool; collect them
+            # in the same call instead of leaving them for the next cycle
+            mx.clear_cache()
         after = self.stats()
         self._idle_evicted = True
         released_gb = (before["cache_bytes"] - after["cache_bytes"]) / 1e9

--- a/mlx_lm/server.py
+++ b/mlx_lm/server.py
@@ -14,7 +14,7 @@ from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
 from pathlib import Path
 from queue import Empty as QueueEmpty
 from queue import Queue
-from threading import Thread
+from threading import Lock, Thread
 from typing import (
     Any,
     Callable,
@@ -271,6 +271,44 @@ class TimeBudget:
         raise StopIteration()
 
 
+class _EvictMessage:
+    """One on-demand eviction request with an atomic claim/abandon handshake.
+
+    Exactly one side wins each message: the generation loop must :meth:`claim`
+    it before servicing, and a timed-out HTTP handler must :meth:`abandon` it
+    before answering ``evicted: false``. If the loop claims first, the handler
+    keeps waiting for the (guaranteed) reply and reports the eviction
+    truthfully; if the handler abandons first, the loop discards the message
+    unserviced. There is no window in which an eviction runs after the client
+    was told it didn't.
+    """
+
+    def __init__(self, clear_prompt_cache: bool):
+        self.clear_prompt_cache = clear_prompt_cache
+        self.response_queue = Queue()
+        self._lock = Lock()
+        self._state = "pending"
+
+    def claim(self) -> bool:
+        """Generation-loop side: atomically take ownership before servicing.
+        Returns False if the handler already abandoned the message."""
+        with self._lock:
+            if self._state == "pending":
+                self._state = "claimed"
+                return True
+            return False
+
+    def abandon(self) -> bool:
+        """Handler side: atomically give up after a timeout, before answering
+        ``evicted: false``. Returns False if the loop already claimed the
+        message (a reply is coming and must be reported instead)."""
+        with self._lock:
+            if self._state == "pending":
+                self._state = "abandoned"
+                return True
+            return False
+
+
 class CacheEvictor:
     """Release MLX's pooled buffer memory when the server is idle.
 
@@ -338,25 +376,31 @@ class CacheEvictor:
         thread. Returns ``{"evicted": False, ...}`` without evicting if the
         server is busy (or stays busy past ``timeout``).
 
-        The queued message carries its deadline: if the generation thread
-        only gets to it after ``timeout`` has expired (e.g. it was blocked in
-        a long non-batched generation), the caller has already been answered
-        ``evicted: false``, so :meth:`step` discards the stale message
-        without servicing it — an eviction must never run after the client
-        was told it didn't.
+        The claim/abandon handshake on the message (see
+        :class:`_EvictMessage`) makes the answer exact even at the timeout
+        boundary: on timeout we atomically abandon the message; if the loop
+        already claimed it (it is servicing right now), we instead wait out
+        the reply and report it — never ``evicted: false`` while an eviction
+        actually ran.
         """
-        response_queue = Queue()
-        deadline = self._clock() + timeout
-        self._requests.put((response_queue, bool(clear_prompt_cache), deadline))
+        message = _EvictMessage(bool(clear_prompt_cache))
+        self._requests.put(message)
         try:
-            result = response_queue.get(timeout=timeout)
+            result = message.response_queue.get(timeout=timeout)
         except QueueEmpty:
-            result = None
-            reason = "timeout"
-        else:
-            reason = "busy"
+            if message.abandon():
+                # We won: the loop will discard the message unserviced.
+                return {"evicted": False, "reason": "timeout", "stats": self.stats()}
+            # The loop claimed the message right at the boundary and a reply
+            # is guaranteed (claim -> put, see step()). Wait it out; the long
+            # backstop only guards against the generation thread dying
+            # mid-service.
+            try:
+                result = message.response_queue.get(timeout=60.0)
+            except QueueEmpty:  # pragma: no cover
+                return {"evicted": False, "reason": "timeout", "stats": self.stats()}
         if result is None:
-            return {"evicted": False, "reason": reason, "stats": self.stats()}
+            return {"evicted": False, "reason": "busy", "stats": self.stats()}
         return result
 
     def step(self, busy: bool):
@@ -373,20 +417,23 @@ class CacheEvictor:
         # deferring: an eviction must never run alongside active requests.
         while True:
             try:
-                response_queue, clear_prompt_cache, deadline = (
-                    self._requests.get_nowait()
-                )
+                message = self._requests.get_nowait()
             except QueueEmpty:
                 break
-            if self._clock() >= deadline:
-                # The handler timed out and already answered `evicted: false`;
-                # never service (or reply to) a stale request, otherwise the
+            if not message.claim():
+                # The handler timed out and abandoned the message (it already
+                # answered `evicted: false`): never service it, otherwise the
                 # eviction would run after the client was told it didn't.
                 continue
-            if busy:
-                response_queue.put(None)
-            else:
-                response_queue.put(self._evict(clear_prompt_cache, "on demand"))
+            # A claimed message is always replied to.
+            result = None
+            if not busy:
+                try:
+                    result = self._evict(message.clear_prompt_cache, "on demand")
+                except Exception:
+                    logging.exception("Cache eviction failed")
+                    result = {"evicted": False, "reason": "error"}
+            message.response_queue.put(result)
 
         # Idle timer: evict once per idle period after `idle_s` seconds.
         if (

--- a/mlx_lm/server.py
+++ b/mlx_lm/server.py
@@ -356,9 +356,12 @@ class CacheEvictor:
 
     def _evict(self, clear_prompt_cache: bool = False, reason: str = "") -> dict:
         before = self.stats()
+        # clear_cache first: it is the riskier operation, so a failure
+        # there leaves the prompt cache untouched and the error reply
+        # exact rather than partially applied
+        mx.clear_cache()
         if clear_prompt_cache:
             self._prompt_cache.trim_to(n_sequences=0, n_bytes=0)
-        mx.clear_cache()
         after = self.stats()
         self._idle_evicted = True
         released_gb = (before["cache_bytes"] - after["cache_bytes"]) / 1e9
@@ -432,7 +435,11 @@ class CacheEvictor:
                     result = self._evict(message.clear_prompt_cache, "on demand")
                 except Exception:
                     logging.exception("Cache eviction failed")
-                    result = {"evicted": False, "reason": "error"}
+                    result = {
+                        "evicted": False,
+                        "reason": "error",
+                        "stats": self.stats(),
+                    }
             message.response_queue.put(result)
 
         # Idle timer: evict once per idle period after `idle_s` seconds.

--- a/mlx_lm/server.py
+++ b/mlx_lm/server.py
@@ -336,9 +336,18 @@ class CacheEvictor:
         """Ask the generation thread to evict now. Called from HTTP handler
         threads; the eviction itself runs in :meth:`step` on the generation
         thread. Returns ``{"evicted": False, ...}`` without evicting if the
-        server is busy (or stays busy past ``timeout``)."""
+        server is busy (or stays busy past ``timeout``).
+
+        The queued message carries its deadline: if the generation thread
+        only gets to it after ``timeout`` has expired (e.g. it was blocked in
+        a long non-batched generation), the caller has already been answered
+        ``evicted: false``, so :meth:`step` discards the stale message
+        without servicing it — an eviction must never run after the client
+        was told it didn't.
+        """
         response_queue = Queue()
-        self._requests.put((response_queue, bool(clear_prompt_cache)))
+        deadline = self._clock() + timeout
+        self._requests.put((response_queue, bool(clear_prompt_cache), deadline))
         try:
             result = response_queue.get(timeout=timeout)
         except QueueEmpty:
@@ -364,9 +373,16 @@ class CacheEvictor:
         # deferring: an eviction must never run alongside active requests.
         while True:
             try:
-                response_queue, clear_prompt_cache = self._requests.get_nowait()
+                response_queue, clear_prompt_cache, deadline = (
+                    self._requests.get_nowait()
+                )
             except QueueEmpty:
                 break
+            if self._clock() >= deadline:
+                # The handler timed out and already answered `evicted: false`;
+                # never service (or reply to) a stale request, otherwise the
+                # eviction would run after the client was told it didn't.
+                continue
             if busy:
                 response_queue.put(None)
             else:
@@ -1737,7 +1753,26 @@ class APIHandler(BaseHTTPRequestHandler):
         ``{"evicted": false}`` if the server is busy — evictions only run
         when no requests are queued or in flight.
         """
-        content_length = int(self.headers.get("Content-Length") or 0)
+        content_length = self.headers.get("Content-Length")
+        if content_length is None:
+            # Mirror the completion endpoints: chunked or length-less bodies
+            # are not read, and silently ignoring one could drop a
+            # `clear_prompt_cache` the client asked for.
+            self._set_completion_headers(411)
+            self.end_headers()
+            self.wfile.write(
+                json.dumps({"error": "Content-Length header is required"}).encode()
+            )
+            return
+        try:
+            content_length = int(content_length)
+        except ValueError:
+            self._set_completion_headers(400)
+            self.end_headers()
+            self.wfile.write(
+                json.dumps({"error": "Invalid Content-Length header"}).encode()
+            )
+            return
         body = {}
         if content_length > 0:
             try:

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -1,17 +1,25 @@
-# Copyright © 2024 Apple Inc.
+# Copyright © 2024-2026 Apple Inc.
 
 import http
 import io
 import json
 import threading
+import time
 import unittest
+from unittest import mock
 
 import mlx.core as mx
 import requests
 
 from mlx_lm.generate import TextStateMachine
 from mlx_lm.models.cache import KVCache
-from mlx_lm.server import APIHandler, LRUPromptCache, Response, ResponseGenerator
+from mlx_lm.server import (
+    APIHandler,
+    CacheEvictor,
+    LRUPromptCache,
+    Response,
+    ResponseGenerator,
+)
 from mlx_lm.utils import load
 
 
@@ -48,6 +56,7 @@ class DummyModelProvider:
                 "prompt_cache_size": 10,
                 "prompt_cache_bytes": 1 << 63,
                 "prompt_cache_total_bytes": None,
+                "cache_idle_evict_s": 0.0,
                 "allowed_origins": ["*"],
             },
         )
@@ -347,6 +356,13 @@ class TestServer(unittest.TestCase):
         stop_state = stop_matcher.make_state()
         stop_state, matched = stop_matcher.match(stop_state, stop_matcher._trie, 2)
         self.assertTrue(matched)
+
+    def test_no_idle_eviction_when_disabled(self):
+        # --cache-idle-evict-s defaults to 0 (off): the generation loop keeps
+        # polling while idle but must never call mx.clear_cache().
+        with mock.patch.object(mx, "clear_cache") as clear_cache:
+            time.sleep(0.6)
+            clear_cache.assert_not_called()
 
     def test_handle_models(self):
         url = f"http://localhost:{self.port}/v1/models"
@@ -725,6 +741,248 @@ class TestLRUPromptCache(unittest.TestCase):
         c, t = cache.fetch_nearest_cache(model, [3, 4])
         self.assertEqual(c, None)
         self.assertEqual(t, [3, 4])
+
+
+class FakeClock:
+    def __init__(self):
+        self.now = 0.0
+
+    def __call__(self):
+        return self.now
+
+    def advance(self, seconds):
+        self.now += seconds
+
+
+class TestCacheEvictor(unittest.TestCase):
+    """Unit tests for the idle/on-demand eviction state machine."""
+
+    def _make_evictor(self, idle_s, prompt_cache=None):
+        clock = FakeClock()
+        evictor = CacheEvictor(
+            prompt_cache or LRUPromptCache(), idle_s=idle_s, clock=clock
+        )
+        return evictor, clock
+
+    def _request_evict_async(self, evictor, **kwargs):
+        """Call request_evict on a helper thread (it blocks until the
+        generation-loop side services it via step)."""
+        results = []
+        thread = threading.Thread(
+            target=lambda: results.append(evictor.request_evict(**kwargs))
+        )
+        thread.start()
+        # Wait until the request is enqueued before stepping
+        while evictor._requests.empty():
+            time.sleep(0.005)
+        return thread, results
+
+    def test_disabled_never_evicts(self):
+        evictor, clock = self._make_evictor(idle_s=0.0)
+        with mock.patch.object(mx, "clear_cache") as clear_cache:
+            for _ in range(3):
+                clock.advance(1e6)
+                evictor.step(busy=False)
+            clear_cache.assert_not_called()
+
+    def test_idle_eviction_fires_once_after_threshold(self):
+        evictor, clock = self._make_evictor(idle_s=60.0)
+        with mock.patch.object(mx, "clear_cache") as clear_cache:
+            evictor.step(busy=False)
+            clear_cache.assert_not_called()
+
+            clock.advance(59.0)
+            evictor.step(busy=False)
+            clear_cache.assert_not_called()
+
+            clock.advance(2.0)
+            evictor.step(busy=False)
+            self.assertEqual(clear_cache.call_count, 1)
+
+            # Only once per idle period, no matter how long the idle lasts
+            clock.advance(1e6)
+            evictor.step(busy=False)
+            self.assertEqual(clear_cache.call_count, 1)
+
+            # Activity re-arms the timer
+            evictor.touch()
+            clock.advance(61.0)
+            evictor.step(busy=False)
+            self.assertEqual(clear_cache.call_count, 2)
+
+    def test_no_eviction_while_busy(self):
+        evictor, clock = self._make_evictor(idle_s=60.0)
+        with mock.patch.object(mx, "clear_cache") as clear_cache:
+            # Way past the threshold, but there is active work
+            clock.advance(120.0)
+            evictor.step(busy=True)
+            clear_cache.assert_not_called()
+
+            # The busy step re-armed the timer, so going idle does not evict
+            evictor.step(busy=False)
+            clear_cache.assert_not_called()
+
+            # Only after a full idle period does the eviction fire
+            clock.advance(61.0)
+            evictor.step(busy=False)
+            self.assertEqual(clear_cache.call_count, 1)
+
+    def test_on_demand_eviction_returns_stats(self):
+        prompt_cache = LRUPromptCache()
+        prompt_cache.insert_cache(("test", None, None), [1, 2], [MockCache("abcd")])
+        evictor, _ = self._make_evictor(idle_s=0.0, prompt_cache=prompt_cache)
+
+        # Plain eviction keeps the prompt cache
+        with mock.patch.object(mx, "clear_cache") as clear_cache:
+            thread, results = self._request_evict_async(evictor)
+            evictor.step(busy=False)
+            thread.join()
+            self.assertEqual(clear_cache.call_count, 1)
+        result = results[0]
+        self.assertTrue(result["evicted"])
+        for key in ("cache_bytes", "active_bytes", "prompt_cache_bytes"):
+            self.assertIn(key, result["before"])
+            self.assertIn(key, result["after"])
+        self.assertEqual(result["before"]["prompt_cache_bytes"], 4)
+        self.assertEqual(result["after"]["prompt_cache_bytes"], 4)
+
+        # clear_prompt_cache=True also drops the stored prompt caches
+        with mock.patch.object(mx, "clear_cache"):
+            thread, results = self._request_evict_async(
+                evictor, clear_prompt_cache=True
+            )
+            evictor.step(busy=False)
+            thread.join()
+        result = results[0]
+        self.assertTrue(result["evicted"])
+        self.assertEqual(result["before"]["prompt_cache_bytes"], 4)
+        self.assertEqual(result["after"]["prompt_cache_bytes"], 0)
+        self.assertEqual(len(prompt_cache), 0)
+
+    def test_on_demand_eviction_refused_while_busy(self):
+        prompt_cache = LRUPromptCache()
+        prompt_cache.insert_cache(("test", None, None), [1, 2], [MockCache("abcd")])
+        evictor, _ = self._make_evictor(idle_s=0.0, prompt_cache=prompt_cache)
+
+        with mock.patch.object(mx, "clear_cache") as clear_cache:
+            thread, results = self._request_evict_async(
+                evictor, clear_prompt_cache=True
+            )
+            evictor.step(busy=True)
+            thread.join()
+            clear_cache.assert_not_called()
+        result = results[0]
+        self.assertFalse(result["evicted"])
+        self.assertEqual(result["reason"], "busy")
+        # Nothing was touched
+        self.assertEqual(len(prompt_cache), 1)
+        self.assertEqual(prompt_cache.nbytes, 4)
+
+
+class TestIdleEviction(unittest.TestCase):
+    """Integration tests: eviction wired into the server's generation loop."""
+
+    @classmethod
+    def setUpClass(cls):
+        provider = DummyModelProvider()
+        provider.cli_args.cache_idle_evict_s = 0.25
+        cls.response_generator = ResponseGenerator(provider, LRUPromptCache())
+        cls.server_address = ("localhost", 0)
+        cls.httpd = http.server.HTTPServer(
+            cls.server_address,
+            lambda *args, **kwargs: APIHandler(cls.response_generator, *args, **kwargs),
+        )
+        cls.port = cls.httpd.server_port
+        cls.server_thread = threading.Thread(target=cls.httpd.serve_forever)
+        cls.server_thread.daemon = True
+        cls.server_thread.start()
+
+    @classmethod
+    def tearDownClass(cls):
+        cls.httpd.shutdown()
+        cls.httpd.server_close()
+        cls.server_thread.join()
+        cls.response_generator.stop_and_join()
+
+    def _completion(self, max_tokens=5):
+        url = f"http://localhost:{self.port}/v1/completions"
+        response = requests.post(
+            url,
+            json={
+                "model": "default_model",
+                "prompt": "Once upon a time",
+                "max_tokens": max_tokens,
+            },
+        )
+        self.assertEqual(response.status_code, 200)
+
+    def test_idle_timer_fires_in_generation_loop(self):
+        with mock.patch.object(mx, "clear_cache") as clear_cache:
+            self._completion()
+            # Generation itself may call mx.clear_cache; only count calls
+            # made after the request completed (i.e. while idle).
+            clear_cache.reset_mock()
+
+            deadline = time.time() + 5.0
+            while clear_cache.call_count == 0 and time.time() < deadline:
+                time.sleep(0.05)
+            self.assertEqual(clear_cache.call_count, 1)
+
+            # Once per idle period: staying idle must not evict again
+            time.sleep(0.6)
+            self.assertEqual(clear_cache.call_count, 1)
+
+    def test_evict_endpoint_returns_before_after_stats(self):
+        # Populate the prompt cache with a completed request
+        self._completion()
+
+        url = f"http://localhost:{self.port}/v1/cache/evict"
+        response = requests.post(url, json={})
+        self.assertEqual(response.status_code, 200)
+        body = response.json()
+        self.assertTrue(body["evicted"])
+        for key in (
+            "cache_bytes",
+            "active_bytes",
+            "prompt_cache_sequences",
+            "prompt_cache_bytes",
+        ):
+            self.assertIsInstance(body["before"][key], int)
+            self.assertIsInstance(body["after"][key], int)
+        # The prompt cache is kept by default
+        self.assertGreater(body["after"]["prompt_cache_bytes"], 0)
+
+        # An empty body works too, and clear_prompt_cache drops the KV caches
+        response = requests.post(url, json={"clear_prompt_cache": True})
+        self.assertEqual(response.status_code, 200)
+        body = response.json()
+        self.assertTrue(body["evicted"])
+        self.assertGreater(body["before"]["prompt_cache_bytes"], 0)
+        self.assertEqual(body["after"]["prompt_cache_bytes"], 0)
+
+        response = requests.post(url)
+        self.assertEqual(response.status_code, 200)
+        self.assertTrue(response.json()["evicted"])
+
+    def test_evict_endpoint_rejects_invalid_body(self):
+        url = f"http://localhost:{self.port}/v1/cache/evict"
+        response = requests.post(url, data=b"not json")
+        self.assertEqual(response.status_code, 400)
+        response = requests.post(url, json=["not", "a", "dict"])
+        self.assertEqual(response.status_code, 400)
+
+    def test_cache_stats_endpoint(self):
+        url = f"http://localhost:{self.port}/v1/cache/stats"
+        response = requests.get(url)
+        self.assertEqual(response.status_code, 200)
+        body = response.json()
+        for key in (
+            "cache_bytes",
+            "active_bytes",
+            "prompt_cache_sequences",
+            "prompt_cache_bytes",
+        ):
+            self.assertIsInstance(body[key], int)
 
 
 if __name__ == "__main__":

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -914,7 +914,9 @@ class TestCacheEvictor(unittest.TestCase):
             evictor.step(busy=False)
             thread.join()
             self.assertTrue(results[0]["evicted"])
-            self.assertEqual(clear_cache.call_count, 1)
+            # clear_prompt_cache evictions clear the pool twice: once up
+            # front, once after the trim to collect the freed entries
+            self.assertEqual(clear_cache.call_count, 2)
 
     def test_boundary_race_exactly_one_side_wins(self):
         # Regression (real clock): a slow eviction that starts right at the
@@ -938,8 +940,9 @@ class TestCacheEvictor(unittest.TestCase):
                 thread.join()
                 result = results[0]
                 if result["evicted"]:
-                    # Loop won: the handler waited out the reply
-                    self.assertEqual(clear_cache.call_count, 1)
+                    # Loop won: the handler waited out the reply (two pool
+                    # clears per clear_prompt_cache eviction by design)
+                    self.assertEqual(clear_cache.call_count, 2)
                     self.assertEqual(len(prompt_cache), 0)
                 else:
                     # Handler won: the eviction must not have run at all

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -3,6 +3,7 @@
 import http
 import io
 import json
+import socket
 import threading
 import time
 import unittest
@@ -878,6 +879,44 @@ class TestCacheEvictor(unittest.TestCase):
         self.assertEqual(len(prompt_cache), 1)
         self.assertEqual(prompt_cache.nbytes, 4)
 
+    def test_timed_out_evict_request_is_discarded(self):
+        # Regression: if the generation thread only reaches a queued evict
+        # request after the handler's timeout expired (e.g. it was blocked in
+        # a long non-batched generation), the client was already answered
+        # `evicted: false` — servicing the stale message anyway would be a
+        # ghost eviction the client was told did not happen.
+        prompt_cache = LRUPromptCache()
+        prompt_cache.insert_cache(("test", None, None), [1, 2], [MockCache("abcd")])
+        evictor, clock = self._make_evictor(idle_s=0.0, prompt_cache=prompt_cache)
+
+        with mock.patch.object(mx, "clear_cache") as clear_cache:
+            # No step() runs while the handler waits: the "loop" is blocked.
+            thread, results = self._request_evict_async(
+                evictor, clear_prompt_cache=True, timeout=0.05
+            )
+            thread.join()
+            result = results[0]
+            self.assertFalse(result["evicted"])
+            self.assertEqual(result["reason"], "timeout")
+
+            # The loop unblocks after the deadline: the stale message must be
+            # discarded, not serviced.
+            clock.advance(1.0)
+            evictor.step(busy=False)
+            clear_cache.assert_not_called()
+            self.assertEqual(len(prompt_cache), 1)
+            self.assertEqual(prompt_cache.nbytes, 4)
+            self.assertTrue(evictor._requests.empty())
+
+            # A fresh request afterwards works normally.
+            thread, results = self._request_evict_async(
+                evictor, clear_prompt_cache=True
+            )
+            evictor.step(busy=False)
+            thread.join()
+            self.assertTrue(results[0]["evicted"])
+            self.assertEqual(clear_cache.call_count, 1)
+
 
 class TestIdleEviction(unittest.TestCase):
     """Integration tests: eviction wired into the server's generation loop."""
@@ -888,7 +927,9 @@ class TestIdleEviction(unittest.TestCase):
         provider.cli_args.cache_idle_evict_s = 0.25
         cls.response_generator = ResponseGenerator(provider, LRUPromptCache())
         cls.server_address = ("localhost", 0)
-        cls.httpd = http.server.HTTPServer(
+        # ThreadingHTTPServer (as in production) so that /v1/cache/evict can
+        # be exercised while a completion request is streaming.
+        cls.httpd = http.server.ThreadingHTTPServer(
             cls.server_address,
             lambda *args, **kwargs: APIHandler(cls.response_generator, *args, **kwargs),
         )
@@ -970,6 +1011,86 @@ class TestIdleEviction(unittest.TestCase):
         self.assertEqual(response.status_code, 400)
         response = requests.post(url, json=["not", "a", "dict"])
         self.assertEqual(response.status_code, 400)
+
+    def _raw_status(self, raw_request: bytes) -> bytes:
+        """Send a raw HTTP request and return the response status line."""
+        with socket.create_connection(("localhost", self.port), timeout=5) as sock:
+            sock.sendall(raw_request)
+            sock.settimeout(5)
+            data = b""
+            while b"\r\n" not in data:
+                chunk = sock.recv(4096)
+                if not chunk:
+                    break
+                data += chunk
+        return data.split(b"\r\n", 1)[0]
+
+    def test_evict_endpoint_invalid_content_length(self):
+        # A malformed Content-Length must get a 400, not a connection reset
+        status = self._raw_status(
+            b"POST /v1/cache/evict HTTP/1.1\r\n"
+            b"Host: localhost\r\n"
+            b"Content-Length: abc\r\n"
+            b"Connection: close\r\n\r\n"
+        )
+        self.assertIn(b" 400 ", status + b" ")
+
+    def test_evict_endpoint_requires_content_length(self):
+        # A chunked (length-less) body is never read, so silently treating it
+        # as empty would drop a `clear_prompt_cache` the client asked for:
+        # require Content-Length like the completion endpoints do (411).
+        status = self._raw_status(
+            b"POST /v1/cache/evict HTTP/1.1\r\n"
+            b"Host: localhost\r\n"
+            b"Transfer-Encoding: chunked\r\n"
+            b"Connection: close\r\n\r\n"
+            b'1c\r\n{"clear_prompt_cache": true}\r\n0\r\n\r\n'
+        )
+        self.assertIn(b" 411 ", status + b" ")
+
+    def test_cache_endpoints_wrong_method(self):
+        response = requests.get(f"http://localhost:{self.port}/v1/cache/evict")
+        self.assertEqual(response.status_code, 404)
+        response = requests.post(f"http://localhost:{self.port}/v1/cache/stats")
+        self.assertEqual(response.status_code, 404)
+
+    def test_evict_endpoint_busy_refusal_over_http(self):
+        # While a batched request is generating, the endpoint must refuse
+        # immediately with `evicted: false` and touch nothing.
+        completion_url = f"http://localhost:{self.port}/v1/completions"
+        evict_url = f"http://localhost:{self.port}/v1/cache/evict"
+        started = threading.Event()
+
+        def long_request():
+            with requests.post(
+                completion_url,
+                json={
+                    "model": "default_model",
+                    "prompt": "Once upon a time",
+                    "max_tokens": 1000,
+                    "stream": True,
+                },
+                stream=True,
+            ) as response:
+                # Streaming headers are sent only after the request has been
+                # inserted into the batch, so the server is busy from here
+                # until the (long) generation finishes.
+                started.set()
+                for _ in response.iter_content(chunk_size=None):
+                    pass
+
+        thread = threading.Thread(target=long_request)
+        thread.start()
+        try:
+            self.assertTrue(started.wait(timeout=15))
+            response = requests.post(evict_url, json={"clear_prompt_cache": True})
+            body = response.json()
+        finally:
+            thread.join()
+
+        self.assertEqual(response.status_code, 200)
+        self.assertFalse(body["evicted"])
+        self.assertEqual(body["reason"], "busy")
 
     def test_cache_stats_endpoint(self):
         url = f"http://localhost:{self.port}/v1/cache/stats"

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -828,6 +828,23 @@ class TestCacheEvictor(unittest.TestCase):
             evictor.step(busy=False)
             self.assertEqual(clear_cache.call_count, 1)
 
+    def test_failed_idle_eviction_backs_off(self):
+        evictor, clock = self._make_evictor(idle_s=60.0)
+        clock.advance(61.0)
+        with mock.patch.object(
+            mx, "clear_cache", side_effect=RuntimeError("boom")
+        ) as clear_cache:
+            # A backend failure is contained and does not become a hot retry
+            # loop while the server remains idle.
+            evictor.step(busy=False)
+            self.assertEqual(clear_cache.call_count, 1)
+            evictor.step(busy=False)
+            self.assertEqual(clear_cache.call_count, 1)
+
+            clock.advance(61.0)
+            evictor.step(busy=False)
+            self.assertEqual(clear_cache.call_count, 2)
+
     def test_on_demand_eviction_returns_stats(self):
         prompt_cache = LRUPromptCache()
         prompt_cache.insert_cache(("test", None, None), [1, 2], [MockCache("abcd")])
@@ -878,6 +895,52 @@ class TestCacheEvictor(unittest.TestCase):
         # Nothing was touched
         self.assertEqual(len(prompt_cache), 1)
         self.assertEqual(prompt_cache.nbytes, 4)
+
+    def test_on_demand_error_cannot_trigger_same_step_idle_eviction(self):
+        evictor, clock = self._make_evictor(idle_s=60.0)
+        clock.advance(61.0)
+
+        # If the on-demand attempt fails at an already-due idle deadline, the
+        # idle path must not immediately retry after queuing an error reply.
+        with mock.patch.object(
+            mx, "clear_cache", side_effect=[RuntimeError("boom"), None]
+        ) as clear_cache:
+            thread, results = self._request_evict_async(evictor)
+            evictor.step(busy=False)
+            thread.join()
+            self.assertEqual(results[0]["reason"], "error")
+            self.assertEqual(clear_cache.call_count, 1)
+
+            clock.advance(61.0)
+            evictor.step(busy=False)
+            self.assertEqual(clear_cache.call_count, 2)
+
+    def test_stats_failure_still_replies_to_claimed_request(self):
+        evictor, _ = self._make_evictor(idle_s=0.0)
+        thread, results = self._request_evict_async(evictor)
+        with mock.patch.object(evictor, "stats", side_effect=RuntimeError("boom")):
+            evictor.step(busy=False)
+        thread.join(timeout=1.0)
+
+        self.assertFalse(thread.is_alive())
+        self.assertEqual(
+            results, [{"evicted": False, "reason": "error", "stats": {}}]
+        )
+
+    def test_stats_failure_does_not_break_busy_or_timeout_refusal(self):
+        evictor, _ = self._make_evictor(idle_s=0.0)
+        with mock.patch.object(evictor, "stats", side_effect=RuntimeError("boom")):
+            thread, results = self._request_evict_async(evictor)
+            evictor.step(busy=True)
+            thread.join(timeout=1.0)
+            self.assertEqual(
+                results, [{"evicted": False, "reason": "busy", "stats": {}}]
+            )
+
+            result = evictor.request_evict(timeout=0.01)
+            self.assertEqual(
+                result, {"evicted": False, "reason": "timeout", "stats": {}}
+            )
 
     def test_timed_out_evict_request_is_discarded(self):
         # Regression: if the generation thread only reaches a queued evict
@@ -1056,6 +1119,11 @@ class TestIdleEviction(unittest.TestCase):
         self.assertEqual(response.status_code, 400)
         response = requests.post(url, json=["not", "a", "dict"])
         self.assertEqual(response.status_code, 400)
+        # Do not truthiness-coerce malformed values: in particular, the
+        # non-empty string "false" must never clear the prompt cache.
+        response = requests.post(url, json={"clear_prompt_cache": "false"})
+        self.assertEqual(response.status_code, 400)
+        self.assertIn("JSON boolean", response.json()["error"])
 
     def _raw_status(self, raw_request: bytes) -> bytes:
         """Send a raw HTTP request and return the response status line."""
@@ -1080,6 +1148,49 @@ class TestIdleEviction(unittest.TestCase):
         )
         self.assertIn(b" 400 ", status + b" ")
 
+        # Do not pick the first value from duplicate request framing. Reject
+        # both identical duplicates and directly conflicting lengths.
+        for second_value in (b"0", b"1"):
+            status = self._raw_status(
+                b"POST /v1/cache/evict HTTP/1.1\r\n"
+                b"Host: localhost\r\n"
+                b"Content-Length: 0\r\n"
+                b"Content-Length: " + second_value + b"\r\n"
+                b"Connection: close\r\n\r\n"
+            )
+            self.assertIn(b" 400 ", status + b" ")
+
+        # int() accepts these, but HTTP Content-Length permits decimal digits
+        # only; accepting either would normalize malformed framing.
+        for value in (b"+1", b"1_0"):
+            status = self._raw_status(
+                b"POST /v1/cache/evict HTTP/1.1\r\n"
+                b"Host: localhost\r\n"
+                b"Content-Length: " + value + b"\r\n"
+                b"Connection: close\r\n\r\n"
+            )
+            self.assertIn(b" 400 ", status + b" ")
+
+        # A negative length is not an empty body. Accepting it would perform
+        # the eviction while silently discarding any requested options.
+        status = self._raw_status(
+            b"POST /v1/cache/evict HTTP/1.1\r\n"
+            b"Host: localhost\r\n"
+            b"Content-Length: -1\r\n"
+            b"Connection: close\r\n\r\n"
+        )
+        self.assertIn(b" 400 ", status + b" ")
+
+    def test_evict_endpoint_rejects_non_utf8_body(self):
+        status = self._raw_status(
+            b"POST /v1/cache/evict HTTP/1.1\r\n"
+            b"Host: localhost\r\n"
+            b"Content-Length: 1\r\n"
+            b"Connection: close\r\n\r\n"
+            b"\xff"
+        )
+        self.assertIn(b" 400 ", status + b" ")
+
     def test_evict_endpoint_requires_content_length(self):
         # A chunked (length-less) body is never read, so silently treating it
         # as empty would drop a `clear_prompt_cache` the client asked for:
@@ -1092,6 +1203,19 @@ class TestIdleEviction(unittest.TestCase):
             b'1c\r\n{"clear_prompt_cache": true}\r\n0\r\n\r\n'
         )
         self.assertIn(b" 411 ", status + b" ")
+
+        # Supplying both headers must not bypass the guard: this server does
+        # not decode chunked bodies, so trusting Content-Length: 0 would
+        # silently discard the requested option.
+        status = self._raw_status(
+            b"POST /v1/cache/evict HTTP/1.1\r\n"
+            b"Host: localhost\r\n"
+            b"Content-Length: 0\r\n"
+            b"Transfer-Encoding: chunked\r\n"
+            b"Connection: close\r\n\r\n"
+            b'1c\r\n{"clear_prompt_cache": true}\r\n0\r\n\r\n'
+        )
+        self.assertIn(b" 400 ", status + b" ")
 
     def test_cache_endpoints_wrong_method(self):
         response = requests.get(f"http://localhost:{self.port}/v1/cache/evict")

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -887,7 +887,7 @@ class TestCacheEvictor(unittest.TestCase):
         # ghost eviction the client was told did not happen.
         prompt_cache = LRUPromptCache()
         prompt_cache.insert_cache(("test", None, None), [1, 2], [MockCache("abcd")])
-        evictor, clock = self._make_evictor(idle_s=0.0, prompt_cache=prompt_cache)
+        evictor, _ = self._make_evictor(idle_s=0.0, prompt_cache=prompt_cache)
 
         with mock.patch.object(mx, "clear_cache") as clear_cache:
             # No step() runs while the handler waits: the "loop" is blocked.
@@ -899,9 +899,8 @@ class TestCacheEvictor(unittest.TestCase):
             self.assertFalse(result["evicted"])
             self.assertEqual(result["reason"], "timeout")
 
-            # The loop unblocks after the deadline: the stale message must be
+            # The loop unblocks later: the abandoned message must be
             # discarded, not serviced.
-            clock.advance(1.0)
             evictor.step(busy=False)
             clear_cache.assert_not_called()
             self.assertEqual(len(prompt_cache), 1)
@@ -916,6 +915,49 @@ class TestCacheEvictor(unittest.TestCase):
             thread.join()
             self.assertTrue(results[0]["evicted"])
             self.assertEqual(clear_cache.call_count, 1)
+
+    def test_boundary_race_exactly_one_side_wins(self):
+        # Regression (real clock): a slow eviction that starts right at the
+        # handler's timeout boundary must never produce `evicted: false`
+        # while the eviction actually ran. The claim/abandon handshake makes
+        # exactly one side win: either the loop claims first and the handler
+        # waits out the reply (`evicted: true`), or the handler abandons
+        # first and the eviction does not run at all.
+        def run_race(step_delay, timeout):
+            prompt_cache = LRUPromptCache()
+            prompt_cache.insert_cache(("test", None, None), [1, 2], [MockCache("abcd")])
+            evictor = CacheEvictor(prompt_cache, idle_s=0.0)  # real clock
+            with mock.patch.object(
+                mx, "clear_cache", side_effect=lambda: time.sleep(0.15)
+            ) as clear_cache:
+                thread, results = self._request_evict_async(
+                    evictor, clear_prompt_cache=True, timeout=timeout
+                )
+                time.sleep(step_delay)
+                evictor.step(busy=False)
+                thread.join()
+                result = results[0]
+                if result["evicted"]:
+                    # Loop won: the handler waited out the reply
+                    self.assertEqual(clear_cache.call_count, 1)
+                    self.assertEqual(len(prompt_cache), 0)
+                else:
+                    # Handler won: the eviction must not have run at all
+                    self.assertEqual(result["reason"], "timeout")
+                    clear_cache.assert_not_called()
+                    self.assertEqual(len(prompt_cache), 1)
+                return result["evicted"]
+
+        # Loop reaches the message just before the deadline; the eviction
+        # (0.15 s) finishes well after it. The claim must force the handler
+        # to wait and report it truthfully.
+        self.assertTrue(run_race(step_delay=0.25, timeout=0.3))
+        # Loop reaches the message after the deadline: handler abandoned it.
+        self.assertFalse(run_race(step_delay=0.3, timeout=0.1))
+        # Genuinely racy step timings: either side may win, but the outcome
+        # asserted inside run_race must always be self-consistent.
+        for step_delay in (0.08, 0.1, 0.12):
+            run_race(step_delay=step_delay, timeout=0.1)
 
 
 class TestIdleEviction(unittest.TestCase):


### PR DESCRIPTION
# server: idle and on-demand eviction of MLX's pooled buffer memory

## Problem

MLX's allocator pools freed buffers instead of returning them to the OS. For a
long-running `mlx_lm.server` this means the process keeps holding the memory of
*completed* requests — KV caches, prefill activations — indefinitely: after a
burst of long-context requests the resident set stays near its peak even though
nothing is active. In one long-session observation, a 12 GB-weights model was
holding 46 GB of pooled memory. (Numbers for this machine/PR: [pending bench
— will be filled in from the local measurement before the PR opens].)

Bounding the admitted live KV state (#1542) does not address this: the
retention happens *after* the buffers are freed, inside the allocator pool. The
missing piece is reclamation, i.e. `mx.clear_cache()` at a moment when it
cannot hurt anything.

## Change

A new `CacheEvictor` tracks generation-loop activity and releases the pool two
ways:

- **Idle timer** — opt-in via `--cache-idle-evict-s N` (default `0` =
  disabled, zero behavior change). Once the server has processed nothing for
  `N` seconds, `mx.clear_cache()` runs, once per idle period; any activity
  re-arms the timer.
- **`POST /v1/cache/evict`** — releases the pool on demand (e.g. an
  orchestrator that knows it is done with this server for a while) and returns
  before/after byte stats. Optional body `{"clear_prompt_cache": true}` also
  drops the stored prompt KV caches first, so their memory is part of what
  gets released. Busy-server semantics differ by generation path:
  - *Batched path* (the default): the generation loop keeps iterating during
    decode, so a busy server answers immediately with
    `{"evicted": false, "reason": "busy"}` — no eviction runs and neither the
    pool nor the prompt cache is touched.
  - *Non-batched path* (`_serve_single`, e.g. draft-model/seeded requests):
    the generation loop blocks for the whole generation, so the endpoint
    blocks with it — up to the handler timeout (10 s). If the generation
    finishes first, the eviction then runs while idle and returns
    `evicted: true`. If the timeout expires first, the client gets
    `{"evicted": false, "reason": "timeout"}` and the message is discarded
    unserviced. Each message carries an atomic claim/abandon state and
    exactly one side wins it: the loop must *claim* the message before
    servicing, and a timed-out handler must *abandon* it before answering.
    If the handler's timeout lands while the loop is mid-eviction (the loop
    claimed first), the abandon fails and the handler waits out the
    guaranteed reply, reporting the eviction truthfully as `evicted: true`.
    So the response is exact even at the timeout boundary
(assuming a live generation thread — if the thread dies or an eviction
exceeds the 60 s backstop after being claimed, the handler eventually
reports a timeout for an eviction that may have run; that path requires
a broken server). On an internal eviction error the reply is
`{"evicted": false, "reason": "error", "stats": ...}` and state may be
partially released — `mx.clear_cache()` runs before the prompt-cache
trim precisely so an error there leaves the prompt cache untouched: an eviction can
    never run after the client was told it didn't (no ghost evictions, and
    a client retry cannot double-evict).
- **`GET /v1/cache/stats`** — read-only exposure of
  `mx.get_cache_memory()`, `mx.get_active_memory()`, and prompt-cache
  sequence/byte counts.

Safety gates:

- Evictions run **only on the generation thread**: the idle check is a step in
  the existing generation loop, and the endpoint hands its work to that loop
  through a queue (with a timeout on the handler side). No new threads touch
  MLX state.
- Evictions run **only when the server is quiescent**: no incoming request, no
  queued requests, and no active or draining batch, so an eviction can never
  interleave with in-flight generation.
- A failing eviction is logged and can never take down the generation loop;
  the non-batched (draft-model) generation path re-arms the idle timer on
  completion so a long generation never counts as idle time.

HTTP behavior of the new endpoint mirrors the completion endpoints: a missing
`Content-Length` (e.g. a chunked body, which would otherwise be silently
ignored — dropping a `clear_prompt_cache` the client asked for) gets `411`; a
malformed `Content-Length` gets `400` instead of an uncaught exception;
non-JSON or non-dict bodies get `400`; `GET /v1/cache/evict` and
`POST /v1/cache/stats` are `404`.

## Correctness

All in `tests/test_server.py`; the full file passes (45 tests).

Unit tests (`TestCacheEvictor`, no model; injected fake clock except the
boundary-race test, which needs the real one):

- `test_disabled_never_evicts` — flag off (`idle_s=0`): `mx.clear_cache` is
  never called no matter how long the server idles.
- `test_idle_eviction_fires_once_after_threshold` — nothing below the
  threshold, fires exactly once past it, stays at once for the whole idle
  period, re-arms after activity.
- `test_no_eviction_while_busy` — a busy step past the threshold does not
  evict and re-arms the timer; a full idle period must elapse afterwards.
- `test_on_demand_eviction_returns_stats` — on-demand eviction returns
  before/after stats (`cache_bytes`, `active_bytes`, `prompt_cache_bytes`);
  the prompt cache is kept by default and dropped with
  `clear_prompt_cache=True`.
- `test_on_demand_eviction_refused_while_busy` — a busy (batched-path) server
  refuses with `evicted: false` / `reason: busy` and touches neither pool nor
  prompt cache.
- `test_timed_out_evict_request_is_discarded` — regression for the ghost
  eviction: when the loop only reaches a queued evict message after the
  handler timed out and abandoned it (client already told `evicted: false`),
  the message is discarded, nothing is evicted, the prompt cache is
  untouched, and a fresh request afterwards works normally.
- `test_boundary_race_exactly_one_side_wins` — regression (real clock) for
  the timeout-boundary race: with a slow eviction injected and the loop
  reaching the message right at the handler's deadline, either the loop
  claims first (handler waits out the reply and reports `evicted: true`,
  eviction ran exactly once) or the handler abandons first (`evicted:
  false`, eviction did not run at all) — never `evicted: false` with the
  eviction run. Covers a claim-wins timing, an abandon-wins timing, and
    genuinely racy timings asserting self-consistency of whichever side wins.
- Adversarial closeout (`25ce14c`) also pins strict JSON-boolean and HTTP
  framing validation (including duplicate `Content-Length`, CL+TE, and invalid
  UTF-8), guaranteed replies when stats collection fails, no same-step retry
  after an on-demand error, and bounded backoff after idle failures.

Integration tests (real `ResponseGenerator` + `ThreadingHTTPServer`, 0.5B
test model):

- `TestIdleEviction::test_idle_timer_fires_in_generation_loop` — with
  `cache_idle_evict_s=0.25`, the eviction fires in the generation loop after a
  completion goes idle, exactly once.
- `TestIdleEviction::test_evict_endpoint_returns_before_after_stats` —
  `POST /v1/cache/evict` returns 200 with integer before/after stats, keeps
  the prompt cache by default, drops it with `{"clear_prompt_cache": true}`,
  and accepts an empty body.
- `TestIdleEviction::test_evict_endpoint_busy_refusal_over_http` — while a
  batched completion is streaming, the endpoint answers 200 with
  `evicted: false` / `reason: busy`.
- `TestIdleEviction::test_evict_endpoint_rejects_invalid_body` — non-JSON and
  non-dict bodies get 400.
- `TestIdleEviction::test_evict_endpoint_invalid_content_length` —
  `Content-Length: abc` gets a 400, not a connection reset.
- `TestIdleEviction::test_evict_endpoint_requires_content_length` — a chunked
  (length-less) body gets a 411, like the completion endpoints.
- `TestIdleEviction::test_cache_endpoints_wrong_method` — `GET` on the evict
  endpoint and `POST` on the stats endpoint are 404.
- `TestIdleEviction::test_cache_stats_endpoint` — `GET /v1/cache/stats`
  returns the stat fields.
- `TestServer::test_no_idle_eviction_when_disabled` — a running server with
  the default configuration never calls `mx.clear_cache` while idle.

Also verified end-to-end against `mlx_lm.server --cache-idle-evict-s 2` with
`mlx-community/Qwen1.5-0.5B-Chat-4bit`: the idle eviction logs 2 s after the
loop goes idle, is re-armed by a completion, fires once 2 s after it finishes,
and never during a request; the endpoint eviction with
`clear_prompt_cache: true` dropped the stored prompt cache (3.3 MB → 0).

## Notes

- `mx.clear_cache()` only releases *freed* buffers, so an eviction can never
  invalidate live arrays; the quiescence gate is a safety margin so eviction
  never runs concurrently with generation, not a correctness requirement.
  Corollary: there is a sub-millisecond window where a request arrives between
  the loop's queue poll and the eviction check — an eviction in that window is
  the designed margin at work, harmless for exactly this reason (it may cost
  the incoming request a pool re-warm, never correctness).
- `evicted: false` responses use HTTP 200 by design (the request was handled
  correctly; the answer is "no"). Orchestrators must parse the response body,
  not just the status code.
- In distributed mode the idle timer runs per rank on its local clock;
  `mx.clear_cache()` is a purely local allocator operation (no collectives),
  so ranks evicting at slightly different times is harmless. The endpoint only
  exists on rank 0 (the HTTP rank).
- The idle timer deliberately does **not** drop the prompt cache: stored
  prompt KV caches are a bounded, deliberate feature (`--prompt-cache-size`,
  `--prompt-cache-bytes`) whose value is precisely to survive idle gaps.
  Dropping them is available on demand via the endpoint body flag.
- Real-model before/after numbers on an M-series machine: [pending bench —
  to be measured on this machine before opening the PR; do not merge this
  placeholder].

## Measured

Apple M5 Max (128 GB), mlx 0.32.0.dev, `mlx_lm.server` with
Qwen3-Coder-30B-A3B-8bit and `--cache-idle-evict-s 6`, observed live via
`/v1/cache/stats`:

- Sequential traffic pools little (4 x 4k completions -> 5.7 MB): the
  generate loop's periodic clears already bound it.
- **Concurrent batched traffic is where the pool grows**: an 8-way
  3k-token burst left **876 MB pooled** after completion; the idle timer
  released it to **0** at the next window, active memory untouched.
- On-demand `{"clear_prompt_cache": true}` dropped 10 LRU sequences
  (**3.2 GB**); freed entries land in the pool and are collected in the
  same call (second-pass clear, unit-pinned — the first live run showed
  802 MB lingering otherwise).

Scope: the NKOS motivating observation (12 GB model holding 46 GB
pooled) was a different serving shim; here the lever's value is bounded
pool growth under concurrent bursts (scales with concurrency x context)
plus explicit LRU prompt-cache reclaim. Pool reclaim costs one cold
generation (~1.2x TTFT observed, small model) — the flag defaults off.
