### PR TITLE
Copy-on-write prefix forks for KV caches

### DIFF
--- a/mlx_lm/prefix_forks.py
+++ b/mlx_lm/prefix_forks.py
@@ -103,7 +103,8 @@ import hashlib
 import threading
 import weakref
 from collections import OrderedDict
-from typing import Any, Dict, List, Optional, Tuple
+from numbers import Integral
+from typing import Any, List, Optional, Tuple
 
 import mlx.core as mx
 
@@ -125,6 +126,22 @@ def _require_model_key(model_key: Any) -> str:
     return model_key
 
 
+def _normalize_tokens(tokens: List[int]) -> Tuple[int, ...]:
+    """Validate exact token IDs without lossy ``int(...)`` coercion."""
+    normalized = []
+    for token in tokens:
+        if isinstance(token, bool):
+            raise TypeError("token IDs must be integers, not bool")
+        try:
+            value = token.__index__()
+        except (AttributeError, TypeError):
+            raise TypeError(
+                f"token IDs must be integers; got {type(token).__name__}"
+            ) from None
+        normalized.append(int(value))
+    return tuple(normalized)
+
+
 def compute_cid(model_key: str, tokens: List[int]) -> str:
     """Content-hash identity for a prefix: (model key, exact token ids).
 
@@ -133,11 +150,19 @@ def compute_cid(model_key: str, tokens: List[int]) -> str:
     model key is subject to the module-level MODEL-KEY CONTRACT.
     """
     model_key = _require_model_key(model_key)
+    tokens = _normalize_tokens(tokens)
     h = hashlib.sha256()
-    h.update(model_key.encode("utf-8", "replace"))
+    # Length-frame every field. A delimiter alone is ambiguous because a
+    # model key is an arbitrary string and may itself contain that delimiter.
+    h.update(b"mlx-lm-prefix-fork-cid-v1")
+    model_key_bytes = model_key.encode("utf-8", "surrogatepass")
+    h.update(len(model_key_bytes).to_bytes(8, "big"))
+    h.update(model_key_bytes)
     for t in tokens:
-        h.update(b"\x00" + str(int(t)).encode())
-    return h.hexdigest()[:16]
+        token_bytes = str(t).encode()
+        h.update(len(token_bytes).to_bytes(8, "big"))
+        h.update(token_bytes)
+    return h.hexdigest()
 
 
 class FrozenPrefixSnapshot:
@@ -166,21 +191,47 @@ class FrozenPrefixSnapshot:
         keys: List[mx.array],
         values: List[mx.array],
     ):
-        self.cid = cid
-        self.model_key = model_key
-        self.tokens = tokens
+        self._cid = cid
+        self._model_key = model_key
+        self._tokens = tokens
         # Fresh slice OBJECTS (zero-copy): a later __setitem__ through the
         # caller's original references rebinds the caller's objects, never
         # these pre-write nodes.
-        self.keys = [k[:] for k in keys]
-        self.values = [v[:] for v in values]
-        self.nbytes = sum(k.nbytes + v.nbytes for k, v in zip(keys, values))
+        self._keys = [k[:] for k in keys]
+        self._values = [v[:] for v in values]
+        self._nbytes = sum(k.nbytes + v.nbytes for k, v in zip(keys, values))
         # Live forks referencing this snapshot (weak: forks hold the strong
         # edge). Lets the registry report pinned-but-undiscoverable bytes.
         self._forks = weakref.WeakSet()
 
     def __len__(self):
         return len(self.tokens)
+
+    @property
+    def cid(self):
+        return self._cid
+
+    @property
+    def model_key(self):
+        return self._model_key
+
+    @property
+    def tokens(self):
+        return self._tokens
+
+    @property
+    def nbytes(self):
+        return self._nbytes
+
+    @property
+    def keys(self):
+        """Fresh sealed views; the stored MLX array objects never escape."""
+        return [k[:] for k in self._keys]
+
+    @property
+    def values(self):
+        """Fresh sealed views; the stored MLX array objects never escape."""
+        return [v[:] for v in self._values]
 
     @property
     def pinned(self) -> bool:
@@ -198,6 +249,7 @@ class FrozenPrefixSnapshot:
         quantized, and stateful (Mamba) caches are not COW-forkable in v1.
         """
         model_key = _require_model_key(model_key)
+        tokens = list(_normalize_tokens(tokens))
         if len(tokens) == 0 or len(prompt_cache) == 0:
             return None
         for c in prompt_cache:
@@ -214,14 +266,14 @@ class FrozenPrefixSnapshot:
             values.append(mx.array(v))
         mx.eval(*keys, *values)
         cid = compute_cid(model_key, tokens)
-        return cls(cid, model_key, tuple(int(t) for t in tokens), keys, values)
+        return cls(cid, model_key, tuple(tokens), keys, values)
 
     def fork(self) -> List["ForkedKVCache"]:
         """A fresh per-layer cache stack referencing this snapshot. O(1):
         no prefix bytes are copied or materialized."""
         forks = [
-            ForkedKVCache(self.keys[l], self.values[l], snapshot=self)
-            for l in range(len(self.keys))
+            ForkedKVCache(self._keys[l], self._values[l], snapshot=self)
+            for l in range(len(self._keys))
         ]
         for f in forks:
             self._forks.add(f)
@@ -351,6 +403,8 @@ class ForkedKVCache(_BaseCache):
         # not. Trimming past the tail must FAIL LOUDLY: trim_prompt_cache
         # callers ignore the returned count, so a silent clamp would leave
         # them generating against KV at the wrong offset.
+        if not isinstance(n, int) or isinstance(n, bool) or n < 0:
+            raise ValueError(f"trim count must be a non-negative integer; got {n!r}")
         if n > self.tail.offset:
             raise ValueError(
                 f"Cannot trim {n} tokens from a ForkedKVCache with a private "
@@ -397,23 +451,35 @@ class PrefixForkRegistry:
     """
 
     def __init__(self, max_snapshots: int = 16, max_bytes: int = 1 << 63):
-        self.max_snapshots = max_snapshots
-        self.max_bytes = max_bytes
+        for name, value in (
+            ("max_snapshots", max_snapshots),
+            ("max_bytes", max_bytes),
+        ):
+            if isinstance(value, bool) or not isinstance(value, Integral):
+                raise TypeError(f"{name} must be a non-negative integer")
+            if value < 0:
+                raise ValueError(f"{name} must be non-negative")
+        self.max_snapshots = int(max_snapshots)
+        self.max_bytes = int(max_bytes)
         self._snapshots: "OrderedDict[str, FrozenPrefixSnapshot]" = OrderedDict()
         self._trie = PromptTrie()  # namespaced by the model-key string
         # Weak refs to every snapshot ever inserted, for pinned_nbytes: a
         # snapshot evicted here stays alive exactly as long as forks pin it.
-        self._tracked: Dict[str, "weakref.ref[FrozenPrefixSnapshot]"] = {}
+        # Track instances, not CIDs: the same CID can be reinserted while an
+        # older invalidated snapshot remains pinned by live forks.
+        self._tracked: List["weakref.ref[FrozenPrefixSnapshot]"] = []
         self._n_bytes = 0
         self._lock = threading.Lock()
 
     def __len__(self):
-        return len(self._snapshots)
+        with self._lock:
+            return len(self._snapshots)
 
     @property
     def nbytes(self):
         """Bytes of the DISCOVERABLE snapshots (what max_bytes bounds)."""
-        return self._n_bytes
+        with self._lock:
+            return self._n_bytes
 
     @property
     def pinned_nbytes(self):
@@ -427,15 +493,14 @@ class PrefixForkRegistry:
         them to estimate memory."""
         total = 0
         with self._lock:
-            dead = []
-            for cid, ref in self._tracked.items():
+            alive = []
+            for ref in self._tracked:
                 snapshot = ref()
-                if snapshot is None:
-                    dead.append(cid)
-                elif snapshot.pinned:
+                if snapshot is not None:
+                    alive.append(ref)
+                if snapshot is not None and snapshot.pinned:
                     total += snapshot.nbytes
-            for cid in dead:
-                del self._tracked[cid]
+            self._tracked = alive
         return total
 
     def freeze(
@@ -451,6 +516,18 @@ class PrefixForkRegistry:
         matching (model_key, tokens) with different KV means the key contract
         was violated (weights changed under a stale key)."""
         model_key = _require_model_key(model_key)
+        tokens = list(_normalize_tokens(tokens))
+        # Validate before the CID fast path. Otherwise an existing entry turns
+        # an unsupported or offset-skewed cache into a false success.
+        if (
+            len(tokens) == 0
+            or len(prompt_cache) == 0
+            or any(
+                type(c) is not KVCache or c.offset != len(tokens)
+                for c in prompt_cache
+            )
+        ):
+            return None
         cid = compute_cid(model_key, tokens)
         existing = self.get(cid)
         if existing is not None:
@@ -469,11 +546,12 @@ class PrefixForkRegistry:
                 self._snapshots.move_to_end(snapshot.cid)
                 return snapshot.cid
             self._snapshots[snapshot.cid] = snapshot
-            self._tracked[snapshot.cid] = weakref.ref(snapshot)
+            self._tracked.append(weakref.ref(snapshot))
             self._trie.add(snapshot.model_key, list(snapshot.tokens), snapshot.cid)
             self._n_bytes += snapshot.nbytes
-            while len(self._snapshots) > self.max_snapshots or (
-                self._n_bytes > self.max_bytes and len(self._snapshots) > 1
+            while self._snapshots and (
+                len(self._snapshots) > self.max_snapshots
+                or self._n_bytes > self.max_bytes
             ):
                 self._evict_lru_locked()
         return snapshot.cid
@@ -492,20 +570,29 @@ class PrefixForkRegistry:
         under a stale key has nothing to compare against — the model-key
         contract is the primary defense."""
         if (
-            len(prompt_cache) != len(snapshot.keys)
+            len(prompt_cache) != len(snapshot._keys)
             or any(type(c) is not KVCache for c in prompt_cache)
             or prompt_cache[0].offset != len(tokens)
         ):
             return  # not comparable; a fresh freeze() would reject it too
         ok = True
         for layer, c in enumerate(prompt_cache):
-            k_new = c.state[0]
-            k_old = snapshot.keys[layer]
-            if k_new.shape != k_old.shape or k_new.dtype != k_old.dtype:
+            k_new, v_new = c.state
+            k_old = snapshot._keys[layer]
+            v_old = snapshot._values[layer]
+            if (
+                k_new.shape != k_old.shape
+                or k_new.dtype != k_old.dtype
+                or v_new.shape != v_old.shape
+                or v_new.dtype != v_old.dtype
+            ):
                 ok = False
                 break
             w = min(4, k_old.shape[2])
-            if not bool(mx.array_equal(k_old[..., -w:, :], k_new[..., -w:, :])):
+            if not (
+                bool(mx.array_equal(k_old[..., -w:, :], k_new[..., -w:, :]))
+                and bool(mx.array_equal(v_old[..., -w:, :], v_new[..., -w:, :]))
+            ):
                 ok = False
                 break
         if not ok:
@@ -528,8 +615,9 @@ class PrefixForkRegistry:
         is deliberately a miss (false-MISS-only invariant).
         """
         model_key = _require_model_key(model_key)
+        normalized_tokens = list(_normalize_tokens(tokens))
         with self._lock:
-            result = self._trie.search(model_key, tokens)
+            result = self._trie.search(model_key, normalized_tokens)
             matched = result.exact if result.exact is not None else result.shorter
             if matched is None:
                 return None, tokens

--- a/mlx_lm/prefix_forks.py
+++ b/mlx_lm/prefix_forks.py
@@ -13,8 +13,8 @@ This module lets N requests fork from ONE frozen, in-RAM parent snapshot,
 paying only for their private suffixes:
 
 * :class:`FrozenPrefixSnapshot` — an immutable, ``mx.eval``-materialized,
-  content-addressed (cid over token ids) snapshot of a prefix's per-layer KV
-  state, trimmed to exact length (no ``step`` slack).
+  content-addressed (cid over model key + token ids) snapshot of a prefix's
+  per-layer KV state, trimmed to exact length (no ``step`` slack).
 * :class:`ForkedKVCache` — a per-layer cache mirroring :class:`KVCache`'s
   interface. It holds a *reference* to the frozen parent arrays (zero copy)
   plus a private, growing tail buffer. Writes go only to the tail, so the
@@ -23,11 +23,30 @@ paying only for their private suffixes:
 * :class:`PrefixForkRegistry` — a small cid-keyed registry with longest-prefix
   lookup (via ``PromptTrie``), LRU eviction, and content dedup.
 
-Aliasing experiment (mlx 0.32.0.dev, 2026-07): the design question was whether
-a fork may share the parent's *live* buffer by reference while the parent
-keeps decoding. ``KVCache.update_and_fetch`` writes via in-place slice
-assignment (``keys[..., prev:offset, :] = new``) into a step(=256)
-preallocated buffer. Empirically:
+THE MODEL-KEY CONTRACT
+======================
+
+Every registry call takes a ``model_key``: a caller-supplied, stable STRING
+that identifies the *exact weights* the KV was computed with — it must encode
+at least the model path, adapter, and revision (e.g.
+``"org/model@rev+adapter-sha"``), and it MUST change whenever the weights
+change (adapter load/unload, revision update, requantization). Cached KV is a
+pure function of (weights, tokens); a key that outlives a weight change turns
+into deterministic stale-KV false HITs. Non-string keys are rejected loudly:
+an ``id()``-derived or object-identity key is forbidden because (a) an
+in-place weight swap keeps the same object and (b) CPython recycles addresses
+of dead objects, both of which alias distinct weight-identities onto one key.
+As defense in depth, cid-dedup hits are spot-checked against the offered KV
+content and raise on mismatch (see ``PrefixForkRegistry.freeze``).
+
+ALIASING EXPERIMENT
+===================
+
+(mlx 0.32.0.dev, 2026-07.) The design question was whether a fork may share
+the parent's *live* buffer by reference while the parent keeps decoding.
+``KVCache.update_and_fetch`` writes via in-place slice assignment
+(``keys[..., prev:offset, :] = new``) into a step(=256) preallocated buffer.
+Empirically:
 
 * Mutation visibility follows PYTHON-OBJECT identity, not buffer identity.
   ``a[...] = x`` (``__setitem__``) rebinds the array *object* to the
@@ -48,51 +67,77 @@ Conclusion: materialize ONCE per unique prefix content into a frozen,
 exact-length snapshot, and let every fork share those arrays by reference.
 That single O(prefix) copy is amortized across all forks (content-addressed
 dedup), fork creation is O(1), a fork's persistent footprint is O(tail), and
-immutability is structural — nothing ever calls ``__setitem__`` on the shared
-arrays, and the registry (plus each live fork) holds references so donation
-is impossible by construction.
+immutability is structural — no code path in this module ever calls
+``__setitem__`` on the shared arrays, raw frozen array objects never escape
+(every boundary hands out fresh zero-copy slice *objects*, so a consumer's
+``__setitem__`` rebinds only the consumer's object), and the registry plus
+each live fork hold references so donation is impossible by construction.
 
-Known v1 cost: each attention step sees ``concat(prefix, tail)``, a transient
-O(prefix + tail) buffer per layer per step (freed immediately by the memory
-pool). Attention already reads all KV bytes each step, so this adds one extra
-write pass; removing it needs a two-segment attention kernel and is left as a
-follow-up.
+KNOWN COSTS AND LIMITS (v1)
+===========================
+
+* Each attention step sees ``concat(prefix, tail)``, a transient
+  O(prefix + tail) buffer per layer per step (freed immediately by the memory
+  pool). Attention already reads all KV bytes each step, so this adds one
+  extra write pass; removing it needs a two-segment attention kernel and is
+  left as a follow-up.
+* Only stacks of plain ``KVCache`` layers are forkable; anything else makes
+  ``freeze`` return ``None`` (a safe miss).
+* A length-1 snapshot is only found by an exact-length fetch (``PromptTrie``'s
+  ``shorter`` result requires a match past position 0) — a false miss, never
+  a false hit.
+* An exact-match ``fetch_fork`` returns ``remaining == []``; as with
+  ``fetch_nearest_cache``, the caller must ensure at least one token is fed
+  to the model (e.g. by keying snapshots on ``tokens[:-1]``).
 
 Invalidation policy: evicting or invalidating a snapshot only removes its
 *discoverability* — the next ``fetch_fork`` misses (a false MISS re-prefills,
 which is always safe). Live forks keep the arrays alive through ordinary
 Python references, so an eviction can never corrupt an in-flight generation
-(a false HIT on freed memory is impossible by construction).
+(a false HIT on freed memory is impossible by construction). Consequently
+``max_bytes``/``nbytes`` bound only the *discoverable* set; snapshots pinned
+by live forks are reported separately via ``pinned_nbytes``.
 """
 
 import hashlib
 import threading
+import weakref
 from collections import OrderedDict
-from typing import Any, List, Optional, Tuple
+from typing import Any, Dict, List, Optional, Tuple
 
 import mlx.core as mx
 
 from .models.cache import KVCache, PromptTrie, _BaseCache, create_attention_mask
 
 
+def _require_model_key(model_key: Any) -> str:
+    """Enforce the model-key contract (see module docstring): a stable str
+    encoding model path + adapter + revision. Anything else raises."""
+    if not isinstance(model_key, str):
+        raise TypeError(
+            "model_key must be a stable string identifying the exact weights "
+            "(model path + adapter + revision, e.g. 'org/model@rev+adapter'); "
+            f"got {type(model_key).__name__}. Object- or id()-derived keys "
+            "are forbidden: in-place weight swaps keep the same object and "
+            "CPython reuses addresses, both of which cause stale-KV false "
+            "HITs. The key MUST change whenever the weights change."
+        )
+    return model_key
+
+
 def compute_cid(model_key: str, tokens: List[int]) -> str:
-    """Content-hash identity for a prefix: (model namespace, exact token ids).
+    """Content-hash identity for a prefix: (model key, exact token ids).
 
     Same content -> same cid, so two independently frozen copies of the same
-    prefix dedup to one snapshot. Different models never collide.
+    prefix dedup to one snapshot. Distinct model keys never collide. The
+    model key is subject to the module-level MODEL-KEY CONTRACT.
     """
+    model_key = _require_model_key(model_key)
     h = hashlib.sha256()
     h.update(model_key.encode("utf-8", "replace"))
     for t in tokens:
         h.update(b"\x00" + str(int(t)).encode())
     return h.hexdigest()[:16]
-
-
-def _model_key(model: Any) -> str:
-    """A stable-within-process namespace string for a model object."""
-    if isinstance(model, str):
-        return model
-    return f"id:{id(model)}"
 
 
 class FrozenPrefixSnapshot:
@@ -103,7 +148,14 @@ class FrozenPrefixSnapshot:
     ``mx.array(...)`` and forced with ``mx.eval`` so they own their buffers —
     the source cache may keep decoding (or be garbage collected) without any
     effect on the snapshot. Consumers must never write to these arrays; the
-    ForkedKVCache only ever reads them.
+    ForkedKVCache only ever reads them, and every boundary that could hand
+    them out returns fresh slice objects instead (see module docstring).
+
+    Construct via :meth:`freeze` (the blessed path, which materializes). The
+    raw constructor stores fresh full-range slice *objects* of the arrays it
+    is given, so a caller retaining (and later ``__setitem__``-ing) its own
+    references cannot mutate the snapshot — but it does NOT copy: the caller
+    must pass materialized arrays it will not share with a writer.
     """
 
     def __init__(
@@ -117,16 +169,27 @@ class FrozenPrefixSnapshot:
         self.cid = cid
         self.model_key = model_key
         self.tokens = tokens
-        self.keys = keys
-        self.values = values
+        # Fresh slice OBJECTS (zero-copy): a later __setitem__ through the
+        # caller's original references rebinds the caller's objects, never
+        # these pre-write nodes.
+        self.keys = [k[:] for k in keys]
+        self.values = [v[:] for v in values]
         self.nbytes = sum(k.nbytes + v.nbytes for k, v in zip(keys, values))
+        # Live forks referencing this snapshot (weak: forks hold the strong
+        # edge). Lets the registry report pinned-but-undiscoverable bytes.
+        self._forks = weakref.WeakSet()
 
     def __len__(self):
         return len(self.tokens)
 
+    @property
+    def pinned(self) -> bool:
+        """Whether any live fork still references this snapshot."""
+        return len(self._forks) > 0
+
     @classmethod
     def freeze(
-        cls, model: Any, tokens: List[int], prompt_cache: List[Any]
+        cls, model_key: str, tokens: List[int], prompt_cache: List[Any]
     ) -> Optional["FrozenPrefixSnapshot"]:
         """Materialize a snapshot from a live prompt cache, or ``None``.
 
@@ -134,6 +197,7 @@ class FrozenPrefixSnapshot:
         ``KVCache`` whose offset matches ``len(tokens)`` — rotating, chunked,
         quantized, and stateful (Mamba) caches are not COW-forkable in v1.
         """
+        model_key = _require_model_key(model_key)
         if len(tokens) == 0 or len(prompt_cache) == 0:
             return None
         for c in prompt_cache:
@@ -149,16 +213,19 @@ class FrozenPrefixSnapshot:
             keys.append(mx.array(k))
             values.append(mx.array(v))
         mx.eval(*keys, *values)
-        cid = compute_cid(_model_key(model), tokens)
-        return cls(cid, _model_key(model), tuple(int(t) for t in tokens), keys, values)
+        cid = compute_cid(model_key, tokens)
+        return cls(cid, model_key, tuple(int(t) for t in tokens), keys, values)
 
     def fork(self) -> List["ForkedKVCache"]:
         """A fresh per-layer cache stack referencing this snapshot. O(1):
         no prefix bytes are copied or materialized."""
-        return [
+        forks = [
             ForkedKVCache(self.keys[l], self.values[l], snapshot=self)
             for l in range(len(self.keys))
         ]
+        for f in forks:
+            self._forks.add(f)
+        return forks
 
 
 class ForkedKVCache(_BaseCache):
@@ -171,23 +238,30 @@ class ForkedKVCache(_BaseCache):
     to the shared arrays — and any number of sibling forks may share it.
 
     Interface parity with :class:`KVCache`: ``update_and_fetch``, ``offset``,
-    ``size``, ``state``, ``meta_state``, ``is_trimmable``/``trim``,
-    ``make_mask``, ``empty``, ``nbytes``. Differences:
+    ``size``, ``state``, ``is_trimmable``/``trim``, ``make_mask``, ``empty``,
+    ``nbytes``. Differences:
 
     * ``trim`` only reaches into the private tail — the frozen prefix cannot
-      be trimmed (it is shared). ``trim(n)`` returns the number actually
-      trimmed, clamped to the tail length.
+      be trimmed (it is shared). ``trim(n)`` RAISES if asked to trim past the
+      tail, because callers of ``trim_prompt_cache`` ignore its return value
+      and would otherwise continue generating against skewed KV. Rollback of
+      tokens generated *after* the fork (the intended use: speculative
+      decoding, retries) always stays within the tail and works normally.
     * ``nbytes`` counts only the PRIVATE tail bytes: for byte budgeting, the
       shared prefix must be counted once (at the snapshot/registry), not once
       per fork. The shared portion is exposed as ``shared_nbytes``.
-    * ``state`` materializes the joined (prefix + tail) arrays — an explicit
-      O(prefix) copy for serialization; use ``to_kv_cache()`` to detach into
-      a plain, independent ``KVCache``. ``state`` is read-only.
+    * ``state`` is read-only. With an empty tail it returns fresh zero-copy
+      slice objects of the frozen arrays (never the raw shared objects — a
+      consumer ``__setitem__`` must not be able to corrupt every sibling
+      fork); with a non-empty tail it materializes the joined arrays, an
+      explicit O(prefix) copy. Use ``to_kv_cache()`` to detach into a plain,
+      independent ``KVCache``.
+    * ``meta_state`` raises: ``save_prompt_cache`` would otherwise write a
+      file that cannot be loaded (``load_prompt_cache`` resolves classes from
+      ``models/cache.py`` only). Detach with ``to_kv_cache()`` to serialize.
     * no ``to_quantized`` — ``maybe_quantize_kv_cache`` skips this cache via
       its ``hasattr`` guard (quantizing would have to copy the prefix anyway).
     """
-
-    step = 256
 
     def __init__(
         self,
@@ -195,8 +269,10 @@ class ForkedKVCache(_BaseCache):
         prefix_values: mx.array,
         snapshot: Optional[FrozenPrefixSnapshot] = None,
     ):
-        self._prefix_keys = prefix_keys
-        self._prefix_values = prefix_values
+        # Fresh slice objects: seal against later __setitem__ through the
+        # caller's references (zero-copy; see module docstring).
+        self._prefix_keys = prefix_keys[:]
+        self._prefix_values = prefix_values[:]
         self._prefix_len = prefix_keys.shape[2]
         # Keep the snapshot alive: registry eviction only removes
         # discoverability, never the arrays under a live fork.
@@ -227,7 +303,10 @@ class ForkedKVCache(_BaseCache):
     @property
     def state(self):
         if self.tail.offset == 0:
-            return self._prefix_keys, self._prefix_values
+            # Fresh zero-copy slice objects, NOT the stored references: a
+            # consumer __setitem__ then rebinds only the consumer's object
+            # and the frozen prefix (shared by every sibling fork) survives.
+            return self._prefix_keys[:], self._prefix_values[:]
         tail_keys, tail_values = self.tail.state
         return (
             mx.concatenate([self._prefix_keys, tail_keys], axis=2),
@@ -238,6 +317,21 @@ class ForkedKVCache(_BaseCache):
     def state(self, v):
         raise ValueError(
             "ForkedKVCache state cannot be set; detach with to_kv_cache() first."
+        )
+
+    @property
+    def meta_state(self):
+        raise ValueError(
+            "ForkedKVCache cannot be serialized (save_prompt_cache would "
+            "write a file load_prompt_cache cannot reconstruct); detach with "
+            "to_kv_cache() first."
+        )
+
+    @meta_state.setter
+    def meta_state(self, v):
+        raise ValueError(
+            "ForkedKVCache cannot be restored from serialized state; "
+            "load a plain KVCache instead."
         )
 
     def to_kv_cache(self) -> KVCache:
@@ -253,8 +347,17 @@ class ForkedKVCache(_BaseCache):
         return True
 
     def trim(self, n):
-        # Only the private tail is trimmable; the shared prefix is frozen.
-        return self.tail.trim(min(n, self.tail.offset))
+        # Only the private tail is trimmable; the shared frozen prefix is
+        # not. Trimming past the tail must FAIL LOUDLY: trim_prompt_cache
+        # callers ignore the returned count, so a silent clamp would leave
+        # them generating against KV at the wrong offset.
+        if n > self.tail.offset:
+            raise ValueError(
+                f"Cannot trim {n} tokens from a ForkedKVCache with a private "
+                f"tail of {self.tail.offset}: the shared frozen prefix is "
+                "immutable. Detach with to_kv_cache() to trim deeper."
+            )
+        return self.tail.trim(n)
 
     def make_mask(self, *args, **kwargs):
         return create_attention_mask(*args, offset=self.offset, **kwargs)
@@ -275,6 +378,11 @@ class ForkedKVCache(_BaseCache):
 class PrefixForkRegistry:
     """cid-keyed store of frozen prefix snapshots with longest-prefix fetch.
 
+    All methods take a ``model_key`` STRING subject to the module-level
+    MODEL-KEY CONTRACT: it must identify the exact weights (model path +
+    adapter + revision) and must change whenever the weights change. Non-str
+    keys raise ``TypeError``.
+
     * ``freeze`` inserts (or dedups to) a snapshot for exact token content.
     * ``fetch_fork`` returns a zero-copy ``ForkedKVCache`` stack for the
       longest known snapshot that prefixes the requested tokens, plus the
@@ -283,16 +391,19 @@ class PrefixForkRegistry:
     * Eviction (LRU by count and bytes) and ``invalidate`` only remove
       discoverability: misses are always safe (re-prefill), and live forks
       keep their snapshot's arrays alive via Python references, so a stale
-      HIT on released memory cannot happen.
+      HIT on released memory cannot happen. ``max_bytes``/``nbytes`` bound
+      the DISCOVERABLE set only; bytes still resident because live forks pin
+      an evicted snapshot are reported by ``pinned_nbytes``.
     """
 
     def __init__(self, max_snapshots: int = 16, max_bytes: int = 1 << 63):
         self.max_snapshots = max_snapshots
         self.max_bytes = max_bytes
         self._snapshots: "OrderedDict[str, FrozenPrefixSnapshot]" = OrderedDict()
-        # The trie is namespaced by the model-key STRING (nn.Module is
-        # dict-derived and unhashable, so the object itself cannot key it).
-        self._trie = PromptTrie()
+        self._trie = PromptTrie()  # namespaced by the model-key string
+        # Weak refs to every snapshot ever inserted, for pinned_nbytes: a
+        # snapshot evicted here stays alive exactly as long as forks pin it.
+        self._tracked: Dict[str, "weakref.ref[FrozenPrefixSnapshot]"] = {}
         self._n_bytes = 0
         self._lock = threading.Lock()
 
@@ -301,28 +412,59 @@ class PrefixForkRegistry:
 
     @property
     def nbytes(self):
+        """Bytes of the DISCOVERABLE snapshots (what max_bytes bounds)."""
         return self._n_bytes
 
+    @property
+    def pinned_nbytes(self):
+        """Bytes of snapshots kept resident by live forks — including ones
+        already evicted/invalidated (discoverability and residency are
+        deliberately decoupled; see class docstring)."""
+        total = 0
+        with self._lock:
+            dead = []
+            for cid, ref in self._tracked.items():
+                snapshot = ref()
+                if snapshot is None:
+                    dead.append(cid)
+                elif snapshot.pinned:
+                    total += snapshot.nbytes
+            for cid in dead:
+                del self._tracked[cid]
+        return total
+
     def freeze(
-        self, model: Any, tokens: List[int], prompt_cache: List[Any]
+        self, model_key: str, tokens: List[int], prompt_cache: List[Any]
     ) -> Optional[str]:
         """Snapshot ``prompt_cache`` (which must cover exactly ``tokens``) and
         register it. Returns the snapshot cid, or ``None`` if the cache is not
         forkable (never raises for unsupported cache types — that is just a
-        future miss)."""
-        cid = compute_cid(_model_key(model), tokens)
-        with self._lock:
-            if cid in self._snapshots:
-                self._snapshots.move_to_end(cid)  # dedup: same content, one copy
-                return cid
-        snapshot = FrozenPrefixSnapshot.freeze(model, tokens, prompt_cache)
+        future miss).
+
+        Dedup safety: if the cid already exists, the offered KV content is
+        spot-checked against the stored snapshot and a mismatch RAISES —
+        matching (model_key, tokens) with different KV means the key contract
+        was violated (weights changed under a stale key)."""
+        model_key = _require_model_key(model_key)
+        cid = compute_cid(model_key, tokens)
+        existing = self.get(cid)
+        if existing is not None:
+            self._dedup_spot_check(existing, tokens, prompt_cache)
+            with self._lock:
+                if cid in self._snapshots:
+                    self._snapshots.move_to_end(cid)
+            return cid
+        snapshot = FrozenPrefixSnapshot.freeze(model_key, tokens, prompt_cache)
         if snapshot is None:
             return None
         with self._lock:
-            if snapshot.cid in self._snapshots:  # lost a freeze race: dedup
+            existing = self._snapshots.get(snapshot.cid)
+            if existing is not None:  # lost a freeze race: dedup
+                self._dedup_spot_check(existing, tokens, prompt_cache)
                 self._snapshots.move_to_end(snapshot.cid)
                 return snapshot.cid
             self._snapshots[snapshot.cid] = snapshot
+            self._tracked[snapshot.cid] = weakref.ref(snapshot)
             self._trie.add(snapshot.model_key, list(snapshot.tokens), snapshot.cid)
             self._n_bytes += snapshot.nbytes
             while len(self._snapshots) > self.max_snapshots or (
@@ -331,8 +473,36 @@ class PrefixForkRegistry:
                 self._evict_lru_locked()
         return snapshot.cid
 
+    @staticmethod
+    def _dedup_spot_check(
+        snapshot: FrozenPrefixSnapshot, tokens: List[int], prompt_cache: List[Any]
+    ):
+        """Cheap content check on a cid-dedup hit: compare a small slice of
+        layer-0 KV. Cannot prove equality (it is a spot check), but catches
+        the realistic failure — same key + tokens over CHANGED weights —
+        and raises instead of silently serving stale KV."""
+        if (
+            not prompt_cache
+            or type(prompt_cache[0]) is not KVCache
+            or prompt_cache[0].offset != len(tokens)
+        ):
+            return  # not comparable; a fresh freeze() would reject it too
+        k_new = prompt_cache[0].state[0]
+        k_old = snapshot.keys[0]
+        ok = k_new.shape == k_old.shape and k_new.dtype == k_old.dtype
+        if ok:
+            w = min(4, k_old.shape[2])
+            ok = bool(mx.array_equal(k_old[..., -w:, :], k_new[..., -w:, :]))
+        if not ok:
+            raise ValueError(
+                f"prefix-fork dedup mismatch for cid {snapshot.cid}: same "
+                "model_key and tokens but different KV content. The model "
+                "key MUST change whenever the weights change (adapter load, "
+                "revision update, requantization)."
+            )
+
     def fetch_fork(
-        self, model: Any, tokens: List[int]
+        self, model_key: str, tokens: List[int]
     ) -> Tuple[Optional[List[ForkedKVCache]], List[int]]:
         """Fork from the longest frozen snapshot prefixing ``tokens``.
 
@@ -342,7 +512,7 @@ class PrefixForkRegistry:
         cache path: a frozen prefix cannot be trimmed, so a longer-only match
         is deliberately a miss (false-MISS-only invariant).
         """
-        model_key = _model_key(model)
+        model_key = _require_model_key(model_key)
         with self._lock:
             result = self._trie.search(model_key, tokens)
             matched = result.exact if result.exact is not None else result.shorter

--- a/mlx_lm/prefix_forks.py
+++ b/mlx_lm/prefix_forks.py
@@ -1,0 +1,381 @@
+# Copyright © 2026 Apple Inc.
+
+"""Copy-on-write prefix forks for KV caches.
+
+Many concurrent requests often share one long common prefix (a system prompt,
+a document, a few-shot preamble). The existing request-level prompt cache
+(``LRUPromptCache``) hands every hit a ``copy.deepcopy`` of the cached KV
+stack — the ``deepcopy`` call itself is cheap (lazy arrays), but the copy is
+materialized on first use, costing O(prefix) memory *and* wall-clock per
+request (multiple seconds at long contexts).
+
+This module lets N requests fork from ONE frozen, in-RAM parent snapshot,
+paying only for their private suffixes:
+
+* :class:`FrozenPrefixSnapshot` — an immutable, ``mx.eval``-materialized,
+  content-addressed (cid over token ids) snapshot of a prefix's per-layer KV
+  state, trimmed to exact length (no ``step`` slack).
+* :class:`ForkedKVCache` — a per-layer cache mirroring :class:`KVCache`'s
+  interface. It holds a *reference* to the frozen parent arrays (zero copy)
+  plus a private, growing tail buffer. Writes go only to the tail, so the
+  parent is structurally immutable: copy-on-write achieved by construction
+  rather than by copy-on-first-write.
+* :class:`PrefixForkRegistry` — a small cid-keyed registry with longest-prefix
+  lookup (via ``PromptTrie``), LRU eviction, and content dedup.
+
+Aliasing experiment (mlx 0.32.0.dev, 2026-07): the design question was whether
+a fork may share the parent's *live* buffer by reference while the parent
+keeps decoding. ``KVCache.update_and_fetch`` writes via in-place slice
+assignment (``keys[..., prev:offset, :] = new``) into a step(=256)
+preallocated buffer. Empirically:
+
+* Mutation visibility follows PYTHON-OBJECT identity, not buffer identity.
+  ``a[...] = x`` (``__setitem__``) rebinds the array *object* to the
+  ``slice_update`` result, so every reference through that same Python object
+  observes the write — but any slice taken *before* the write (lazy or
+  evaluated) references the pre-write graph node and is preserved. MLX's
+  donation machinery never recycles a buffer that another live node
+  references, so even the refcount-hungry decode loop cannot scribble an
+  exported slice.
+* HOWEVER, an (evaluated) slice of the step-padded ``(B, H, S, D)`` buffer
+  along axis 2 is strided, so materializing it costs an O(prefix) copy — per
+  fork. And a lazy slice pins the parent's entire step-padded buffer alive
+  while remaining one MLX donation-optimization away from unsoundness (live
+  ``.state`` aliases have scribbled snapshots before; see the ``mx.array`` +
+  ``mx.eval`` park recipe this module reuses).
+
+Conclusion: materialize ONCE per unique prefix content into a frozen,
+exact-length snapshot, and let every fork share those arrays by reference.
+That single O(prefix) copy is amortized across all forks (content-addressed
+dedup), fork creation is O(1), a fork's persistent footprint is O(tail), and
+immutability is structural — nothing ever calls ``__setitem__`` on the shared
+arrays, and the registry (plus each live fork) holds references so donation
+is impossible by construction.
+
+Known v1 cost: each attention step sees ``concat(prefix, tail)``, a transient
+O(prefix + tail) buffer per layer per step (freed immediately by the memory
+pool). Attention already reads all KV bytes each step, so this adds one extra
+write pass; removing it needs a two-segment attention kernel and is left as a
+follow-up.
+
+Invalidation policy: evicting or invalidating a snapshot only removes its
+*discoverability* — the next ``fetch_fork`` misses (a false MISS re-prefills,
+which is always safe). Live forks keep the arrays alive through ordinary
+Python references, so an eviction can never corrupt an in-flight generation
+(a false HIT on freed memory is impossible by construction).
+"""
+
+import hashlib
+import threading
+from collections import OrderedDict
+from typing import Any, List, Optional, Tuple
+
+import mlx.core as mx
+
+from .models.cache import KVCache, PromptTrie, _BaseCache, create_attention_mask
+
+
+def compute_cid(model_key: str, tokens: List[int]) -> str:
+    """Content-hash identity for a prefix: (model namespace, exact token ids).
+
+    Same content -> same cid, so two independently frozen copies of the same
+    prefix dedup to one snapshot. Different models never collide.
+    """
+    h = hashlib.sha256()
+    h.update(model_key.encode("utf-8", "replace"))
+    for t in tokens:
+        h.update(b"\x00" + str(int(t)).encode())
+    return h.hexdigest()[:16]
+
+
+def _model_key(model: Any) -> str:
+    """A stable-within-process namespace string for a model object."""
+    if isinstance(model, str):
+        return model
+    return f"id:{id(model)}"
+
+
+class FrozenPrefixSnapshot:
+    """An immutable, materialized, content-addressed prefix KV snapshot.
+
+    ``keys[l]`` / ``values[l]`` are per-layer arrays of EXACT length
+    ``len(tokens)`` (no step slack), copied out of the source cache with
+    ``mx.array(...)`` and forced with ``mx.eval`` so they own their buffers —
+    the source cache may keep decoding (or be garbage collected) without any
+    effect on the snapshot. Consumers must never write to these arrays; the
+    ForkedKVCache only ever reads them.
+    """
+
+    def __init__(
+        self,
+        cid: str,
+        model_key: str,
+        tokens: Tuple[int, ...],
+        keys: List[mx.array],
+        values: List[mx.array],
+    ):
+        self.cid = cid
+        self.model_key = model_key
+        self.tokens = tokens
+        self.keys = keys
+        self.values = values
+        self.nbytes = sum(k.nbytes + v.nbytes for k, v in zip(keys, values))
+
+    def __len__(self):
+        return len(self.tokens)
+
+    @classmethod
+    def freeze(
+        cls, model: Any, tokens: List[int], prompt_cache: List[Any]
+    ) -> Optional["FrozenPrefixSnapshot"]:
+        """Materialize a snapshot from a live prompt cache, or ``None``.
+
+        Returns ``None`` (a safe miss) unless every layer is a plain
+        ``KVCache`` whose offset matches ``len(tokens)`` — rotating, chunked,
+        quantized, and stateful (Mamba) caches are not COW-forkable in v1.
+        """
+        if len(tokens) == 0 or len(prompt_cache) == 0:
+            return None
+        for c in prompt_cache:
+            if type(c) is not KVCache or c.offset != len(tokens):
+                return None
+        keys, values = [], []
+        for c in prompt_cache:
+            # .state may be a lazy slice of (or at full capacity, the very
+            # same Python object as) the live buffer the source cache keeps
+            # writing into. mx.array + mx.eval takes an independent,
+            # exact-length device buffer NOW (the proven park recipe).
+            k, v = c.state
+            keys.append(mx.array(k))
+            values.append(mx.array(v))
+        mx.eval(*keys, *values)
+        cid = compute_cid(_model_key(model), tokens)
+        return cls(cid, _model_key(model), tuple(int(t) for t in tokens), keys, values)
+
+    def fork(self) -> List["ForkedKVCache"]:
+        """A fresh per-layer cache stack referencing this snapshot. O(1):
+        no prefix bytes are copied or materialized."""
+        return [
+            ForkedKVCache(self.keys[l], self.values[l], snapshot=self)
+            for l in range(len(self.keys))
+        ]
+
+
+class ForkedKVCache(_BaseCache):
+    """A KVCache-compatible cache = frozen shared prefix + private tail.
+
+    Reads (``update_and_fetch`` results, ``.state``) present the concatenation
+    of the immutable prefix and the private tail; writes go exclusively into
+    the tail's step-preallocated buffer (a plain :class:`KVCache`). The
+    parent snapshot is therefore structurally immutable — no code path writes
+    to the shared arrays — and any number of sibling forks may share it.
+
+    Interface parity with :class:`KVCache`: ``update_and_fetch``, ``offset``,
+    ``size``, ``state``, ``meta_state``, ``is_trimmable``/``trim``,
+    ``make_mask``, ``empty``, ``nbytes``. Differences:
+
+    * ``trim`` only reaches into the private tail — the frozen prefix cannot
+      be trimmed (it is shared). ``trim(n)`` returns the number actually
+      trimmed, clamped to the tail length.
+    * ``nbytes`` counts only the PRIVATE tail bytes: for byte budgeting, the
+      shared prefix must be counted once (at the snapshot/registry), not once
+      per fork. The shared portion is exposed as ``shared_nbytes``.
+    * ``state`` materializes the joined (prefix + tail) arrays — an explicit
+      O(prefix) copy for serialization; use ``to_kv_cache()`` to detach into
+      a plain, independent ``KVCache``. ``state`` is read-only.
+    * no ``to_quantized`` — ``maybe_quantize_kv_cache`` skips this cache via
+      its ``hasattr`` guard (quantizing would have to copy the prefix anyway).
+    """
+
+    step = 256
+
+    def __init__(
+        self,
+        prefix_keys: mx.array,
+        prefix_values: mx.array,
+        snapshot: Optional[FrozenPrefixSnapshot] = None,
+    ):
+        self._prefix_keys = prefix_keys
+        self._prefix_values = prefix_values
+        self._prefix_len = prefix_keys.shape[2]
+        # Keep the snapshot alive: registry eviction only removes
+        # discoverability, never the arrays under a live fork.
+        self._snapshot = snapshot
+        self.tail = KVCache()
+
+    @property
+    def offset(self):
+        return self._prefix_len + self.tail.offset
+
+    @property
+    def prefix_length(self):
+        return self._prefix_len
+
+    def update_and_fetch(self, keys, values):
+        tail_keys, tail_values = self.tail.update_and_fetch(keys, values)
+        # The concat reads the frozen prefix (never writes it) and produces a
+        # fresh transient buffer for attention; the tail slice stays a view of
+        # the private buffer that the next step writes in place.
+        return (
+            mx.concatenate([self._prefix_keys, tail_keys], axis=2),
+            mx.concatenate([self._prefix_values, tail_values], axis=2),
+        )
+
+    def size(self):
+        return self.offset
+
+    @property
+    def state(self):
+        if self.tail.offset == 0:
+            return self._prefix_keys, self._prefix_values
+        tail_keys, tail_values = self.tail.state
+        return (
+            mx.concatenate([self._prefix_keys, tail_keys], axis=2),
+            mx.concatenate([self._prefix_values, tail_values], axis=2),
+        )
+
+    @state.setter
+    def state(self, v):
+        raise ValueError(
+            "ForkedKVCache state cannot be set; detach with to_kv_cache() first."
+        )
+
+    def to_kv_cache(self) -> KVCache:
+        """Detach into an independent plain KVCache (explicit O(prefix) copy)."""
+        cache = KVCache()
+        keys, values = self.state
+        keys, values = mx.array(keys), mx.array(values)
+        mx.eval(keys, values)
+        cache.state = (keys, values)
+        return cache
+
+    def is_trimmable(self):
+        return True
+
+    def trim(self, n):
+        # Only the private tail is trimmable; the shared prefix is frozen.
+        return self.tail.trim(min(n, self.tail.offset))
+
+    def make_mask(self, *args, **kwargs):
+        return create_attention_mask(*args, offset=self.offset, **kwargs)
+
+    def empty(self):
+        return False
+
+    @property
+    def nbytes(self):
+        """Private (per-fork) bytes only; see class docstring."""
+        return self.tail.nbytes
+
+    @property
+    def shared_nbytes(self):
+        return self._prefix_keys.nbytes + self._prefix_values.nbytes
+
+
+class PrefixForkRegistry:
+    """cid-keyed store of frozen prefix snapshots with longest-prefix fetch.
+
+    * ``freeze`` inserts (or dedups to) a snapshot for exact token content.
+    * ``fetch_fork`` returns a zero-copy ``ForkedKVCache`` stack for the
+      longest known snapshot that prefixes the requested tokens, plus the
+      remaining suffix to prefill — the fork-aware analogue of
+      ``LRUPromptCache.fetch_nearest_cache`` without its deepcopy.
+    * Eviction (LRU by count and bytes) and ``invalidate`` only remove
+      discoverability: misses are always safe (re-prefill), and live forks
+      keep their snapshot's arrays alive via Python references, so a stale
+      HIT on released memory cannot happen.
+    """
+
+    def __init__(self, max_snapshots: int = 16, max_bytes: int = 1 << 63):
+        self.max_snapshots = max_snapshots
+        self.max_bytes = max_bytes
+        self._snapshots: "OrderedDict[str, FrozenPrefixSnapshot]" = OrderedDict()
+        # The trie is namespaced by the model-key STRING (nn.Module is
+        # dict-derived and unhashable, so the object itself cannot key it).
+        self._trie = PromptTrie()
+        self._n_bytes = 0
+        self._lock = threading.Lock()
+
+    def __len__(self):
+        return len(self._snapshots)
+
+    @property
+    def nbytes(self):
+        return self._n_bytes
+
+    def freeze(
+        self, model: Any, tokens: List[int], prompt_cache: List[Any]
+    ) -> Optional[str]:
+        """Snapshot ``prompt_cache`` (which must cover exactly ``tokens``) and
+        register it. Returns the snapshot cid, or ``None`` if the cache is not
+        forkable (never raises for unsupported cache types — that is just a
+        future miss)."""
+        cid = compute_cid(_model_key(model), tokens)
+        with self._lock:
+            if cid in self._snapshots:
+                self._snapshots.move_to_end(cid)  # dedup: same content, one copy
+                return cid
+        snapshot = FrozenPrefixSnapshot.freeze(model, tokens, prompt_cache)
+        if snapshot is None:
+            return None
+        with self._lock:
+            if snapshot.cid in self._snapshots:  # lost a freeze race: dedup
+                self._snapshots.move_to_end(snapshot.cid)
+                return snapshot.cid
+            self._snapshots[snapshot.cid] = snapshot
+            self._trie.add(snapshot.model_key, list(snapshot.tokens), snapshot.cid)
+            self._n_bytes += snapshot.nbytes
+            while len(self._snapshots) > self.max_snapshots or (
+                self._n_bytes > self.max_bytes and len(self._snapshots) > 1
+            ):
+                self._evict_lru_locked()
+        return snapshot.cid
+
+    def fetch_fork(
+        self, model: Any, tokens: List[int]
+    ) -> Tuple[Optional[List[ForkedKVCache]], List[int]]:
+        """Fork from the longest frozen snapshot prefixing ``tokens``.
+
+        Returns ``(forks, remaining_tokens)`` where ``forks`` is a per-layer
+        ``ForkedKVCache`` list (or ``None`` on a miss, with ``remaining ==
+        tokens``). Unlike ``fetch_nearest_cache`` there is no trim-a-longer-
+        cache path: a frozen prefix cannot be trimmed, so a longer-only match
+        is deliberately a miss (false-MISS-only invariant).
+        """
+        model_key = _model_key(model)
+        with self._lock:
+            result = self._trie.search(model_key, tokens)
+            matched = result.exact if result.exact is not None else result.shorter
+            if matched is None:
+                return None, tokens
+            cid = self._trie.get(model_key, matched)
+            snapshot = self._snapshots.get(cid)
+            if snapshot is None:  # stale trie entry: treat as a miss
+                return None, tokens
+            self._snapshots.move_to_end(cid)
+        return snapshot.fork(), tokens[len(matched) :]
+
+    def get(self, cid: str) -> Optional[FrozenPrefixSnapshot]:
+        with self._lock:
+            return self._snapshots.get(cid)
+
+    def invalidate(self, cid: str) -> bool:
+        """Remove a snapshot from the registry (future fetches miss). Live
+        forks referencing it are unaffected. Returns whether it was held."""
+        with self._lock:
+            snapshot = self._snapshots.pop(cid, None)
+            if snapshot is None:
+                return False
+            self._remove_locked(snapshot)
+            return True
+
+    def _remove_locked(self, snapshot: FrozenPrefixSnapshot):
+        self._n_bytes -= snapshot.nbytes
+        try:
+            self._trie.pop(snapshot.model_key, list(snapshot.tokens))
+        except KeyError:
+            pass  # already unlinked; the miss it causes is safe
+
+    def _evict_lru_locked(self):
+        cid, snapshot = self._snapshots.popitem(last=False)
+        self._remove_locked(snapshot)

--- a/mlx_lm/prefix_forks.py
+++ b/mlx_lm/prefix_forks.py
@@ -419,7 +419,12 @@ class PrefixForkRegistry:
     def pinned_nbytes(self):
         """Bytes of snapshots kept resident by live forks — including ones
         already evicted/invalidated (discoverability and residency are
-        deliberately decoupled; see class docstring)."""
+        deliberately decoupled; see class docstring).
+
+        NOTE: a snapshot that is both discoverable and pinned is counted in
+        BOTH ``nbytes`` and ``pinned_nbytes`` — the two are overlapping
+        views (discoverable set vs resident set), not additive; do not sum
+        them to estimate memory."""
         total = 0
         with self._lock:
             dead = []
@@ -477,22 +482,32 @@ class PrefixForkRegistry:
     def _dedup_spot_check(
         snapshot: FrozenPrefixSnapshot, tokens: List[int], prompt_cache: List[Any]
     ):
-        """Cheap content check on a cid-dedup hit: compare a small slice of
-        layer-0 KV. Cannot prove equality (it is a spot check), but catches
-        the realistic failure — same key + tokens over CHANGED weights —
-        and raises instead of silently serving stale KV."""
+        """Cheap content check on a cid-dedup hit: compare the last-4-token
+        KV slice of EVERY layer (a layer-N-only weight change — e.g. a LoRA
+        that leaves embeddings and early attention untouched — produces
+        bit-identical early-layer KV, so a single-layer check is blind to
+        it). Cannot prove equality (position window is limited), but
+        catches per-layer-visible changes at freeze time and raises instead
+        of silently serving stale KV. Freeze-time backstop only: fetch_fork
+        under a stale key has nothing to compare against — the model-key
+        contract is the primary defense."""
         if (
-            not prompt_cache
-            or type(prompt_cache[0]) is not KVCache
+            len(prompt_cache) != len(snapshot.keys)
+            or any(type(c) is not KVCache for c in prompt_cache)
             or prompt_cache[0].offset != len(tokens)
         ):
             return  # not comparable; a fresh freeze() would reject it too
-        k_new = prompt_cache[0].state[0]
-        k_old = snapshot.keys[0]
-        ok = k_new.shape == k_old.shape and k_new.dtype == k_old.dtype
-        if ok:
+        ok = True
+        for layer, c in enumerate(prompt_cache):
+            k_new = c.state[0]
+            k_old = snapshot.keys[layer]
+            if k_new.shape != k_old.shape or k_new.dtype != k_old.dtype:
+                ok = False
+                break
             w = min(4, k_old.shape[2])
-            ok = bool(mx.array_equal(k_old[..., -w:, :], k_new[..., -w:, :]))
+            if not bool(mx.array_equal(k_old[..., -w:, :], k_new[..., -w:, :])):
+                ok = False
+                break
         if not ok:
             raise ValueError(
                 f"prefix-fork dedup mismatch for cid {snapshot.cid}: same "

--- a/tests/test_prefix_forks.py
+++ b/tests/test_prefix_forks.py
@@ -1,0 +1,311 @@
+# Copyright © 2026 Apple Inc.
+
+import copy
+import unittest
+
+import mlx.core as mx
+
+from mlx_lm.generate import generate_step
+from mlx_lm.models.cache import KVCache, RotatingKVCache, make_prompt_cache
+from mlx_lm.prefix_forks import (
+    ForkedKVCache,
+    FrozenPrefixSnapshot,
+    PrefixForkRegistry,
+    compute_cid,
+)
+from mlx_lm.utils import load
+
+HF_MODEL_PATH = "mlx-community/Qwen1.5-0.5B-Chat-4bit"
+
+
+def _random_kv(n, dims=(1, 2, 8)):
+    B, H, D = dims
+    k = mx.random.normal((B, H, n, D)).astype(mx.float16)
+    v = mx.random.normal((B, H, n, D)).astype(mx.float16)
+    mx.eval(k, v)
+    return k, v
+
+
+def _prime_cache(tokens, n_layers=2, dims=(1, 2, 8)):
+    """A KVCache stack filled with len(tokens) of random KV."""
+    cache = [KVCache() for _ in range(n_layers)]
+    for c in cache:
+        k, v = _random_kv(len(tokens), dims)
+        c.update_and_fetch(k, v)
+    mx.eval(*(x for c in cache for x in c.state))
+    return cache
+
+
+class TestForkedKVCache(unittest.TestCase):
+    """Pure-array tests: a ForkedKVCache must be observationally identical to
+    a plain KVCache fed the same KV stream."""
+
+    def test_update_and_fetch_matches_kvcache(self):
+        mx.random.seed(0)
+        prefix_len = 300  # crosses the step=256 boundary and is not a multiple
+        full = KVCache()
+        pk, pv = _random_kv(prefix_len)
+        full.update_and_fetch(pk, pv)
+
+        snapshot = FrozenPrefixSnapshot(
+            "cid", "m", tuple(range(prefix_len)), [mx.array(pk)], [mx.array(pv)]
+        )
+        fork = snapshot.fork()[0]
+
+        # Mixed prefill/decode chunks; total tail crosses another step boundary
+        for n in (1, 7, 1, 1, 256, 1, 40):
+            k, v = _random_kv(n)
+            fk, fv = full.update_and_fetch(k, v)
+            gk, gv = fork.update_and_fetch(k, v)
+            self.assertEqual(fork.offset, full.offset)
+            self.assertEqual(fork.size(), full.size())
+            self.assertTrue(mx.array_equal(fk, gk))
+            self.assertTrue(mx.array_equal(fv, gv))
+
+        # state is the joined exact-length view
+        sk, sv = fork.state
+        self.assertTrue(mx.array_equal(sk, full.state[0]))
+        self.assertTrue(mx.array_equal(sv, full.state[1]))
+
+        # detaching gives an equal, independent KVCache
+        detached = fork.to_kv_cache()
+        self.assertIsInstance(detached, KVCache)
+        self.assertEqual(detached.offset, full.offset)
+        self.assertTrue(mx.array_equal(detached.state[0], full.state[0]))
+
+    def test_trim_is_clamped_to_tail(self):
+        pk, pv = _random_kv(64)
+        fork = ForkedKVCache(pk, pv)
+        k, v = _random_kv(10)
+        fork.update_and_fetch(k, v)
+        self.assertEqual(fork.offset, 74)
+        # Trim deeper than the tail: only the 10 private tokens go
+        self.assertTrue(fork.is_trimmable())
+        self.assertEqual(fork.trim(30), 10)
+        self.assertEqual(fork.offset, 64)
+        self.assertEqual(fork.trim(5), 0)
+
+    def test_nbytes_counts_private_tail_only(self):
+        pk, pv = _random_kv(128)
+        fork = ForkedKVCache(pk, pv)
+        self.assertEqual(fork.nbytes, 0)  # fork creation costs no private bytes
+        self.assertEqual(fork.shared_nbytes, pk.nbytes + pv.nbytes)
+        k, v = _random_kv(4)
+        fork.update_and_fetch(k, v)
+        self.assertEqual(fork.nbytes, fork.tail.nbytes)
+        self.assertGreater(fork.nbytes, 0)
+
+    def test_make_mask_matches_kvcache(self):
+        pk, pv = _random_kv(32)
+        fork = ForkedKVCache(pk, pv)
+        k, v = _random_kv(8)
+        fork.update_and_fetch(k, v)
+        ref = KVCache()
+        rk, rv = _random_kv(40)
+        ref.update_and_fetch(rk, rv)
+        for N, kwargs in [
+            (1, dict(return_array=False, window_size=None)),
+            (5, dict(return_array=False, window_size=None)),
+            (5, dict(return_array=True, window_size=None)),
+            (5, dict(return_array=False, window_size=16)),
+        ]:
+            a = fork.make_mask(N, **kwargs)
+            b = ref.make_mask(N, **kwargs)
+            if isinstance(b, (str, type(None))):
+                self.assertEqual(a, b)
+            else:
+                self.assertTrue(mx.array_equal(a, b))
+
+    def test_state_is_read_only(self):
+        pk, pv = _random_kv(8)
+        fork = ForkedKVCache(pk, pv)
+        with self.assertRaises(ValueError):
+            fork.state = (pk, pv)
+
+    def test_parent_arrays_untouched_by_tail_writes(self):
+        prefix_len = 260
+        pk, pv = _random_kv(prefix_len)
+        before_k, before_v = mx.array(pk), mx.array(pv)
+        mx.eval(before_k, before_v)
+        fork = ForkedKVCache(pk, pv)
+        for _ in range(300):  # force several tail buffer growths
+            k, v = _random_kv(1)
+            fork.update_and_fetch(k, v)
+        mx.eval(*fork.state)
+        self.assertTrue(mx.array_equal(pk, before_k))
+        self.assertTrue(mx.array_equal(pv, before_v))
+
+
+class TestPrefixForkRegistry(unittest.TestCase):
+
+    def test_freeze_rejects_unsupported_caches(self):
+        registry = PrefixForkRegistry()
+        tokens = list(range(16))
+        # Wrong cache type
+        rot = [RotatingKVCache(max_size=8)]
+        k, v = _random_kv(16)
+        rot[0].update_and_fetch(k, v)
+        self.assertIsNone(registry.freeze("m", tokens, rot))
+        # Offset mismatch
+        cache = _prime_cache(tokens)
+        self.assertIsNone(registry.freeze("m", tokens + [1, 2], cache))
+        # Empty
+        self.assertIsNone(registry.freeze("m", [], []))
+        self.assertEqual(len(registry), 0)
+
+    def test_cid_dedup(self):
+        registry = PrefixForkRegistry()
+        tokens = list(range(32))
+        mx.random.seed(3)
+        cache_a = _prime_cache(tokens)
+        mx.random.seed(4)
+        cache_b = _prime_cache(tokens)
+
+        cid_a = registry.freeze("m", tokens, cache_a)
+        nbytes = registry.nbytes
+        cid_b = registry.freeze("m", tokens, cache_b)
+        # Same content (model, tokens) -> same cid, ONE snapshot, bytes once
+        self.assertEqual(cid_a, cid_b)
+        self.assertEqual(len(registry), 1)
+        self.assertEqual(registry.nbytes, nbytes)
+
+        # Different tokens or model namespace -> different cid
+        self.assertNotEqual(compute_cid("m", tokens), compute_cid("m", tokens[:-1]))
+        self.assertNotEqual(compute_cid("m", tokens), compute_cid("m2", tokens))
+
+    def test_fetch_longest_prefix_and_false_miss(self):
+        registry = PrefixForkRegistry()
+        short, long_ = list(range(8)), list(range(20))
+        registry.freeze("m", short, _prime_cache(short))
+        cid_long = registry.freeze("m", long_, _prime_cache(long_))
+
+        request = long_ + [99, 100]
+        forks, remaining = registry.fetch_fork("m", request)
+        self.assertIsNotNone(forks)
+        self.assertEqual(remaining, [99, 100])  # longest match won
+        self.assertEqual(forks[0].prefix_length, len(long_))
+
+        # A snapshot that only EXTENDS the request is a deliberate miss
+        forks2, remaining2 = registry.fetch_fork("m", long_[:15])
+        self.assertIsNotNone(forks2)  # falls back to the shorter snapshot
+        self.assertEqual(forks2[0].prefix_length, len(short))
+
+        # Unknown model / tokens: miss returns the tokens unchanged
+        forks3, remaining3 = registry.fetch_fork("other", request)
+        self.assertIsNone(forks3)
+        self.assertEqual(remaining3, request)
+
+        # Invalidation errs toward false MISS: fetch misses afterwards...
+        self.assertTrue(registry.invalidate(cid_long))
+        self.assertFalse(registry.invalidate(cid_long))
+        forks4, _ = registry.fetch_fork("m", request)
+        self.assertEqual(forks4[0].prefix_length, len(short))
+        # ...but live forks made earlier still hold their arrays
+        k, v = _random_kv(1)
+        out_k, _ = forks[0].update_and_fetch(k, v)
+        mx.eval(out_k)
+        self.assertEqual(out_k.shape[2], len(long_) + 1)
+
+    def test_lru_eviction(self):
+        registry = PrefixForkRegistry(max_snapshots=2)
+        toks = [list(range(i, i + 8)) for i in (0, 100, 200)]
+        cids = [registry.freeze("m", t, _prime_cache(t)) for t in toks]
+        self.assertEqual(len(registry), 2)
+        # Oldest evicted -> miss; newer ones still hit
+        self.assertIsNone(registry.get(cids[0]))
+        self.assertIsNone(registry.fetch_fork("m", toks[0])[0])
+        self.assertIsNotNone(registry.fetch_fork("m", toks[1])[0])
+        self.assertIsNotNone(registry.fetch_fork("m", toks[2])[0])
+
+
+class TestPrefixForksWithModel(unittest.TestCase):
+    """End-to-end correctness against the real model used by the prompt-cache
+    suite. Bar: a fork must be indistinguishable (greedy, token-exact) from a
+    full deepcopy of the same cache, while never touching the parent."""
+
+    @classmethod
+    def setUpClass(cls):
+        cls.model, cls.tokenizer = load(HF_MODEL_PATH)
+        text = (
+            "The lighthouse keeper counted ships every morning. " * 40
+            + "One day the fog rolled in and"
+        )
+        cls.tokens = cls.tokenizer.encode(text)
+        assert len(cls.tokens) > 300  # prefix must cross the step=256 boundary
+        cls.prefix = cls.tokens[:-1]
+        cls.cache = make_prompt_cache(cls.model)
+        cls.model(mx.array(cls.prefix)[None], cache=cls.cache)
+        mx.eval(*(x for c in cls.cache for x in c.state))
+
+    def _greedy(self, tokens, cache, n):
+        out = []
+        for token, _ in generate_step(
+            mx.array(tokens), self.model, prompt_cache=cache, max_tokens=n
+        ):
+            out.append(int(token))
+        return out
+
+    def test_fork_generation_matches_deepcopy(self):
+        registry = PrefixForkRegistry()
+        cid = registry.freeze(self.model, self.prefix, self.cache)
+        self.assertIsNotNone(cid)
+        snapshot = registry.get(cid)
+
+        # Fork creation must be O(tail): no prefix-sized materialization
+        mx.eval(*(a for s in [snapshot] for a in s.keys + s.values))
+        base_mem = mx.get_active_memory()
+        forks, remaining = registry.fetch_fork(self.model, self.tokens)
+        fork_mem = mx.get_active_memory() - base_mem
+        self.assertIsNotNone(forks)
+        self.assertEqual(remaining, [self.tokens[-1]])
+        self.assertLess(fork_mem, max(1 << 20, snapshot.nbytes // 20))
+        self.assertEqual(sum(f.nbytes for f in forks), 0)
+
+        # Snapshot state before anyone generates
+        before = [mx.array(a) for a in snapshot.keys + snapshot.values]
+        mx.eval(*before)
+
+        # (1) Token-exact equivalence with a full deepcopy continuation
+        ref_cache = copy.deepcopy(self.cache)
+        ref = self._greedy(remaining, ref_cache, 110)
+        got = self._greedy(remaining, forks, 110)
+        self.assertEqual(ref, got)
+
+        # (2) Parent immutability after 110 generated tokens
+        for arr, prev in zip(snapshot.keys + snapshot.values, before):
+            self.assertTrue(mx.array_equal(arr, prev))
+
+        # The original primed cache is also untouched (freeze copied it)
+        self.assertEqual(self.cache[0].offset, len(self.prefix))
+
+    def test_sibling_forks_do_not_contaminate(self):
+        registry = PrefixForkRegistry()
+        cid = registry.freeze(self.model, self.prefix, self.cache)
+        snapshot = registry.get(cid)
+
+        suffix_a = [self.tokens[-1]]
+        suffix_b = self.tokenizer.encode(" thunder shook the")
+
+        forks_a, _ = registry.fetch_fork(self.model, self.prefix + suffix_a)
+        forks_b, _ = registry.fetch_fork(self.model, self.prefix + suffix_b)
+
+        # Independent single-user references for both continuations
+        ref_a = self._greedy(suffix_a, copy.deepcopy(self.cache), 40)
+        ref_b = self._greedy(suffix_b, copy.deepcopy(self.cache), 40)
+
+        # Generate on A first, then B: if A's writes leaked into the shared
+        # prefix (or into B), B would diverge from its clean reference.
+        got_a = self._greedy(suffix_a, forks_a, 40)
+        got_b = self._greedy(suffix_b, forks_b, 40)
+        self.assertEqual(ref_a, got_a)
+        self.assertEqual(ref_b, got_b)
+        self.assertNotEqual(got_a, got_b)  # sanity: they really diverged
+
+        # And the shared parent still froze exactly the prefix
+        self.assertEqual(len(snapshot), len(self.prefix))
+        for f_a, f_b in zip(forks_a, forks_b):
+            self.assertIs(f_a._prefix_keys, f_b._prefix_keys)  # truly shared
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_prefix_forks.py
+++ b/tests/test_prefix_forks.py
@@ -100,6 +100,13 @@ class TestForkedKVCache(unittest.TestCase):
         self.assertEqual(fork.offset, 70)  # untouched by the failed trim
         self.assertEqual(fork.trim(0), 0)
 
+        # A negative rollback must not flow through to KVCache.trim(), where
+        # subtracting a negative value grows the logical offset into
+        # uninitialised capacity.
+        with self.assertRaises(ValueError):
+            fork.trim(-1)
+        self.assertEqual(fork.offset, 70)
+
     def test_trim_prompt_cache_fails_loudly_not_skewed(self):
         # F1 regression (reviewer's exact scenario): a fork inside the
         # trim-longer path of a request-level cache. trim_prompt_cache used
@@ -189,6 +196,35 @@ class TestForkedKVCache(unittest.TestCase):
         self.assertTrue(mx.array_equal(snapshot.keys[0], before))
         self.assertTrue(mx.array_equal(fork.state[0], before))
 
+    def test_registry_snapshot_views_cannot_corrupt_future_forks(self):
+        # registry.get() is a public boundary too.  Mutating an array obtained
+        # from it must not rewrite the snapshot used by forks created later.
+        tokens = list(range(16))
+        registry = PrefixForkRegistry()
+        cid = registry.freeze("m", tokens, _prime_cache(tokens))
+        snapshot = registry.get(cid)
+        before = mx.array(snapshot.keys[0])
+        mx.eval(before)
+
+        exposed = snapshot.keys[0]
+        exposed[..., 0, :] = 777.0
+        mx.eval(exposed)
+
+        future = registry.fetch_fork("m", tokens)[0][0]
+        self.assertTrue(mx.array_equal(future.state[0], before))
+
+        # Registry bookkeeping metadata is part of the immutable snapshot too.
+        for name, value in (
+            ("cid", "wrong"),
+            ("model_key", "wrong"),
+            ("tokens", (999,)),
+            ("nbytes", 0),
+        ):
+            with self.assertRaises(AttributeError):
+                setattr(snapshot, name, value)
+        self.assertTrue(registry.invalidate(cid))
+        self.assertEqual(registry.nbytes, 0)
+
     def test_meta_state_and_save_refuse(self):
         # N4: save_prompt_cache would write a file load_prompt_cache cannot
         # reconstruct (class lookup is models/cache.py globals); refuse loudly.
@@ -215,6 +251,25 @@ class TestForkedKVCache(unittest.TestCase):
 
 
 class TestPrefixForkRegistry(unittest.TestCase):
+
+    def test_cid_framing_separates_model_key_from_tokens(self):
+        # Without length/domain framing these serialize to the same bytes:
+        # b"m" + b"\\0" + b"1" + b"\\0" + b"2".
+        self.assertNotEqual(
+            compute_cid("m", [1, 2]), compute_cid("m\x001", [2])
+        )
+        self.assertEqual(len(compute_cid("m", [1, 2])), 64)
+
+    def test_token_identity_rejects_lossy_coercions(self):
+        registry = PrefixForkRegistry()
+        cache = _prime_cache([1])
+        for bad in ([1.9], ["1"], [True]):
+            with self.assertRaises(TypeError):
+                compute_cid("m", bad)
+            with self.assertRaises(TypeError):
+                registry.freeze("m", bad, cache)
+            with self.assertRaises(TypeError):
+                registry.fetch_fork("m", bad)
 
     def test_model_key_must_be_str(self):
         # B1 regression: id()-derived and object keys are forbidden. An
@@ -284,6 +339,24 @@ class TestPrefixForkRegistry(unittest.TestCase):
         with self.assertRaises(ValueError):
             registry.freeze("m@v1", tokens, altered)
 
+    def test_dedup_value_only_mismatch_raises(self):
+        # A V-projection-only change can leave every key bit-identical.  The
+        # advertised KV-content check must inspect values on every layer too.
+        registry = PrefixForkRegistry()
+        tokens = list(range(40))
+        mx.random.seed(41)
+        registry.freeze("m@v1", tokens, _prime_cache(tokens))
+
+        mx.random.seed(41)
+        altered = _prime_cache(tokens)
+        _, v1 = altered[1].state
+        v1_mod = mx.array(v1)
+        v1_mod[..., -1, :] = 321.0
+        altered[1].values[..., : altered[1].offset, :] = v1_mod
+        mx.eval(altered[1].values)
+        with self.assertRaises(ValueError):
+            registry.freeze("m@v1", tokens, altered)
+
     def test_dedup_content_mismatch_raises(self):
         # F3 regression: same key + tokens but DIFFERENT KV content (weights
         # changed under a stale key) must raise, not silently dedup.
@@ -310,6 +383,19 @@ class TestPrefixForkRegistry(unittest.TestCase):
         # Empty
         self.assertIsNone(registry.freeze("m", [], []))
         self.assertEqual(len(registry), 0)
+
+    def test_existing_cid_does_not_turn_unsupported_freeze_into_success(self):
+        registry = PrefixForkRegistry()
+        tokens = list(range(16))
+        cid = registry.freeze("m", tokens, _prime_cache(tokens))
+
+        rotating = RotatingKVCache(max_size=32)
+        rotating.update_and_fetch(*_random_kv(len(tokens)))
+        self.assertIsNone(registry.freeze("m", tokens, [rotating]))
+
+        wrong_offset = _prime_cache(tokens[:-1])
+        self.assertIsNone(registry.freeze("m", tokens, wrong_offset))
+        self.assertEqual(registry.get(cid).cid, cid)
 
     def test_cid_dedup(self):
         registry = PrefixForkRegistry()
@@ -396,6 +482,48 @@ class TestPrefixForkRegistry(unittest.TestCase):
         del forks
         gc.collect()
         self.assertEqual(registry.pinned_nbytes, 0)
+
+    def test_pinned_nbytes_survives_same_cid_reinsertion(self):
+        registry = PrefixForkRegistry()
+        tokens = list(range(40))
+        cache = _prime_cache(tokens)
+        cid = registry.freeze("m", tokens, cache)
+        old_bytes = registry.get(cid).nbytes
+        old_forks, _ = registry.fetch_fork("m", tokens)
+        registry.invalidate(cid)
+
+        # Reinserting the same CID must not overwrite tracking for the older,
+        # still-live snapshot held by old_forks.
+        self.assertEqual(registry.freeze("m", tokens, cache), cid)
+        self.assertEqual(registry.pinned_nbytes, old_bytes)
+        del old_forks
+        gc.collect()
+        self.assertEqual(registry.pinned_nbytes, 0)
+
+    def test_max_bytes_is_a_strict_discoverable_cap(self):
+        registry = PrefixForkRegistry(max_bytes=1)
+        tokens = list(range(8))
+        cid = registry.freeze("m", tokens, _prime_cache(tokens))
+        self.assertGreater(cid is not None, 0)
+        self.assertEqual(registry.nbytes, 0)
+        self.assertEqual(len(registry), 0)
+        self.assertIsNone(registry.fetch_fork("m", tokens)[0])
+
+    def test_registry_limits_reject_negative_values_and_allow_zero(self):
+        with self.assertRaises(ValueError):
+            PrefixForkRegistry(max_snapshots=-1)
+        with self.assertRaises(ValueError):
+            PrefixForkRegistry(max_bytes=-1)
+        for bad in (True, 1.5, float("nan"), "1"):
+            with self.assertRaises(TypeError):
+                PrefixForkRegistry(max_snapshots=bad)
+            with self.assertRaises(TypeError):
+                PrefixForkRegistry(max_bytes=bad)
+        registry = PrefixForkRegistry(max_snapshots=0, max_bytes=0)
+        tokens = list(range(8))
+        registry.freeze("m", tokens, _prime_cache(tokens))
+        self.assertEqual(len(registry), 0)
+        self.assertEqual(registry.nbytes, 0)
 
 
 class TestPrefixForksWithModel(unittest.TestCase):

--- a/tests/test_prefix_forks.py
+++ b/tests/test_prefix_forks.py
@@ -263,6 +263,27 @@ class TestPrefixForkRegistry(unittest.TestCase):
         self.assertIsNone(forks)
         self.assertEqual(remaining, tokens)
 
+    def test_dedup_mismatch_beyond_layer0_raises(self):
+        """A layer-1-only KV difference (layer 0 bit-identical — the
+        realistic LoRA-that-skips-early-layers shape) must be caught by
+        the all-layer dedup spot-check."""
+        registry = PrefixForkRegistry()
+        tokens = list(range(40))
+        mx.random.seed(31)
+        base = _prime_cache(tokens)
+        registry.freeze("m@v1", tokens, base)
+
+        # Rebuild with layer 0 bit-identical and layer 1 perturbed only
+        mx.random.seed(31)
+        altered = _prime_cache(tokens)  # same seed -> same content
+        k1, v1 = altered[1].state
+        k1_mod = mx.array(k1)
+        k1_mod[..., -1, :] = 123.0
+        altered[1].keys[..., : altered[1].offset, :] = k1_mod
+        mx.eval(altered[1].keys)
+        with self.assertRaises(ValueError):
+            registry.freeze("m@v1", tokens, altered)
+
     def test_dedup_content_mismatch_raises(self):
         # F3 regression: same key + tokens but DIFFERENT KV content (weights
         # changed under a stale key) must raise, not silently dedup.

--- a/tests/test_prefix_forks.py
+++ b/tests/test_prefix_forks.py
@@ -1,12 +1,21 @@
 # Copyright © 2026 Apple Inc.
 
 import copy
+import gc
+import os
+import tempfile
 import unittest
 
 import mlx.core as mx
 
 from mlx_lm.generate import generate_step
-from mlx_lm.models.cache import KVCache, RotatingKVCache, make_prompt_cache
+from mlx_lm.models.cache import (
+    KVCache,
+    RotatingKVCache,
+    make_prompt_cache,
+    save_prompt_cache,
+    trim_prompt_cache,
+)
 from mlx_lm.prefix_forks import (
     ForkedKVCache,
     FrozenPrefixSnapshot,
@@ -73,17 +82,36 @@ class TestForkedKVCache(unittest.TestCase):
         self.assertEqual(detached.offset, full.offset)
         self.assertTrue(mx.array_equal(detached.state[0], full.state[0]))
 
-    def test_trim_is_clamped_to_tail(self):
+    def test_trim_within_tail_and_raises_beyond(self):
         pk, pv = _random_kv(64)
         fork = ForkedKVCache(pk, pv)
         k, v = _random_kv(10)
         fork.update_and_fetch(k, v)
         self.assertEqual(fork.offset, 74)
-        # Trim deeper than the tail: only the 10 private tokens go
         self.assertTrue(fork.is_trimmable())
-        self.assertEqual(fork.trim(30), 10)
-        self.assertEqual(fork.offset, 64)
-        self.assertEqual(fork.trim(5), 0)
+        # Rollback within the private tail works like KVCache
+        self.assertEqual(fork.trim(4), 4)
+        self.assertEqual(fork.offset, 70)
+        # Trimming into the frozen prefix must FAIL LOUDLY (F1): callers of
+        # trim_prompt_cache ignore the return value, so a silent clamp would
+        # leave generation running against skewed KV.
+        with self.assertRaises(ValueError):
+            fork.trim(30)
+        self.assertEqual(fork.offset, 70)  # untouched by the failed trim
+        self.assertEqual(fork.trim(0), 0)
+
+    def test_trim_prompt_cache_fails_loudly_not_skewed(self):
+        # F1 regression (reviewer's exact scenario): a fork inside the
+        # trim-longer path of a request-level cache. trim_prompt_cache used
+        # to under-trim silently (offset skew); now it raises.
+        tokens = list(range(300))
+        registry = PrefixForkRegistry()
+        registry.freeze("m", tokens, _prime_cache(tokens))
+        forks, _ = registry.fetch_fork("m", tokens)
+        for f in forks:
+            f.update_and_fetch(*_random_kv(10))
+        with self.assertRaises(ValueError):
+            trim_prompt_cache(forks, 50)  # 50 > tail of 10
 
     def test_nbytes_counts_private_tail_only(self):
         pk, pv = _random_kv(128)
@@ -122,6 +150,56 @@ class TestForkedKVCache(unittest.TestCase):
         with self.assertRaises(ValueError):
             fork.state = (pk, pv)
 
+    def test_empty_tail_state_is_sealed(self):
+        # F2 regression: .state with an EMPTY tail must never hand out the
+        # raw frozen array objects — a consumer __setitem__ would corrupt
+        # the snapshot and every sibling fork.
+        tokens = list(range(32))
+        registry = PrefixForkRegistry()
+        cid = registry.freeze("m", tokens, _prime_cache(tokens))
+        snapshot = registry.get(cid)
+        fork_a = registry.fetch_fork("m", tokens)[0]
+        fork_b = registry.fetch_fork("m", tokens)[0]
+        before_k = mx.array(snapshot.keys[0])
+        before_v = mx.array(snapshot.values[0])
+        mx.eval(before_k, before_v)
+
+        k, v = fork_a[0].state  # tail empty
+        self.assertIsNot(k, snapshot.keys[0])
+        k[..., 0, :] = 999.0  # hostile consumer edits .state in place
+        v[..., 0, :] = -999.0
+        mx.eval(k, v)
+
+        self.assertTrue(mx.array_equal(snapshot.keys[0], before_k))
+        self.assertTrue(mx.array_equal(snapshot.values[0], before_v))
+        kb, vb = fork_b[0].state  # sibling unaffected
+        self.assertTrue(mx.array_equal(kb, before_k))
+        self.assertTrue(mx.array_equal(vb, before_v))
+
+    def test_snapshot_init_seals_caller_arrays(self):
+        # F2 (defensive): a caller that retains its arrays and later mutates
+        # them via __setitem__ must not reach the snapshot's stored nodes.
+        pk, pv = _random_kv(16)
+        before = mx.array(pk)
+        mx.eval(before)
+        snapshot = FrozenPrefixSnapshot("cid", "m", tuple(range(16)), [pk], [pv])
+        fork = ForkedKVCache(pk, pv)
+        pk[..., 0, :] = 123.0  # caller scribbles its own reference
+        mx.eval(pk)
+        self.assertTrue(mx.array_equal(snapshot.keys[0], before))
+        self.assertTrue(mx.array_equal(fork.state[0], before))
+
+    def test_meta_state_and_save_refuse(self):
+        # N4: save_prompt_cache would write a file load_prompt_cache cannot
+        # reconstruct (class lookup is models/cache.py globals); refuse loudly.
+        pk, pv = _random_kv(8)
+        forks = [ForkedKVCache(pk, pv)]
+        with self.assertRaises(ValueError):
+            _ = forks[0].meta_state
+        path = os.path.join(tempfile.mkdtemp(), "fork.safetensors")
+        with self.assertRaises(ValueError):
+            save_prompt_cache(path, forks)
+
     def test_parent_arrays_untouched_by_tail_writes(self):
         prefix_len = 260
         pk, pv = _random_kv(prefix_len)
@@ -137,6 +215,65 @@ class TestForkedKVCache(unittest.TestCase):
 
 
 class TestPrefixForkRegistry(unittest.TestCase):
+
+    def test_model_key_must_be_str(self):
+        # B1 regression: id()-derived and object keys are forbidden. An
+        # in-place weight swap keeps the same object, and CPython recycles
+        # addresses of dead objects — both turned into stale-KV false HITs.
+        registry = PrefixForkRegistry()
+        tokens = list(range(8))
+        cache = _prime_cache(tokens)
+
+        class FakeModel:
+            pass
+
+        for bad in (FakeModel(), ("path", "adapter", None), 42, None, b"key"):
+            with self.assertRaises(TypeError):
+                registry.freeze(bad, tokens, cache)
+            with self.assertRaises(TypeError):
+                registry.fetch_fork(bad, tokens)
+            with self.assertRaises(TypeError):
+                compute_cid(bad, tokens)
+        self.assertEqual(len(registry), 0)
+
+    def test_distinct_string_keys_never_collide(self):
+        registry = PrefixForkRegistry()
+        tokens = list(range(16))
+        mx.random.seed(11)
+        cache_a = _prime_cache(tokens)
+        mx.random.seed(12)
+        cache_b = _prime_cache(tokens)
+        cid_a = registry.freeze("org/model@rev1", tokens, cache_a)
+        cid_b = registry.freeze("org/model@rev2", tokens, cache_b)
+        self.assertNotEqual(cid_a, cid_b)
+        self.assertEqual(len(registry), 2)
+        got_a = registry.fetch_fork("org/model@rev1", tokens)[0]
+        got_b = registry.fetch_fork("org/model@rev2", tokens)[0]
+        self.assertTrue(mx.array_equal(got_a[0].state[0], cache_a[0].state[0]))
+        self.assertTrue(mx.array_equal(got_b[0].state[0], cache_b[0].state[0]))
+
+    def test_key_contract_weight_swap_misses(self):
+        # B1 contract, documented: the key MUST change when the weights
+        # change (adapter load). The caller changing the key converts what
+        # was a deterministic stale-KV HIT into a safe MISS.
+        registry = PrefixForkRegistry()
+        tokens = list(range(24))
+        registry.freeze("org/model@base", tokens, _prime_cache(tokens))
+        forks, remaining = registry.fetch_fork("org/model@base+adapterX", tokens)
+        self.assertIsNone(forks)
+        self.assertEqual(remaining, tokens)
+
+    def test_dedup_content_mismatch_raises(self):
+        # F3 regression: same key + tokens but DIFFERENT KV content (weights
+        # changed under a stale key) must raise, not silently dedup.
+        registry = PrefixForkRegistry()
+        tokens = list(range(32))
+        mx.random.seed(21)
+        registry.freeze("org/model@base", tokens, _prime_cache(tokens))
+        mx.random.seed(22)
+        post_adapter = _prime_cache(tokens)
+        with self.assertRaises(ValueError):
+            registry.freeze("org/model@base", tokens, post_adapter)
 
     def test_freeze_rejects_unsupported_caches(self):
         registry = PrefixForkRegistry()
@@ -156,20 +293,19 @@ class TestPrefixForkRegistry(unittest.TestCase):
     def test_cid_dedup(self):
         registry = PrefixForkRegistry()
         tokens = list(range(32))
-        mx.random.seed(3)
         cache_a = _prime_cache(tokens)
-        mx.random.seed(4)
-        cache_b = _prime_cache(tokens)
+        cache_b = copy.deepcopy(cache_a)  # same content, different arrays
 
         cid_a = registry.freeze("m", tokens, cache_a)
         nbytes = registry.nbytes
         cid_b = registry.freeze("m", tokens, cache_b)
-        # Same content (model, tokens) -> same cid, ONE snapshot, bytes once
+        # Same content (model key, tokens, KV) -> same cid, ONE snapshot,
+        # bytes counted once
         self.assertEqual(cid_a, cid_b)
         self.assertEqual(len(registry), 1)
         self.assertEqual(registry.nbytes, nbytes)
 
-        # Different tokens or model namespace -> different cid
+        # Different tokens or model key -> different cid
         self.assertNotEqual(compute_cid("m", tokens), compute_cid("m", tokens[:-1]))
         self.assertNotEqual(compute_cid("m", tokens), compute_cid("m2", tokens))
 
@@ -190,7 +326,7 @@ class TestPrefixForkRegistry(unittest.TestCase):
         self.assertIsNotNone(forks2)  # falls back to the shorter snapshot
         self.assertEqual(forks2[0].prefix_length, len(short))
 
-        # Unknown model / tokens: miss returns the tokens unchanged
+        # Unknown model key / tokens: miss returns the tokens unchanged
         forks3, remaining3 = registry.fetch_fork("other", request)
         self.assertIsNone(forks3)
         self.assertEqual(remaining3, request)
@@ -217,11 +353,38 @@ class TestPrefixForkRegistry(unittest.TestCase):
         self.assertIsNotNone(registry.fetch_fork("m", toks[1])[0])
         self.assertIsNotNone(registry.fetch_fork("m", toks[2])[0])
 
+    def test_pinned_nbytes_tracks_live_forks(self):
+        # F4 regression: nbytes drops on invalidate while live forks still
+        # pin the snapshot's memory. pinned_nbytes reports that residency.
+        registry = PrefixForkRegistry()
+        tokens = list(range(400))
+        cid = registry.freeze("m", tokens, _prime_cache(tokens))
+        snap_bytes = registry.get(cid).nbytes
+        self.assertEqual(registry.nbytes, snap_bytes)
+        self.assertEqual(registry.pinned_nbytes, 0)  # no forks yet
+
+        forks, _ = registry.fetch_fork("m", tokens)
+        self.assertEqual(registry.pinned_nbytes, snap_bytes)
+
+        registry.invalidate(cid)
+        # Discoverability gone, residency not: max_bytes bounds the
+        # discoverable set only.
+        self.assertEqual(registry.nbytes, 0)
+        self.assertEqual(registry.pinned_nbytes, snap_bytes)
+
+        del forks
+        gc.collect()
+        self.assertEqual(registry.pinned_nbytes, 0)
+
 
 class TestPrefixForksWithModel(unittest.TestCase):
     """End-to-end correctness against the real model used by the prompt-cache
     suite. Bar: a fork must be indistinguishable (greedy, token-exact) from a
     full deepcopy of the same cache, while never touching the parent."""
+
+    # The stable weight-identity string the registry requires (see the
+    # MODEL-KEY CONTRACT in prefix_forks.py).
+    MODEL_KEY = HF_MODEL_PATH + "@main"
 
     @classmethod
     def setUpClass(cls):
@@ -232,7 +395,11 @@ class TestPrefixForksWithModel(unittest.TestCase):
         )
         cls.tokens = cls.tokenizer.encode(text)
         assert len(cls.tokens) > 300  # prefix must cross the step=256 boundary
-        cls.prefix = cls.tokens[:-1]
+        # Multi-token suffix: N>1 prefill through the fork exercises the
+        # causal mask / position handling (a flipped prefix/tail concat is
+        # invisible to N=1 decode, which is permutation-invariant over keys).
+        cls.prefix = cls.tokens[:-4]
+        cls.suffix = cls.tokens[-4:]
         cls.cache = make_prompt_cache(cls.model)
         cls.model(mx.array(cls.prefix)[None], cache=cls.cache)
         mx.eval(*(x for c in cls.cache for x in c.state))
@@ -247,17 +414,20 @@ class TestPrefixForksWithModel(unittest.TestCase):
 
     def test_fork_generation_matches_deepcopy(self):
         registry = PrefixForkRegistry()
-        cid = registry.freeze(self.model, self.prefix, self.cache)
+        cid = registry.freeze(self.MODEL_KEY, self.prefix, self.cache)
         self.assertIsNotNone(cid)
         snapshot = registry.get(cid)
 
-        # Fork creation must be O(tail): no prefix-sized materialization
+        # Fork creation must be O(tail): no prefix-sized materialization.
+        # Measure AFTER evaluating everything the fork exposes, so a lazy
+        # O(prefix) copy cannot hide behind deferred execution.
         mx.eval(*(a for s in [snapshot] for a in s.keys + s.values))
         base_mem = mx.get_active_memory()
-        forks, remaining = registry.fetch_fork(self.model, self.tokens)
-        fork_mem = mx.get_active_memory() - base_mem
+        forks, remaining = registry.fetch_fork(self.MODEL_KEY, self.tokens)
         self.assertIsNotNone(forks)
-        self.assertEqual(remaining, [self.tokens[-1]])
+        self.assertEqual(remaining, self.suffix)
+        mx.eval(*(a for f in forks for a in f.state))
+        fork_mem = mx.get_active_memory() - base_mem
         self.assertLess(fork_mem, max(1 << 20, snapshot.nbytes // 20))
         self.assertEqual(sum(f.nbytes for f in forks), 0)
 
@@ -265,7 +435,8 @@ class TestPrefixForksWithModel(unittest.TestCase):
         before = [mx.array(a) for a in snapshot.keys + snapshot.values]
         mx.eval(*before)
 
-        # (1) Token-exact equivalence with a full deepcopy continuation
+        # (1) Token-exact equivalence with a full deepcopy continuation,
+        # through an N>1 prefill (position-sensitive) then 110 decode steps
         ref_cache = copy.deepcopy(self.cache)
         ref = self._greedy(remaining, ref_cache, 110)
         got = self._greedy(remaining, forks, 110)
@@ -280,14 +451,14 @@ class TestPrefixForksWithModel(unittest.TestCase):
 
     def test_sibling_forks_do_not_contaminate(self):
         registry = PrefixForkRegistry()
-        cid = registry.freeze(self.model, self.prefix, self.cache)
+        cid = registry.freeze(self.MODEL_KEY, self.prefix, self.cache)
         snapshot = registry.get(cid)
 
-        suffix_a = [self.tokens[-1]]
+        suffix_a = self.suffix
         suffix_b = self.tokenizer.encode(" thunder shook the")
 
-        forks_a, _ = registry.fetch_fork(self.model, self.prefix + suffix_a)
-        forks_b, _ = registry.fetch_fork(self.model, self.prefix + suffix_b)
+        forks_a, _ = registry.fetch_fork(self.MODEL_KEY, self.prefix + suffix_a)
+        forks_b, _ = registry.fetch_fork(self.MODEL_KEY, self.prefix + suffix_b)
 
         # Independent single-user references for both continuations
         ref_a = self._greedy(suffix_a, copy.deepcopy(self.cache), 40)
@@ -301,10 +472,12 @@ class TestPrefixForksWithModel(unittest.TestCase):
         self.assertEqual(ref_b, got_b)
         self.assertNotEqual(got_a, got_b)  # sanity: they really diverged
 
-        # And the shared parent still froze exactly the prefix
+        # And the shared parent still froze exactly the prefix, with both
+        # forks referencing the SAME snapshot (no per-fork copies)
         self.assertEqual(len(snapshot), len(self.prefix))
         for f_a, f_b in zip(forks_a, forks_b):
-            self.assertIs(f_a._prefix_keys, f_b._prefix_keys)  # truly shared
+            self.assertIs(f_a._snapshot, f_b._snapshot)
+            self.assertIs(f_a._snapshot, snapshot)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
# Copy-on-write prefix forks for KV caches

Branch: `pr/cow-prefix-forks`, off `main` @ a790972.
Commits: `a6bcf1f` → `7dfae09` → `e973043` → `15b344b` (final adversarial hardening).
New `mlx_lm/prefix_forks.py` + `tests/test_prefix_forks.py`; no existing files touched.

## Problem

Many concurrent requests often share one long common prefix — a system prompt, a
document, a few-shot preamble. The request-level prompt cache
(`LRUPromptCache.fetch_nearest_cache`) hands every hit a `copy.deepcopy` of the
cached KV stack. The `deepcopy` *call* is sub-millisecond (MLX arrays copy
lazily), but the copy is materialized on first use: an O(prefix) allocation and
copy per request — measured at ~4 s for a 16k-token prefix in prior benches.
N concurrent requests on the same prefix pay that N times and hold N full
copies in RAM.

## Change

Fork from ONE frozen in-RAM parent snapshot, paying only for private suffixes:

- **`FrozenPrefixSnapshot`** — an immutable, `mx.eval`-materialized,
  content-addressed (sha256 cid over model key + token ids) snapshot of a
  prefix's per-layer KV state, trimmed to exact length (no `step` slack).
  Materialized once per unique prefix content.
- **`ForkedKVCache`** — per-layer cache mirroring `KVCache`'s interface
  (`update_and_fetch`, `offset`, `size`, `state`, `trim`, `make_mask`,
  `nbytes`, `empty`). Holds a *reference* to the frozen parent arrays (zero
  copy) plus a private, growing `KVCache` tail; attention consumers see
  `concat(prefix, tail)`. Writes go only to the tail → the parent is
  structurally immutable: **COW by construction**, not copy-on-first-write.
  Fork creation is O(1); a fork's persistent footprint is O(tail).
- **`PrefixForkRegistry`** — cid-keyed snapshot store with longest-prefix
  lookup (reuses `PromptTrie`), content dedup with a spot-check, LRU eviction
  by count/bytes, pinned-bytes reporting, and thread-safe access.
  `fetch_fork(model_key, tokens)` is the fork-aware analogue of
  `fetch_nearest_cache` — same `(cache, remaining_tokens)` contract, no
  deepcopy.

Library + tests only (opt-in, alongside `LRUPromptCache`); no server rewiring
in v1.

### The model-key contract (B1)

Every registry call takes a **caller-supplied stable string** identifying the
*exact weights* the KV was computed with — it must encode at least model path,
adapter, and revision (e.g. `"org/model@rev+adapter-sha"`), and it **MUST
change whenever the weights change** (adapter load/unload, revision update,
requantization). Non-string keys raise `TypeError` — there is no fallback.
Object/`id()`-derived keys are forbidden because both failure modes were
*reproduced* in review: an in-place weight swap keeps the same object (same id
→ deterministic stale-KV hit), and CPython recycles addresses of dead objects
(a freed key's address reused by a distinct key → cross-namespace hit). Cached
KV is a pure function of (weights, tokens); the key must be too.

## How it works — the aliasing experiment

`KVCache.update_and_fetch` writes via in-place slice assignment
(`keys[..., prev:offset, :] = new`) into a step(=256)-preallocated buffer, so
the design hinged on: *if a fork shares the parent's array and the parent keeps
writing, does the fork observe the mutation?* Probed empirically on
mlx 0.32.0.dev (same-object sharing, lazy and evaluated slices, a
refcount-donation decode loop, and real `KVCache.state` exports across 64
parent decode steps):

- **Mutation visibility follows Python-OBJECT identity, not buffer identity.**
  `a[...] = x` (`__setitem__`) rebinds the array object to the `slice_update`
  result; every reference through that same Python object observes the write,
  but any slice taken *before* the write — lazy or evaluated — references the
  pre-write graph node and is preserved. MLX donation never recycles a buffer
  another live node references, so even a refcount-1-style decode loop cannot
  scribble an exported slice.
- **However**, sharing the live buffer is the wrong primitive anyway: an
  evaluated slice of the step-padded `(B, H, S, D)` buffer along axis 2 is
  strided, so materializing it costs an O(prefix) copy *per fork*; a lazy
  slice pins the parent's entire step-padded buffer and sits one MLX
  donation-optimization away from unsoundness (live `.state` aliases have
  scribbled snapshots before — hence the established `mx.array` + `mx.eval`
  park recipe, which `freeze` reuses).

**Conclusion (implemented):** materialize once per unique prefix content into a
frozen exact-length snapshot; all forks share those arrays by reference. The
single O(prefix) copy is amortized across forks via cid dedup; immutability is
structural — no code path calls `__setitem__` on the shared arrays, **raw
frozen array objects never escape** (every boundary — `.state` with an empty
tail, snapshot/fork constructors — hands out fresh zero-copy slice *objects*,
so a consumer's `__setitem__` rebinds only the consumer's object; the same
rebinding semantics give the seal for free), and the registry plus each live
fork hold references, so donation is impossible by construction.

Known v1 cost: each attention step materializes a transient
`concat(prefix, tail)` per layer (attention already reads all KV bytes each
step; this adds one extra write pass). Removing it needs two-segment attention
(e.g., flash-decoding-style log-sum-exp merge) — left as a follow-up.

### Failure-direction policy

- **Invalidation errs toward false MISS only:** eviction/invalidation removes
  discoverability (next fetch re-prefills — always safe); live forks keep
  their snapshot's arrays alive through ordinary Python references, so a stale
  HIT on released memory cannot happen. Consequently `max_bytes`/`nbytes`
  bound the **discoverable** set only; bytes kept resident by live forks
  pinning an evicted snapshot are reported separately via `pinned_nbytes`
  (weakref-tracked, F4).
- **Dedup errs toward loud failure:** a cid-dedup hit spot-checks the offered
  KV content (layer-0 tail slice) against the stored snapshot and **raises**
  on mismatch — same key+tokens over changed weights is a key-contract
  violation, not a cache hit (F3: contract documented *and* spot-check
  implemented).
- **`trim` errs toward loud failure:** trimming within the private tail
  (rollback of post-fork tokens — speculative decoding, retries: the intended
  integration) works like `KVCache`; trimming *past* the tail into the frozen
  prefix **raises** `ValueError`. Chosen over `is_trimmable() → False` because
  it preserves the rollback story while making the reproduced
  `LRUPromptCache` trim-longer offset-skew impossible — callers of
  `trim_prompt_cache` ignore its return value, so a silent clamp meant
  generating against wrong KV (F1).
- **Serialization refuses loudly:** `save_prompt_cache` of a fork raises
  (`load_prompt_cache` could never reconstruct it); `to_kv_cache()` is the
  explicit detach-and-copy escape hatch (N4).

## Correctness

`tests/test_prefix_forks.py` — 30 tests, all passing (plus
`tests/test_prompt_cache.py` 22/22 unaffected). The suite was validated
against the reviewer's mutation battery: flipped prefix/tail concat, off-by-one
offset, lazy O(prefix) fork copy, and skewed mask offset each fail at least one
test (the lazy-copy mutant is caught because the memory assertion measures
*after* forcing evaluation of everything the fork exposes).

1. **Next-token equivalence** — greedy generation continuing from a fork is
   token-identical (4-token suffix prefill + 110 decode steps) to continuing
   from a full `deepcopy` of the same cache
   (`mlx-community/Qwen1.5-0.5B-Chat-4bit`, prefix > step boundary). The N>1
   prefill is position-sensitive: N=1 decode is permutation-invariant over
   keys and cannot see a flipped concat.
2. **Parent immutability** — after a fork generates 110 tokens, the snapshot's
   arrays are bit-identical to copies taken before. Review additionally
   verified 500-token interleaved sibling generation clean on both mlx
   versions, and capacity-boundary freeze exact.
3. **Sibling isolation** — two forks with different suffixes each match their
   own clean-reference generations; both verified to share the same snapshot.
4. **Memory** — fork creation's `mx.get_active_memory()` delta (measured after
   eval) is bounded far below prefix size; `fork.nbytes` is 0 at creation and
   counts only the private tail (`shared_nbytes` exposes the prefix once).
5. **Identity** — non-str model keys raise everywhere; distinct string keys
   never collide; a weight swap under a changed key misses (contract test);
   same key + different KV content raises at freeze (dedup spot-check).
6. **cid dedup & false-miss-only invalidation** — bit-identical content dedups
   to one snapshot with bytes counted once; LRU eviction and `invalidate`
   produce misses while pre-existing forks keep generating; `pinned_nbytes`
   tracks fork-pinned residency through invalidation and drops to zero when
   forks die.
7. **Loud failure paths** — over-trim raises (directly and through
   `trim_prompt_cache`); `.state` is read-only; empty-tail `.state` is sealed
   (hostile `__setitem__` on it leaves snapshot and siblings bit-identical);
   constructor-provided arrays are sealed; `save_prompt_cache` refuses.
8. **Final adversarial closeout** — unambiguous full-SHA CID framing; exact
   token types; read-only snapshot arrays/metadata; K+V all-layer dedup;
   negative-trim rejection; unsupported-cache fast-path rejection; strict
   byte caps; and same-CID reincarnation accounting under concurrent stress.

## Known limits (documented in-module)

- Only stacks of plain `KVCache` layers are forkable; anything else makes
  `freeze` return `None` (safe miss). Quantized-KV prefixes are a natural
  follow-up.
- A length-1 snapshot is only found by an exact-length fetch (`PromptTrie`'s
  `shorter` result requires a match past position 0) — false miss, never a
  false hit.
- Exact-match `fetch_fork` returns `remaining == []`; as with
  `fetch_nearest_cache`, the caller must keep ≥1 token to feed the model
  (e.g. freeze on `tokens[:-1]`).
- The dedup spot-check is a spot check (layer-0 tail slice), not a proof of
  equality — the model-key contract remains the real identity boundary.

## Measured

Apple M5 Max (128 GB), mlx 0.32.0.dev, Qwen3-0.6B-4bit; one shared
8192-token prefix continued by 8 consumers with distinct suffixes:

| approach | resident delta (8 consumers) | first-token median | total |
|---|---|---|---|
| deepcopy (upstream prompt-cache pattern) | +7.73 GB | 15.6 ms | 0.129 s |
| fork (this change) | **+0.21 GB** | **7.2 ms** | **0.068 s** |

**37x less resident memory** (one frozen snapshot + private tails vs
eight materialized copies), 2.2x faster first continued token (a
deepcopy is lazily materialized on first use), first tokens identical
across approaches. Caveat: the fork run's transient peak was ~1 GB
higher — the per-step `concat(prefix, tail)` materializes both segments;
a two-segment attention (LSE-merge) follow-up removes that transient.
The durable win is resident memory, which is what bounds concurrent
capacity.
