### PR TITLE
sample_utils: dynamic cost-braked budget for make_reasoning_budget (stacks on #1489)

### DIFF
--- a/mlx_lm/sample_utils.py
+++ b/mlx_lm/sample_utils.py
@@ -1,6 +1,7 @@
 # Copyright © 2023-2024 Apple Inc.
 
 import math
+from collections import Counter
 from functools import partial
 from typing import Callable, Dict, List, Optional
 
@@ -365,3 +366,132 @@ def make_frequency_penalty(penalty: float, context_size: int = 20):
         return logits
 
     return frequency_penalty_processor
+
+
+def _is_token_cycle(ids, max_cycle, min_span, window=800):
+    """True if the tail of ``ids`` is a period-``p`` cycle (1..max_cycle)
+    repeated back-to-back for at least ``min_span`` tokens. Decode-free and
+    not newline-aligned, so it catches loops in flowing prose that a
+    line-based check misses. ``min_span`` scales the required repeat count
+    with the cycle size (a 1-token cycle must repeat many times before it
+    counts, a longer phrase only a few)."""
+    t = ids[-window:]
+    n = len(t)
+    for p in range(1, min(max_cycle, n // 3) + 1):
+        block = t[-p:]
+        reps, i = 1, n - 2 * p
+        while i >= 0 and t[i : i + p] == block:
+            reps += 1
+            i -= p
+        if reps >= 3 and reps * p >= min_span:
+            return True
+    return False
+
+
+def _is_line_repetition(text, min_line=20, max_repeats=3):
+    """True if any substantive line (>= ``min_line`` chars) recurs at least
+    ``max_repeats`` times — the signature of a trace that found its point and
+    is now looping on it."""
+    counts = Counter(
+        ln.strip() for ln in (text or "").splitlines() if len(ln.strip()) >= min_line
+    )
+    return bool(counts) and counts.most_common(1)[0][1] >= max_repeats
+
+
+def make_reasoning_budget(
+    think_close: int,
+    max_think_tokens: int,
+    *,
+    think_open: Optional[int] = None,
+    tokenizer=None,
+    check_every: int = 16,
+    max_cycle: int = 80,
+    min_cycle_span: int = 30,
+):
+    """
+    Make a logits processor that bounds a runaway reasoning channel.
+
+    Reasoning models can enter a "thinking" channel and never leave it —
+    finding an answer, then looping or over-deliberating until the token cap,
+    yielding a long trace and no usable answer. Soft sampling pressure
+    (``repetition_penalty``) does not robustly bound this. This processor is a
+    hard, adaptive cap: it stays out of the way while the model reasons and
+    only intervenes — by forcing the ``think_close`` token, so generation
+    leaves the reasoning channel and produces an answer from what it has —
+    once the reasoning is provably running away.
+
+    A trip fires on any of:
+
+    * a hard budget of ``max_think_tokens`` spent inside the channel;
+    * a repeated token cycle in the tail of the channel (decode-free);
+    * a repeated substantive line (only if a ``tokenizer`` is given).
+
+    Args:
+        think_close (int): Token id that closes the reasoning channel; this is
+            what gets forced on a trip (e.g. the id of ``</think>``).
+        max_think_tokens (int): Hard ceiling on tokens spent inside the
+            channel before the close is forced.
+        think_open (int, optional): Token id that opens the channel. If
+            ``None``, generation is assumed to start inside the channel (as
+            with templates that open it for the model). Default: ``None``.
+        tokenizer (optional): If given, enables the decode-based line-repetition
+            detector. Only its ``decode`` method is used. Default: ``None``.
+        check_every (int): How often (in channel tokens) to run the loop
+            detectors. Default: ``16``.
+        max_cycle (int): Longest token-cycle period considered. Default: ``80``.
+        min_cycle_span (int): Minimum repeated span (in tokens) for a cycle to
+            count. Default: ``30``.
+
+    Returns:
+        Callable[[mx.array, mx.array], mx.array]: The logits processor. It
+        operates on a single sequence (as the other processors here do).
+    """
+    if max_think_tokens <= 0:
+        raise ValueError(f"max_think_tokens must be positive, got {max_think_tokens}")
+
+    state = {
+        "n": 0,  # tokens consumed from the running `tokens` array so far
+        "in_think": think_open is None,
+        "ids": [],  # ids seen inside the current channel
+        "since_check": 0,
+    }
+
+    def reasoning_budget_processor(tokens, logits):
+        new = tokens[state["n"] :].tolist()
+        state["n"] = len(tokens)
+        for tid in new:
+            if tid == think_close:
+                state["in_think"] = False
+                state["ids"] = []
+                state["since_check"] = 0
+            elif think_open is not None and tid == think_open:
+                state["in_think"] = True
+                state["ids"] = []
+                state["since_check"] = 0
+            elif state["in_think"]:
+                state["ids"].append(tid)
+
+        if not state["in_think"]:
+            return logits
+
+        ids = state["ids"]
+        trip = len(ids) >= max_think_tokens
+        if not trip:
+            state["since_check"] += len(new)
+            if state["since_check"] >= check_every:
+                state["since_check"] = 0
+                trip = _is_token_cycle(ids, max_cycle, min_cycle_span) or (
+                    tokenizer is not None
+                    and _is_line_repetition(tokenizer.decode(ids[-1500:]))
+                )
+
+        if not trip:
+            return logits
+
+        # Force the channel-close token: -inf everywhere else so the sampler
+        # (greedy or stochastic) must emit `think_close` next.
+        forced = mx.full(logits.shape, -float("inf"), dtype=logits.dtype)
+        forced[:, think_close] = 0.0
+        return forced
+
+    return reasoning_budget_processor

--- a/mlx_lm/sample_utils.py
+++ b/mlx_lm/sample_utils.py
@@ -1,9 +1,10 @@
-# Copyright © 2023-2024 Apple Inc.
+# Copyright © 2023-2026 Apple Inc.
 
 import math
+import time
 from collections import Counter
 from functools import partial
-from typing import Callable, Dict, List, Optional
+from typing import Callable, Dict, List, Optional, Union
 
 import mlx.core as mx
 
@@ -400,7 +401,7 @@ def _is_line_repetition(text, min_line=20, max_repeats=3):
 
 def make_reasoning_budget(
     think_close: int,
-    max_think_tokens: int,
+    max_think_tokens: Union[int, Callable[[], int]],
     *,
     think_open: Optional[int] = None,
     tokenizer=None,
@@ -426,11 +427,28 @@ def make_reasoning_budget(
     * a repeated token cycle in the tail of the channel (decode-free);
     * a repeated substantive line (only if a ``tokenizer`` is given).
 
+    .. note::
+        The processor tracks channel state from the running token stream and
+        never rewinds it, so it does not support speculative decoding's
+        draft-token rejection: tokens it has ingested are counted even if the
+        generator later discards them. Use it with standard (non-speculative)
+        generation.
+
     Args:
         think_close (int): Token id that closes the reasoning channel; this is
             what gets forced on a trip (e.g. the id of ``</think>``).
-        max_think_tokens (int): Hard ceiling on tokens spent inside the
-            channel before the close is forced.
+        max_think_tokens (int or callable): Hard ceiling on tokens spent
+            inside the channel before the close is forced. May be a zero-arg
+            callable returning the current ceiling, evaluated at every
+            generation step until a trip fires — this makes the budget
+            *dynamic*, e.g. one that tightens under live host cost (see
+            ``make_cost_braked_budget``). The callable must return a finite
+            positive number; anything else raises a labeled ``ValueError``.
+            Once a trip fires it latches until a ``think_close`` token is
+            actually emitted: a budget that later grows — or an in-channel
+            ``think_open`` seen before any close — cannot undo a forced
+            close, and the callable is not invoked again while the latch
+            holds.
         think_open (int, optional): Token id that opens the channel. If
             ``None``, generation is assumed to start inside the channel (as
             with templates that open it for the model). Default: ``None``.
@@ -446,7 +464,8 @@ def make_reasoning_budget(
         Callable[[mx.array, mx.array], mx.array]: The logits processor. It
         operates on a single sequence (as the other processors here do).
     """
-    if max_think_tokens <= 0:
+    dynamic_budget = callable(max_think_tokens)
+    if not dynamic_budget and max_think_tokens <= 0:
         raise ValueError(f"max_think_tokens must be positive, got {max_think_tokens}")
 
     state = {
@@ -454,6 +473,12 @@ def make_reasoning_budget(
         "in_think": think_open is None,
         "ids": [],  # ids seen inside the current channel
         "since_check": 0,
+        # Trip latch: with a *dynamic* budget the ceiling can grow between
+        # steps (e.g. host cost dropped), which would otherwise "un-trip" a
+        # budget trip before the forced close token is actually emitted. Once
+        # tripped, keep forcing until a close token is actually seen — an
+        # in-channel re-open does NOT release it (only a real close does).
+        "tripped": False,
     }
 
     def reasoning_budget_processor(tokens, logits):
@@ -464,6 +489,7 @@ def make_reasoning_budget(
                 state["in_think"] = False
                 state["ids"] = []
                 state["since_check"] = 0
+                state["tripped"] = False
             elif think_open is not None and tid == think_open:
                 state["in_think"] = True
                 state["ids"] = []
@@ -475,7 +501,28 @@ def make_reasoning_budget(
             return logits
 
         ids = state["ids"]
-        trip = len(ids) >= max_think_tokens
+        if state["tripped"]:
+            # Latched: do not re-evaluate the budget (a dynamic callable is
+            # not invoked again — a sensor failing after the trip cannot
+            # crash the forced close).
+            trip = True
+        else:
+            if dynamic_budget:
+                try:
+                    budget = int(max_think_tokens())
+                except (TypeError, ValueError, OverflowError) as e:
+                    raise ValueError(
+                        "make_reasoning_budget: the max_think_tokens callable "
+                        f"must return a finite number ({e})"
+                    ) from e
+                if budget <= 0:
+                    raise ValueError(
+                        "make_reasoning_budget: the max_think_tokens callable "
+                        f"must return a positive budget, got {budget}"
+                    )
+            else:
+                budget = max_think_tokens
+            trip = len(ids) >= budget
         if not trip:
             state["since_check"] += len(new)
             if state["since_check"] >= check_every:
@@ -488,6 +535,7 @@ def make_reasoning_budget(
         if not trip:
             return logits
 
+        state["tripped"] = True
         # Force the channel-close token: -inf everywhere else so the sampler
         # (greedy or stochastic) must emit `think_close` next.
         forced = mx.full(logits.shape, -float("inf"), dtype=logits.dtype)
@@ -495,3 +543,144 @@ def make_reasoning_budget(
         return forced
 
     return reasoning_budget_processor
+
+
+# Base think-token budget by expected task size, and the difficulty scaling
+# hard reasoning earns. Used by ``make_cost_braked_budget``.
+REASONING_LEN_BASE = {"short": 512, "medium": 1280, "long": 3200}
+REASONING_DIFF_MULT = {"easy": 1.0, "medium": 1.25, "hard": 1.5}
+
+
+def make_cost_braked_budget(
+    prompt_len: Optional[int] = None,
+    difficulty: str = "medium",
+    *,
+    length_class: Optional[str] = None,
+    floor: int = 256,
+    ceil: int = 4096,
+    cost_brake: float = 0.35,
+    cost_fn: Optional[Callable[[], float]] = None,
+    brake_horizon: float = 120.0,
+    clock: Optional[Callable[[], float]] = None,
+    short_prompt: int = 256,
+    long_prompt: int = 2048,
+) -> Callable[[], int]:
+    """
+    Make a dynamic, cost-braked think-token budget for ``make_reasoning_budget``.
+
+    A static reasoning budget must be sized for the worst case; a dynamic one
+    can be thin by default and spend where the task earns it. This helper
+    builds the budget as::
+
+        budget = clamp(base(length) * difficulty_mult * brake(cost), floor, ceil)
+
+    * **base** comes from the task's expected size: an explicit
+      ``length_class`` (``"short"``/``"medium"``/``"long"``), or one derived
+      from ``prompt_len`` (below ``short_prompt`` tokens is short, at or above
+      ``long_prompt`` is long, otherwise medium).
+    * **difficulty** scales it — hard reasoning earns more room
+      (easy 1.0x / medium 1.25x / hard 1.5x).
+    * **brake** tightens the budget under live cost: with cost in ``[0, 1]``,
+      ``brake = 1 - cost_brake * cost``, so at full cost the budget shrinks by
+      ``cost_brake`` (default 35%). The cost signal is an injected zero-arg
+      callable so any host metric can drive it (load, memory, GPU
+      contention, ...); out-of-range values are clamped to ``[0, 1]`` and a
+      NaN cost raises a labeled ``ValueError``. The default is a wall-clock
+      brake: cost ramps 0 -> 1 over ``brake_horizon`` seconds from the first
+      evaluation, so long generations progressively tighten.
+    * **clamp** bounds it: a hard ``ceil`` is the anti-runaway guard (a loop
+      cannot burn a worst-case flat cap), and ``floor`` guarantees even short
+      tasks room to answer — the brake is discretionary, never below floor.
+
+    The returned zero-arg callable is re-evaluated at every generation step by
+    ``make_reasoning_budget``, so the brake is live, not sampled once.
+
+    Build one budget per generation: the default wall-clock brake anchors on
+    the first evaluation and never resets, so a callable reused across
+    generations starts the later ones already braked.
+
+    Args:
+        prompt_len (int, optional): Prompt length in tokens, used to derive
+            the length class when ``length_class`` is not given. ``None``
+            means medium. Default: ``None``.
+        difficulty (str): ``"easy"``, ``"medium"``, or ``"hard"``.
+            Default: ``"medium"``.
+        length_class (str, optional): Explicit ``"short"``/``"medium"``/
+            ``"long"`` override; takes precedence over ``prompt_len``.
+            Default: ``None``.
+        floor (int): Minimum budget; the brake never cuts below it.
+            Default: ``256``.
+        ceil (int): Hard maximum budget. Default: ``4096``.
+        cost_brake (float): Maximum fractional budget reduction at full cost,
+            in ``[0, 1]``. Default: ``0.35``.
+        cost_fn (callable, optional): Zero-arg callable returning the live
+            cost in ``[0, 1]`` (out-of-range values are clamped; NaN raises).
+            If ``None``, a wall-clock-elapsed brake is used. Default: ``None``.
+        brake_horizon (float): Seconds over which the default wall-clock cost
+            ramps from 0 to 1. Ignored when ``cost_fn`` is given.
+            Default: ``120.0``.
+        clock (callable, optional): Zero-arg monotonic time source for the
+            default wall-clock brake (for testing). Ignored when ``cost_fn``
+            is given. Default: ``time.monotonic``.
+        short_prompt (int): ``prompt_len`` below this is short. Default: ``256``.
+        long_prompt (int): ``prompt_len`` at or above this is long.
+            Default: ``2048``.
+
+    Returns:
+        Callable[[], int]: A zero-arg callable returning the current budget;
+        pass it as ``max_think_tokens`` to ``make_reasoning_budget``.
+    """
+    if floor < 1:
+        raise ValueError(f"floor must be positive, got {floor}")
+    if ceil < floor:
+        raise ValueError(f"ceil must be >= floor, got ceil={ceil}, floor={floor}")
+    if not (0 <= cost_brake <= 1):
+        raise ValueError(f"cost_brake must be in [0, 1], got {cost_brake}")
+    if difficulty not in REASONING_DIFF_MULT:
+        raise ValueError(
+            f"difficulty must be one of {sorted(REASONING_DIFF_MULT)}, got {difficulty!r}"
+        )
+    if short_prompt >= long_prompt:
+        raise ValueError(
+            f"short_prompt must be < long_prompt, got {short_prompt} >= {long_prompt}"
+        )
+    if prompt_len is not None and prompt_len < 0:
+        raise ValueError(f"prompt_len must be non-negative, got {prompt_len}")
+    if length_class is None:
+        if prompt_len is None:
+            length_class = "medium"
+        elif prompt_len < short_prompt:
+            length_class = "short"
+        elif prompt_len >= long_prompt:
+            length_class = "long"
+        else:
+            length_class = "medium"
+    elif length_class not in REASONING_LEN_BASE:
+        raise ValueError(
+            f"length_class must be one of {sorted(REASONING_LEN_BASE)}, got {length_class!r}"
+        )
+
+    base = REASONING_LEN_BASE[length_class] * REASONING_DIFF_MULT[difficulty]
+
+    if cost_fn is None:
+        if brake_horizon <= 0:
+            raise ValueError(f"brake_horizon must be positive, got {brake_horizon}")
+        read_clock = clock if clock is not None else time.monotonic
+        start = None
+
+        def cost_fn():
+            nonlocal start
+            now = read_clock()
+            if start is None:
+                start = now
+            return (now - start) / brake_horizon
+
+    def cost_braked_budget():
+        cost = float(cost_fn())
+        if math.isnan(cost):
+            raise ValueError("make_cost_braked_budget: cost_fn returned NaN")
+        cost = max(0.0, min(1.0, cost))
+        brake = 1.0 - cost_brake * cost
+        return max(floor, min(ceil, int(base * brake)))
+
+    return cost_braked_budget

--- a/mlx_lm/sample_utils.py
+++ b/mlx_lm/sample_utils.py
@@ -4,6 +4,7 @@ import math
 import time
 from collections import Counter
 from functools import partial
+from numbers import Integral, Real
 from typing import Callable, Dict, List, Optional, Union
 
 import mlx.core as mx
@@ -442,8 +443,8 @@ def make_reasoning_budget(
             callable returning the current ceiling, evaluated at every
             generation step until a trip fires — this makes the budget
             *dynamic*, e.g. one that tightens under live host cost (see
-            ``make_cost_braked_budget``). The callable must return a finite
-            positive number; anything else raises a labeled ``ValueError``.
+            ``make_cost_braked_budget``). The callable must return a positive
+            integer; anything else raises a labeled ``ValueError``.
             Once a trip fires it latches until a ``think_close`` token is
             actually emitted: a budget that later grows — or an in-channel
             ``think_open`` seen before any close — cannot undo a forced
@@ -465,8 +466,18 @@ def make_reasoning_budget(
         operates on a single sequence (as the other processors here do).
     """
     dynamic_budget = callable(max_think_tokens)
-    if not dynamic_budget and max_think_tokens <= 0:
-        raise ValueError(f"max_think_tokens must be positive, got {max_think_tokens}")
+    if not dynamic_budget:
+        if isinstance(max_think_tokens, bool) or not isinstance(
+            max_think_tokens, Integral
+        ):
+            raise ValueError(
+                "max_think_tokens must be a positive integer or a zero-arg "
+                f"callable, got {max_think_tokens!r}"
+            )
+        if max_think_tokens <= 0:
+            raise ValueError(
+                f"max_think_tokens must be positive, got {max_think_tokens}"
+            )
 
     state = {
         "n": 0,  # tokens consumed from the running `tokens` array so far
@@ -508,13 +519,13 @@ def make_reasoning_budget(
             trip = True
         else:
             if dynamic_budget:
-                try:
-                    budget = int(max_think_tokens())
-                except (TypeError, ValueError, OverflowError) as e:
+                raw_budget = max_think_tokens()
+                if isinstance(raw_budget, bool) or not isinstance(raw_budget, Integral):
                     raise ValueError(
                         "make_reasoning_budget: the max_think_tokens callable "
-                        f"must return a finite number ({e})"
-                    ) from e
+                        f"must return a positive integer, got {raw_budget!r}"
+                    )
+                budget = int(raw_budget)
                 if budget <= 0:
                     raise ValueError(
                         "make_reasoning_budget: the max_think_tokens callable "
@@ -630,15 +641,34 @@ def make_cost_braked_budget(
         Callable[[], int]: A zero-arg callable returning the current budget;
         pass it as ``max_think_tokens`` to ``make_reasoning_budget``.
     """
+    integer_args = {
+        "floor": floor,
+        "ceil": ceil,
+        "short_prompt": short_prompt,
+        "long_prompt": long_prompt,
+    }
+    if prompt_len is not None:
+        integer_args["prompt_len"] = prompt_len
+    for name, value in integer_args.items():
+        if isinstance(value, bool) or not isinstance(value, Integral):
+            raise ValueError(f"{name} must be an integer, got {value!r}")
+
     if floor < 1:
         raise ValueError(f"floor must be positive, got {floor}")
     if ceil < floor:
         raise ValueError(f"ceil must be >= floor, got ceil={ceil}, floor={floor}")
-    if not (0 <= cost_brake <= 1):
+    if isinstance(cost_brake, bool) or not isinstance(cost_brake, Real):
+        raise ValueError(f"cost_brake must be a number in [0, 1], got {cost_brake!r}")
+    if not math.isfinite(cost_brake) or not (0 <= cost_brake <= 1):
         raise ValueError(f"cost_brake must be in [0, 1], got {cost_brake}")
-    if difficulty not in REASONING_DIFF_MULT:
+    if not isinstance(difficulty, str) or difficulty not in REASONING_DIFF_MULT:
         raise ValueError(
             f"difficulty must be one of {sorted(REASONING_DIFF_MULT)}, got {difficulty!r}"
+        )
+    if short_prompt < 0 or long_prompt < 0:
+        raise ValueError(
+            "short_prompt and long_prompt must be non-negative, got "
+            f"short_prompt={short_prompt}, long_prompt={long_prompt}"
         )
     if short_prompt >= long_prompt:
         raise ValueError(
@@ -655,7 +685,7 @@ def make_cost_braked_budget(
             length_class = "long"
         else:
             length_class = "medium"
-    elif length_class not in REASONING_LEN_BASE:
+    elif not isinstance(length_class, str) or length_class not in REASONING_LEN_BASE:
         raise ValueError(
             f"length_class must be one of {sorted(REASONING_LEN_BASE)}, got {length_class!r}"
         )
@@ -663,24 +693,59 @@ def make_cost_braked_budget(
     base = REASONING_LEN_BASE[length_class] * REASONING_DIFF_MULT[difficulty]
 
     if cost_fn is None:
-        if brake_horizon <= 0:
-            raise ValueError(f"brake_horizon must be positive, got {brake_horizon}")
+        if isinstance(brake_horizon, bool) or not isinstance(brake_horizon, Real):
+            raise ValueError(
+                f"brake_horizon must be a positive finite number, got {brake_horizon!r}"
+            )
+        if not math.isfinite(brake_horizon) or brake_horizon <= 0:
+            raise ValueError(
+                f"brake_horizon must be positive and finite, got {brake_horizon}"
+            )
+        if clock is not None and not callable(clock):
+            raise ValueError(f"clock must be callable, got {clock!r}")
         read_clock = clock if clock is not None else time.monotonic
         start = None
+        previous = None
 
         def cost_fn():
-            nonlocal start
-            now = read_clock()
+            nonlocal previous, start
+            raw_now = read_clock()
+            if isinstance(raw_now, bool) or not isinstance(raw_now, Real):
+                raise ValueError(
+                    "make_cost_braked_budget: clock must return a real number, "
+                    f"got {raw_now!r}"
+                )
+            now = float(raw_now)
+            if not math.isfinite(now):
+                raise ValueError(
+                    "make_cost_braked_budget: clock must return a finite number, "
+                    f"got {raw_now!r}"
+                )
             if start is None:
                 start = now
+            elif now < previous:
+                raise ValueError(
+                    "make_cost_braked_budget: clock moved backwards, "
+                    f"from {previous} to {now}"
+                )
+            previous = now
             return (now - start) / brake_horizon
 
+    elif not callable(cost_fn):
+        raise ValueError(f"cost_fn must be callable, got {cost_fn!r}")
+
     def cost_braked_budget():
-        cost = float(cost_fn())
+        raw_cost = cost_fn()
+        if isinstance(raw_cost, bool) or not isinstance(raw_cost, Real):
+            raise ValueError(
+                "make_cost_braked_budget: cost_fn must return a real number, "
+                f"got {raw_cost!r}"
+            )
+        cost = float(raw_cost)
         if math.isnan(cost):
             raise ValueError("make_cost_braked_budget: cost_fn returned NaN")
         cost = max(0.0, min(1.0, cost))
         brake = 1.0 - cost_brake * cost
-        return max(floor, min(ceil, int(base * brake)))
+        return int(max(floor, min(ceil, int(base * brake))))
 
     return cost_braked_budget

--- a/tests/test_sample_utils.py
+++ b/tests/test_sample_utils.py
@@ -235,6 +235,269 @@ class TestSampleUtils(unittest.TestCase):
             out = proc(mx.array(toks), logits)
         self.assertEqual(int(mx.argmax(out[0]).item()), 5)
 
+    def test_reasoning_budget_callable_matches_static(self):
+        # A constant callable budget must close at the exact same step as the
+        # static int (regression pin for the static path).
+        from mlx_lm.sample_utils import make_reasoning_budget
+
+        close, vocab, budget = 5, 10, 8
+        static = make_reasoning_budget(think_close=close, max_think_tokens=budget)
+        dynamic = make_reasoning_budget(
+            think_close=close, max_think_tokens=lambda: budget
+        )
+        logits = mx.zeros((1, vocab))
+        toks = []
+        for i in range(budget):
+            toks.append(i % 4)
+            out_s = static(mx.array(toks), logits)
+            out_d = dynamic(mx.array(toks), logits)
+            self.assertTrue(mx.all(out_s == out_d).item())
+            if i < budget - 1:
+                self.assertTrue(mx.all(out_s == logits).item())
+        # Both force the close on the same (budget-th) step.
+        self.assertEqual(int(mx.argmax(out_s[0]).item()), close)
+        self.assertEqual(int(mx.argmax(out_d[0]).item()), close)
+
+    def test_reasoning_budget_callable_dynamic(self):
+        # A live budget is re-evaluated each step: shrinking it mid-generation
+        # trips the close earlier than its starting value would.
+        from mlx_lm.sample_utils import make_reasoning_budget
+
+        close, vocab = 5, 10
+        budget = {"v": 100}
+        proc = make_reasoning_budget(
+            think_close=close,
+            max_think_tokens=lambda: budget["v"],
+            check_every=10**9,  # isolate the budget path
+        )
+        logits = mx.zeros((1, vocab))
+        toks = []
+        for i in range(4):
+            toks.append(i % 3)
+            out = proc(mx.array(toks), logits)
+            self.assertTrue(mx.all(out == logits).item())
+        budget["v"] = 3  # cost spiked: tighten below the 4 tokens already spent
+        toks.append(1)
+        out = proc(mx.array(toks), logits)
+        self.assertEqual(int(mx.argmax(out[0]).item()), close)
+
+    def test_reasoning_budget_dynamic_monotonic_close(self):
+        # (a) A trip latches: a budget that grows again before the forced
+        # close token is emitted cannot un-trip it. (b) After the channel
+        # closes, a shrinking budget cannot re-force outside the channel.
+        from mlx_lm.sample_utils import make_reasoning_budget
+
+        close, vocab = 5, 10
+        budget = {"v": 100}
+        proc = make_reasoning_budget(
+            think_close=close,
+            max_think_tokens=lambda: budget["v"],
+            check_every=10**9,
+        )
+        logits = mx.zeros((1, vocab))
+        toks = [0, 1, 2]
+        proc(mx.array(toks), logits)
+        budget["v"] = 2  # trip
+        toks.append(0)
+        out = proc(mx.array(toks), logits)
+        self.assertEqual(int(mx.argmax(out[0]).item()), close)
+        budget["v"] = 10**6  # brake released before the close was emitted...
+        toks.append(1)  # ...and the stream somehow carried content
+        out = proc(mx.array(toks), logits)
+        # ...the trip is latched: still forcing the close.
+        self.assertEqual(int(mx.argmax(out[0]).item()), close)
+        # The channel now actually closes; shrink the budget to its minimum.
+        toks.append(close)
+        proc(mx.array(toks), logits)
+        budget["v"] = 1
+        for t in range(6):
+            toks.append(t % 3)
+            out = proc(mx.array(toks), logits)
+            self.assertTrue(mx.all(out == logits).item())
+
+    def test_reasoning_budget_latch_survives_in_channel_open(self):
+        # F1: an in-channel `think_open` (no close ever emitted) must NOT
+        # release a tripped latch — only a real close does.
+        from mlx_lm.sample_utils import make_reasoning_budget
+
+        close, opn, vocab = 5, 4, 10
+        budget = {"v": 100}
+        proc = make_reasoning_budget(
+            think_close=close,
+            think_open=opn,
+            max_think_tokens=lambda: budget["v"],
+            check_every=10**9,
+        )
+        logits = mx.zeros((1, vocab))
+        toks = [opn, 0, 1, 2]
+        proc(mx.array(toks), logits)
+        budget["v"] = 2  # trip
+        toks.append(0)
+        out = proc(mx.array(toks), logits)
+        self.assertEqual(int(mx.argmax(out[0]).item()), close)
+        # A stray in-channel re-open plus a grown budget: still latched.
+        budget["v"] = 10**6
+        toks.extend([opn, 1])
+        out = proc(mx.array(toks), logits)
+        self.assertEqual(int(mx.argmax(out[0]).item()), close)
+        # A real close releases it; a fresh open re-arms a clean channel.
+        toks.append(close)
+        proc(mx.array(toks), logits)
+        toks.extend([opn, 0, 1])
+        out = proc(mx.array(toks), logits)
+        self.assertTrue(mx.all(out == logits).item())
+
+    def test_reasoning_budget_no_budget_eval_while_latched(self):
+        # F3: once tripped, the budget callable is not invoked again — a cost
+        # sensor that starts raising after the trip cannot crash the forced
+        # close.
+        from mlx_lm.sample_utils import make_reasoning_budget
+
+        close, vocab = 5, 10
+        sensor = {"down": False}
+
+        def budget():
+            if sensor["down"]:
+                raise RuntimeError("cost sensor offline")
+            return 3
+
+        proc = make_reasoning_budget(
+            think_close=close, max_think_tokens=budget, check_every=10**9
+        )
+        logits = mx.zeros((1, vocab))
+        toks = [0, 1, 2]
+        out = proc(mx.array(toks), logits)  # trip at the 3rd think token
+        self.assertEqual(int(mx.argmax(out[0]).item()), close)
+        sensor["down"] = True
+        toks.append(1)
+        out = proc(mx.array(toks), logits)  # latched: sensor never queried
+        self.assertEqual(int(mx.argmax(out[0]).item()), close)
+
+    def test_reasoning_budget_callable_return_validation(self):
+        # F4: a dynamic budget must return a finite positive number, matching
+        # the static constructor's positivity check; failures are labeled.
+        from mlx_lm.sample_utils import make_reasoning_budget
+
+        logits = mx.zeros((1, 10))
+        for bad in (0, -5, float("inf"), float("nan")):
+            proc = make_reasoning_budget(think_close=5, max_think_tokens=lambda: bad)
+            with self.assertRaises(ValueError) as ctx:
+                proc(mx.array([0]), logits)
+            self.assertIn("max_think_tokens", str(ctx.exception))
+
+    def test_cost_braked_budget_brake(self):
+        from mlx_lm.sample_utils import make_cost_braked_budget
+
+        # Default medium/medium: base 1280 * 1.25 = 1600, brake 0.35 at full
+        # cost -> 1600 * 0.65 = 1040.
+        cost = {"v": 0.0}
+        b = make_cost_braked_budget(cost_fn=lambda: cost["v"])
+        self.assertEqual(b(), 1600)
+        cost["v"] = 1.0
+        self.assertEqual(b(), 1040)
+        cost["v"] = 0.5
+        self.assertEqual(b(), 1320)
+        # Out-of-range cost is clamped, not amplified.
+        cost["v"] = 7.0
+        self.assertEqual(b(), 1040)
+        cost["v"] = -3.0
+        self.assertEqual(b(), 1600)
+        # N4: a NaN cost is an explicit, labeled error — never a silent brake.
+        cost["v"] = float("nan")
+        with self.assertRaises(ValueError) as ctx:
+            b()
+        self.assertIn("cost_fn", str(ctx.exception))
+
+    def test_cost_braked_budget_clamps(self):
+        from mlx_lm.sample_utils import make_cost_braked_budget
+
+        # Floor: short/easy base 512 fully braked (cost_brake=1) -> 0 -> floor.
+        b = make_cost_braked_budget(
+            length_class="short",
+            difficulty="easy",
+            cost_brake=1.0,
+            cost_fn=lambda: 1.0,
+        )
+        self.assertEqual(b(), 256)
+        # Ceil: long/hard 3200 * 1.5 = 4800 caps at 4096 even with zero cost.
+        b = make_cost_braked_budget(
+            length_class="long", difficulty="hard", cost_fn=lambda: 0.0
+        )
+        self.assertEqual(b(), 4096)
+
+    def test_cost_braked_budget_length_class(self):
+        from mlx_lm.sample_utils import make_cost_braked_budget
+
+        zero = lambda: 0.0
+        # Derived from prompt_len (difficulty defaults to medium, 1.25x).
+        self.assertEqual(make_cost_braked_budget(10, cost_fn=zero)(), 640)
+        self.assertEqual(make_cost_braked_budget(1000, cost_fn=zero)(), 1600)
+        self.assertEqual(make_cost_braked_budget(5000, cost_fn=zero)(), 4000)
+        # Explicit length_class wins over prompt_len.
+        self.assertEqual(
+            make_cost_braked_budget(5000, length_class="short", cost_fn=zero)(), 640
+        )
+
+    def test_cost_braked_budget_wall_clock(self):
+        # The default cost signal is wall-clock elapsed since first
+        # evaluation, ramping to 1 over brake_horizon (injected clock).
+        from mlx_lm.sample_utils import make_cost_braked_budget
+
+        t = {"now": 100.0}
+        b = make_cost_braked_budget(clock=lambda: t["now"], brake_horizon=60.0)
+        self.assertEqual(b(), 1600)  # first call anchors the clock: cost 0
+        t["now"] = 130.0  # half the horizon -> cost 0.5
+        self.assertEqual(b(), 1320)
+        t["now"] = 1000.0  # far past the horizon -> cost clamps at 1
+        self.assertEqual(b(), 1040)
+
+    def test_cost_braked_budget_validation(self):
+        from mlx_lm.sample_utils import make_cost_braked_budget
+
+        with self.assertRaises(ValueError):
+            make_cost_braked_budget(floor=0)
+        with self.assertRaises(ValueError):
+            make_cost_braked_budget(floor=512, ceil=256)
+        with self.assertRaises(ValueError):
+            make_cost_braked_budget(cost_brake=1.5)
+        with self.assertRaises(ValueError):
+            make_cost_braked_budget(difficulty="impossible")
+        with self.assertRaises(ValueError):
+            make_cost_braked_budget(length_class="epic")
+        with self.assertRaises(ValueError):
+            make_cost_braked_budget(brake_horizon=0.0)
+        with self.assertRaises(ValueError):
+            make_cost_braked_budget(short_prompt=2048, long_prompt=256)
+        with self.assertRaises(ValueError):
+            make_cost_braked_budget(prompt_len=-1)
+
+    def test_reasoning_budget_with_cost_braked_budget(self):
+        # End to end: a cost-braked budget drives the processor, and a cost
+        # spike mid-generation pulls the close in.
+        from mlx_lm.sample_utils import make_cost_braked_budget, make_reasoning_budget
+
+        close, vocab = 5, 10
+        cost = {"v": 0.0}
+        budget = make_cost_braked_budget(
+            length_class="short",
+            difficulty="easy",  # base 512
+            floor=1,
+            cost_fn=lambda: cost["v"],
+        )
+        proc = make_reasoning_budget(
+            think_close=close, max_think_tokens=budget, check_every=10**9
+        )
+        logits = mx.zeros((1, vocab))
+        toks = []
+        for i in range(332):  # under both 512 (cost 0) and 332 (full cost)
+            toks.append(i % 4)
+            out = proc(mx.array(toks), logits)
+            self.assertTrue(mx.all(out == logits).item())
+        cost["v"] = 1.0  # host under full load: 512 * 0.65 = 332
+        toks.append(0)  # 333rd think token >= braked budget -> forced close
+        out = proc(mx.array(toks), logits)
+        self.assertEqual(int(mx.argmax(out[0]).item()), close)
+
     def test_make_logits_processors(self):
         from mlx_lm.sample_utils import make_logits_processors
 

--- a/tests/test_sample_utils.py
+++ b/tests/test_sample_utils.py
@@ -1,3 +1,4 @@
+import math
 import unittest
 
 import mlx.core as mx
@@ -146,6 +147,93 @@ class TestSampleUtils(unittest.TestCase):
         # Tokens not in context not penalized
         self.assertAlmostEqual(result[0, 2].item(), 0.0)
         self.assertAlmostEqual(result[0, 3].item(), 0.0)
+
+    def test_reasoning_budget_hard_cap(self):
+        from mlx_lm.sample_utils import make_reasoning_budget
+
+        close, vocab = 5, 10
+        proc = make_reasoning_budget(think_close=close, max_think_tokens=8)
+        logits = mx.zeros((1, vocab))
+
+        toks = []
+        # 7 tokens inside the (implicitly open) channel: under budget, untouched
+        for i in range(7):
+            toks.append(i % 4)  # content ids, never the close id
+            out = proc(mx.array(toks), logits)
+            self.assertTrue(mx.all(out == logits).item())
+        # 8th token hits the budget -> close is forced
+        toks.append(3)
+        out = proc(mx.array(toks), logits)
+        self.assertEqual(int(mx.argmax(out[0]).item()), close)
+        self.assertEqual(out[0, close].item(), 0.0)
+        self.assertTrue(math.isinf(out[0, 0].item()))
+
+    def test_reasoning_budget_resets_on_natural_close(self):
+        from mlx_lm.sample_utils import make_reasoning_budget
+
+        proc = make_reasoning_budget(think_close=5, max_think_tokens=4)
+        logits = mx.zeros((1, 8))
+        toks = []
+        # Channel closes on its own after two tokens (id 5)...
+        for t in [0, 1, 5]:
+            toks.append(t)
+            proc(mx.array(toks), logits)
+        # ...so subsequent tokens are outside it and never trigger a force,
+        # even well past the budget.
+        for t in range(10):
+            toks.append(t % 3)
+            out = proc(mx.array(toks), logits)
+            self.assertTrue(mx.all(out == logits).item())
+
+    def test_reasoning_budget_open_token_gates(self):
+        from mlx_lm.sample_utils import make_reasoning_budget
+
+        proc = make_reasoning_budget(think_close=5, max_think_tokens=4, think_open=4)
+        logits = mx.zeros((1, 8))
+        toks = []
+        # Before the open token, content does not count toward the budget.
+        for _ in range(6):
+            toks.append(0)
+            out = proc(mx.array(toks), logits)
+            self.assertTrue(mx.all(out == logits).item())
+        # Open the channel, then 4 tokens hit the budget.
+        toks.append(4)
+        proc(mx.array(toks), logits)
+        forced = None
+        for i in range(4):
+            toks.append(i % 2)  # 0/1, not the open/close ids
+            forced = proc(mx.array(toks), logits)
+        self.assertEqual(int(mx.argmax(forced[0]).item()), 5)
+
+    def test_reasoning_budget_token_cycle(self):
+        from mlx_lm.sample_utils import make_reasoning_budget
+
+        proc = make_reasoning_budget(
+            think_close=5, max_think_tokens=10_000, check_every=4
+        )
+        logits = mx.zeros((1, 10))
+        toks, out = [], None
+        for _ in range(20):  # a period-2 loop that never terminates
+            toks += [7, 8]
+            out = proc(mx.array(toks), logits)
+        self.assertEqual(int(mx.argmax(out[0]).item()), 5)
+
+    def test_reasoning_budget_line_repetition(self):
+        from mlx_lm.sample_utils import make_reasoning_budget
+
+        class _Tok:
+            def decode(self, ids):
+                return "this is the same reasoning line\n" * 4
+
+        proc = make_reasoning_budget(
+            think_close=5, max_think_tokens=10_000, tokenizer=_Tok(), check_every=1
+        )
+        logits = mx.zeros((1, 10))
+        toks, out = [], None
+        for i in range(3):
+            toks.append(i)
+            out = proc(mx.array(toks), logits)
+        self.assertEqual(int(mx.argmax(out[0]).item()), 5)
 
     def test_make_logits_processors(self):
         from mlx_lm.sample_utils import make_logits_processors

--- a/tests/test_sample_utils.py
+++ b/tests/test_sample_utils.py
@@ -374,16 +374,58 @@ class TestSampleUtils(unittest.TestCase):
         self.assertEqual(int(mx.argmax(out[0]).item()), close)
 
     def test_reasoning_budget_callable_return_validation(self):
-        # F4: a dynamic budget must return a finite positive number, matching
+        # F4: a dynamic budget must return a positive integer, matching
         # the static constructor's positivity check; failures are labeled.
         from mlx_lm.sample_utils import make_reasoning_budget
 
         logits = mx.zeros((1, 10))
-        for bad in (0, -5, float("inf"), float("nan")):
+        for bad in (0, -5, True, 1.5, "3", float("inf"), float("nan")):
             proc = make_reasoning_budget(think_close=5, max_think_tokens=lambda: bad)
             with self.assertRaises(ValueError) as ctx:
                 proc(mx.array([0]), logits)
             self.assertIn("max_think_tokens", str(ctx.exception))
+
+        # Integer scalar types remain valid; only lossy/coercive conversions
+        # are rejected.
+        import numpy as np
+
+        proc = make_reasoning_budget(
+            think_close=5, max_think_tokens=lambda: np.int64(1)
+        )
+        out = proc(mx.array([0]), logits)
+        self.assertEqual(int(mx.argmax(out[0]).item()), 5)
+
+    def test_reasoning_budget_static_validation_matches_callable(self):
+        from mlx_lm.sample_utils import make_reasoning_budget
+
+        for bad in (True, 1.5, "3", float("inf"), float("nan")):
+            with self.subTest(bad=bad), self.assertRaises(ValueError) as ctx:
+                make_reasoning_budget(think_close=5, max_think_tokens=bad)
+            self.assertIn("max_think_tokens", str(ctx.exception))
+
+        import numpy as np
+
+        # Valid integer scalars preserve static-vs-callable parity.
+        logits = mx.zeros((1, 10))
+        static = make_reasoning_budget(5, np.int64(2), check_every=10**9)
+        dynamic = make_reasoning_budget(5, lambda: np.int64(2), check_every=10**9)
+        for tokens in (mx.array([0]), mx.array([0, 1])):
+            self.assertTrue(
+                mx.array_equal(static(tokens, logits), dynamic(tokens, logits))
+            )
+
+    def test_reasoning_budget_callable_failure_propagates(self):
+        from mlx_lm.sample_utils import make_reasoning_budget
+
+        failure = ValueError("cost sensor offline")
+
+        def budget():
+            raise failure
+
+        proc = make_reasoning_budget(think_close=5, max_think_tokens=budget)
+        with self.assertRaises(ValueError) as ctx:
+            proc(mx.array([0]), mx.zeros((1, 10)))
+        self.assertIs(ctx.exception, failure)
 
     def test_cost_braked_budget_brake(self):
         from mlx_lm.sample_utils import make_cost_braked_budget
@@ -451,6 +493,23 @@ class TestSampleUtils(unittest.TestCase):
         t["now"] = 1000.0  # far past the horizon -> cost clamps at 1
         self.assertEqual(b(), 1040)
 
+    def test_cost_braked_budget_clock_validation(self):
+        from mlx_lm.sample_utils import make_cost_braked_budget
+
+        for bad in (True, "100", float("nan"), float("inf")):
+            budget = make_cost_braked_budget(clock=lambda bad=bad: bad)
+            with self.subTest(bad=bad), self.assertRaises(ValueError) as ctx:
+                budget()
+            self.assertIn("clock", str(ctx.exception))
+
+        t = {"now": 100.0}
+        budget = make_cost_braked_budget(clock=lambda: t["now"])
+        budget()
+        t["now"] = 99.0
+        with self.assertRaises(ValueError) as ctx:
+            budget()
+        self.assertIn("backwards", str(ctx.exception))
+
     def test_cost_braked_budget_validation(self):
         from mlx_lm.sample_utils import make_cost_braked_budget
 
@@ -470,6 +529,51 @@ class TestSampleUtils(unittest.TestCase):
             make_cost_braked_budget(short_prompt=2048, long_prompt=256)
         with self.assertRaises(ValueError):
             make_cost_braked_budget(prompt_len=-1)
+        for kwargs in (
+            {"floor": 256.5},
+            {"ceil": 4096.5},
+            {"floor": float("nan")},
+            {"ceil": float("nan")},
+            {"prompt_len": float("nan")},
+            {"prompt_len": 10.5},
+            {"floor": True},
+            {"cost_brake": True},
+            {"brake_horizon": float("inf")},
+            {"cost_fn": True},
+            {"clock": True},
+            {"short_prompt": -1},
+            {"short_prompt": 256.5},
+            {"long_prompt": 2048.5},
+            {"difficulty": []},
+            {"length_class": []},
+        ):
+            with self.subTest(kwargs=kwargs), self.assertRaises(ValueError):
+                make_cost_braked_budget(**kwargs)
+
+        # NumPy integer/real scalars honor the numeric contract without
+        # forcing callers to convert otherwise-valid measurements manually.
+        import numpy as np
+
+        budget = make_cost_braked_budget(
+            length_class="long",
+            difficulty="hard",
+            prompt_len=np.int64(10),
+            floor=np.int64(1),
+            ceil=np.int64(4095),
+            cost_brake=np.float64(0.35),
+            cost_fn=lambda: np.float64(0.0),
+        )
+        self.assertEqual(budget(), 4095)
+        self.assertIsInstance(budget(), int)
+
+    def test_cost_braked_budget_rejects_non_numeric_cost(self):
+        from mlx_lm.sample_utils import make_cost_braked_budget
+
+        for bad in (True, "0.5", None, complex(0.5, 0)):
+            budget = make_cost_braked_budget(cost_fn=lambda bad=bad: bad)
+            with self.subTest(bad=bad), self.assertRaises(ValueError) as ctx:
+                budget()
+            self.assertIn("cost_fn", str(ctx.exception))
 
     def test_reasoning_budget_with_cost_braked_budget(self):
         # End to end: a cost-braked budget drives the processor, and a cost


### PR DESCRIPTION
# sample_utils: dynamic cost-braked budget for `make_reasoning_budget`

> **Stacks on #1489** (`make_reasoning_budget` logits processor). Branch
> `pr/reasoning-budget-dynamic` = #1489's branch + two commits
> (`1e4fb24`, `9bd0bf4`). Rebase/retarget once #1489 lands.

## Problem

The reasoning-budget processor from #1489 takes a **static** think-token
budget, so it has to be sized for the worst case up front. That has two
costs:

- A ceiling generous enough for a hard task over-spends on easy ones —
  the budget can't reflect what the task actually earns.
- On a shared host there is no way to tighten discretionary reasoning
  spend under load: the cap is the same whether the machine is idle or a
  co-resident inference job is pinning the GPU.

## Change

`max_think_tokens` may now be a **zero-arg callable** returning the
current ceiling, evaluated at every generation step until a trip fires —
the budget becomes live instead of sampled once. Two pieces:

1. **Processor** — accepts `Union[int, Callable[[], int]]`.
   - The callable's return is validated on every evaluation: non-finite
     (inf/NaN) or non-positive values raise a clearly labeled
     `ValueError` naming `max_think_tokens`, matching the static
     constructor's positivity check — no silent step-one force-close,
     no bare `OverflowError` mid-decode.
   - A trip *latches* until a `think_close` token is actually emitted:
     a budget that later grows — or a stray **in-channel `think_open`**
     seen before any close — cannot un-trip a forced close. A real
     close releases the latch; a subsequent `think_open` then re-arms a
     clean channel. So a shrinking budget can never re-force (or
     "un-close") an already-closed channel — the close is monotonic.
   - While the latch holds, the budget callable is **not invoked** — a
     cost sensor that starts failing after the trip cannot crash the
     forced close at exactly the step the latch protects.

2. **`make_cost_braked_budget` helper** — builds such a callable as

   ```
   budget = clamp(base(length) * difficulty_mult * (1 - cost_brake * cost),
                  floor, ceil)
   ```

   - **base** from an explicit `length_class`
     (short/medium/long → 512/1280/3200) or derived from `prompt_len`;
   - **difficulty** scales it (easy/medium/hard → 1.0/1.25/1.5) — hard
     reasoning earns more room;
   - **brake** tightens under live cost: `cost_fn() -> [0, 1]` is an
     injected callable (any host metric can drive it), defaulting to a
     wall-clock brake that ramps 0→1 over `brake_horizon` seconds.
     Out-of-range cost is clamped; **NaN cost raises a labeled error**
     (a deliberate decision, not an argument-order accident of `min`);
   - **clamp**: a hard `ceil` (4096) is the anti-runaway guard, and a
     `floor` (256) the brake never cuts below — braking is
     discretionary, short tasks always get room to answer.

   Dependency-free by construction: the cost signal is injected, never
   a psutil/OS probe, and the default clock (`time.monotonic`) is also
   injectable for deterministic tests. Build **one budget per
   generation**: the default wall-clock brake anchors on its first
   evaluation and never resets, so a reused callable would start later
   generations already braked (documented in the docstring).

Static-int behavior is **behaviorally identical under standard
generation** — pinned by the existing tests (exact close step on a
fixed stream), a static-vs-constant-callable parity test, and verified
by a 300-trial randomized fuzz during review.

## Correctness

`tests/test_sample_utils.py`: 28 passed + 29 subtests, fully synthetic —
injected fake cost/clock, no sleeps, no model
loads.

New coverage:

- static-vs-constant-callable parity (identical forced-close step and
  logits on the same stream);
- live budget re-evaluated each step: a mid-generation shrink trips the
  close earlier than the starting value would;
- trip latch: budget grows back after a trip → close still forced;
  after natural close, a floor-level budget cannot re-force outside the
  channel (monotonic close);
- latch survives a stray in-channel `think_open` (multi-token ingestion
  path) — only a real close releases it, and a fresh open after a real
  close re-arms cleanly;
- no budget evaluation while latched: a sensor that raises after the
  trip never gets queried and the forced close proceeds;
- callable-return validation: 0, -5, `inf`, `nan` each raise a labeled
  `ValueError` naming `max_think_tokens`;
- brake curve values at cost 0 / 0.5 / 1, out-of-range cost clamped,
  NaN cost raises a labeled error;
- both clamp bounds hit (floor via full brake, ceil via long×hard);
- prompt-length → length-class derivation + explicit override;
- default wall-clock brake with an injected fake clock (anchor, half
  horizon, past horizon);
- argument validation (floor/ceil/cost_brake/difficulty/length_class/
  brake_horizon/short_prompt<long_prompt/prompt_len≥0);
- final adversarial validation (`9bd0bf4`): strict positive integer budgets
  (static and callable), no bool/string/fraction/NaN coercion, finite monotonic
  clock inputs, labeled helper type errors, and unchanged sensor exceptions;
- end-to-end: `make_cost_braked_budget` driving the processor, cost
  spike at token 332 of a 512-budget stream pulls the close in.

`black` + `isort --profile black` clean.

## Notes

- **No speculative-decoding support**: the processor tracks channel
  state from the running token stream and never rewinds it, so draft
  tokens it has ingested count even if the generator later rejects
  them. This is true of the base #1489 processor as well, not a
  regression of this PR; documented in the docstring.
- **Inherited from #1489, unchanged here**: an in-channel `think_open`
  resets the think-token counter (`ids`) for the "new" channel. This PR
  only ensures such a re-open cannot release an armed trip latch.
- The budget policy (bases, multipliers, bounds, 35% full-load brake)
  is ported from an internal scheduler's cost-braked per-task token
  budget that has been running against local mlx-lm serving; the
  brake-under-load behavior is field-tested there. The host-cost
  *sensor* was deliberately not ported — injecting `cost_fn` keeps
  mlx-lm dependency-free and lets servers plug in whatever pressure
  signal they already have.
- Like #1489, this is opt-in via the existing `logits_processors` hook;
  nothing changes for callers passing an int.
- `check_every`-gated loop detectors are orthogonal and unchanged.
