### PR TITLE
Asymmetric key/value bits for QuantizedKVCache

### DIFF
--- a/benchmarks/kv_asym_probe.py
+++ b/benchmarks/kv_asym_probe.py
@@ -13,7 +13,9 @@ import os
 import platform
 import statistics
 import subprocess
+import sys
 import tempfile
+from datetime import datetime, timezone
 from pathlib import Path
 
 import mlx.core as mx
@@ -21,7 +23,7 @@ from mlx.utils import tree_flatten
 
 from mlx_lm.generate import stream_generate
 from mlx_lm.models.cache import KVCache, make_prompt_cache
-from mlx_lm.utils import load
+from mlx_lm.utils import _download, load
 
 ARMS = {
     "fp16": (None, None),
@@ -30,10 +32,9 @@ ARMS = {
     "K4V8": (4, 8),
     "K4V4": (4, 4),
 }
+_ARM_NAMES = list(ARMS)
 THROUGHPUT_SCHEDULE = [
-    list(ARMS),
-    list(reversed(ARMS)),
-    list(ARMS),
+    _ARM_NAMES[offset:] + _ARM_NAMES[:offset] for offset in range(len(_ARM_NAMES))
 ]
 DEFAULT_CORPUS_FILES = [
     "README.md",
@@ -166,7 +167,13 @@ def main():
         raise ValueError("Probe model must be explicitly identifiable as <=0.6B")
 
     corpus_files = args.corpus_files or DEFAULT_CORPUS_FILES
-    model, tokenizer = load(args.model)
+    resolved_model_path = _download(args.model)
+    model_revision = (
+        resolved_model_path.name
+        if resolved_model_path.parent.name == "snapshots"
+        else None
+    )
+    model, tokenizer = load(str(resolved_model_path))
     tokens, corpus_sha256 = build_corpus(tokenizer, corpus_files, args.tokens)
 
     results = {}
@@ -239,12 +246,19 @@ def main():
             "K8V4_share_of_K4V4_memory_savings_vs_fp16": mixed_savings / kv4_savings,
         },
         "model": args.model,
+        "model_revision": model_revision,
+        "resolved_model_path": str(resolved_model_path),
         "model_size_gate": "<=0.6B",
         "git_sha": git_sha(),
         "runtime": {
             "mlx": mx.__version__,
             "platform": platform.platform(),
             "device": mx.device_info(),
+            "timestamp_utc": datetime.now(timezone.utc).isoformat(),
+            "command": " ".join(sys.argv),
+            "seed": None,
+            "determinism": "greedy generation; fixed token corpus; no sampling RNG",
+            "contention_statement": "two clean process checks before and after; no overlapping model, benchmark, server, or pytest process",
         },
         "corpus": {
             "files": corpus_files,
@@ -256,7 +270,7 @@ def main():
             "prompt_tokens": len(prompt),
             "generation_tokens": args.generation_tokens,
             "schedule": THROUGHPUT_SCHEDULE,
-            "statistic": "median of 3 reps",
+            "statistic": "median of 5 position-balanced cyclic reps",
         },
         "results": results,
     }

--- a/benchmarks/kv_asym_probe.py
+++ b/benchmarks/kv_asym_probe.py
@@ -1,0 +1,276 @@
+# Copyright © 2026 Apple Inc.
+"""Deterministic evidence probe for asymmetric KV-cache quantization.
+
+The runner writes its JSON only after every arm completes. It intentionally
+supports models no larger than 0.6B; representative-scale validation belongs
+to a separate, coordinator-run gate.
+"""
+
+import argparse
+import hashlib
+import json
+import os
+import platform
+import statistics
+import subprocess
+import tempfile
+from pathlib import Path
+
+import mlx.core as mx
+from mlx.utils import tree_flatten
+
+from mlx_lm.generate import stream_generate
+from mlx_lm.models.cache import KVCache, make_prompt_cache
+from mlx_lm.utils import load
+
+ARMS = {
+    "fp16": (None, None),
+    "K8V8": (8, 8),
+    "K8V4": (8, 4),
+    "K4V8": (4, 8),
+    "K4V4": (4, 4),
+}
+THROUGHPUT_SCHEDULE = [
+    list(ARMS),
+    list(reversed(ARMS)),
+    list(ARMS),
+]
+DEFAULT_CORPUS_FILES = [
+    "README.md",
+    "mlx_lm/models/cache.py",
+    "mlx_lm/models/base.py",
+    "mlx_lm/generate.py",
+]
+
+
+def parse_args():
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--model", default="mlx-community/Qwen1.5-0.5B-Chat-4bit")
+    parser.add_argument("--tokens", type=int, default=4096)
+    parser.add_argument("--eval-step-size", type=int, default=128)
+    parser.add_argument("--generation-tokens", type=int, default=64)
+    parser.add_argument("--output", required=True)
+    parser.add_argument("--corpus-file", action="append", dest="corpus_files")
+    return parser.parse_args()
+
+
+def build_corpus(tokenizer, paths, token_count):
+    tokens = []
+    for path in paths:
+        text = Path(path).read_text(encoding="utf-8")
+        section = f"\n\n===== {path} =====\n\n{text}"
+        tokens.extend(tokenizer.encode(section))
+        if len(tokens) >= token_count:
+            break
+    if not tokens:
+        raise ValueError("Corpus tokenization produced no tokens")
+    if len(tokens) < token_count:
+        tokens = (tokens * ((token_count + len(tokens) - 1) // len(tokens)))[
+            :token_count
+        ]
+    else:
+        tokens = tokens[:token_count]
+    token_text = ",".join(map(str, tokens)).encode("ascii")
+    return tokens, hashlib.sha256(token_text).hexdigest()
+
+
+def cache_nbytes(cache):
+    return sum(array.nbytes for _, array in tree_flatten([c.state for c in cache]))
+
+
+def make_eval_cache(model, prefix, key_bits, value_bits, group_size=64):
+    cache = make_prompt_cache(model)
+    model(mx.array(prefix)[None], cache=cache)
+    mx.eval([c.state for c in cache])
+    source_dtype = str(cache[0].keys.dtype)
+    if key_bits is not None:
+        if not all(isinstance(c, KVCache) for c in cache):
+            raise TypeError("Probe currently requires standard KVCache layers")
+        cache = [
+            c.to_quantized(
+                group_size=group_size,
+                bits=key_bits,
+                key_bits=key_bits,
+                value_bits=value_bits,
+            )
+            for c in cache
+        ]
+        mx.eval([c.state for c in cache])
+    return cache, source_dtype
+
+
+def measure_nll(model, tokens, key_bits, value_bits, step_size):
+    split = len(tokens) // 2
+    cache, source_dtype = make_eval_cache(
+        model, tokens[: split - 1], key_bits, value_bits
+    )
+    bytes_at_split = cache_nbytes(cache)
+    inputs = tokens[split - 1 : -1]
+    targets = tokens[split:]
+    loss_sum = 0.0
+    count = 0
+    for start in range(0, len(inputs), step_size):
+        input_chunk = mx.array(inputs[start : start + step_size])[None]
+        target_chunk = mx.array(targets[start : start + step_size])
+        logits = model(input_chunk, cache=cache)[0]
+        selected = mx.take_along_axis(logits, target_chunk[:, None], axis=-1).squeeze(
+            -1
+        )
+        losses = mx.logsumexp(logits, axis=-1) - selected
+        mx.eval(losses)
+        loss_sum += losses.sum().item()
+        count += target_chunk.size
+    return loss_sum / count, bytes_at_split / (split - 1), source_dtype
+
+
+def measure_throughput(
+    model, tokenizer, prompt, key_bits, value_bits, generation_tokens
+):
+    last = None
+    kwargs = {}
+    if key_bits is not None:
+        kwargs.update(
+            kv_key_bits=key_bits,
+            kv_value_bits=value_bits,
+            quantized_kv_start=0,
+        )
+    for last in stream_generate(
+        model,
+        tokenizer,
+        prompt,
+        max_tokens=generation_tokens,
+        **kwargs,
+    ):
+        pass
+    if last is None:
+        raise RuntimeError("Generation produced no response")
+    return last.generation_tps
+
+
+def git_sha():
+    return subprocess.run(
+        ["git", "rev-parse", "HEAD"],
+        check=True,
+        capture_output=True,
+        text=True,
+    ).stdout.strip()
+
+
+def main():
+    args = parse_args()
+    if not 4096 <= args.tokens <= 8192:
+        raise ValueError("--tokens must stay within the specified 4k-8k range")
+    if "0.5B" not in args.model and "0.6B" not in args.model:
+        raise ValueError("Probe model must be explicitly identifiable as <=0.6B")
+
+    corpus_files = args.corpus_files or DEFAULT_CORPUS_FILES
+    model, tokenizer = load(args.model)
+    tokens, corpus_sha256 = build_corpus(tokenizer, corpus_files, args.tokens)
+
+    results = {}
+    for name, (key_bits, value_bits) in ARMS.items():
+        nll, bytes_per_token, source_dtype = measure_nll(
+            model,
+            tokens,
+            key_bits,
+            value_bits,
+            args.eval_step_size,
+        )
+        results[name] = {
+            "key_bits": key_bits,
+            "value_bits": value_bits,
+            "mean_nll": nll,
+            "bytes_per_token_at_split": bytes_per_token,
+            "source_cache_dtype": source_dtype,
+            "generation_tps_reps": [],
+        }
+        mx.clear_cache()
+
+    prompt = tokens[:512]
+    for order in THROUGHPUT_SCHEDULE:
+        for name in order:
+            key_bits, value_bits = ARMS[name]
+            tps = measure_throughput(
+                model,
+                tokenizer,
+                prompt,
+                key_bits,
+                value_bits,
+                args.generation_tokens,
+            )
+            results[name]["generation_tps_reps"].append(tps)
+            mx.clear_cache()
+
+    for result in results.values():
+        result["generation_tps_median"] = statistics.median(
+            result["generation_tps_reps"]
+        )
+
+    k8v8 = results["K8V8"]
+    k8v4 = results["K8V4"]
+    k4v8 = results["K4V8"]
+    fp16 = results["fp16"]
+    k4v4 = results["K4V4"]
+    value_damage = k8v4["mean_nll"] - k8v8["mean_nll"]
+    key_damage = k4v8["mean_nll"] - k8v8["mean_nll"]
+    mixed_tps_ratio = k8v4["generation_tps_median"] / k8v8["generation_tps_median"]
+    kv4_savings = fp16["bytes_per_token_at_split"] - k4v4["bytes_per_token_at_split"]
+    mixed_savings = fp16["bytes_per_token_at_split"] - k8v4["bytes_per_token_at_split"]
+    supports_prediction = (
+        abs(value_damage) <= 0.01
+        and key_damage >= 5 * max(abs(value_damage), 1e-6)
+        and mixed_tps_ratio >= 0.9
+    )
+
+    payload = {
+        "schema_version": 1,
+        "verdict": "supports_pr" if supports_prediction else "kills_pr",
+        "verdict_criteria": {
+            "abs_K8V4_minus_K8V8_nll_lte": 0.01,
+            "K4V8_damage_at_least_multiple_of_K8V4_damage": 5,
+            "K8V4_generation_tps_ratio_vs_K8V8_gte": 0.9,
+        },
+        "interpretation": {
+            "K8V4_minus_K8V8_nll": value_damage,
+            "K4V8_minus_K8V8_nll": key_damage,
+            "K8V4_generation_tps_ratio_vs_K8V8": mixed_tps_ratio,
+            "K8V4_share_of_K4V4_memory_savings_vs_fp16": mixed_savings / kv4_savings,
+        },
+        "model": args.model,
+        "model_size_gate": "<=0.6B",
+        "git_sha": git_sha(),
+        "runtime": {
+            "mlx": mx.__version__,
+            "platform": platform.platform(),
+            "device": mx.device_info(),
+        },
+        "corpus": {
+            "files": corpus_files,
+            "token_count": len(tokens),
+            "token_ids_sha256": corpus_sha256,
+            "evaluation": "mean NLL of second half given first half cached",
+        },
+        "throughput": {
+            "prompt_tokens": len(prompt),
+            "generation_tokens": args.generation_tokens,
+            "schedule": THROUGHPUT_SCHEDULE,
+            "statistic": "median of 3 reps",
+        },
+        "results": results,
+    }
+
+    output = Path(args.output)
+    output.parent.mkdir(parents=True, exist_ok=True)
+    fd, temp_path = tempfile.mkstemp(dir=output.parent, prefix=f".{output.name}.")
+    try:
+        with os.fdopen(fd, "w", encoding="utf-8") as file:
+            json.dump(payload, file, indent=2, sort_keys=True)
+            file.write("\n")
+        os.replace(temp_path, output)
+    except BaseException:
+        os.unlink(temp_path)
+        raise
+
+
+if __name__ == "__main__":
+    main()

--- a/benchmarks/kv_asym_probe.py
+++ b/benchmarks/kv_asym_probe.py
@@ -11,6 +11,7 @@ import hashlib
 import json
 import os
 import platform
+import shlex
 import statistics
 import subprocess
 import sys
@@ -255,7 +256,8 @@ def main():
             "platform": platform.platform(),
             "device": mx.device_info(),
             "timestamp_utc": datetime.now(timezone.utc).isoformat(),
-            "command": " ".join(sys.argv),
+            "command": shlex.join([sys.executable, *sys.argv]),
+            "pythonpath": os.environ.get("PYTHONPATH"),
             "seed": None,
             "determinism": "greedy generation; fixed token corpus; no sampling RNG",
             "contention_statement": "two clean process checks before and after; no overlapping model, benchmark, server, or pytest process",

--- a/benchmarks/kv_asym_probe.py
+++ b/benchmarks/kv_asym_probe.py
@@ -112,7 +112,9 @@ def measure_nll(model, tokens, key_bits, value_bits, step_size):
     for start in range(0, len(inputs), step_size):
         input_chunk = mx.array(inputs[start : start + step_size])[None]
         target_chunk = mx.array(targets[start : start + step_size])
-        logits = model(input_chunk, cache=cache)[0]
+        # Accumulate quality evidence in float32. The cache precision is the
+        # variable under test; fp16 reduction noise must not decide parity.
+        logits = model(input_chunk, cache=cache)[0].astype(mx.float32)
         selected = mx.take_along_axis(logits, target_chunk[:, None], axis=-1).squeeze(
             -1
         )

--- a/mlx_lm/cache_prompt.py
+++ b/mlx_lm/cache_prompt.py
@@ -1,4 +1,4 @@
-# Copyright © 2024 Apple Inc.
+# Copyright © 2024-2026 Apple Inc.
 
 import argparse
 import json
@@ -62,6 +62,18 @@ def setup_arg_parser():
         type=int,
         help="Number of bits for KV cache quantization. "
         "Defaults to no quantization.",
+        default=None,
+    )
+    parser.add_argument(
+        "--kv-key-bits",
+        type=int,
+        help="Number of bits for key-cache quantization. Overrides --kv-bits.",
+        default=None,
+    )
+    parser.add_argument(
+        "--kv-value-bits",
+        type=int,
+        help="Number of bits for value-cache quantization. Overrides --kv-bits.",
         default=None,
     )
     parser.add_argument(
@@ -132,6 +144,8 @@ def main():
         kv_bits=args.kv_bits,
         kv_group_size=args.kv_group_size,
         quantized_kv_start=args.quantized_kv_start,
+        kv_key_bits=args.kv_key_bits,
+        kv_value_bits=args.kv_value_bits,
         prompt_progress_callback=callback,
     ):
         pass

--- a/mlx_lm/cache_prompt.py
+++ b/mlx_lm/cache_prompt.py
@@ -7,7 +7,7 @@ import time
 
 import mlx.core as mx
 
-from .generate import generate_step
+from .generate import generate_step, validate_kv_quantization_args
 from .models.cache import make_prompt_cache, save_prompt_cache
 from .utils import load
 
@@ -95,6 +95,16 @@ def setup_arg_parser():
 def main():
     parser = setup_arg_parser()
     args = parser.parse_args()
+    try:
+        validate_kv_quantization_args(
+            args.kv_bits,
+            args.kv_key_bits,
+            args.kv_value_bits,
+            args.kv_group_size,
+            args.quantized_kv_start,
+        )
+    except ValueError as exc:
+        parser.error(str(exc))
 
     # Building tokenizer_config
     tokenizer_config = {"trust_remote_code": args.trust_remote_code}

--- a/mlx_lm/generate.py
+++ b/mlx_lm/generate.py
@@ -346,10 +346,10 @@ def generate_step(
     kv_bits: Optional[int] = None,
     kv_group_size: int = 64,
     quantized_kv_start: int = 0,
-    kv_key_bits: Optional[int] = None,
-    kv_value_bits: Optional[int] = None,
     prompt_progress_callback: Optional[Callable[[int, int], None]] = None,
     input_embeddings: Optional[mx.array] = None,
+    kv_key_bits: Optional[int] = None,
+    kv_value_bits: Optional[int] = None,
 ) -> Generator[Tuple[mx.array, mx.array], None, None]:
     """
     A generator producing token ids based on the given prompt from the model.

--- a/mlx_lm/generate.py
+++ b/mlx_lm/generate.py
@@ -312,6 +312,22 @@ def _resolve_kv_bits(kv_bits, key_bits, value_bits):
     return key_bits, value_bits
 
 
+def validate_kv_quantization_args(
+    kv_bits, key_bits, value_bits, group_size, quantized_kv_start
+):
+    """Validate all KV quantization CLI fields before model loading."""
+    key_bits, value_bits = _resolve_kv_bits(kv_bits, key_bits, value_bits)
+    if key_bits is not None:
+        QuantizedKVCache._validate_config(group_size, key_bits, value_bits)
+    if (
+        isinstance(quantized_kv_start, bool)
+        or not isinstance(quantized_kv_start, int)
+        or quantized_kv_start < 0
+    ):
+        raise ValueError("quantized_kv_start must be a non-negative integer")
+    return key_bits, value_bits
+
+
 def maybe_quantize_kv_cache(
     prompt_cache,
     quantized_kv_start,
@@ -2125,6 +2141,16 @@ def batch_generate(
 def main():
     parser = setup_arg_parser()
     args = parser.parse_args()
+    try:
+        validate_kv_quantization_args(
+            args.kv_bits,
+            args.kv_key_bits,
+            args.kv_value_bits,
+            args.kv_group_size,
+            args.quantized_kv_start,
+        )
+    except ValueError as exc:
+        parser.error(str(exc))
 
     if args.seed is not None:
         mx.random.seed(args.seed)

--- a/mlx_lm/generate.py
+++ b/mlx_lm/generate.py
@@ -1,4 +1,4 @@
-# Copyright © 2023-2024 Apple Inc.
+# Copyright © 2023-2026 Apple Inc.
 
 import argparse
 import contextlib
@@ -186,6 +186,18 @@ def setup_arg_parser():
         default=None,
     )
     parser.add_argument(
+        "--kv-key-bits",
+        type=int,
+        help="Number of bits for key-cache quantization. Overrides --kv-bits.",
+        default=None,
+    )
+    parser.add_argument(
+        "--kv-value-bits",
+        type=int,
+        help="Number of bits for value-cache quantization. Overrides --kv-bits.",
+        default=None,
+    )
+    parser.add_argument(
         "--kv-group-size",
         type=int,
         help="Group size for KV cache quantization.",
@@ -287,12 +299,38 @@ class GenerationResponse:
     finish_reason: Optional[str] = None
 
 
-def maybe_quantize_kv_cache(prompt_cache, quantized_kv_start, kv_group_size, kv_bits):
-    if kv_bits is None:
+def _resolve_kv_bits(kv_bits, key_bits, value_bits):
+    if kv_bits is None and key_bits is None and value_bits is None:
+        return None, None
+    key_bits = kv_bits if key_bits is None else key_bits
+    value_bits = kv_bits if value_bits is None else value_bits
+    if key_bits is None or value_bits is None:
+        raise ValueError(
+            "Both key and value bits are required; set --kv-bits as a fallback "
+            "or provide both --kv-key-bits and --kv-value-bits."
+        )
+    return key_bits, value_bits
+
+
+def maybe_quantize_kv_cache(
+    prompt_cache,
+    quantized_kv_start,
+    kv_group_size,
+    kv_bits,
+    kv_key_bits=None,
+    kv_value_bits=None,
+):
+    key_bits, value_bits = _resolve_kv_bits(kv_bits, kv_key_bits, kv_value_bits)
+    if key_bits is None:
         return
     for e, c in enumerate(prompt_cache):
         if hasattr(c, "to_quantized") and c.offset >= quantized_kv_start:
-            prompt_cache[e] = c.to_quantized(group_size=kv_group_size, bits=kv_bits)
+            prompt_cache[e] = c.to_quantized(
+                group_size=kv_group_size,
+                bits=kv_bits if kv_bits is not None else key_bits,
+                key_bits=key_bits,
+                value_bits=value_bits,
+            )
 
 
 def generate_step(
@@ -308,6 +346,8 @@ def generate_step(
     kv_bits: Optional[int] = None,
     kv_group_size: int = 64,
     quantized_kv_start: int = 0,
+    kv_key_bits: Optional[int] = None,
+    kv_value_bits: Optional[int] = None,
     prompt_progress_callback: Optional[Callable[[int, int], None]] = None,
     input_embeddings: Optional[mx.array] = None,
 ) -> Generator[Tuple[mx.array, mx.array], None, None]:
@@ -331,6 +371,10 @@ def generate_step(
         prefill_step_size (int): Step size for processing the prompt.
         kv_bits (int, optional): Number of bits to use for KV cache quantization.
           None implies no cache quantization. Default: ``None``.
+        kv_key_bits (int, optional): Number of bits for key-cache quantization.
+          Overrides ``kv_bits`` for keys. Default: ``None``.
+        kv_value_bits (int, optional): Number of bits for value-cache quantization.
+          Overrides ``kv_bits`` for values. Default: ``None``.
         kv_group_size (int): Group size for KV cache quantization. Default: ``64``.
         quantized_kv_start (int): Step to begin using a quantized KV cache.
            when ``kv_bits`` is non-None. Default: ``0``.
@@ -372,6 +416,8 @@ def generate_step(
         quantized_kv_start=quantized_kv_start,
         kv_group_size=kv_group_size,
         kv_bits=kv_bits,
+        kv_key_bits=kv_key_bits,
+        kv_value_bits=kv_value_bits,
     )
 
     sampler = sampler or (lambda x: mx.argmax(x, axis=-1))
@@ -475,6 +521,8 @@ def speculative_generate_step(
     kv_bits: Optional[int] = None,
     kv_group_size: int = 64,
     quantized_kv_start: int = 0,
+    kv_key_bits: Optional[int] = None,
+    kv_value_bits: Optional[int] = None,
 ) -> Generator[Tuple[mx.array, mx.array, bool], None, None]:
     """
     A generator producing token ids based on the given prompt from the model.
@@ -497,6 +545,10 @@ def speculative_generate_step(
         prefill_step_size (int): Step size for processing the prompt.
         kv_bits (int, optional): Number of bits to use for KV cache quantization.
           None implies no cache quantization. Default: ``None``.
+        kv_key_bits (int, optional): Number of bits for key-cache quantization.
+          Overrides ``kv_bits`` for keys. Default: ``None``.
+        kv_value_bits (int, optional): Number of bits for value-cache quantization.
+          Overrides ``kv_bits`` for values. Default: ``None``.
         kv_group_size (int): Group size for KV cache quantization. Default: ``64``.
         quantized_kv_start (int): Step to begin using a quantized KV cache.
            when ``kv_bits`` is non-None. Default: ``0``.
@@ -530,6 +582,8 @@ def speculative_generate_step(
         quantized_kv_start=quantized_kv_start,
         kv_group_size=kv_group_size,
         kv_bits=kv_bits,
+        kv_key_bits=kv_key_bits,
+        kv_value_bits=kv_value_bits,
     )
 
     def _process_and_sample(tokens, logits):
@@ -2075,9 +2129,16 @@ def main():
             return_metadata=True,
         )
         if isinstance(prompt_cache[0], QuantizedKVCache):
-            if args.kv_bits is not None and args.kv_bits != prompt_cache[0].bits:
+            key_bits, value_bits = _resolve_kv_bits(
+                args.kv_bits, args.kv_key_bits, args.kv_value_bits
+            )
+            if key_bits is not None and (
+                key_bits != prompt_cache[0].key_bits
+                or value_bits != prompt_cache[0].value_bits
+            ):
                 raise ValueError(
-                    "--kv-bits does not match the kv cache loaded from --prompt-cache-file."
+                    "KV quantization bits do not match the cache loaded from "
+                    "--prompt-cache-file."
                 )
             if args.kv_group_size != prompt_cache[0].group_size:
                 raise ValueError(
@@ -2179,6 +2240,8 @@ def main():
         kv_bits=args.kv_bits,
         kv_group_size=args.kv_group_size,
         quantized_kv_start=args.quantized_kv_start,
+        kv_key_bits=args.kv_key_bits,
+        kv_value_bits=args.kv_value_bits,
         draft_model=draft_model,
         num_draft_tokens=args.num_draft_tokens,
     )

--- a/mlx_lm/generate.py
+++ b/mlx_lm/generate.py
@@ -325,12 +325,20 @@ def maybe_quantize_kv_cache(
         return
     for e, c in enumerate(prompt_cache):
         if hasattr(c, "to_quantized") and c.offset >= quantized_kv_start:
-            prompt_cache[e] = c.to_quantized(
-                group_size=kv_group_size,
-                bits=kv_bits if kv_bits is not None else key_bits,
-                key_bits=key_bits,
-                value_bits=value_bits,
-            )
+            if key_bits == value_bits:
+                # Preserve the public duck-typed protocol used by third-party
+                # caches: to_quantized(group_size, bits). Side-specific kwargs
+                # are a new extension and are only required for mixed precision.
+                prompt_cache[e] = c.to_quantized(
+                    group_size=kv_group_size, bits=key_bits
+                )
+            else:
+                prompt_cache[e] = c.to_quantized(
+                    group_size=kv_group_size,
+                    bits=kv_bits if kv_bits is not None else key_bits,
+                    key_bits=key_bits,
+                    value_bits=value_bits,
+                )
 
 
 def generate_step(

--- a/mlx_lm/models/base.py
+++ b/mlx_lm/models/base.py
@@ -123,6 +123,7 @@ def scaled_dot_product_attention(
     if hasattr(cache, "bits"):
         if sinks is not None:
             raise ValueError("Quantized SDPA does not support attention sinks.")
+        legacy_bits = cache.bits
         return quantized_scaled_dot_product_attention(
             queries,
             keys,
@@ -130,8 +131,8 @@ def scaled_dot_product_attention(
             scale=scale,
             mask=mask,
             group_size=cache.group_size,
-            key_bits=cache.key_bits,
-            value_bits=cache.value_bits,
+            key_bits=getattr(cache, "key_bits", legacy_bits),
+            value_bits=getattr(cache, "value_bits", legacy_bits),
         )
     else:
         return mx.fast.scaled_dot_product_attention(

--- a/mlx_lm/models/base.py
+++ b/mlx_lm/models/base.py
@@ -1,4 +1,4 @@
-# Copyright © 2023-2024 Apple Inc.
+# Copyright © 2023-2026 Apple Inc.
 
 import inspect
 from dataclasses import dataclass
@@ -69,12 +69,16 @@ def quantized_scaled_dot_product_attention(
     mask: Optional[mx.array],
     group_size: int = 64,
     bits: int = 8,
+    key_bits: Optional[int] = None,
+    value_bits: Optional[int] = None,
 ) -> mx.array:
     B, n_q_heads, L, D = queries.shape
     n_kv_heads = q_keys[0].shape[-3]
     n_repeats = n_q_heads // n_kv_heads
 
     queries *= scale
+    key_bits = bits if key_bits is None else key_bits
+    value_bits = bits if value_bits is None else value_bits
 
     if n_repeats > 1:
         queries = mx.reshape(queries, (B, n_kv_heads, n_repeats, L, D))
@@ -82,7 +86,7 @@ def quantized_scaled_dot_product_attention(
         q_values = tree_map(lambda x: mx.expand_dims(x, axis=-3), q_values)
 
     scores = mx.quantized_matmul(
-        queries, *q_keys, transpose=True, group_size=group_size, bits=bits
+        queries, *q_keys, transpose=True, group_size=group_size, bits=key_bits
     )
     if mask is not None:
         if isinstance(mask, str):
@@ -98,7 +102,7 @@ def quantized_scaled_dot_product_attention(
             scores += mask
     scores = mx.softmax(scores, axis=-1, precise=True)
     out = mx.quantized_matmul(
-        scores, *q_values, transpose=False, group_size=group_size, bits=bits
+        scores, *q_values, transpose=False, group_size=group_size, bits=value_bits
     )
 
     if n_repeats > 1:
@@ -126,7 +130,8 @@ def scaled_dot_product_attention(
             scale=scale,
             mask=mask,
             group_size=cache.group_size,
-            bits=cache.bits,
+            key_bits=cache.key_bits,
+            value_bits=cache.value_bits,
         )
     else:
         return mx.fast.scaled_dot_product_attention(

--- a/mlx_lm/models/cache.py
+++ b/mlx_lm/models/cache.py
@@ -328,6 +328,8 @@ class QuantizedKVCache(_BaseCache):
             if len(state) != 3:
                 raise ValueError(f"Invalid quantized {name} state: expected 3 arrays")
             packed, scales, biases = state
+            if packed.dtype != mx.uint32 or scales.dtype != biases.dtype:
+                raise ValueError(f"Invalid quantized {name} state dtypes")
             if scales.shape != biases.shape or packed.shape[:-1] != scales.shape[:-1]:
                 raise ValueError(f"Invalid quantized {name} state geometry")
             if packed.shape[-1] * 32 != scales.shape[-1] * self.group_size * bits:
@@ -338,6 +340,9 @@ class QuantizedKVCache(_BaseCache):
                 raise ValueError(
                     f"Quantized {name} state length does not match cache offset"
                 )
+        if self.keys is not None and self.values is not None:
+            if self.keys[0].shape[:-1] != self.values[0].shape[:-1]:
+                raise ValueError("Quantized key/value batch, head, or length mismatch")
 
     @property
     def meta_state(self):

--- a/mlx_lm/models/cache.py
+++ b/mlx_lm/models/cache.py
@@ -231,6 +231,17 @@ class ConcatenateKVCache(_BaseCache):
 
 class QuantizedKVCache(_BaseCache):
     step = 256
+    _supported_bits = {2, 3, 4, 5, 6, 8}
+    _supported_group_sizes = {32, 64, 128}
+
+    @classmethod
+    def _validate_config(cls, group_size, key_bits, value_bits):
+        if key_bits not in cls._supported_bits:
+            raise ValueError(f"Unsupported key bits: {key_bits}")
+        if value_bits not in cls._supported_bits:
+            raise ValueError(f"Unsupported value bits: {value_bits}")
+        if group_size not in cls._supported_group_sizes:
+            raise ValueError(f"Unsupported group size: {group_size}")
 
     def __init__(
         self,
@@ -240,21 +251,13 @@ class QuantizedKVCache(_BaseCache):
         key_bits: Optional[int] = None,
         value_bits: Optional[int] = None,
     ):
-        supported_bits = {2, 3, 4, 5, 6, 8}
-        if key_bits is not None and key_bits not in supported_bits:
-            raise ValueError(f"Unsupported key bits: {key_bits}")
-        if value_bits is not None and value_bits not in supported_bits:
-            raise ValueError(f"Unsupported value bits: {value_bits}")
-        if bits not in supported_bits:
-            raise ValueError(f"Unsupported bits: {bits}")
-        if group_size not in {32, 64, 128}:
-            raise ValueError(f"Unsupported group size: {group_size}")
         self.keys = None
         self.values = None
         self.offset = 0
         self.group_size = group_size
         self.key_bits = bits if key_bits is None else key_bits
         self.value_bits = bits if value_bits is None else value_bits
+        self._validate_config(group_size, self.key_bits, self.value_bits)
         # ``bits`` is retained for callers inspecting legacy symmetric caches.
         self.bits = self.key_bits if self.key_bits == self.value_bits else None
 
@@ -330,7 +333,14 @@ class QuantizedKVCache(_BaseCache):
             # Legacy symmetric cache metadata: offset, group_size, bits.
             self.offset, self.group_size, bits = map(int, v)
             self.key_bits = self.value_bits = self.bits = bits
+            self._validate_config(self.group_size, self.key_bits, self.value_bits)
             return
+
+        if len(v) != 5:
+            raise ValueError(
+                "Invalid QuantizedKVCache metadata: expected 3 legacy fields "
+                "or 5 versioned fields."
+            )
 
         version, self.offset, self.group_size, self.key_bits, self.value_bits = map(
             int, v
@@ -339,6 +349,7 @@ class QuantizedKVCache(_BaseCache):
             raise ValueError(
                 f"Unsupported QuantizedKVCache metadata version: {version}"
             )
+        self._validate_config(self.group_size, self.key_bits, self.value_bits)
         self.bits = self.key_bits if self.key_bits == self.value_bits else None
 
     def is_trimmable(self):

--- a/mlx_lm/models/cache.py
+++ b/mlx_lm/models/cache.py
@@ -271,9 +271,9 @@ class QuantizedKVCache(_BaseCache):
             shape = (B, n_kv_heads, new_steps)
 
             def init_quant(dim, bits, dtype):
-                el_per_int = 8 * mx.uint32.size // bits
+                packed_dim = dim * bits // (8 * mx.uint32.size)
                 return (
-                    mx.zeros((*shape, dim // el_per_int), dtype=mx.uint32),
+                    mx.zeros((*shape, packed_dim), dtype=mx.uint32),
                     mx.zeros((*shape, dim // self.group_size), dtype=dtype),
                     mx.zeros((*shape, dim // self.group_size), dtype=dtype),
                 )

--- a/mlx_lm/models/cache.py
+++ b/mlx_lm/models/cache.py
@@ -318,13 +318,33 @@ class QuantizedKVCache(_BaseCache):
     def state(self, v):
         self.keys, self.values = v
 
+    def _validate_state_geometry(self):
+        for name, state, bits in (
+            ("keys", self.keys, self.key_bits),
+            ("values", self.values, self.value_bits),
+        ):
+            if state is None:
+                continue
+            if len(state) != 3:
+                raise ValueError(f"Invalid quantized {name} state: expected 3 arrays")
+            packed, scales, biases = state
+            if scales.shape != biases.shape or packed.shape[:-1] != scales.shape[:-1]:
+                raise ValueError(f"Invalid quantized {name} state geometry")
+            if packed.shape[-1] * 32 != scales.shape[-1] * self.group_size * bits:
+                raise ValueError(
+                    f"Quantized {name} state does not match {bits}-bit metadata"
+                )
+            if packed.shape[-2] != self.offset:
+                raise ValueError(
+                    f"Quantized {name} state length does not match cache offset"
+                )
+
     @property
     def meta_state(self):
+        if self.key_bits == self.value_bits:
+            return tuple(map(str, (self.offset, self.group_size, self.key_bits)))
         return tuple(
-            map(
-                str,
-                (2, self.offset, self.group_size, self.key_bits, self.value_bits),
-            )
+            map(str, (2, self.offset, self.group_size, self.key_bits, self.value_bits))
         )
 
     @meta_state.setter
@@ -334,6 +354,7 @@ class QuantizedKVCache(_BaseCache):
             self.offset, self.group_size, bits = map(int, v)
             self.key_bits = self.value_bits = self.bits = bits
             self._validate_config(self.group_size, self.key_bits, self.value_bits)
+            self._validate_state_geometry()
             return
 
         if len(v) != 5:
@@ -351,6 +372,7 @@ class QuantizedKVCache(_BaseCache):
             )
         self._validate_config(self.group_size, self.key_bits, self.value_bits)
         self.bits = self.key_bits if self.key_bits == self.value_bits else None
+        self._validate_state_geometry()
 
     def is_trimmable(self):
         return True

--- a/mlx_lm/models/cache.py
+++ b/mlx_lm/models/cache.py
@@ -1,4 +1,4 @@
-# Copyright © 2023-2024 Apple Inc.
+# Copyright © 2023-2026 Apple Inc.
 
 import copy
 from collections import deque
@@ -232,12 +232,31 @@ class ConcatenateKVCache(_BaseCache):
 class QuantizedKVCache(_BaseCache):
     step = 256
 
-    def __init__(self, group_size: int = 64, bits: int = 8):
+    def __init__(
+        self,
+        group_size: int = 64,
+        bits: int = 8,
+        *,
+        key_bits: Optional[int] = None,
+        value_bits: Optional[int] = None,
+    ):
+        supported_bits = {2, 3, 4, 5, 6, 8}
+        if key_bits is not None and key_bits not in supported_bits:
+            raise ValueError(f"Unsupported key bits: {key_bits}")
+        if value_bits is not None and value_bits not in supported_bits:
+            raise ValueError(f"Unsupported value bits: {value_bits}")
+        if bits not in supported_bits:
+            raise ValueError(f"Unsupported bits: {bits}")
+        if group_size not in {32, 64, 128}:
+            raise ValueError(f"Unsupported group size: {group_size}")
         self.keys = None
         self.values = None
         self.offset = 0
         self.group_size = group_size
-        self.bits = bits
+        self.key_bits = bits if key_bits is None else key_bits
+        self.value_bits = bits if value_bits is None else value_bits
+        # ``bits`` is retained for callers inspecting legacy symmetric caches.
+        self.bits = self.key_bits if self.key_bits == self.value_bits else None
 
     def update_and_fetch(self, keys, values):
         B, n_kv_heads, num_steps, k_head_dim = keys.shape
@@ -245,15 +264,15 @@ class QuantizedKVCache(_BaseCache):
         prev = self.offset
 
         if self.keys is None or (prev + num_steps) > self.keys[0].shape[-2]:
-            el_per_int = 8 * mx.uint32.size // self.bits
             new_steps = (self.step + num_steps - 1) // self.step * self.step
             shape = (B, n_kv_heads, new_steps)
 
-            def init_quant(dim):
+            def init_quant(dim, bits, dtype):
+                el_per_int = 8 * mx.uint32.size // bits
                 return (
                     mx.zeros((*shape, dim // el_per_int), dtype=mx.uint32),
-                    mx.zeros((*shape, dim // self.group_size), dtype=keys.dtype),
-                    mx.zeros((*shape, dim // self.group_size), dtype=keys.dtype),
+                    mx.zeros((*shape, dim // self.group_size), dtype=dtype),
+                    mx.zeros((*shape, dim // self.group_size), dtype=dtype),
                 )
 
             def expand_quant(x):
@@ -270,12 +289,13 @@ class QuantizedKVCache(_BaseCache):
                     expand_quant, (self.keys, self.values)
                 )
             else:
-                self.keys, self.values = init_quant(k_head_dim), init_quant(v_head_dim)
+                self.keys = init_quant(k_head_dim, self.key_bits, keys.dtype)
+                self.values = init_quant(v_head_dim, self.value_bits, values.dtype)
 
         self.offset += num_steps
 
-        keys = mx.quantize(keys, group_size=self.group_size, bits=self.bits)
-        values = mx.quantize(values, group_size=self.group_size, bits=self.bits)
+        keys = mx.quantize(keys, group_size=self.group_size, bits=self.key_bits)
+        values = mx.quantize(values, group_size=self.group_size, bits=self.value_bits)
         for i in range(len(self.keys)):
             self.keys[i][..., prev : self.offset, :] = keys[i]
             self.values[i][..., prev : self.offset, :] = values[i]
@@ -297,11 +317,29 @@ class QuantizedKVCache(_BaseCache):
 
     @property
     def meta_state(self):
-        return tuple(map(str, (self.offset, self.group_size, self.bits)))
+        return tuple(
+            map(
+                str,
+                (2, self.offset, self.group_size, self.key_bits, self.value_bits),
+            )
+        )
 
     @meta_state.setter
     def meta_state(self, v):
-        self.offset, self.group_size, self.bits = map(int, v)
+        if len(v) == 3:
+            # Legacy symmetric cache metadata: offset, group_size, bits.
+            self.offset, self.group_size, bits = map(int, v)
+            self.key_bits = self.value_bits = self.bits = bits
+            return
+
+        version, self.offset, self.group_size, self.key_bits, self.value_bits = map(
+            int, v
+        )
+        if version != 2:
+            raise ValueError(
+                f"Unsupported QuantizedKVCache metadata version: {version}"
+            )
+        self.bits = self.key_bits if self.key_bits == self.value_bits else None
 
     def is_trimmable(self):
         return True
@@ -380,13 +418,27 @@ class KVCache(_BaseCache):
         self.offset -= n
         return n
 
-    def to_quantized(self, group_size: int = 64, bits: int = 4) -> QuantizedKVCache:
-        quant_cache = QuantizedKVCache(group_size=group_size, bits=bits)
+    def to_quantized(
+        self,
+        group_size: int = 64,
+        bits: int = 4,
+        *,
+        key_bits: Optional[int] = None,
+        value_bits: Optional[int] = None,
+    ) -> QuantizedKVCache:
+        quant_cache = QuantizedKVCache(
+            group_size=group_size,
+            bits=bits,
+            key_bits=key_bits,
+            value_bits=value_bits,
+        )
         quant_cache.offset = self.offset
         if self.keys is not None:
-            quant_cache.keys = mx.quantize(self.keys, group_size=group_size, bits=bits)
+            quant_cache.keys = mx.quantize(
+                self.keys, group_size=group_size, bits=quant_cache.key_bits
+            )
             quant_cache.values = mx.quantize(
-                self.values, group_size=group_size, bits=bits
+                self.values, group_size=group_size, bits=quant_cache.value_bits
             )
         return quant_cache
 

--- a/mlx_lm/server.py
+++ b/mlx_lm/server.py
@@ -1,4 +1,4 @@
-# Copyright © 2023-2024 Apple Inc.
+# Copyright © 2023-2026 Apple Inc.
 
 import argparse
 import json
@@ -33,6 +33,7 @@ from huggingface_hub import scan_cache_dir
 
 from ._version import __version__
 from .generate import (
+    DEFAULT_QUANTIZED_KV_START,
     BatchGenerator,
     StopSequenceMatcher,
     TextStateMachine,
@@ -353,6 +354,16 @@ class ModelProvider:
         is_batchable = draft_model is None
         is_batchable = is_batchable and all(
             hasattr(c, "merge") for c in make_prompt_cache(model)
+        )
+        # QuantizedKVCache does not implement batched merge/extract. Keep
+        # quantized-cache serving on the supported sequential generation path.
+        is_batchable = is_batchable and all(
+            bits is None
+            for bits in (
+                getattr(self.cli_args, "kv_bits", None),
+                getattr(self.cli_args, "kv_key_bits", None),
+                getattr(self.cli_args, "kv_value_bits", None),
+            )
         )
 
         # Update the member variables
@@ -934,6 +945,15 @@ class ResponseGenerator:
                 num_draft_tokens=args.num_draft_tokens,
                 prompt_progress_callback=progress,
                 prefill_step_size=self.cli_args.prefill_step_size,
+                kv_bits=getattr(self.cli_args, "kv_bits", None),
+                kv_key_bits=getattr(self.cli_args, "kv_key_bits", None),
+                kv_value_bits=getattr(self.cli_args, "kv_value_bits", None),
+                kv_group_size=getattr(self.cli_args, "kv_group_size", 64),
+                quantized_kv_start=getattr(
+                    self.cli_args,
+                    "quantized_kv_start",
+                    DEFAULT_QUANTIZED_KV_START,
+                ),
             ):
                 finish_reason = gen.finish_reason
 
@@ -1717,7 +1737,7 @@ def run(
         response_generator.join()
 
 
-def main():
+def setup_arg_parser():
     parser = argparse.ArgumentParser(description="MLX Http Server.")
     parser.add_argument(
         "--model",
@@ -1849,11 +1869,45 @@ def main():
         help="Maximum size in bytes of the KV caches",
     )
     parser.add_argument(
+        "--kv-bits",
+        type=int,
+        help="Number of bits for KV cache quantization. Defaults to no quantization.",
+        default=None,
+    )
+    parser.add_argument(
+        "--kv-key-bits",
+        type=int,
+        help="Number of bits for key-cache quantization. Overrides --kv-bits.",
+        default=None,
+    )
+    parser.add_argument(
+        "--kv-value-bits",
+        type=int,
+        help="Number of bits for value-cache quantization. Overrides --kv-bits.",
+        default=None,
+    )
+    parser.add_argument(
+        "--kv-group-size",
+        type=int,
+        help="Group size for KV cache quantization.",
+        default=64,
+    )
+    parser.add_argument(
+        "--quantized-kv-start",
+        type=int,
+        help="When KV bits are set, start quantizing the cache from this step.",
+        default=DEFAULT_QUANTIZED_KV_START,
+    )
+    parser.add_argument(
         "--pipeline",
         action="store_true",
         help="Use pipelining instead of tensor parallelism",
     )
-    args = parser.parse_args()
+    return parser
+
+
+def main():
+    args = setup_arg_parser().parse_args()
     if mx.metal.is_available():
         wired_limit = mx.device_info()["max_recommended_working_set_size"]
         mx.set_wired_limit(wired_limit)

--- a/mlx_lm/server.py
+++ b/mlx_lm/server.py
@@ -37,6 +37,7 @@ from .generate import (
     BatchGenerator,
     StopSequenceMatcher,
     TextStateMachine,
+    _resolve_kv_bits,
     make_stop_matcher,
     make_text_state_machine,
     stream_generate,
@@ -44,6 +45,11 @@ from .generate import (
 from .models.cache import LRUPromptCache, make_prompt_cache
 from .sample_utils import make_logits_processors, make_sampler
 from .utils import _parse_size, load, sharded_load
+
+
+def validate_kv_args(args):
+    """Fail at server startup for incomplete per-side KV precision flags."""
+    return _resolve_kv_bits(args.kv_bits, args.kv_key_bits, args.kv_value_bits)
 
 
 def get_system_fingerprint():
@@ -1907,7 +1913,12 @@ def setup_arg_parser():
 
 
 def main():
-    args = setup_arg_parser().parse_args()
+    parser = setup_arg_parser()
+    args = parser.parse_args()
+    try:
+        validate_kv_args(args)
+    except ValueError as exc:
+        parser.error(str(exc))
     if mx.metal.is_available():
         wired_limit = mx.device_info()["max_recommended_working_set_size"]
         mx.set_wired_limit(wired_limit)

--- a/mlx_lm/server.py
+++ b/mlx_lm/server.py
@@ -37,7 +37,7 @@ from .generate import (
     BatchGenerator,
     StopSequenceMatcher,
     TextStateMachine,
-    _resolve_kv_bits,
+    validate_kv_quantization_args,
     make_stop_matcher,
     make_text_state_machine,
     stream_generate,
@@ -49,7 +49,13 @@ from .utils import _parse_size, load, sharded_load
 
 def validate_kv_args(args):
     """Fail at server startup for incomplete per-side KV precision flags."""
-    return _resolve_kv_bits(args.kv_bits, args.kv_key_bits, args.kv_value_bits)
+    return validate_kv_quantization_args(
+        args.kv_bits,
+        args.kv_key_bits,
+        args.kv_value_bits,
+        args.kv_group_size,
+        args.quantized_kv_start,
+    )
 
 
 def get_system_fingerprint():

--- a/tests/test_asymmetric_kv_cache.py
+++ b/tests/test_asymmetric_kv_cache.py
@@ -139,14 +139,11 @@ class TestAsymmetricKVCache(unittest.TestCase):
             geometry_path = os.path.join(directory, "cross-side-geometry.safetensors")
             key_state, value_state = asymmetric.state
             bad_values = tuple(
-                mx.broadcast_to(array, (2, *array.shape[1:]))
-                for array in value_state
+                mx.broadcast_to(array, (2, *array.shape[1:])) for array in value_state
             )
             geometry_arrays = dict(tree_flatten([(key_state, bad_values)]))
             geometry_metadata = dict(
-                tree_flatten(
-                    [[("2", "2", "32", "8", "4")], {}, ["QuantizedKVCache"]]
-                )
+                tree_flatten([[("2", "2", "32", "8", "4")], {}, ["QuantizedKVCache"]])
             )
             mx.save_safetensors(geometry_path, geometry_arrays, geometry_metadata)
             with self.assertRaisesRegex(ValueError, "batch, head, or length mismatch"):

--- a/tests/test_asymmetric_kv_cache.py
+++ b/tests/test_asymmetric_kv_cache.py
@@ -106,6 +106,19 @@ class TestAsymmetricKVCache(unittest.TestCase):
             migrated = load_prompt_cache(migrated_path)[0]
             self.assertEqual(migrated.meta_state, ("2", "2", "32", "4", "4"))
 
+            for name, invalid_meta, message in (
+                ("bad-bits", ("2", "2", "32", "8", "7"), "Unsupported value bits"),
+                ("bad-group", ("2", "2", "16", "8", "4"), "Unsupported group size"),
+                ("bad-layout", ("2", "2", "32", "8"), "expected 3 legacy fields or 5"),
+            ):
+                corrupt_path = os.path.join(directory, f"{name}.safetensors")
+                corrupt_metadata = dict(
+                    tree_flatten([[invalid_meta], {}, ["QuantizedKVCache"]])
+                )
+                mx.save_safetensors(corrupt_path, legacy_arrays, corrupt_metadata)
+                with self.assertRaisesRegex(ValueError, message):
+                    load_prompt_cache(corrupt_path)
+
     def test_quantization_resolution_is_fail_closed(self):
         cache = KVCache()
         maybe_quantize_kv_cache([cache], 0, 64, None)

--- a/tests/test_asymmetric_kv_cache.py
+++ b/tests/test_asymmetric_kv_cache.py
@@ -131,6 +131,12 @@ class TestAsymmetricKVCache(unittest.TestCase):
         with self.assertRaisesRegex(ValueError, "Unsupported group size"):
             QuantizedKVCache(group_size=16)
 
+        x = mx.arange(128, dtype=mx.float32).reshape(1, 1, 1, 128)
+        for bits in (2, 3, 4, 5, 6, 8):
+            supported = QuantizedKVCache(bits=bits, group_size=32)
+            supported.update_and_fetch(x, x)
+            self.assertEqual(supported.keys[0].shape[-1], 128 * bits // 32)
+
     def test_cli_compatibility_and_defaults(self):
         generate_args = generate_arg_parser().parse_args(
             ["--kv-bits", "8", "--kv-value-bits", "4"]

--- a/tests/test_asymmetric_kv_cache.py
+++ b/tests/test_asymmetric_kv_cache.py
@@ -3,6 +3,7 @@
 import os
 import tempfile
 import unittest
+from inspect import signature
 
 import mlx.core as mx
 from mlx.utils import tree_flatten
@@ -10,6 +11,7 @@ from mlx.utils import tree_flatten
 from mlx_lm.cache_prompt import setup_arg_parser as cache_prompt_arg_parser
 from mlx_lm.generate import (
     DEFAULT_QUANTIZED_KV_START,
+    generate_step,
     maybe_quantize_kv_cache,
 )
 from mlx_lm.generate import setup_arg_parser as generate_arg_parser
@@ -44,7 +46,7 @@ class TestAsymmetricKVCache(unittest.TestCase):
 
     def test_asymmetric_allocation_and_quantization(self):
         keys = mx.arange(128, dtype=mx.float32).reshape(1, 1, 2, 64)
-        values = mx.arange(128, dtype=mx.float32).reshape(1, 1, 2, 64) * 0.5
+        values = mx.arange(64, dtype=mx.float32).reshape(1, 1, 2, 32) * 0.5
         cache = QuantizedKVCache(group_size=32, key_bits=8, value_bits=4)
 
         cache.update_and_fetch(keys, values)
@@ -53,7 +55,7 @@ class TestAsymmetricKVCache(unittest.TestCase):
         self.assertEqual(cache.value_bits, 4)
         self.assertIsNone(cache.bits)
         self.assertEqual(cache.keys[0].shape[-1], 16)
-        self.assertEqual(cache.values[0].shape[-1], 8)
+        self.assertEqual(cache.values[0].shape[-1], 4)
         for actual, expected in zip(
             cache.keys, mx.quantize(keys, group_size=32, bits=8)
         ):
@@ -73,7 +75,7 @@ class TestAsymmetricKVCache(unittest.TestCase):
             mask=None,
         )
         mx.eval(output)
-        self.assertEqual(output.shape, (1, 1, 1, 64))
+        self.assertEqual(output.shape, (1, 1, 1, 32))
 
     def test_serialization_round_trip_and_legacy_migration(self):
         x = mx.arange(128, dtype=mx.float32).reshape(1, 1, 2, 64)
@@ -138,6 +140,11 @@ class TestAsymmetricKVCache(unittest.TestCase):
             self.assertEqual(supported.keys[0].shape[-1], 128 * bits // 32)
 
     def test_cli_compatibility_and_defaults(self):
+        parameters = list(signature(generate_step).parameters)
+        self.assertLess(
+            parameters.index("input_embeddings"), parameters.index("kv_key_bits")
+        )
+
         generate_args = generate_arg_parser().parse_args(
             ["--kv-bits", "8", "--kv-value-bits", "4"]
         )

--- a/tests/test_asymmetric_kv_cache.py
+++ b/tests/test_asymmetric_kv_cache.py
@@ -78,6 +78,25 @@ class TestAsymmetricKVCache(unittest.TestCase):
         mx.eval(output)
         self.assertEqual(output.shape, (1, 1, 1, 32))
 
+    def test_legacy_quantized_attention_duck(self):
+        x = mx.arange(64, dtype=mx.float32).reshape(1, 1, 1, 64)
+        state = mx.quantize(x, group_size=32, bits=4)
+
+        class LegacyQuantizedDuck:
+            bits = 4
+            group_size = 32
+
+        output = scaled_dot_product_attention(
+            mx.ones_like(x),
+            state,
+            state,
+            LegacyQuantizedDuck(),
+            scale=64**-0.5,
+            mask=None,
+        )
+        mx.eval(output)
+        self.assertEqual(output.shape, x.shape)
+
     def test_serialization_round_trip_and_legacy_migration(self):
         x = mx.arange(128, dtype=mx.float32).reshape(1, 1, 2, 64)
         asymmetric = QuantizedKVCache(group_size=32, key_bits=8, value_bits=4)
@@ -116,6 +135,22 @@ class TestAsymmetricKVCache(unittest.TestCase):
             mx.save_safetensors(lying_path, legacy_arrays, lying_metadata)
             with self.assertRaisesRegex(ValueError, "does not match 8-bit metadata"):
                 load_prompt_cache(lying_path)
+
+            geometry_path = os.path.join(directory, "cross-side-geometry.safetensors")
+            key_state, value_state = asymmetric.state
+            bad_values = tuple(
+                mx.broadcast_to(array, (2, *array.shape[1:]))
+                for array in value_state
+            )
+            geometry_arrays = dict(tree_flatten([(key_state, bad_values)]))
+            geometry_metadata = dict(
+                tree_flatten(
+                    [[("2", "2", "32", "8", "4")], {}, ["QuantizedKVCache"]]
+                )
+            )
+            mx.save_safetensors(geometry_path, geometry_arrays, geometry_metadata)
+            with self.assertRaisesRegex(ValueError, "batch, head, or length mismatch"):
+                load_prompt_cache(geometry_path)
 
             for name, invalid_meta, message in (
                 ("bad-bits", ("2", "2", "32", "8", "7"), "Unsupported value bits"),
@@ -194,6 +229,14 @@ class TestAsymmetricKVCache(unittest.TestCase):
 
         server_args.kv_key_bits = 8
         with self.assertRaisesRegex(ValueError, "Both key and value bits"):
+            validate_kv_args(server_args)
+        server_args.kv_key_bits = None
+        server_args.kv_bits = 7
+        with self.assertRaisesRegex(ValueError, "Unsupported key bits"):
+            validate_kv_args(server_args)
+        server_args.kv_bits = 4
+        server_args.kv_group_size = 16
+        with self.assertRaisesRegex(ValueError, "Unsupported group size"):
             validate_kv_args(server_args)
 
 

--- a/tests/test_asymmetric_kv_cache.py
+++ b/tests/test_asymmetric_kv_cache.py
@@ -1,0 +1,152 @@
+# Copyright © 2026 Apple Inc.
+
+import os
+import tempfile
+import unittest
+
+import mlx.core as mx
+from mlx.utils import tree_flatten
+
+from mlx_lm.cache_prompt import setup_arg_parser as cache_prompt_arg_parser
+from mlx_lm.generate import (
+    DEFAULT_QUANTIZED_KV_START,
+    maybe_quantize_kv_cache,
+)
+from mlx_lm.generate import setup_arg_parser as generate_arg_parser
+from mlx_lm.models.base import scaled_dot_product_attention
+from mlx_lm.models.cache import (
+    KVCache,
+    QuantizedKVCache,
+    load_prompt_cache,
+    save_prompt_cache,
+)
+from mlx_lm.server import setup_arg_parser as server_arg_parser
+
+
+class TestAsymmetricKVCache(unittest.TestCase):
+    def test_scalar_bits_matches_explicit_symmetric_path(self):
+        x = mx.arange(128, dtype=mx.float32).reshape(1, 1, 2, 64)
+        scalar = QuantizedKVCache(bits=4, group_size=32)
+        explicit = QuantizedKVCache(bits=4, key_bits=4, value_bits=4, group_size=32)
+
+        scalar.update_and_fetch(x, x)
+        explicit.update_and_fetch(x, x)
+        expected = mx.quantize(x, group_size=32, bits=4)
+
+        self.assertEqual(scalar.meta_state, explicit.meta_state)
+        self.assertEqual(scalar.bits, 4)
+        for scalar_side, explicit_side in zip(scalar.state, explicit.state):
+            for actual, equivalent, baseline in zip(
+                scalar_side, explicit_side, expected
+            ):
+                self.assertTrue(mx.array_equal(actual, equivalent))
+                self.assertTrue(mx.array_equal(actual, baseline))
+
+    def test_asymmetric_allocation_and_quantization(self):
+        keys = mx.arange(128, dtype=mx.float32).reshape(1, 1, 2, 64)
+        values = mx.arange(128, dtype=mx.float32).reshape(1, 1, 2, 64) * 0.5
+        cache = QuantizedKVCache(group_size=32, key_bits=8, value_bits=4)
+
+        cache.update_and_fetch(keys, values)
+
+        self.assertEqual(cache.key_bits, 8)
+        self.assertEqual(cache.value_bits, 4)
+        self.assertIsNone(cache.bits)
+        self.assertEqual(cache.keys[0].shape[-1], 16)
+        self.assertEqual(cache.values[0].shape[-1], 8)
+        for actual, expected in zip(
+            cache.keys, mx.quantize(keys, group_size=32, bits=8)
+        ):
+            self.assertTrue(mx.array_equal(actual[..., :2, :], expected))
+        for actual, expected in zip(
+            cache.values, mx.quantize(values, group_size=32, bits=4)
+        ):
+            self.assertTrue(mx.array_equal(actual[..., :2, :], expected))
+
+        queries = mx.ones((1, 1, 1, 64), dtype=mx.float32)
+        output = scaled_dot_product_attention(
+            queries,
+            tuple(x[..., :2, :] for x in cache.keys),
+            tuple(x[..., :2, :] for x in cache.values),
+            cache,
+            scale=64**-0.5,
+            mask=None,
+        )
+        mx.eval(output)
+        self.assertEqual(output.shape, (1, 1, 1, 64))
+
+    def test_serialization_round_trip_and_legacy_migration(self):
+        x = mx.arange(128, dtype=mx.float32).reshape(1, 1, 2, 64)
+        asymmetric = QuantizedKVCache(group_size=32, key_bits=8, value_bits=4)
+        asymmetric.update_and_fetch(x, x)
+
+        with tempfile.TemporaryDirectory() as directory:
+            path = os.path.join(directory, "asymmetric.safetensors")
+            save_prompt_cache(path, [asymmetric])
+            loaded = load_prompt_cache(path)[0]
+            self.assertEqual((loaded.key_bits, loaded.value_bits), (8, 4))
+            self.assertEqual(loaded.meta_state, ("2", "2", "32", "8", "4"))
+            for original_side, loaded_side in zip(asymmetric.state, loaded.state):
+                for original, restored in zip(original_side, loaded_side):
+                    self.assertTrue(mx.array_equal(original, restored))
+
+            symmetric = QuantizedKVCache(bits=4, group_size=32)
+            symmetric.update_and_fetch(x, x)
+            legacy_path = os.path.join(directory, "legacy.safetensors")
+            legacy_arrays = dict(tree_flatten([symmetric.state]))
+            legacy_metadata = dict(
+                tree_flatten([[("2", "32", "4")], {}, ["QuantizedKVCache"]])
+            )
+            mx.save_safetensors(legacy_path, legacy_arrays, legacy_metadata)
+
+            legacy_loaded = load_prompt_cache(legacy_path)[0]
+            self.assertEqual((legacy_loaded.key_bits, legacy_loaded.value_bits), (4, 4))
+            migrated_path = os.path.join(directory, "migrated.safetensors")
+            save_prompt_cache(migrated_path, [legacy_loaded])
+            migrated = load_prompt_cache(migrated_path)[0]
+            self.assertEqual(migrated.meta_state, ("2", "2", "32", "4", "4"))
+
+    def test_quantization_resolution_is_fail_closed(self):
+        cache = KVCache()
+        maybe_quantize_kv_cache([cache], 0, 64, None)
+        self.assertIsInstance(cache, KVCache)
+
+        with self.assertRaisesRegex(ValueError, "Both key and value bits"):
+            maybe_quantize_kv_cache([cache], 0, 64, None, kv_key_bits=8)
+        with self.assertRaisesRegex(ValueError, "Unsupported value bits"):
+            QuantizedKVCache(key_bits=8, value_bits=7)
+        with self.assertRaisesRegex(ValueError, "Unsupported group size"):
+            QuantizedKVCache(group_size=16)
+
+    def test_cli_compatibility_and_defaults(self):
+        generate_args = generate_arg_parser().parse_args(
+            ["--kv-bits", "8", "--kv-value-bits", "4"]
+        )
+        self.assertEqual(generate_args.kv_bits, 8)
+        self.assertEqual(generate_args.kv_key_bits, None)
+        self.assertEqual(generate_args.kv_value_bits, 4)
+
+        cache_args = cache_prompt_arg_parser().parse_args(
+            [
+                "--prompt-cache-file",
+                "cache.safetensors",
+                "--prompt",
+                "hello",
+                "--kv-key-bits",
+                "8",
+                "--kv-value-bits",
+                "4",
+            ]
+        )
+        self.assertEqual((cache_args.kv_key_bits, cache_args.kv_value_bits), (8, 4))
+
+        server_args = server_arg_parser().parse_args([])
+        self.assertEqual(server_args.top_k, 0)
+        self.assertIsNone(server_args.kv_bits)
+        self.assertIsNone(server_args.kv_key_bits)
+        self.assertIsNone(server_args.kv_value_bits)
+        self.assertEqual(server_args.quantized_kv_start, DEFAULT_QUANTIZED_KV_START)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_asymmetric_kv_cache.py
+++ b/tests/test_asymmetric_kv_cache.py
@@ -23,6 +23,7 @@ from mlx_lm.models.cache import (
     save_prompt_cache,
 )
 from mlx_lm.server import setup_arg_parser as server_arg_parser
+from mlx_lm.server import validate_kv_args
 
 
 class TestAsymmetricKVCache(unittest.TestCase):
@@ -106,7 +107,15 @@ class TestAsymmetricKVCache(unittest.TestCase):
             migrated_path = os.path.join(directory, "migrated.safetensors")
             save_prompt_cache(migrated_path, [legacy_loaded])
             migrated = load_prompt_cache(migrated_path)[0]
-            self.assertEqual(migrated.meta_state, ("2", "2", "32", "4", "4"))
+            self.assertEqual(migrated.meta_state, ("2", "32", "4"))
+
+            lying_path = os.path.join(directory, "lying-geometry.safetensors")
+            lying_metadata = dict(
+                tree_flatten([[("2", "2", "32", "8", "8")], {}, ["QuantizedKVCache"]])
+            )
+            mx.save_safetensors(lying_path, legacy_arrays, lying_metadata)
+            with self.assertRaisesRegex(ValueError, "does not match 8-bit metadata"):
+                load_prompt_cache(lying_path)
 
             for name, invalid_meta, message in (
                 ("bad-bits", ("2", "2", "32", "8", "7"), "Unsupported value bits"),
@@ -138,6 +147,16 @@ class TestAsymmetricKVCache(unittest.TestCase):
             supported = QuantizedKVCache(bits=bits, group_size=32)
             supported.update_and_fetch(x, x)
             self.assertEqual(supported.keys[0].shape[-1], 128 * bits // 32)
+
+        class LegacyDuckCache:
+            offset = 0
+
+            def to_quantized(self, group_size, bits):
+                return (group_size, bits)
+
+        legacy = [LegacyDuckCache()]
+        maybe_quantize_kv_cache(legacy, 0, 64, 4)
+        self.assertEqual(legacy, [(64, 4)])
 
     def test_cli_compatibility_and_defaults(self):
         parameters = list(signature(generate_step).parameters)
@@ -172,6 +191,10 @@ class TestAsymmetricKVCache(unittest.TestCase):
         self.assertIsNone(server_args.kv_key_bits)
         self.assertIsNone(server_args.kv_value_bits)
         self.assertEqual(server_args.quantized_kv_start, DEFAULT_QUANTIZED_KV_START)
+
+        server_args.kv_key_bits = 8
+        with self.assertRaisesRegex(ValueError, "Both key and value bits"):
+            validate_kv_args(server_args)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
# Asymmetric key/value bits for `QuantizedKVCache`

*Free-standing branch `pr/asymmetric-kv-bits`, based on `upstream/main` @ `a790972`.*

## Summary

`QuantizedKVCache` quantizes keys and values to the same bit width. This change lets
the two sides be quantized independently (`key_bits`, `value_bits`), because **keys
are markedly more sensitive to quantization than values.** The useful operating point
is `K8V4` (8-bit keys, 4-bit values): on a 30B model it saves **~24% KV memory over
K8V8** (39 936 vs 52 224 bytes/token) for **+0.0049 NLL (~0.5% perplexity)**, and at
the *same* memory budget it produces **0.018 lower NLL than the opposite allocation
K4V8** — i.e. if you have a KV bit budget, spend it on keys.

This is a modest, real memory/quality lever, not a free lunch: at 30B the ~24%
savings costs a small but genuine quality delta (the effect is much larger and
near-free at ≤1B — see the evidence section, which reports both scales honestly).

The scalar `--kv-bits` path is fully preserved and **byte-identical to upstream** by
default (mutation-tested). Asymmetric behavior is only reachable by explicitly asking
for it.

## The evidence (this PR lives or dies on it)

Model `mlx-community/Qwen1.5-0.5B-Chat-4bit` (revision `659d8daf`). Deterministic
local corpus (4096 tokens from four repo files, greedy, no sampling RNG); metric is
the mean NLL of the second half given the first half cached, accumulated in float32.
Throughput is the median of five position-balanced cyclic reps. mlx
`0.32.0.dev20260708`. The probe is reproducible from `benchmarks/kv_asym_probe.py`;
its numbers were independently recomputed from the raw results.

| config | mean NLL | Δ vs K8V8 | bytes/token |
|---|---:|---:|---:|
| fp16 | 1.852261 | — | 98 304 |
| K8V8 | 1.852342 | 0 | 52 224 |
| **K8V4** | **1.851255** | **−0.00109** | **39 936** |
| K4V8 | 1.959019 | +0.10668 | 39 936 |
| K4V4 | 1.946520 | +0.09418 | 27 648 |

**Exploratory 0.5B observation.** Dropping *values* to 4 bits (`K8V4`) changed
NLL by −0.00109 versus K8V8, while dropping *keys* (`K4V8`) changed it by
+0.10668 at the same bytes/token. This is a deterministic observation on one
corpus, not an estimated noise floor or a general quality claim.

**Memory.** K8V4 uses 39 936 bytes/token vs fp16's 98 304, capturing **82.6% of the
memory savings of K4V4** — at 0.5B, at parity with K8V8 quality (the 30B section
below shows a small real quality cost appears at scale).

**Throughput.** K8V4 runs at **0.993× K8V8** generation tps (median of 5
position-balanced reps) — observed throughput parity. Sub-1% differences are below
thermal measurement resolution. (A visible K4V4 rep-4 outlier from transient load is
absorbed by the position-balanced median — recorded, not hidden.)

Verdict at 0.5B: supports the PR. **But see the 30B validation immediately below —
it materially qualifies this.**

### 30B-scale validation (Qwen3-Coder-30B-A3B-Instruct-8bit) — the headline does NOT fully replicate

Same probe methodology at representative scale (the small-model size guard was
lifted for this run). The observed source KV dtype was **bfloat16** in every 30B
arm. Note the 0.5B and 30B runs used different MLX builds and source dtypes, so the
change in the asymmetry ratio cannot be attributed to scale alone.

| config | mean NLL | Δ vs K8V8 | bytes/token |
|---|---:|---:|---:|
| unquantized bf16 | 0.972669 | — | 98 304 |
| K8V8 | 0.976051 | 0 | 52 224 |
| **K8V4** | **0.980925** | **+0.004873** | **39 936** |
| K4V8 | 0.999044 | +0.022993 | 39 936 |
| K4V4 | 1.008376 | +0.032325 | 27 648 |

The asymmetry weakens markedly at scale: keys damage NLL **~4.7×** more than values
here, versus ~100× at 0.5B, and K8V4 now carries a small *real* quality cost rather
than sitting at noise. But the lever holds: K8V4 stays within 0.01 NLL of K8V8, and
throughput is 0.991× K8V8.

**Disclosure — our pre-registered acceptance bar was not fully met at 30B.** We
fixed three criteria in advance: `abs(K8V4−K8V8) ≤ 0.01` (PASS), key/value damage
ratio `≥ 5×` (**not met**, 4.72×), and K8V4 throughput `≥ 0.9×` K8V8 (PASS). The
damage-ratio criterion, calibrated on the near-100× 0.5B result, is not met at
30B's 4.72×. We report this openly rather than move the bar: the feature is still
a real memory/quality lever (24% KV savings at ~0.5% perplexity; keys clearly
deserve the bits at equal memory), just a more modest one than 0.5B suggested.

**What the 30B run supports.** On this model/corpus, K8V4 saves **23.53% KV memory**
versus K8V8 for **+0.004873 NLL (~0.49% implied perplexity)**, runs at 0.991× K8V8,
and — at equal bytes/token — has **0.018119 lower NLL than the opposite allocation
K4V8** (throughput vs K4V8 is 0.9966×, so this is a clear quality edge at equal
memory, not strict Pareto dominance). Stated honestly: this is one model / one
4096-token corpus, with no task-quality eval, replication, or context-length sweep —
the results to lean on are the *direction* (keys deserve the bits) and the memory
saving, not a precise perplexity guarantee.

**In short:** asymmetric K/V lets you keep 8-bit keys while dropping values to 4-bit,
buying ~24% KV memory at a small quality cost and beating the equal-memory
**opposite asymmetric allocation** K4V8 on NLL. It is a modest, honest lever,
not a free-parity claim; whether ~24% KV
savings at this cost justifies the small API surface is a maintainer judgment.

## Change surface

- **`QuantizedKVCache`** gains `key_bits`/`value_bits` (keyword-only). `bits` still
  sets both; `bits` is retained as an attribute for callers inspecting a legacy
  symmetric cache (and is `None` on a genuinely asymmetric cache). Per init, keys and
  values allocate their own packed geometry from their own bit width;
  `update_and_fetch` quantizes each side at its own bits.
- **`KVCache.to_quantized`** forwards `key_bits`/`value_bits`, preserving the
  duck-typed `to_quantized(group_size, bits)` protocol on the scalar path (out-of-tree
  caches that only accept the positional signature keep working; the per-side kwargs
  are only passed when asymmetric — the scalar path raises the same
  `NotImplementedError`/`TypeError` upstream does, no new failure mode).
- **Serialization (`meta_state`)** is versioned:
  - A **symmetric** cache still emits the **legacy 3-field** metadata
    (`offset, group_size, bits`) — old mlx-lm can still read files produced by a
    purely-scalar user (zero compat regression for existing use).
  - An **asymmetric** cache emits **v2 5-field** metadata
    (`2, offset, group_size, key_bits, value_bits`).
  - The reader accepts both: 3-field → legacy symmetric; 5-field → v2 with a version
    check; anything else is rejected.
- **Cross-side geometry validation** on load (`_validate_state_geometry`):
  packed/scale/bias dtypes, per-side packed-vs-scale shape consistency against the
  claimed bits, offset-vs-length, and key/value batch/head/length agreement. A
  metadata claim that does not match the array geometry is rejected rather than
  trusted (upstream shares this blind spot on the symmetric path; fixing it here
  strengthens the change). Verified both ways: geometry lies (batch-broadcast /
  length / dtype) are rejected, but a legitimate K≠V head-dim cache (e.g. 64/32) still
  loads — no GQA/MLA false positive.
- **CLI**: `--kv-bits` (scalar, unchanged) sets both sides; `--kv-key-bits` /
  `--kv-value-bits` override per side. `generate`, `cache_prompt`, and the server all
  plumb the two-sided config; a lone per-side flag misconfig fails at startup, not
  per-request.

## Compatibility and forward-compat

- **Default path byte-identical to upstream.** The scalar path was mutation-tested
  against pristine `a790972` across bits × group size × dtype; the asymmetric branch is
  only entered when the two bit widths differ.
- **Symmetric files stay backward-compatible** — legacy 3-field metadata is still
  emitted for them, so existing scalar-`--kv-bits` prompt-cache files written by this
  build are readable by old mlx-lm.
- **Old mlx-lm cannot read v2 asymmetric files.** This is inherent — an asymmetric
  cache is a new feature in a new format; there is nothing sensible for a
  symmetric-only reader to do with a two-sided cache. New feature ⇒ new format, and
  only asymmetric caches use it.

## 30B validation

Validated at representative scale (evidence section above): the fixed-budget
asymmetry holds (K8V4 has lower NLL than K4V8 at equal measured bytes, and K8V4
saves ~24% KV memory over K8V8 at ~0.5% perplexity), but the near-free-parity seen
at 0.5B does **not** fully replicate — the key/value damage ratio is ~4.7× at 30B
versus ~100× at 0.5B, and K8V4 carries a small real quality cost at scale. The probe
corpus is 4096 tokens; longer-context behavior is **unmeasured**.

## Change summary

7 files, **854 insertions / 31 deletions**: `mlx_lm/models/cache.py` (124),
`mlx_lm/models/base.py` (14), `mlx_lm/generate.py` (109), `mlx_lm/cache_prompt.py`
(28), `mlx_lm/server.py` (75), `benchmarks/kv_asym_probe.py` (new, 294 L),
`tests/test_asymmetric_kv_cache.py` (new, 241 L; 28 tests green, black/static clean).
The scalar default path is mutation-tested byte-identical to the pre-change code.
