### PR TITLE
Warm-restart persistence tier for prefix-fork KV snapshots

### DIFF
--- a/mlx_lm/prefix_forks.py
+++ b/mlx_lm/prefix_forks.py
@@ -103,7 +103,8 @@ import hashlib
 import threading
 import weakref
 from collections import OrderedDict
-from typing import Any, Dict, List, Optional, Tuple
+from numbers import Integral
+from typing import Any, List, Optional, Tuple
 
 import mlx.core as mx
 
@@ -125,6 +126,22 @@ def _require_model_key(model_key: Any) -> str:
     return model_key
 
 
+def _normalize_tokens(tokens: List[int]) -> Tuple[int, ...]:
+    """Validate exact token IDs without lossy ``int(...)`` coercion."""
+    normalized = []
+    for token in tokens:
+        if isinstance(token, bool):
+            raise TypeError("token IDs must be integers, not bool")
+        try:
+            value = token.__index__()
+        except (AttributeError, TypeError):
+            raise TypeError(
+                f"token IDs must be integers; got {type(token).__name__}"
+            ) from None
+        normalized.append(int(value))
+    return tuple(normalized)
+
+
 def compute_cid(model_key: str, tokens: List[int]) -> str:
     """Content-hash identity for a prefix: (model key, exact token ids).
 
@@ -133,11 +150,19 @@ def compute_cid(model_key: str, tokens: List[int]) -> str:
     model key is subject to the module-level MODEL-KEY CONTRACT.
     """
     model_key = _require_model_key(model_key)
+    tokens = _normalize_tokens(tokens)
     h = hashlib.sha256()
-    h.update(model_key.encode("utf-8", "replace"))
+    # Length-frame every field. A delimiter alone is ambiguous because a
+    # model key is an arbitrary string and may itself contain that delimiter.
+    h.update(b"mlx-lm-prefix-fork-cid-v1")
+    model_key_bytes = model_key.encode("utf-8", "surrogatepass")
+    h.update(len(model_key_bytes).to_bytes(8, "big"))
+    h.update(model_key_bytes)
     for t in tokens:
-        h.update(b"\x00" + str(int(t)).encode())
-    return h.hexdigest()[:16]
+        token_bytes = str(t).encode()
+        h.update(len(token_bytes).to_bytes(8, "big"))
+        h.update(token_bytes)
+    return h.hexdigest()
 
 
 class FrozenPrefixSnapshot:
@@ -166,21 +191,47 @@ class FrozenPrefixSnapshot:
         keys: List[mx.array],
         values: List[mx.array],
     ):
-        self.cid = cid
-        self.model_key = model_key
-        self.tokens = tokens
+        self._cid = cid
+        self._model_key = model_key
+        self._tokens = tokens
         # Fresh slice OBJECTS (zero-copy): a later __setitem__ through the
         # caller's original references rebinds the caller's objects, never
         # these pre-write nodes.
-        self.keys = [k[:] for k in keys]
-        self.values = [v[:] for v in values]
-        self.nbytes = sum(k.nbytes + v.nbytes for k, v in zip(keys, values))
+        self._keys = [k[:] for k in keys]
+        self._values = [v[:] for v in values]
+        self._nbytes = sum(k.nbytes + v.nbytes for k, v in zip(keys, values))
         # Live forks referencing this snapshot (weak: forks hold the strong
         # edge). Lets the registry report pinned-but-undiscoverable bytes.
         self._forks = weakref.WeakSet()
 
     def __len__(self):
         return len(self.tokens)
+
+    @property
+    def cid(self):
+        return self._cid
+
+    @property
+    def model_key(self):
+        return self._model_key
+
+    @property
+    def tokens(self):
+        return self._tokens
+
+    @property
+    def nbytes(self):
+        return self._nbytes
+
+    @property
+    def keys(self):
+        """Fresh sealed views; the stored MLX array objects never escape."""
+        return [k[:] for k in self._keys]
+
+    @property
+    def values(self):
+        """Fresh sealed views; the stored MLX array objects never escape."""
+        return [v[:] for v in self._values]
 
     @property
     def pinned(self) -> bool:
@@ -198,6 +249,7 @@ class FrozenPrefixSnapshot:
         quantized, and stateful (Mamba) caches are not COW-forkable in v1.
         """
         model_key = _require_model_key(model_key)
+        tokens = list(_normalize_tokens(tokens))
         if len(tokens) == 0 or len(prompt_cache) == 0:
             return None
         for c in prompt_cache:
@@ -214,14 +266,14 @@ class FrozenPrefixSnapshot:
             values.append(mx.array(v))
         mx.eval(*keys, *values)
         cid = compute_cid(model_key, tokens)
-        return cls(cid, model_key, tuple(int(t) for t in tokens), keys, values)
+        return cls(cid, model_key, tuple(tokens), keys, values)
 
     def fork(self) -> List["ForkedKVCache"]:
         """A fresh per-layer cache stack referencing this snapshot. O(1):
         no prefix bytes are copied or materialized."""
         forks = [
-            ForkedKVCache(self.keys[l], self.values[l], snapshot=self)
-            for l in range(len(self.keys))
+            ForkedKVCache(self._keys[l], self._values[l], snapshot=self)
+            for l in range(len(self._keys))
         ]
         for f in forks:
             self._forks.add(f)
@@ -351,6 +403,8 @@ class ForkedKVCache(_BaseCache):
         # not. Trimming past the tail must FAIL LOUDLY: trim_prompt_cache
         # callers ignore the returned count, so a silent clamp would leave
         # them generating against KV at the wrong offset.
+        if not isinstance(n, int) or isinstance(n, bool) or n < 0:
+            raise ValueError(f"trim count must be a non-negative integer; got {n!r}")
         if n > self.tail.offset:
             raise ValueError(
                 f"Cannot trim {n} tokens from a ForkedKVCache with a private "
@@ -397,23 +451,35 @@ class PrefixForkRegistry:
     """
 
     def __init__(self, max_snapshots: int = 16, max_bytes: int = 1 << 63):
-        self.max_snapshots = max_snapshots
-        self.max_bytes = max_bytes
+        for name, value in (
+            ("max_snapshots", max_snapshots),
+            ("max_bytes", max_bytes),
+        ):
+            if isinstance(value, bool) or not isinstance(value, Integral):
+                raise TypeError(f"{name} must be a non-negative integer")
+            if value < 0:
+                raise ValueError(f"{name} must be non-negative")
+        self.max_snapshots = int(max_snapshots)
+        self.max_bytes = int(max_bytes)
         self._snapshots: "OrderedDict[str, FrozenPrefixSnapshot]" = OrderedDict()
         self._trie = PromptTrie()  # namespaced by the model-key string
         # Weak refs to every snapshot ever inserted, for pinned_nbytes: a
         # snapshot evicted here stays alive exactly as long as forks pin it.
-        self._tracked: Dict[str, "weakref.ref[FrozenPrefixSnapshot]"] = {}
+        # Track instances, not CIDs: the same CID can be reinserted while an
+        # older invalidated snapshot remains pinned by live forks.
+        self._tracked: List["weakref.ref[FrozenPrefixSnapshot]"] = []
         self._n_bytes = 0
         self._lock = threading.Lock()
 
     def __len__(self):
-        return len(self._snapshots)
+        with self._lock:
+            return len(self._snapshots)
 
     @property
     def nbytes(self):
         """Bytes of the DISCOVERABLE snapshots (what max_bytes bounds)."""
-        return self._n_bytes
+        with self._lock:
+            return self._n_bytes
 
     @property
     def pinned_nbytes(self):
@@ -427,15 +493,14 @@ class PrefixForkRegistry:
         them to estimate memory."""
         total = 0
         with self._lock:
-            dead = []
-            for cid, ref in self._tracked.items():
+            alive = []
+            for ref in self._tracked:
                 snapshot = ref()
-                if snapshot is None:
-                    dead.append(cid)
-                elif snapshot.pinned:
+                if snapshot is not None:
+                    alive.append(ref)
+                if snapshot is not None and snapshot.pinned:
                     total += snapshot.nbytes
-            for cid in dead:
-                del self._tracked[cid]
+            self._tracked = alive
         return total
 
     def freeze(
@@ -451,6 +516,18 @@ class PrefixForkRegistry:
         matching (model_key, tokens) with different KV means the key contract
         was violated (weights changed under a stale key)."""
         model_key = _require_model_key(model_key)
+        tokens = list(_normalize_tokens(tokens))
+        # Validate before the CID fast path. Otherwise an existing entry turns
+        # an unsupported or offset-skewed cache into a false success.
+        if (
+            len(tokens) == 0
+            or len(prompt_cache) == 0
+            or any(
+                type(c) is not KVCache or c.offset != len(tokens)
+                for c in prompt_cache
+            )
+        ):
+            return None
         cid = compute_cid(model_key, tokens)
         existing = self.get(cid)
         if existing is not None:
@@ -469,11 +546,12 @@ class PrefixForkRegistry:
                 self._snapshots.move_to_end(snapshot.cid)
                 return snapshot.cid
             self._snapshots[snapshot.cid] = snapshot
-            self._tracked[snapshot.cid] = weakref.ref(snapshot)
+            self._tracked.append(weakref.ref(snapshot))
             self._trie.add(snapshot.model_key, list(snapshot.tokens), snapshot.cid)
             self._n_bytes += snapshot.nbytes
-            while len(self._snapshots) > self.max_snapshots or (
-                self._n_bytes > self.max_bytes and len(self._snapshots) > 1
+            while self._snapshots and (
+                len(self._snapshots) > self.max_snapshots
+                or self._n_bytes > self.max_bytes
             ):
                 self._evict_lru_locked()
         return snapshot.cid
@@ -492,20 +570,29 @@ class PrefixForkRegistry:
         under a stale key has nothing to compare against — the model-key
         contract is the primary defense."""
         if (
-            len(prompt_cache) != len(snapshot.keys)
+            len(prompt_cache) != len(snapshot._keys)
             or any(type(c) is not KVCache for c in prompt_cache)
             or prompt_cache[0].offset != len(tokens)
         ):
             return  # not comparable; a fresh freeze() would reject it too
         ok = True
         for layer, c in enumerate(prompt_cache):
-            k_new = c.state[0]
-            k_old = snapshot.keys[layer]
-            if k_new.shape != k_old.shape or k_new.dtype != k_old.dtype:
+            k_new, v_new = c.state
+            k_old = snapshot._keys[layer]
+            v_old = snapshot._values[layer]
+            if (
+                k_new.shape != k_old.shape
+                or k_new.dtype != k_old.dtype
+                or v_new.shape != v_old.shape
+                or v_new.dtype != v_old.dtype
+            ):
                 ok = False
                 break
             w = min(4, k_old.shape[2])
-            if not bool(mx.array_equal(k_old[..., -w:, :], k_new[..., -w:, :])):
+            if not (
+                bool(mx.array_equal(k_old[..., -w:, :], k_new[..., -w:, :]))
+                and bool(mx.array_equal(v_old[..., -w:, :], v_new[..., -w:, :]))
+            ):
                 ok = False
                 break
         if not ok:
@@ -528,8 +615,9 @@ class PrefixForkRegistry:
         is deliberately a miss (false-MISS-only invariant).
         """
         model_key = _require_model_key(model_key)
+        normalized_tokens = list(_normalize_tokens(tokens))
         with self._lock:
-            result = self._trie.search(model_key, tokens)
+            result = self._trie.search(model_key, normalized_tokens)
             matched = result.exact if result.exact is not None else result.shorter
             if matched is None:
                 return None, tokens

--- a/mlx_lm/prefix_forks.py
+++ b/mlx_lm/prefix_forks.py
@@ -523,8 +523,7 @@ class PrefixForkRegistry:
             len(tokens) == 0
             or len(prompt_cache) == 0
             or any(
-                type(c) is not KVCache or c.offset != len(tokens)
-                for c in prompt_cache
+                type(c) is not KVCache or c.offset != len(tokens) for c in prompt_cache
             )
         ):
             return None
@@ -555,6 +554,57 @@ class PrefixForkRegistry:
             ):
                 self._evict_lru_locked()
         return snapshot.cid
+
+    def register_snapshot(self, snapshot: FrozenPrefixSnapshot) -> bool:
+        """Register a trusted snapshot-like object without materializing it.
+
+        This is the disk-tier startup hook.  ``SnapshotStore`` supplies a
+        header-validated proxy implementing the immutable snapshot interface;
+        its KV arrays are not loaded until :meth:`fetch_fork` calls ``fork``.
+        Existing RAM snapshots win, so a startup rescan can never replace hot
+        data with a disk proxy.
+        """
+        _require_model_key(snapshot.model_key)
+        tokens = tuple(_normalize_tokens(snapshot.tokens))
+        if snapshot.cid != compute_cid(snapshot.model_key, tokens):
+            raise ValueError("snapshot cid does not match model_key and tokens")
+        with self._lock:
+            if snapshot.cid in self._snapshots:
+                return False
+            self._snapshots[snapshot.cid] = snapshot
+            self._tracked.append(weakref.ref(snapshot))
+            self._trie.add(snapshot.model_key, list(tokens), snapshot.cid)
+            self._n_bytes += snapshot.nbytes
+            while self._snapshots and (
+                len(self._snapshots) > self.max_snapshots
+                or self._n_bytes > self.max_bytes
+            ):
+                self._evict_lru_locked()
+        return True
+
+    def snapshots(self) -> List[FrozenPrefixSnapshot]:
+        """Return the discoverable snapshots in LRU order."""
+        with self._lock:
+            return list(self._snapshots.values())
+
+    def replace_snapshot(self, snapshot: FrozenPrefixSnapshot) -> bool:
+        """Replace a same-identity proxy with a materialized snapshot."""
+        _require_model_key(snapshot.model_key)
+        if snapshot.cid != compute_cid(snapshot.model_key, snapshot.tokens):
+            raise ValueError("snapshot cid does not match model_key and tokens")
+        with self._lock:
+            previous = self._snapshots.get(snapshot.cid)
+            if previous is None:
+                return False
+            if previous.model_key != snapshot.model_key or tuple(
+                previous.tokens
+            ) != tuple(snapshot.tokens):
+                raise ValueError("replacement snapshot identity mismatch")
+            self._n_bytes += snapshot.nbytes - previous.nbytes
+            self._snapshots[snapshot.cid] = snapshot
+            self._snapshots.move_to_end(snapshot.cid)
+            self._tracked.append(weakref.ref(snapshot))
+        return True
 
     @staticmethod
     def _dedup_spot_check(
@@ -626,7 +676,13 @@ class PrefixForkRegistry:
             if snapshot is None:  # stale trie entry: treat as a miss
                 return None, tokens
             self._snapshots.move_to_end(cid)
-        return snapshot.fork(), tokens[len(matched) :]
+        forks = snapshot.fork()
+        if forks is None:
+            # A disk-backed snapshot discovered corruption while lazily
+            # materializing.  Integrity doubt is always a full safe miss.
+            self.invalidate(cid)
+            return None, tokens
+        return forks, tokens[len(matched) :]
 
     def get(self, cid: str) -> Optional[FrozenPrefixSnapshot]:
         with self._lock:

--- a/mlx_lm/prefix_forks.py
+++ b/mlx_lm/prefix_forks.py
@@ -13,8 +13,8 @@ This module lets N requests fork from ONE frozen, in-RAM parent snapshot,
 paying only for their private suffixes:
 
 * :class:`FrozenPrefixSnapshot` — an immutable, ``mx.eval``-materialized,
-  content-addressed (cid over token ids) snapshot of a prefix's per-layer KV
-  state, trimmed to exact length (no ``step`` slack).
+  content-addressed (cid over model key + token ids) snapshot of a prefix's
+  per-layer KV state, trimmed to exact length (no ``step`` slack).
 * :class:`ForkedKVCache` — a per-layer cache mirroring :class:`KVCache`'s
   interface. It holds a *reference* to the frozen parent arrays (zero copy)
   plus a private, growing tail buffer. Writes go only to the tail, so the
@@ -23,11 +23,30 @@ paying only for their private suffixes:
 * :class:`PrefixForkRegistry` — a small cid-keyed registry with longest-prefix
   lookup (via ``PromptTrie``), LRU eviction, and content dedup.
 
-Aliasing experiment (mlx 0.32.0.dev, 2026-07): the design question was whether
-a fork may share the parent's *live* buffer by reference while the parent
-keeps decoding. ``KVCache.update_and_fetch`` writes via in-place slice
-assignment (``keys[..., prev:offset, :] = new``) into a step(=256)
-preallocated buffer. Empirically:
+THE MODEL-KEY CONTRACT
+======================
+
+Every registry call takes a ``model_key``: a caller-supplied, stable STRING
+that identifies the *exact weights* the KV was computed with — it must encode
+at least the model path, adapter, and revision (e.g.
+``"org/model@rev+adapter-sha"``), and it MUST change whenever the weights
+change (adapter load/unload, revision update, requantization). Cached KV is a
+pure function of (weights, tokens); a key that outlives a weight change turns
+into deterministic stale-KV false HITs. Non-string keys are rejected loudly:
+an ``id()``-derived or object-identity key is forbidden because (a) an
+in-place weight swap keeps the same object and (b) CPython recycles addresses
+of dead objects, both of which alias distinct weight-identities onto one key.
+As defense in depth, cid-dedup hits are spot-checked against the offered KV
+content and raise on mismatch (see ``PrefixForkRegistry.freeze``).
+
+ALIASING EXPERIMENT
+===================
+
+(mlx 0.32.0.dev, 2026-07.) The design question was whether a fork may share
+the parent's *live* buffer by reference while the parent keeps decoding.
+``KVCache.update_and_fetch`` writes via in-place slice assignment
+(``keys[..., prev:offset, :] = new``) into a step(=256) preallocated buffer.
+Empirically:
 
 * Mutation visibility follows PYTHON-OBJECT identity, not buffer identity.
   ``a[...] = x`` (``__setitem__``) rebinds the array *object* to the
@@ -48,51 +67,77 @@ Conclusion: materialize ONCE per unique prefix content into a frozen,
 exact-length snapshot, and let every fork share those arrays by reference.
 That single O(prefix) copy is amortized across all forks (content-addressed
 dedup), fork creation is O(1), a fork's persistent footprint is O(tail), and
-immutability is structural — nothing ever calls ``__setitem__`` on the shared
-arrays, and the registry (plus each live fork) holds references so donation
-is impossible by construction.
+immutability is structural — no code path in this module ever calls
+``__setitem__`` on the shared arrays, raw frozen array objects never escape
+(every boundary hands out fresh zero-copy slice *objects*, so a consumer's
+``__setitem__`` rebinds only the consumer's object), and the registry plus
+each live fork hold references so donation is impossible by construction.
 
-Known v1 cost: each attention step sees ``concat(prefix, tail)``, a transient
-O(prefix + tail) buffer per layer per step (freed immediately by the memory
-pool). Attention already reads all KV bytes each step, so this adds one extra
-write pass; removing it needs a two-segment attention kernel and is left as a
-follow-up.
+KNOWN COSTS AND LIMITS (v1)
+===========================
+
+* Each attention step sees ``concat(prefix, tail)``, a transient
+  O(prefix + tail) buffer per layer per step (freed immediately by the memory
+  pool). Attention already reads all KV bytes each step, so this adds one
+  extra write pass; removing it needs a two-segment attention kernel and is
+  left as a follow-up.
+* Only stacks of plain ``KVCache`` layers are forkable; anything else makes
+  ``freeze`` return ``None`` (a safe miss).
+* A length-1 snapshot is only found by an exact-length fetch (``PromptTrie``'s
+  ``shorter`` result requires a match past position 0) — a false miss, never
+  a false hit.
+* An exact-match ``fetch_fork`` returns ``remaining == []``; as with
+  ``fetch_nearest_cache``, the caller must ensure at least one token is fed
+  to the model (e.g. by keying snapshots on ``tokens[:-1]``).
 
 Invalidation policy: evicting or invalidating a snapshot only removes its
 *discoverability* — the next ``fetch_fork`` misses (a false MISS re-prefills,
 which is always safe). Live forks keep the arrays alive through ordinary
 Python references, so an eviction can never corrupt an in-flight generation
-(a false HIT on freed memory is impossible by construction).
+(a false HIT on freed memory is impossible by construction). Consequently
+``max_bytes``/``nbytes`` bound only the *discoverable* set; snapshots pinned
+by live forks are reported separately via ``pinned_nbytes``.
 """
 
 import hashlib
 import threading
+import weakref
 from collections import OrderedDict
-from typing import Any, List, Optional, Tuple
+from typing import Any, Dict, List, Optional, Tuple
 
 import mlx.core as mx
 
 from .models.cache import KVCache, PromptTrie, _BaseCache, create_attention_mask
 
 
+def _require_model_key(model_key: Any) -> str:
+    """Enforce the model-key contract (see module docstring): a stable str
+    encoding model path + adapter + revision. Anything else raises."""
+    if not isinstance(model_key, str):
+        raise TypeError(
+            "model_key must be a stable string identifying the exact weights "
+            "(model path + adapter + revision, e.g. 'org/model@rev+adapter'); "
+            f"got {type(model_key).__name__}. Object- or id()-derived keys "
+            "are forbidden: in-place weight swaps keep the same object and "
+            "CPython reuses addresses, both of which cause stale-KV false "
+            "HITs. The key MUST change whenever the weights change."
+        )
+    return model_key
+
+
 def compute_cid(model_key: str, tokens: List[int]) -> str:
-    """Content-hash identity for a prefix: (model namespace, exact token ids).
+    """Content-hash identity for a prefix: (model key, exact token ids).
 
     Same content -> same cid, so two independently frozen copies of the same
-    prefix dedup to one snapshot. Different models never collide.
+    prefix dedup to one snapshot. Distinct model keys never collide. The
+    model key is subject to the module-level MODEL-KEY CONTRACT.
     """
+    model_key = _require_model_key(model_key)
     h = hashlib.sha256()
     h.update(model_key.encode("utf-8", "replace"))
     for t in tokens:
         h.update(b"\x00" + str(int(t)).encode())
     return h.hexdigest()[:16]
-
-
-def _model_key(model: Any) -> str:
-    """A stable-within-process namespace string for a model object."""
-    if isinstance(model, str):
-        return model
-    return f"id:{id(model)}"
 
 
 class FrozenPrefixSnapshot:
@@ -103,7 +148,14 @@ class FrozenPrefixSnapshot:
     ``mx.array(...)`` and forced with ``mx.eval`` so they own their buffers —
     the source cache may keep decoding (or be garbage collected) without any
     effect on the snapshot. Consumers must never write to these arrays; the
-    ForkedKVCache only ever reads them.
+    ForkedKVCache only ever reads them, and every boundary that could hand
+    them out returns fresh slice objects instead (see module docstring).
+
+    Construct via :meth:`freeze` (the blessed path, which materializes). The
+    raw constructor stores fresh full-range slice *objects* of the arrays it
+    is given, so a caller retaining (and later ``__setitem__``-ing) its own
+    references cannot mutate the snapshot — but it does NOT copy: the caller
+    must pass materialized arrays it will not share with a writer.
     """
 
     def __init__(
@@ -117,16 +169,27 @@ class FrozenPrefixSnapshot:
         self.cid = cid
         self.model_key = model_key
         self.tokens = tokens
-        self.keys = keys
-        self.values = values
+        # Fresh slice OBJECTS (zero-copy): a later __setitem__ through the
+        # caller's original references rebinds the caller's objects, never
+        # these pre-write nodes.
+        self.keys = [k[:] for k in keys]
+        self.values = [v[:] for v in values]
         self.nbytes = sum(k.nbytes + v.nbytes for k, v in zip(keys, values))
+        # Live forks referencing this snapshot (weak: forks hold the strong
+        # edge). Lets the registry report pinned-but-undiscoverable bytes.
+        self._forks = weakref.WeakSet()
 
     def __len__(self):
         return len(self.tokens)
 
+    @property
+    def pinned(self) -> bool:
+        """Whether any live fork still references this snapshot."""
+        return len(self._forks) > 0
+
     @classmethod
     def freeze(
-        cls, model: Any, tokens: List[int], prompt_cache: List[Any]
+        cls, model_key: str, tokens: List[int], prompt_cache: List[Any]
     ) -> Optional["FrozenPrefixSnapshot"]:
         """Materialize a snapshot from a live prompt cache, or ``None``.
 
@@ -134,6 +197,7 @@ class FrozenPrefixSnapshot:
         ``KVCache`` whose offset matches ``len(tokens)`` — rotating, chunked,
         quantized, and stateful (Mamba) caches are not COW-forkable in v1.
         """
+        model_key = _require_model_key(model_key)
         if len(tokens) == 0 or len(prompt_cache) == 0:
             return None
         for c in prompt_cache:
@@ -149,16 +213,19 @@ class FrozenPrefixSnapshot:
             keys.append(mx.array(k))
             values.append(mx.array(v))
         mx.eval(*keys, *values)
-        cid = compute_cid(_model_key(model), tokens)
-        return cls(cid, _model_key(model), tuple(int(t) for t in tokens), keys, values)
+        cid = compute_cid(model_key, tokens)
+        return cls(cid, model_key, tuple(int(t) for t in tokens), keys, values)
 
     def fork(self) -> List["ForkedKVCache"]:
         """A fresh per-layer cache stack referencing this snapshot. O(1):
         no prefix bytes are copied or materialized."""
-        return [
+        forks = [
             ForkedKVCache(self.keys[l], self.values[l], snapshot=self)
             for l in range(len(self.keys))
         ]
+        for f in forks:
+            self._forks.add(f)
+        return forks
 
 
 class ForkedKVCache(_BaseCache):
@@ -171,23 +238,30 @@ class ForkedKVCache(_BaseCache):
     to the shared arrays — and any number of sibling forks may share it.
 
     Interface parity with :class:`KVCache`: ``update_and_fetch``, ``offset``,
-    ``size``, ``state``, ``meta_state``, ``is_trimmable``/``trim``,
-    ``make_mask``, ``empty``, ``nbytes``. Differences:
+    ``size``, ``state``, ``is_trimmable``/``trim``, ``make_mask``, ``empty``,
+    ``nbytes``. Differences:
 
     * ``trim`` only reaches into the private tail — the frozen prefix cannot
-      be trimmed (it is shared). ``trim(n)`` returns the number actually
-      trimmed, clamped to the tail length.
+      be trimmed (it is shared). ``trim(n)`` RAISES if asked to trim past the
+      tail, because callers of ``trim_prompt_cache`` ignore its return value
+      and would otherwise continue generating against skewed KV. Rollback of
+      tokens generated *after* the fork (the intended use: speculative
+      decoding, retries) always stays within the tail and works normally.
     * ``nbytes`` counts only the PRIVATE tail bytes: for byte budgeting, the
       shared prefix must be counted once (at the snapshot/registry), not once
       per fork. The shared portion is exposed as ``shared_nbytes``.
-    * ``state`` materializes the joined (prefix + tail) arrays — an explicit
-      O(prefix) copy for serialization; use ``to_kv_cache()`` to detach into
-      a plain, independent ``KVCache``. ``state`` is read-only.
+    * ``state`` is read-only. With an empty tail it returns fresh zero-copy
+      slice objects of the frozen arrays (never the raw shared objects — a
+      consumer ``__setitem__`` must not be able to corrupt every sibling
+      fork); with a non-empty tail it materializes the joined arrays, an
+      explicit O(prefix) copy. Use ``to_kv_cache()`` to detach into a plain,
+      independent ``KVCache``.
+    * ``meta_state`` raises: ``save_prompt_cache`` would otherwise write a
+      file that cannot be loaded (``load_prompt_cache`` resolves classes from
+      ``models/cache.py`` only). Detach with ``to_kv_cache()`` to serialize.
     * no ``to_quantized`` — ``maybe_quantize_kv_cache`` skips this cache via
       its ``hasattr`` guard (quantizing would have to copy the prefix anyway).
     """
-
-    step = 256
 
     def __init__(
         self,
@@ -195,8 +269,10 @@ class ForkedKVCache(_BaseCache):
         prefix_values: mx.array,
         snapshot: Optional[FrozenPrefixSnapshot] = None,
     ):
-        self._prefix_keys = prefix_keys
-        self._prefix_values = prefix_values
+        # Fresh slice objects: seal against later __setitem__ through the
+        # caller's references (zero-copy; see module docstring).
+        self._prefix_keys = prefix_keys[:]
+        self._prefix_values = prefix_values[:]
         self._prefix_len = prefix_keys.shape[2]
         # Keep the snapshot alive: registry eviction only removes
         # discoverability, never the arrays under a live fork.
@@ -227,7 +303,10 @@ class ForkedKVCache(_BaseCache):
     @property
     def state(self):
         if self.tail.offset == 0:
-            return self._prefix_keys, self._prefix_values
+            # Fresh zero-copy slice objects, NOT the stored references: a
+            # consumer __setitem__ then rebinds only the consumer's object
+            # and the frozen prefix (shared by every sibling fork) survives.
+            return self._prefix_keys[:], self._prefix_values[:]
         tail_keys, tail_values = self.tail.state
         return (
             mx.concatenate([self._prefix_keys, tail_keys], axis=2),
@@ -238,6 +317,21 @@ class ForkedKVCache(_BaseCache):
     def state(self, v):
         raise ValueError(
             "ForkedKVCache state cannot be set; detach with to_kv_cache() first."
+        )
+
+    @property
+    def meta_state(self):
+        raise ValueError(
+            "ForkedKVCache cannot be serialized (save_prompt_cache would "
+            "write a file load_prompt_cache cannot reconstruct); detach with "
+            "to_kv_cache() first."
+        )
+
+    @meta_state.setter
+    def meta_state(self, v):
+        raise ValueError(
+            "ForkedKVCache cannot be restored from serialized state; "
+            "load a plain KVCache instead."
         )
 
     def to_kv_cache(self) -> KVCache:
@@ -253,8 +347,17 @@ class ForkedKVCache(_BaseCache):
         return True
 
     def trim(self, n):
-        # Only the private tail is trimmable; the shared prefix is frozen.
-        return self.tail.trim(min(n, self.tail.offset))
+        # Only the private tail is trimmable; the shared frozen prefix is
+        # not. Trimming past the tail must FAIL LOUDLY: trim_prompt_cache
+        # callers ignore the returned count, so a silent clamp would leave
+        # them generating against KV at the wrong offset.
+        if n > self.tail.offset:
+            raise ValueError(
+                f"Cannot trim {n} tokens from a ForkedKVCache with a private "
+                f"tail of {self.tail.offset}: the shared frozen prefix is "
+                "immutable. Detach with to_kv_cache() to trim deeper."
+            )
+        return self.tail.trim(n)
 
     def make_mask(self, *args, **kwargs):
         return create_attention_mask(*args, offset=self.offset, **kwargs)
@@ -275,6 +378,11 @@ class ForkedKVCache(_BaseCache):
 class PrefixForkRegistry:
     """cid-keyed store of frozen prefix snapshots with longest-prefix fetch.
 
+    All methods take a ``model_key`` STRING subject to the module-level
+    MODEL-KEY CONTRACT: it must identify the exact weights (model path +
+    adapter + revision) and must change whenever the weights change. Non-str
+    keys raise ``TypeError``.
+
     * ``freeze`` inserts (or dedups to) a snapshot for exact token content.
     * ``fetch_fork`` returns a zero-copy ``ForkedKVCache`` stack for the
       longest known snapshot that prefixes the requested tokens, plus the
@@ -283,16 +391,19 @@ class PrefixForkRegistry:
     * Eviction (LRU by count and bytes) and ``invalidate`` only remove
       discoverability: misses are always safe (re-prefill), and live forks
       keep their snapshot's arrays alive via Python references, so a stale
-      HIT on released memory cannot happen.
+      HIT on released memory cannot happen. ``max_bytes``/``nbytes`` bound
+      the DISCOVERABLE set only; bytes still resident because live forks pin
+      an evicted snapshot are reported by ``pinned_nbytes``.
     """
 
     def __init__(self, max_snapshots: int = 16, max_bytes: int = 1 << 63):
         self.max_snapshots = max_snapshots
         self.max_bytes = max_bytes
         self._snapshots: "OrderedDict[str, FrozenPrefixSnapshot]" = OrderedDict()
-        # The trie is namespaced by the model-key STRING (nn.Module is
-        # dict-derived and unhashable, so the object itself cannot key it).
-        self._trie = PromptTrie()
+        self._trie = PromptTrie()  # namespaced by the model-key string
+        # Weak refs to every snapshot ever inserted, for pinned_nbytes: a
+        # snapshot evicted here stays alive exactly as long as forks pin it.
+        self._tracked: Dict[str, "weakref.ref[FrozenPrefixSnapshot]"] = {}
         self._n_bytes = 0
         self._lock = threading.Lock()
 
@@ -301,28 +412,59 @@ class PrefixForkRegistry:
 
     @property
     def nbytes(self):
+        """Bytes of the DISCOVERABLE snapshots (what max_bytes bounds)."""
         return self._n_bytes
 
+    @property
+    def pinned_nbytes(self):
+        """Bytes of snapshots kept resident by live forks — including ones
+        already evicted/invalidated (discoverability and residency are
+        deliberately decoupled; see class docstring)."""
+        total = 0
+        with self._lock:
+            dead = []
+            for cid, ref in self._tracked.items():
+                snapshot = ref()
+                if snapshot is None:
+                    dead.append(cid)
+                elif snapshot.pinned:
+                    total += snapshot.nbytes
+            for cid in dead:
+                del self._tracked[cid]
+        return total
+
     def freeze(
-        self, model: Any, tokens: List[int], prompt_cache: List[Any]
+        self, model_key: str, tokens: List[int], prompt_cache: List[Any]
     ) -> Optional[str]:
         """Snapshot ``prompt_cache`` (which must cover exactly ``tokens``) and
         register it. Returns the snapshot cid, or ``None`` if the cache is not
         forkable (never raises for unsupported cache types — that is just a
-        future miss)."""
-        cid = compute_cid(_model_key(model), tokens)
-        with self._lock:
-            if cid in self._snapshots:
-                self._snapshots.move_to_end(cid)  # dedup: same content, one copy
-                return cid
-        snapshot = FrozenPrefixSnapshot.freeze(model, tokens, prompt_cache)
+        future miss).
+
+        Dedup safety: if the cid already exists, the offered KV content is
+        spot-checked against the stored snapshot and a mismatch RAISES —
+        matching (model_key, tokens) with different KV means the key contract
+        was violated (weights changed under a stale key)."""
+        model_key = _require_model_key(model_key)
+        cid = compute_cid(model_key, tokens)
+        existing = self.get(cid)
+        if existing is not None:
+            self._dedup_spot_check(existing, tokens, prompt_cache)
+            with self._lock:
+                if cid in self._snapshots:
+                    self._snapshots.move_to_end(cid)
+            return cid
+        snapshot = FrozenPrefixSnapshot.freeze(model_key, tokens, prompt_cache)
         if snapshot is None:
             return None
         with self._lock:
-            if snapshot.cid in self._snapshots:  # lost a freeze race: dedup
+            existing = self._snapshots.get(snapshot.cid)
+            if existing is not None:  # lost a freeze race: dedup
+                self._dedup_spot_check(existing, tokens, prompt_cache)
                 self._snapshots.move_to_end(snapshot.cid)
                 return snapshot.cid
             self._snapshots[snapshot.cid] = snapshot
+            self._tracked[snapshot.cid] = weakref.ref(snapshot)
             self._trie.add(snapshot.model_key, list(snapshot.tokens), snapshot.cid)
             self._n_bytes += snapshot.nbytes
             while len(self._snapshots) > self.max_snapshots or (
@@ -331,8 +473,36 @@ class PrefixForkRegistry:
                 self._evict_lru_locked()
         return snapshot.cid
 
+    @staticmethod
+    def _dedup_spot_check(
+        snapshot: FrozenPrefixSnapshot, tokens: List[int], prompt_cache: List[Any]
+    ):
+        """Cheap content check on a cid-dedup hit: compare a small slice of
+        layer-0 KV. Cannot prove equality (it is a spot check), but catches
+        the realistic failure — same key + tokens over CHANGED weights —
+        and raises instead of silently serving stale KV."""
+        if (
+            not prompt_cache
+            or type(prompt_cache[0]) is not KVCache
+            or prompt_cache[0].offset != len(tokens)
+        ):
+            return  # not comparable; a fresh freeze() would reject it too
+        k_new = prompt_cache[0].state[0]
+        k_old = snapshot.keys[0]
+        ok = k_new.shape == k_old.shape and k_new.dtype == k_old.dtype
+        if ok:
+            w = min(4, k_old.shape[2])
+            ok = bool(mx.array_equal(k_old[..., -w:, :], k_new[..., -w:, :]))
+        if not ok:
+            raise ValueError(
+                f"prefix-fork dedup mismatch for cid {snapshot.cid}: same "
+                "model_key and tokens but different KV content. The model "
+                "key MUST change whenever the weights change (adapter load, "
+                "revision update, requantization)."
+            )
+
     def fetch_fork(
-        self, model: Any, tokens: List[int]
+        self, model_key: str, tokens: List[int]
     ) -> Tuple[Optional[List[ForkedKVCache]], List[int]]:
         """Fork from the longest frozen snapshot prefixing ``tokens``.
 
@@ -342,7 +512,7 @@ class PrefixForkRegistry:
         cache path: a frozen prefix cannot be trimmed, so a longer-only match
         is deliberately a miss (false-MISS-only invariant).
         """
-        model_key = _model_key(model)
+        model_key = _require_model_key(model_key)
         with self._lock:
             result = self._trie.search(model_key, tokens)
             matched = result.exact if result.exact is not None else result.shorter

--- a/mlx_lm/prefix_forks.py
+++ b/mlx_lm/prefix_forks.py
@@ -1,0 +1,381 @@
+# Copyright © 2026 Apple Inc.
+
+"""Copy-on-write prefix forks for KV caches.
+
+Many concurrent requests often share one long common prefix (a system prompt,
+a document, a few-shot preamble). The existing request-level prompt cache
+(``LRUPromptCache``) hands every hit a ``copy.deepcopy`` of the cached KV
+stack — the ``deepcopy`` call itself is cheap (lazy arrays), but the copy is
+materialized on first use, costing O(prefix) memory *and* wall-clock per
+request (multiple seconds at long contexts).
+
+This module lets N requests fork from ONE frozen, in-RAM parent snapshot,
+paying only for their private suffixes:
+
+* :class:`FrozenPrefixSnapshot` — an immutable, ``mx.eval``-materialized,
+  content-addressed (cid over token ids) snapshot of a prefix's per-layer KV
+  state, trimmed to exact length (no ``step`` slack).
+* :class:`ForkedKVCache` — a per-layer cache mirroring :class:`KVCache`'s
+  interface. It holds a *reference* to the frozen parent arrays (zero copy)
+  plus a private, growing tail buffer. Writes go only to the tail, so the
+  parent is structurally immutable: copy-on-write achieved by construction
+  rather than by copy-on-first-write.
+* :class:`PrefixForkRegistry` — a small cid-keyed registry with longest-prefix
+  lookup (via ``PromptTrie``), LRU eviction, and content dedup.
+
+Aliasing experiment (mlx 0.32.0.dev, 2026-07): the design question was whether
+a fork may share the parent's *live* buffer by reference while the parent
+keeps decoding. ``KVCache.update_and_fetch`` writes via in-place slice
+assignment (``keys[..., prev:offset, :] = new``) into a step(=256)
+preallocated buffer. Empirically:
+
+* Mutation visibility follows PYTHON-OBJECT identity, not buffer identity.
+  ``a[...] = x`` (``__setitem__``) rebinds the array *object* to the
+  ``slice_update`` result, so every reference through that same Python object
+  observes the write — but any slice taken *before* the write (lazy or
+  evaluated) references the pre-write graph node and is preserved. MLX's
+  donation machinery never recycles a buffer that another live node
+  references, so even the refcount-hungry decode loop cannot scribble an
+  exported slice.
+* HOWEVER, an (evaluated) slice of the step-padded ``(B, H, S, D)`` buffer
+  along axis 2 is strided, so materializing it costs an O(prefix) copy — per
+  fork. And a lazy slice pins the parent's entire step-padded buffer alive
+  while remaining one MLX donation-optimization away from unsoundness (live
+  ``.state`` aliases have scribbled snapshots before; see the ``mx.array`` +
+  ``mx.eval`` park recipe this module reuses).
+
+Conclusion: materialize ONCE per unique prefix content into a frozen,
+exact-length snapshot, and let every fork share those arrays by reference.
+That single O(prefix) copy is amortized across all forks (content-addressed
+dedup), fork creation is O(1), a fork's persistent footprint is O(tail), and
+immutability is structural — nothing ever calls ``__setitem__`` on the shared
+arrays, and the registry (plus each live fork) holds references so donation
+is impossible by construction.
+
+Known v1 cost: each attention step sees ``concat(prefix, tail)``, a transient
+O(prefix + tail) buffer per layer per step (freed immediately by the memory
+pool). Attention already reads all KV bytes each step, so this adds one extra
+write pass; removing it needs a two-segment attention kernel and is left as a
+follow-up.
+
+Invalidation policy: evicting or invalidating a snapshot only removes its
+*discoverability* — the next ``fetch_fork`` misses (a false MISS re-prefills,
+which is always safe). Live forks keep the arrays alive through ordinary
+Python references, so an eviction can never corrupt an in-flight generation
+(a false HIT on freed memory is impossible by construction).
+"""
+
+import hashlib
+import threading
+from collections import OrderedDict
+from typing import Any, List, Optional, Tuple
+
+import mlx.core as mx
+
+from .models.cache import KVCache, PromptTrie, _BaseCache, create_attention_mask
+
+
+def compute_cid(model_key: str, tokens: List[int]) -> str:
+    """Content-hash identity for a prefix: (model namespace, exact token ids).
+
+    Same content -> same cid, so two independently frozen copies of the same
+    prefix dedup to one snapshot. Different models never collide.
+    """
+    h = hashlib.sha256()
+    h.update(model_key.encode("utf-8", "replace"))
+    for t in tokens:
+        h.update(b"\x00" + str(int(t)).encode())
+    return h.hexdigest()[:16]
+
+
+def _model_key(model: Any) -> str:
+    """A stable-within-process namespace string for a model object."""
+    if isinstance(model, str):
+        return model
+    return f"id:{id(model)}"
+
+
+class FrozenPrefixSnapshot:
+    """An immutable, materialized, content-addressed prefix KV snapshot.
+
+    ``keys[l]`` / ``values[l]`` are per-layer arrays of EXACT length
+    ``len(tokens)`` (no step slack), copied out of the source cache with
+    ``mx.array(...)`` and forced with ``mx.eval`` so they own their buffers —
+    the source cache may keep decoding (or be garbage collected) without any
+    effect on the snapshot. Consumers must never write to these arrays; the
+    ForkedKVCache only ever reads them.
+    """
+
+    def __init__(
+        self,
+        cid: str,
+        model_key: str,
+        tokens: Tuple[int, ...],
+        keys: List[mx.array],
+        values: List[mx.array],
+    ):
+        self.cid = cid
+        self.model_key = model_key
+        self.tokens = tokens
+        self.keys = keys
+        self.values = values
+        self.nbytes = sum(k.nbytes + v.nbytes for k, v in zip(keys, values))
+
+    def __len__(self):
+        return len(self.tokens)
+
+    @classmethod
+    def freeze(
+        cls, model: Any, tokens: List[int], prompt_cache: List[Any]
+    ) -> Optional["FrozenPrefixSnapshot"]:
+        """Materialize a snapshot from a live prompt cache, or ``None``.
+
+        Returns ``None`` (a safe miss) unless every layer is a plain
+        ``KVCache`` whose offset matches ``len(tokens)`` — rotating, chunked,
+        quantized, and stateful (Mamba) caches are not COW-forkable in v1.
+        """
+        if len(tokens) == 0 or len(prompt_cache) == 0:
+            return None
+        for c in prompt_cache:
+            if type(c) is not KVCache or c.offset != len(tokens):
+                return None
+        keys, values = [], []
+        for c in prompt_cache:
+            # .state may be a lazy slice of (or at full capacity, the very
+            # same Python object as) the live buffer the source cache keeps
+            # writing into. mx.array + mx.eval takes an independent,
+            # exact-length device buffer NOW (the proven park recipe).
+            k, v = c.state
+            keys.append(mx.array(k))
+            values.append(mx.array(v))
+        mx.eval(*keys, *values)
+        cid = compute_cid(_model_key(model), tokens)
+        return cls(cid, _model_key(model), tuple(int(t) for t in tokens), keys, values)
+
+    def fork(self) -> List["ForkedKVCache"]:
+        """A fresh per-layer cache stack referencing this snapshot. O(1):
+        no prefix bytes are copied or materialized."""
+        return [
+            ForkedKVCache(self.keys[l], self.values[l], snapshot=self)
+            for l in range(len(self.keys))
+        ]
+
+
+class ForkedKVCache(_BaseCache):
+    """A KVCache-compatible cache = frozen shared prefix + private tail.
+
+    Reads (``update_and_fetch`` results, ``.state``) present the concatenation
+    of the immutable prefix and the private tail; writes go exclusively into
+    the tail's step-preallocated buffer (a plain :class:`KVCache`). The
+    parent snapshot is therefore structurally immutable — no code path writes
+    to the shared arrays — and any number of sibling forks may share it.
+
+    Interface parity with :class:`KVCache`: ``update_and_fetch``, ``offset``,
+    ``size``, ``state``, ``meta_state``, ``is_trimmable``/``trim``,
+    ``make_mask``, ``empty``, ``nbytes``. Differences:
+
+    * ``trim`` only reaches into the private tail — the frozen prefix cannot
+      be trimmed (it is shared). ``trim(n)`` returns the number actually
+      trimmed, clamped to the tail length.
+    * ``nbytes`` counts only the PRIVATE tail bytes: for byte budgeting, the
+      shared prefix must be counted once (at the snapshot/registry), not once
+      per fork. The shared portion is exposed as ``shared_nbytes``.
+    * ``state`` materializes the joined (prefix + tail) arrays — an explicit
+      O(prefix) copy for serialization; use ``to_kv_cache()`` to detach into
+      a plain, independent ``KVCache``. ``state`` is read-only.
+    * no ``to_quantized`` — ``maybe_quantize_kv_cache`` skips this cache via
+      its ``hasattr`` guard (quantizing would have to copy the prefix anyway).
+    """
+
+    step = 256
+
+    def __init__(
+        self,
+        prefix_keys: mx.array,
+        prefix_values: mx.array,
+        snapshot: Optional[FrozenPrefixSnapshot] = None,
+    ):
+        self._prefix_keys = prefix_keys
+        self._prefix_values = prefix_values
+        self._prefix_len = prefix_keys.shape[2]
+        # Keep the snapshot alive: registry eviction only removes
+        # discoverability, never the arrays under a live fork.
+        self._snapshot = snapshot
+        self.tail = KVCache()
+
+    @property
+    def offset(self):
+        return self._prefix_len + self.tail.offset
+
+    @property
+    def prefix_length(self):
+        return self._prefix_len
+
+    def update_and_fetch(self, keys, values):
+        tail_keys, tail_values = self.tail.update_and_fetch(keys, values)
+        # The concat reads the frozen prefix (never writes it) and produces a
+        # fresh transient buffer for attention; the tail slice stays a view of
+        # the private buffer that the next step writes in place.
+        return (
+            mx.concatenate([self._prefix_keys, tail_keys], axis=2),
+            mx.concatenate([self._prefix_values, tail_values], axis=2),
+        )
+
+    def size(self):
+        return self.offset
+
+    @property
+    def state(self):
+        if self.tail.offset == 0:
+            return self._prefix_keys, self._prefix_values
+        tail_keys, tail_values = self.tail.state
+        return (
+            mx.concatenate([self._prefix_keys, tail_keys], axis=2),
+            mx.concatenate([self._prefix_values, tail_values], axis=2),
+        )
+
+    @state.setter
+    def state(self, v):
+        raise ValueError(
+            "ForkedKVCache state cannot be set; detach with to_kv_cache() first."
+        )
+
+    def to_kv_cache(self) -> KVCache:
+        """Detach into an independent plain KVCache (explicit O(prefix) copy)."""
+        cache = KVCache()
+        keys, values = self.state
+        keys, values = mx.array(keys), mx.array(values)
+        mx.eval(keys, values)
+        cache.state = (keys, values)
+        return cache
+
+    def is_trimmable(self):
+        return True
+
+    def trim(self, n):
+        # Only the private tail is trimmable; the shared prefix is frozen.
+        return self.tail.trim(min(n, self.tail.offset))
+
+    def make_mask(self, *args, **kwargs):
+        return create_attention_mask(*args, offset=self.offset, **kwargs)
+
+    def empty(self):
+        return False
+
+    @property
+    def nbytes(self):
+        """Private (per-fork) bytes only; see class docstring."""
+        return self.tail.nbytes
+
+    @property
+    def shared_nbytes(self):
+        return self._prefix_keys.nbytes + self._prefix_values.nbytes
+
+
+class PrefixForkRegistry:
+    """cid-keyed store of frozen prefix snapshots with longest-prefix fetch.
+
+    * ``freeze`` inserts (or dedups to) a snapshot for exact token content.
+    * ``fetch_fork`` returns a zero-copy ``ForkedKVCache`` stack for the
+      longest known snapshot that prefixes the requested tokens, plus the
+      remaining suffix to prefill — the fork-aware analogue of
+      ``LRUPromptCache.fetch_nearest_cache`` without its deepcopy.
+    * Eviction (LRU by count and bytes) and ``invalidate`` only remove
+      discoverability: misses are always safe (re-prefill), and live forks
+      keep their snapshot's arrays alive via Python references, so a stale
+      HIT on released memory cannot happen.
+    """
+
+    def __init__(self, max_snapshots: int = 16, max_bytes: int = 1 << 63):
+        self.max_snapshots = max_snapshots
+        self.max_bytes = max_bytes
+        self._snapshots: "OrderedDict[str, FrozenPrefixSnapshot]" = OrderedDict()
+        # The trie is namespaced by the model-key STRING (nn.Module is
+        # dict-derived and unhashable, so the object itself cannot key it).
+        self._trie = PromptTrie()
+        self._n_bytes = 0
+        self._lock = threading.Lock()
+
+    def __len__(self):
+        return len(self._snapshots)
+
+    @property
+    def nbytes(self):
+        return self._n_bytes
+
+    def freeze(
+        self, model: Any, tokens: List[int], prompt_cache: List[Any]
+    ) -> Optional[str]:
+        """Snapshot ``prompt_cache`` (which must cover exactly ``tokens``) and
+        register it. Returns the snapshot cid, or ``None`` if the cache is not
+        forkable (never raises for unsupported cache types — that is just a
+        future miss)."""
+        cid = compute_cid(_model_key(model), tokens)
+        with self._lock:
+            if cid in self._snapshots:
+                self._snapshots.move_to_end(cid)  # dedup: same content, one copy
+                return cid
+        snapshot = FrozenPrefixSnapshot.freeze(model, tokens, prompt_cache)
+        if snapshot is None:
+            return None
+        with self._lock:
+            if snapshot.cid in self._snapshots:  # lost a freeze race: dedup
+                self._snapshots.move_to_end(snapshot.cid)
+                return snapshot.cid
+            self._snapshots[snapshot.cid] = snapshot
+            self._trie.add(snapshot.model_key, list(snapshot.tokens), snapshot.cid)
+            self._n_bytes += snapshot.nbytes
+            while len(self._snapshots) > self.max_snapshots or (
+                self._n_bytes > self.max_bytes and len(self._snapshots) > 1
+            ):
+                self._evict_lru_locked()
+        return snapshot.cid
+
+    def fetch_fork(
+        self, model: Any, tokens: List[int]
+    ) -> Tuple[Optional[List[ForkedKVCache]], List[int]]:
+        """Fork from the longest frozen snapshot prefixing ``tokens``.
+
+        Returns ``(forks, remaining_tokens)`` where ``forks`` is a per-layer
+        ``ForkedKVCache`` list (or ``None`` on a miss, with ``remaining ==
+        tokens``). Unlike ``fetch_nearest_cache`` there is no trim-a-longer-
+        cache path: a frozen prefix cannot be trimmed, so a longer-only match
+        is deliberately a miss (false-MISS-only invariant).
+        """
+        model_key = _model_key(model)
+        with self._lock:
+            result = self._trie.search(model_key, tokens)
+            matched = result.exact if result.exact is not None else result.shorter
+            if matched is None:
+                return None, tokens
+            cid = self._trie.get(model_key, matched)
+            snapshot = self._snapshots.get(cid)
+            if snapshot is None:  # stale trie entry: treat as a miss
+                return None, tokens
+            self._snapshots.move_to_end(cid)
+        return snapshot.fork(), tokens[len(matched) :]
+
+    def get(self, cid: str) -> Optional[FrozenPrefixSnapshot]:
+        with self._lock:
+            return self._snapshots.get(cid)
+
+    def invalidate(self, cid: str) -> bool:
+        """Remove a snapshot from the registry (future fetches miss). Live
+        forks referencing it are unaffected. Returns whether it was held."""
+        with self._lock:
+            snapshot = self._snapshots.pop(cid, None)
+            if snapshot is None:
+                return False
+            self._remove_locked(snapshot)
+            return True
+
+    def _remove_locked(self, snapshot: FrozenPrefixSnapshot):
+        self._n_bytes -= snapshot.nbytes
+        try:
+            self._trie.pop(snapshot.model_key, list(snapshot.tokens))
+        except KeyError:
+            pass  # already unlinked; the miss it causes is safe
+
+    def _evict_lru_locked(self):
+        cid, snapshot = self._snapshots.popitem(last=False)
+        self._remove_locked(snapshot)

--- a/mlx_lm/prefix_forks.py
+++ b/mlx_lm/prefix_forks.py
@@ -450,7 +450,12 @@ class PrefixForkRegistry:
       an evicted snapshot are reported by ``pinned_nbytes``.
     """
 
-    def __init__(self, max_snapshots: int = 16, max_bytes: int = 1 << 63):
+    def __init__(
+        self,
+        max_snapshots: int = 16,
+        max_bytes: int = 1 << 63,
+        on_evict=None,
+    ):
         for name, value in (
             ("max_snapshots", max_snapshots),
             ("max_bytes", max_bytes),
@@ -469,7 +474,8 @@ class PrefixForkRegistry:
         # older invalidated snapshot remains pinned by live forks.
         self._tracked: List["weakref.ref[FrozenPrefixSnapshot]"] = []
         self._n_bytes = 0
-        self._lock = threading.Lock()
+        self.on_evict = on_evict
+        self._lock = threading.RLock()
 
     def __len__(self):
         with self._lock:
@@ -530,6 +536,14 @@ class PrefixForkRegistry:
         cid = compute_cid(model_key, tokens)
         existing = self.get(cid)
         if existing is not None:
+            if not isinstance(existing, FrozenPrefixSnapshot):
+                materialize = getattr(existing, "materialize", None)
+                if materialize is None:
+                    return None
+                existing = materialize()
+                if existing is None:
+                    self.invalidate(cid)
+                    return None
             self._dedup_spot_check(existing, tokens, prompt_cache)
             with self._lock:
                 if cid in self._snapshots:
@@ -541,6 +555,11 @@ class PrefixForkRegistry:
         with self._lock:
             existing = self._snapshots.get(snapshot.cid)
             if existing is not None:  # lost a freeze race: dedup
+                if not isinstance(existing, FrozenPrefixSnapshot):
+                    materialize = getattr(existing, "materialize", None)
+                    existing = materialize() if materialize is not None else None
+                    if existing is None:
+                        return None
                 self._dedup_spot_check(existing, tokens, prompt_cache)
                 self._snapshots.move_to_end(snapshot.cid)
                 return snapshot.cid
@@ -707,4 +726,10 @@ class PrefixForkRegistry:
 
     def _evict_lru_locked(self):
         cid, snapshot = self._snapshots.popitem(last=False)
+        if self.on_evict is not None and isinstance(snapshot, FrozenPrefixSnapshot):
+            try:
+                self.on_evict(snapshot)
+            except Exception:
+                self._snapshots[cid] = snapshot
+                raise
         self._remove_locked(snapshot)

--- a/mlx_lm/prefix_forks.py
+++ b/mlx_lm/prefix_forks.py
@@ -419,7 +419,12 @@ class PrefixForkRegistry:
     def pinned_nbytes(self):
         """Bytes of snapshots kept resident by live forks — including ones
         already evicted/invalidated (discoverability and residency are
-        deliberately decoupled; see class docstring)."""
+        deliberately decoupled; see class docstring).
+
+        NOTE: a snapshot that is both discoverable and pinned is counted in
+        BOTH ``nbytes`` and ``pinned_nbytes`` — the two are overlapping
+        views (discoverable set vs resident set), not additive; do not sum
+        them to estimate memory."""
         total = 0
         with self._lock:
             dead = []
@@ -477,22 +482,32 @@ class PrefixForkRegistry:
     def _dedup_spot_check(
         snapshot: FrozenPrefixSnapshot, tokens: List[int], prompt_cache: List[Any]
     ):
-        """Cheap content check on a cid-dedup hit: compare a small slice of
-        layer-0 KV. Cannot prove equality (it is a spot check), but catches
-        the realistic failure — same key + tokens over CHANGED weights —
-        and raises instead of silently serving stale KV."""
+        """Cheap content check on a cid-dedup hit: compare the last-4-token
+        KV slice of EVERY layer (a layer-N-only weight change — e.g. a LoRA
+        that leaves embeddings and early attention untouched — produces
+        bit-identical early-layer KV, so a single-layer check is blind to
+        it). Cannot prove equality (position window is limited), but
+        catches per-layer-visible changes at freeze time and raises instead
+        of silently serving stale KV. Freeze-time backstop only: fetch_fork
+        under a stale key has nothing to compare against — the model-key
+        contract is the primary defense."""
         if (
-            not prompt_cache
-            or type(prompt_cache[0]) is not KVCache
+            len(prompt_cache) != len(snapshot.keys)
+            or any(type(c) is not KVCache for c in prompt_cache)
             or prompt_cache[0].offset != len(tokens)
         ):
             return  # not comparable; a fresh freeze() would reject it too
-        k_new = prompt_cache[0].state[0]
-        k_old = snapshot.keys[0]
-        ok = k_new.shape == k_old.shape and k_new.dtype == k_old.dtype
-        if ok:
+        ok = True
+        for layer, c in enumerate(prompt_cache):
+            k_new = c.state[0]
+            k_old = snapshot.keys[layer]
+            if k_new.shape != k_old.shape or k_new.dtype != k_old.dtype:
+                ok = False
+                break
             w = min(4, k_old.shape[2])
-            ok = bool(mx.array_equal(k_old[..., -w:, :], k_new[..., -w:, :]))
+            if not bool(mx.array_equal(k_old[..., -w:, :], k_new[..., -w:, :])):
+                ok = False
+                break
         if not ok:
             raise ValueError(
                 f"prefix-fork dedup mismatch for cid {snapshot.cid}: same "

--- a/mlx_lm/server.py
+++ b/mlx_lm/server.py
@@ -410,7 +410,21 @@ def _persistent_model_key(model_key) -> str:
     def hf_snapshot_identity(path):
         parts = path.parts
         for index in range(len(parts) - 2, -1, -1):
-            if parts[index] != "snapshots" or index + 1 >= len(parts):
+            if parts[index] != "snapshots" or index < 1 or index + 1 >= len(parts):
+                continue
+            # Hugging Face encodes a model repo as
+            # models--<namespace>--<name>/snapshots/<commit>. A generic local
+            # directory named snapshots/<hex> has no immutable-revision
+            # authority and must fall through to byte hashing.
+            repo_parts = parts[index - 1].split("--")
+            if (
+                len(repo_parts) < 3
+                or repo_parts[0] != "models"
+                or any(not part for part in repo_parts[1:])
+            ):
+                continue
+            repo_root = Path(*parts[:index])
+            if not (repo_root / "blobs").is_dir():
                 continue
             revision = parts[index + 1]
             if len(revision) < 7 or any(

--- a/mlx_lm/server.py
+++ b/mlx_lm/server.py
@@ -1,6 +1,7 @@
-# Copyright © 2023-2024 Apple Inc.
+# Copyright © 2023-2026 Apple Inc.
 
 import argparse
+import hashlib
 import json
 import logging
 import pickle
@@ -41,7 +42,9 @@ from .generate import (
     stream_generate,
 )
 from .models.cache import LRUPromptCache, make_prompt_cache
+from .prefix_forks import FrozenPrefixSnapshot, PrefixForkRegistry, compute_cid
 from .sample_utils import make_logits_processors, make_sampler
+from .snapshot_store import SnapshotStore
 from .utils import _parse_size, load, sharded_load
 
 
@@ -378,6 +381,184 @@ class ModelProvider:
         return self.model, self.tokenizer
 
 
+def _persistent_model_key(model_key) -> str:
+    """Build the mandatory stable-string identity for persisted KV.
+
+    Hugging Face cache paths already contain immutable snapshot revisions.
+    For local paths, include a deterministic manifest of weight/config file
+    names, sizes, and nanosecond mtimes so an ordinary weight or adapter swap
+    changes identity.  Callers that mutate bytes while preserving all three
+    violate the same explicit model-key contract documented by prefix_forks.
+    """
+
+    def identify(value):
+        if value is None:
+            return None
+        path = Path(str(value)).expanduser()
+        if not path.exists():
+            source = str(value)
+            try:
+                cache_info = scan_cache_dir()
+                repo = next(
+                    repo
+                    for repo in cache_info.repos
+                    if repo.repo_type == "model" and repo.repo_id == source
+                )
+                revision = max(
+                    repo.revisions, key=lambda item: item.last_modified
+                ).commit_hash
+                return {"source": source, "revision": revision}
+            except (OSError, StopIteration, ValueError):
+                raise ValueError(
+                    f"cannot resolve an immutable cached revision for {source!r}; "
+                    "persistent prompt caching is disabled for this model"
+                ) from None
+        path = path.resolve()
+        files = (
+            [path]
+            if path.is_file()
+            else sorted(p for p in path.rglob("*") if p.is_file())
+        )
+        manifest = []
+        for item in files:
+            if item.suffix in {".safetensors", ".json"} or "adapter" in item.name:
+                stat = item.stat()
+                manifest.append(
+                    [
+                        str(item.relative_to(path) if path.is_dir() else item.name),
+                        stat.st_size,
+                        stat.st_mtime_ns,
+                    ]
+                )
+        digest = hashlib.sha256(
+            json.dumps(manifest, separators=(",", ":")).encode()
+        ).hexdigest()
+        return {"path": str(path), "revision_manifest": digest}
+
+    parts = model_key if isinstance(model_key, tuple) else (model_key,)
+    return json.dumps(
+        {"mlx_lm_persistent_model_key": 1, "parts": [identify(x) for x in parts]},
+        sort_keys=True,
+        separators=(",", ":"),
+    )
+
+
+class PersistentPromptCache:
+    """Server bridge combining COW RAM forks with the restart disk tier.
+
+    Unsupported cache types safely fall back to the existing LRU cache.  A
+    successful forkable insert is held once in the prefix registry and is
+    flushed on the generation thread's next quiescent tick.  Before a later
+    insert could evict unsaved RAM state, all prior state is written back.
+    """
+
+    def __init__(self, max_size, directory, *, max_bytes, max_files):
+        self._fallback = LRUPromptCache(max_size)
+        self._max_ram_snapshots = max_size
+        self._registry = PrefixForkRegistry(max_snapshots=max_files)
+        self._store = SnapshotStore(
+            directory,
+            max_bytes=max_bytes,
+            max_files=max_files,
+            registry=self._registry,
+        )
+        self._last_scrub = 0.0
+        self._stable_keys = {}
+
+    def _model_key(self, model):
+        try:
+            cache_key = model
+            hash(cache_key)
+        except TypeError:
+            cache_key = repr(model)
+        if cache_key not in self._stable_keys:
+            self._stable_keys[cache_key] = _persistent_model_key(model)
+        return self._stable_keys[cache_key]
+
+    def __len__(self):
+        return len(self._registry) + len(self._fallback)
+
+    @property
+    def nbytes(self):
+        return self._registry.nbytes + self._fallback.nbytes
+
+    @property
+    def persistent_stats(self):
+        return self._store.stats
+
+    def stats_by_type(self):
+        stats = self._fallback.stats_by_type()
+        stats["persistent-prefix"] = {
+            "n_sequences": len(self._registry),
+            "n_bytes": self._registry.nbytes,
+        }
+        return stats
+
+    def fetch_nearest_cache(self, model, tokens):
+        try:
+            stable_key = self._model_key(model)
+        except ValueError as exc:
+            logging.warning("Persistent prompt cache safe miss: %s", exc)
+            return self._fallback.fetch_nearest_cache(model, tokens)
+        self._store.note_request_cid(compute_cid(stable_key, tokens))
+        forks, rest = self._registry.fetch_fork(stable_key, tokens)
+        if forks is not None:
+            self._enforce_ram_limit()
+            return forks, rest
+        return self._fallback.fetch_nearest_cache(model, tokens)
+
+    def insert_cache(self, model, tokens, prompt_cache, *, cache_type="assistant"):
+        self._store.flush_registry(self._registry)
+        offsets = [getattr(cache, "offset", None) for cache in prompt_cache]
+        if (
+            offsets
+            and offsets[0] is not None
+            and all(offset == offsets[0] for offset in offsets)
+        ):
+            length = int(offsets[0])
+            if 0 < length <= len(tokens):
+                try:
+                    stable_key = self._model_key(model)
+                except ValueError as exc:
+                    logging.warning("Persistent prompt cache not written: %s", exc)
+                    self._fallback.insert_cache(
+                        model, tokens, prompt_cache, cache_type=cache_type
+                    )
+                    return
+                cid = compute_cid(stable_key, tokens[:length])
+                existing = self._registry.get(cid)
+                if existing is not None and not isinstance(
+                    existing, FrozenPrefixSnapshot
+                ):
+                    self._store.restore(cid)
+                cid = self._registry.freeze(stable_key, tokens[:length], prompt_cache)
+                if cid is not None:
+                    self._enforce_ram_limit()
+                    return
+        self._fallback.insert_cache(model, tokens, prompt_cache, cache_type=cache_type)
+
+    def trim_to(self, **kwargs):
+        self._fallback.trim_to(**kwargs)
+
+    def _enforce_ram_limit(self):
+        materialized = [
+            snapshot
+            for snapshot in self._registry.snapshots()
+            if isinstance(snapshot, FrozenPrefixSnapshot)
+        ]
+        while len(materialized) > self._max_ram_snapshots:
+            victim = materialized.pop(0)
+            self._store.demote_from_ram(victim.cid)
+
+    def flush_persistent(self, *, scrub=True):
+        count = self._store.flush_registry(self._registry)
+        now = time.monotonic()
+        if scrub and now - self._last_scrub >= 1.0:
+            self._store.scrub_one()
+            self._last_scrub = now
+        return count
+
+
 def _make_sampler(args, tokenizer):
     return make_sampler(
         args.sampling.temperature,
@@ -436,6 +617,8 @@ class ResponseGenerator:
     def stop_and_join(self):
         self._stop = True
         self._generation_thread.join()
+        if hasattr(self.prompt_cache, "flush_persistent"):
+            self.prompt_cache.flush_persistent(scrub=False)
 
     def join(self):
         self._generation_thread.join()
@@ -449,6 +632,10 @@ class ResponseGenerator:
             n_bytes = stats["n_bytes"]
             logging.info(
                 f"- {cache_type}: {n_sequences} sequences, {n_bytes / 1e9:.2f} GB"
+            )
+        if hasattr(self.prompt_cache, "persistent_stats"):
+            logging.info(
+                "Persistent Prompt Cache: %s", self.prompt_cache.persistent_stats
             )
 
     def _next_request(self, timeout=None):
@@ -622,7 +809,16 @@ class ResponseGenerator:
         return stop_matcher, text_sm
 
     def _is_batchable(self, args):
-        return self.model_provider.is_batchable and args.seed is None
+        # ForkedKVCache intentionally has no batch ``merge`` operation on the
+        # COW base branch.  Persistence is opt-in, so route it through the
+        # fully wired sequential path instead of handing an incompatible
+        # cache to BatchGenerator or silently bypassing disk hits.
+        persistence_off = not getattr(
+            self.model_provider.cli_args, "prompt_cache_persist_dir", None
+        )
+        return (
+            self.model_provider.is_batchable and args.seed is None and persistence_off
+        )
 
     def _generate(self):
         # Local thread stream that we 'll pass to the BatchGenerator to make
@@ -662,6 +858,15 @@ class ResponseGenerator:
                     else 0.1
                 )
                 request = get_next_request(timeout=timeout)
+
+            if (
+                request is None
+                and (batch_generator is None or len(batch_results) == 0)
+                and hasattr(self.prompt_cache, "flush_persistent")
+            ):
+                # Generation-thread-only, quiescent hook.  One bounded scrub
+                # follows write-back; no background thread can race a cache.
+                self.prompt_cache.flush_persistent(scrub=True)
 
             # We got a request
             if request is not None:
@@ -1709,7 +1914,25 @@ def run(
     handler_class=APIHandler,
 ):
     group = mx.distributed.init()
-    prompt_cache = LRUPromptCache(model_provider.cli_args.prompt_cache_size)
+    persist_dir = getattr(model_provider.cli_args, "prompt_cache_persist_dir", None)
+    if persist_dir:
+        prompt_cache = PersistentPromptCache(
+            model_provider.cli_args.prompt_cache_size,
+            persist_dir,
+            max_bytes=getattr(
+                model_provider.cli_args, "prompt_cache_persist_bytes", 32 << 30
+            ),
+            max_files=getattr(
+                model_provider.cli_args, "prompt_cache_persist_files", 4096
+            ),
+        )
+        logging.info(
+            "%d snapshots / %.2f GiB indexed (no data loaded)",
+            prompt_cache.persistent_stats["files"],
+            prompt_cache.persistent_stats["bytes"] / (1 << 30),
+        )
+    else:
+        prompt_cache = LRUPromptCache(model_provider.cli_args.prompt_cache_size)
     response_generator = ResponseGenerator(model_provider, prompt_cache)
     if group.rank() == 0:
         _run_http_server(host, port, response_generator)
@@ -1847,6 +2070,23 @@ def main():
         "--prompt-cache-bytes",
         type=_parse_size,
         help="Maximum size in bytes of the KV caches",
+    )
+    parser.add_argument(
+        "--prompt-cache-persist-dir",
+        type=str,
+        help="Opt-in directory for restart-persistent prefix snapshots",
+    )
+    parser.add_argument(
+        "--prompt-cache-persist-bytes",
+        type=_parse_size,
+        default=32 << 30,
+        help="Maximum persistent-cache disk usage (default: 32 GiB)",
+    )
+    parser.add_argument(
+        "--prompt-cache-persist-files",
+        type=int,
+        default=4096,
+        help="Maximum files in the persistent-cache directory",
     )
     parser.add_argument(
         "--pipeline",

--- a/mlx_lm/server.py
+++ b/mlx_lm/server.py
@@ -399,12 +399,35 @@ class ModelProvider:
 def _persistent_model_key(model_key) -> str:
     """Build the mandatory stable-string identity for persisted KV.
 
-    Hugging Face cache paths already contain immutable snapshot revisions.
-    For local paths, include a deterministic manifest of weight/config file
-    names, sizes, and nanosecond mtimes so an ordinary weight or adapter swap
-    changes identity.  Callers that mutate bytes while preserving all three
-    violate the same explicit model-key contract documented by prefix_forks.
+    Loader-resolved Hugging Face cache paths contain an immutable
+    ``snapshots/<revision>`` component, so their trusted revision and resolved
+    path identify the loaded bytes without reopening multi-gigabyte payloads.
+    Ordinary local paths have no immutable revision authority and therefore
+    hash every file byte; same-size/mtime-preserving weight or adapter swaps
+    still change identity.
     """
+
+    def hf_snapshot_identity(path):
+        parts = path.parts
+        for index in range(len(parts) - 2, -1, -1):
+            if parts[index] != "snapshots" or index + 1 >= len(parts):
+                continue
+            revision = parts[index + 1]
+            if len(revision) < 7 or any(
+                char not in "0123456789abcdef" for char in revision.lower()
+            ):
+                continue
+            snapshot_root = Path(*parts[: index + 2])
+            try:
+                subpath = path.relative_to(snapshot_root)
+            except ValueError:
+                continue
+            return {
+                "hf_snapshot_path": str(snapshot_root),
+                "revision": revision,
+                "subpath": str(subpath),
+            }
+        return None
 
     def identify(value):
         if value is None:
@@ -416,6 +439,9 @@ def _persistent_model_key(model_key) -> str:
                 "persistent prompt caching is disabled"
             )
         path = path.resolve()
+        hf_identity = hf_snapshot_identity(path)
+        if hf_identity is not None:
+            return hf_identity
         files = (
             [path]
             if path.is_file()

--- a/mlx_lm/server.py
+++ b/mlx_lm/server.py
@@ -6,16 +6,18 @@ import json
 import logging
 import pickle
 import platform
+import signal
 import socket
 import time
 import uuid
 import warnings
+from concurrent.futures import ThreadPoolExecutor
 from dataclasses import dataclass
 from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
 from pathlib import Path
 from queue import Empty as QueueEmpty
 from queue import Queue
-from threading import Thread
+from threading import Lock, Thread
 from typing import (
     Any,
     Callable,
@@ -45,7 +47,7 @@ from .models.cache import LRUPromptCache, make_prompt_cache
 from .prefix_forks import FrozenPrefixSnapshot, PrefixForkRegistry, compute_cid
 from .sample_utils import make_logits_processors, make_sampler
 from .snapshot_store import SnapshotStore
-from .utils import _parse_size, load, sharded_load
+from .utils import _download, _parse_size, load, sharded_load
 
 
 def get_system_fingerprint():
@@ -279,6 +281,7 @@ class ModelProvider:
         """Load models on demand and persist them across the whole process."""
         self.cli_args = cli_args
         self.model_key = None
+        self._request_model_key = None
         self.model = None
         self.tokenizer = None
         self.draft_model = None
@@ -316,9 +319,20 @@ class ModelProvider:
 
         # Remove the old model if it exists.
         self.model_key = None
+        self._request_model_key = None
         self.model = None
         self.tokenizer = None
         self.draft_model = None
+
+        # Resolve the exact immutable snapshot paths through the SAME helper
+        # used by the loader. Persistent identity must describe loaded bytes,
+        # never whichever unrelated revision was downloaded most recently.
+        request_key = (model_path, adapter_path, draft_model_path)
+        model_path = str(_download(model_path))
+        if draft_model_path is not None:
+            draft_model_path = str(_download(draft_model_path))
+        if adapter_path is not None:
+            adapter_path = str(Path(adapter_path).expanduser().resolve())
 
         # Load the model and tokenizer
         if self.is_distributed:
@@ -360,6 +374,7 @@ class ModelProvider:
 
         # Update the member variables
         self.model_key = (model_path, adapter_path, draft_model_path)
+        self._request_model_key = request_key
         self.model = model
         self.tokenizer = tokenizer
         self.draft_model = draft_model
@@ -375,7 +390,7 @@ class ModelProvider:
         draft_model_path = self._draft_model_map.get(draft_model_path, draft_model_path)
 
         model_key = (model_path, adapter_path, draft_model_path)
-        if self.model_key != model_key:
+        if self._request_model_key != model_key:
             self._load(*model_key)
 
         return self.model, self.tokenizer
@@ -396,44 +411,25 @@ def _persistent_model_key(model_key) -> str:
             return None
         path = Path(str(value)).expanduser()
         if not path.exists():
-            source = str(value)
-            try:
-                cache_info = scan_cache_dir()
-                repo = next(
-                    repo
-                    for repo in cache_info.repos
-                    if repo.repo_type == "model" and repo.repo_id == source
-                )
-                revision = max(
-                    repo.revisions, key=lambda item: item.last_modified
-                ).commit_hash
-                return {"source": source, "revision": revision}
-            except (OSError, StopIteration, ValueError):
-                raise ValueError(
-                    f"cannot resolve an immutable cached revision for {source!r}; "
-                    "persistent prompt caching is disabled for this model"
-                ) from None
+            raise ValueError(
+                f"model identity path {str(value)!r} was not loader-resolved; "
+                "persistent prompt caching is disabled"
+            )
         path = path.resolve()
         files = (
             [path]
             if path.is_file()
             else sorted(p for p in path.rglob("*") if p.is_file())
         )
-        manifest = []
+        h = hashlib.sha256()
         for item in files:
-            if item.suffix in {".safetensors", ".json"} or "adapter" in item.name:
-                stat = item.stat()
-                manifest.append(
-                    [
-                        str(item.relative_to(path) if path.is_dir() else item.name),
-                        stat.st_size,
-                        stat.st_mtime_ns,
-                    ]
-                )
-        digest = hashlib.sha256(
-            json.dumps(manifest, separators=(",", ":")).encode()
-        ).hexdigest()
-        return {"path": str(path), "revision_manifest": digest}
+            relative = str(item.relative_to(path) if path.is_dir() else item.name)
+            h.update(len(relative.encode()).to_bytes(8, "big"))
+            h.update(relative.encode())
+            with item.open("rb") as handle:
+                while chunk := handle.read(4 << 20):
+                    h.update(chunk)
+        return {"path": str(path), "content_sha256": h.hexdigest()}
 
     parts = model_key if isinstance(model_key, tuple) else (model_key,)
     return json.dumps(
@@ -455,7 +451,9 @@ class PersistentPromptCache:
     def __init__(self, max_size, directory, *, max_bytes, max_files):
         self._fallback = LRUPromptCache(max_size)
         self._max_ram_snapshots = max_size
-        self._registry = PrefixForkRegistry(max_snapshots=max_files)
+        # Disk proxies remain indexed independently of the RAM promotion cap;
+        # store GC owns the actual file bound.
+        self._registry = PrefixForkRegistry(max_snapshots=1 << 63)
         self._store = SnapshotStore(
             directory,
             max_bytes=max_bytes,
@@ -464,6 +462,11 @@ class PersistentPromptCache:
         )
         self._last_scrub = 0.0
         self._stable_keys = {}
+        self._registry.on_evict = self._store.save
+        self._maintenance_pool = ThreadPoolExecutor(
+            max_workers=1, thread_name_prefix="mlx-kv-persist"
+        )
+        self._maintenance_future = None
 
     def _model_key(self, model):
         try:
@@ -500,15 +503,17 @@ class PersistentPromptCache:
         except ValueError as exc:
             logging.warning("Persistent prompt cache safe miss: %s", exc)
             return self._fallback.fetch_nearest_cache(model, tokens)
-        self._store.note_request_cid(compute_cid(stable_key, tokens))
+        self._store.note_request(stable_key, tokens)
         forks, rest = self._registry.fetch_fork(stable_key, tokens)
         if forks is not None:
+            snapshot = getattr(forks[0], "_snapshot", None) if forks else None
+            if snapshot is not None:
+                self._store.note_ram_hit(snapshot.cid)
             self._enforce_ram_limit()
             return forks, rest
         return self._fallback.fetch_nearest_cache(model, tokens)
 
     def insert_cache(self, model, tokens, prompt_cache, *, cache_type="assistant"):
-        self._store.flush_registry(self._registry)
         offsets = [getattr(cache, "offset", None) for cache in prompt_cache]
         if (
             offsets
@@ -531,7 +536,18 @@ class PersistentPromptCache:
                     existing, FrozenPrefixSnapshot
                 ):
                     self._store.restore(cid)
-                cid = self._registry.freeze(stable_key, tokens[:length], prompt_cache)
+                try:
+                    cid = self._registry.freeze(
+                        stable_key, tokens[:length], prompt_cache
+                    )
+                except ValueError:
+                    # A recomputed disk prefix disagrees with the persisted
+                    # bytes (kernel/runtime drift): quarantine and re-freeze,
+                    # never kill serving or preserve an ambiguous HIT.
+                    self._store.quarantine_cid(cid, "recomputed KV mismatch")
+                    cid = self._registry.freeze(
+                        stable_key, tokens[:length], prompt_cache
+                    )
                 if cid is not None:
                     self._enforce_ram_limit()
                     return
@@ -550,13 +566,46 @@ class PersistentPromptCache:
             victim = materialized.pop(0)
             self._store.demote_from_ram(victim.cid)
 
-    def flush_persistent(self, *, scrub=True):
-        count = self._store.flush_registry(self._registry)
+    def flush_persistent(self, *, scrub=True, shutdown=False):
+        """Best-effort maintenance; persistence can never kill serving."""
+        try:
+            if shutdown:
+                if self._maintenance_future is not None:
+                    self._maintenance_future.result()
+                count = self._store.flush_registry(self._registry)
+                self._store.flush_index()
+                return count
+            if self._maintenance_future is not None:
+                if not self._maintenance_future.done():
+                    return 0
+                self._maintenance_future.result()
+            self._maintenance_future = self._maintenance_pool.submit(
+                self._maintenance_tick, scrub
+            )
+            return 0
+        except Exception:
+            logging.exception("Persistent prompt-cache maintenance failed; continuing")
+            self._maintenance_future = None
+            return 0
+
+    def _maintenance_tick(self, scrub):
+        deadline = time.monotonic() + 0.02
+        count = self._store.flush_registry(
+            self._registry,
+            max_snapshots=1,
+            max_bytes=8 << 20,
+            deadline=deadline,
+        )
         now = time.monotonic()
         if scrub and now - self._last_scrub >= 1.0:
-            self._store.scrub_one()
+            self._store.scrub_increment(max_bytes=1 << 20, deadline=deadline)
             self._last_scrub = now
         return count
+
+    def close(self):
+        self.flush_persistent(scrub=False, shutdown=True)
+        self._maintenance_pool.shutdown(wait=True)
+        self._store.close()
 
 
 def _make_sampler(args, tokenizer):
@@ -611,14 +660,24 @@ class ResponseGenerator:
         self._is_distributed = mx.distributed.init().size() > 1
         self._rank = mx.distributed.init().rank()
         self._stop = False
+        self._joined = False
+        self._stop_lock = Lock()
         self._generation_thread = Thread(target=self._generate)
         self._generation_thread.start()
 
     def stop_and_join(self):
-        self._stop = True
-        self._generation_thread.join()
-        if hasattr(self.prompt_cache, "flush_persistent"):
-            self.prompt_cache.flush_persistent(scrub=False)
+        with self._stop_lock:
+            if self._joined:
+                return
+            self._stop = True
+            if self._generation_thread.is_alive():
+                self._generation_thread.join()
+            if hasattr(self.prompt_cache, "close"):
+                try:
+                    self.prompt_cache.close()
+                except Exception:
+                    logging.exception("Persistent prompt-cache shutdown failed")
+            self._joined = True
 
     def join(self):
         self._generation_thread.join()
@@ -1902,8 +1961,16 @@ def _run_http_server(
     try:
         httpd.serve_forever()
     except KeyboardInterrupt:
-        httpd.shutdown()
-        response_generator.stop_and_join()
+        pass
+    finally:
+        try:
+            httpd.shutdown()
+        except Exception:
+            logging.exception("HTTP server shutdown failed")
+        try:
+            response_generator.stop_and_join()
+        except Exception:
+            logging.exception("Response generator shutdown failed")
 
 
 def run(
@@ -1934,10 +2001,16 @@ def run(
     else:
         prompt_cache = LRUPromptCache(model_provider.cli_args.prompt_cache_size)
     response_generator = ResponseGenerator(model_provider, prompt_cache)
-    if group.rank() == 0:
-        _run_http_server(host, port, response_generator)
-    else:
-        response_generator.join()
+    try:
+        if group.rank() == 0:
+            _run_http_server(host, port, response_generator)
+        else:
+            response_generator.join()
+    finally:
+        try:
+            response_generator.stop_and_join()
+        except Exception:
+            logging.exception("Response generator shutdown failed")
 
 
 def main():
@@ -2102,6 +2175,10 @@ def main():
         level=getattr(logging, args.log_level.upper(), None),
         format="%(asctime)s - %(levelname)s - %(message)s",
     )
+    # SIGINT/SIGTERM take the same graceful path. SIGKILL cannot flush; at
+    # worst it loses unsaved recomputable snapshots, never exposes a partial
+    # cid because writes are temp+replace.
+    signal.signal(signal.SIGTERM, lambda *_: (_ for _ in ()).throw(KeyboardInterrupt()))
     run(args.host, args.port, ModelProvider(args))
 
 

--- a/mlx_lm/server.py
+++ b/mlx_lm/server.py
@@ -32,6 +32,7 @@ from typing import (
 )
 
 import mlx.core as mx
+from huggingface_hub import constants as hf_constants
 from huggingface_hub import scan_cache_dir
 
 from ._version import __version__
@@ -399,15 +400,21 @@ class ModelProvider:
 def _persistent_model_key(model_key) -> str:
     """Build the mandatory stable-string identity for persisted KV.
 
-    Loader-resolved Hugging Face cache paths contain an immutable
-    ``snapshots/<revision>`` component, so their trusted revision and resolved
-    path identify the loaded bytes without reopening multi-gigabyte payloads.
+    Loader-resolved Hugging Face paths beneath the configured ``HF_HUB_CACHE``
+    contain an immutable ``models--.../snapshots/<revision>`` component, so
+    their trusted revision and resolved path identify loaded bytes without
+    reopening multi-gigabyte payloads.
     Ordinary local paths have no immutable revision authority and therefore
     hash every file byte; same-size/mtime-preserving weight or adapter swaps
     still change identity.
     """
 
     def hf_snapshot_identity(path):
+        cache_root = Path(hf_constants.HF_HUB_CACHE).expanduser().resolve()
+        try:
+            path.relative_to(cache_root)
+        except ValueError:
+            return None
         parts = path.parts
         for index in range(len(parts) - 2, -1, -1):
             if parts[index] != "snapshots" or index < 1 or index + 1 >= len(parts):

--- a/mlx_lm/snapshot_store.py
+++ b/mlx_lm/snapshot_store.py
@@ -8,16 +8,23 @@ uncompressed because compression prevents ``mx.load`` from memory mapping the
 payload.  The store provides no repair, redundancy, lossy re-quantization,
 OS-sleep handling, or adaptive sizing: cached KV is recomputable, so every
 integrity doubt becomes quarantine plus a safe miss.
+
+Chain restore concatenates cumulative root-to-leaf state. At the default
+depth cap of eight this can transiently allocate several times the final KV
+size; representative-scale benchmarks must include that state-budget cost.
 """
 
 import fcntl
+import functools
 import hashlib
 import json
 import logging
 import math
 import os
+import threading
 import time
 import uuid
+import weakref
 from collections import Counter, OrderedDict, deque
 from dataclasses import dataclass
 from numbers import Integral
@@ -31,11 +38,22 @@ from .prefix_forks import FrozenPrefixSnapshot, compute_cid
 
 FORMAT_VERSION = "1"
 KNOWN_FEATURES = frozenset({"delta-chain", "payload-sha256"})
-_PROCESS_LOCKS = {}
+_PROCESS_OWNERS = {}
+_OWNERS_LOCK = threading.Lock()
 
 
 class SnapshotCorruptError(RuntimeError):
     """A snapshot cannot be trusted and must be treated as a miss."""
+
+
+def _owned_operation(method):
+    @functools.wraps(method)
+    def wrapped(self, *args, **kwargs):
+        self._assert_owner()
+        with self._operation_lock:
+            return method(self, *args, **kwargs)
+
+    return wrapped
 
 
 def _array_digest(array: mx.array) -> str:
@@ -97,16 +115,18 @@ class SnapshotRecord:
     parent_length: int
     depth: int
     logical_nbytes: int
+    payload_nbytes: int
     file_bytes: int
     last_use: float
     digests: Tuple[Tuple[str, str], ...]
+    tensor_offsets: Tuple[Tuple[Tuple[int, int], Tuple[int, int]], ...]
 
 
 class DiskBackedSnapshot:
     """Header-only registry entry; KV payload is restored on first fork."""
 
     def __init__(self, store: "SnapshotStore", record: SnapshotRecord):
-        self._store = store
+        self._store_ref = weakref.ref(store)
         self._record = record
         self._forks = ()
 
@@ -134,8 +154,15 @@ class DiskBackedSnapshot:
         return len(self.tokens)
 
     def fork(self):
-        snapshot = self._store.restore(self.cid)
+        store = self._store_ref()
+        if store is None:
+            return None
+        snapshot = store.restore(self.cid)
         return None if snapshot is None else snapshot.fork()
+
+    def materialize(self):
+        store = self._store_ref()
+        return None if store is None else store.restore(self.cid)
 
 
 class SnapshotStore:
@@ -162,9 +189,16 @@ class SnapshotStore:
         self.directory = Path(directory)
         self.directory.mkdir(parents=True, exist_ok=True, mode=0o700)
         os.chmod(self.directory, 0o700)
-        lock_key = str(self.directory.resolve())
-        lock_fd = _PROCESS_LOCKS.get(lock_key)
-        if lock_fd is None:
+        self._lock_key = str(self.directory.resolve())
+        self._owner_pid = os.getpid()
+        self._closed = False
+        with _OWNERS_LOCK:
+            owner_ref = _PROCESS_OWNERS.get(self._lock_key)
+            owner = owner_ref() if owner_ref is not None else None
+            if owner is not None:
+                raise RuntimeError(
+                    f"snapshot directory already has a live writer: {self.directory}"
+                )
             lock_path = self.directory / ".writer.lock"
             lock_fd = os.open(lock_path, os.O_CREAT | os.O_RDWR, 0o600)
             try:
@@ -175,8 +209,9 @@ class SnapshotStore:
                     f"snapshot directory already has a live writer: {self.directory}"
                 ) from exc
             os.chmod(lock_path, 0o600)
-            _PROCESS_LOCKS[lock_key] = lock_fd
+            _PROCESS_OWNERS[self._lock_key] = weakref.ref(self)
         self._lock_fd = lock_fd
+        self._operation_lock = threading.RLock()
         self.max_bytes = int(max_bytes)
         self.max_files = int(max_files)
         self.max_chain_depth = int(max_chain_depth)
@@ -185,8 +220,49 @@ class SnapshotStore:
         self._ram_ghosts = deque(maxlen=256)
         self._disk_ghosts = deque(maxlen=256)
         self._scrub_cursor = 0
+        self._scrub_state = None
+        self._index_dirty = False
         self._stats = Counter()
-        self.rebuild(registry)
+        self._blocked_cids = set()
+        try:
+            self.rebuild(registry)
+        except Exception:
+            self.close()
+            raise
+
+    def _assert_owner(self):
+        if self._closed or os.getpid() != self._owner_pid:
+            raise RuntimeError("snapshot store is closed or inherited across fork")
+
+    def close(self):
+        if getattr(self, "_closed", True):
+            return
+        if os.getpid() != self._owner_pid:
+            # A fork inherited the descriptor but not ownership. Closing the
+            # child copy is safe; LOCK_UN would release the parent's flock.
+            os.close(self._lock_fd)
+            self._closed = True
+            return
+        try:
+            if getattr(self, "_index_dirty", False):
+                self._write_index()
+        except Exception:
+            logging.exception("Failed to flush snapshot LRU index during close")
+        with _OWNERS_LOCK:
+            owner_ref = _PROCESS_OWNERS.get(self._lock_key)
+            if owner_ref is not None and owner_ref() is self:
+                _PROCESS_OWNERS.pop(self._lock_key, None)
+        try:
+            fcntl.flock(self._lock_fd, fcntl.LOCK_UN)
+        finally:
+            os.close(self._lock_fd)
+            self._closed = True
+
+    def __del__(self):
+        try:
+            self.close()
+        except Exception:
+            pass
 
     @property
     def stats(self):
@@ -199,7 +275,7 @@ class SnapshotStore:
 
     def _parse_record(self, path: Path) -> SnapshotRecord:
         os.chmod(path, 0o600)
-        header, _ = _read_header(path)
+        header, data_start = _read_header(path)
         metadata = header.get("__metadata__")
         if not isinstance(metadata, dict):
             raise SnapshotCorruptError("missing metadata")
@@ -251,6 +327,7 @@ class SnapshotStore:
         ):
             raise SnapshotCorruptError("invalid parent cid")
         digests = []
+        tensor_offsets = []
         expected_names = {f"{side}.{layer}" for layer in range(layers) for side in "kv"}
         actual_names = {name for name in header if name != "__metadata__"}
         if actual_names != expected_names:
@@ -274,6 +351,15 @@ class SnapshotStore:
             ):
                 raise SnapshotCorruptError("invalid payload digest")
             digests.append(pair)
+            tensor_offsets.append(
+                (
+                    tuple(data_start + x for x in header[k_name]["data_offsets"]),
+                    tuple(data_start + x for x in header[v_name]["data_offsets"]),
+                )
+            )
+        payload_nbytes = sum(
+            end - start for pair in tensor_offsets for start, end in pair
+        )
         return SnapshotRecord(
             cid=cid,
             path=path,
@@ -284,14 +370,16 @@ class SnapshotStore:
             parent_length=parent_length,
             depth=depth,
             logical_nbytes=logical_nbytes,
+            payload_nbytes=payload_nbytes,
             file_bytes=path.stat().st_size,
             last_use=created_at,
             digests=tuple(digests),
+            tensor_offsets=tuple(tensor_offsets),
         )
 
-    def _quarantine(self, path: Path, reason: str):
+    def _quarantine(self, path: Path, reason: str) -> bool:
         if not path.exists():
-            return
+            return False
         target = path.with_suffix(".quarantined")
         if target.exists():
             target = path.with_name(f"{path.stem}.{uuid.uuid4().hex}.quarantined")
@@ -300,14 +388,18 @@ class SnapshotStore:
             os.chmod(target, 0o600)
         except OSError:
             logging.warning("Snapshot quarantine failed for %s", path)
+            return False
         self._stats["quarantines"] += 1
         logging.warning("Snapshot %s quarantined: %s", path.stem, reason)
+        return True
 
+    @_owned_operation
     def rebuild(self, registry=None):
         """Header-only directory scan; tensor payloads remain untouched."""
         if registry is not None:
             self.registry = registry
         self._records.clear()
+        self._blocked_cids.clear()
         # A temp is never authoritative.  A previous crash may leave one.
         for path in self.directory.iterdir():
             if ".tmp-" in path.name:
@@ -328,7 +420,8 @@ class SnapshotStore:
         self._load_index_lru()
         if self.registry is not None:
             for record in self._records.values():
-                self.registry.register_snapshot(DiskBackedSnapshot(self, record))
+                if record.cid not in self._blocked_cids:
+                    self.registry.register_snapshot(DiskBackedSnapshot(self, record))
         self._write_index()
         self.gc()
         return len(self._records)
@@ -350,6 +443,16 @@ class SnapshotStore:
                     or record.depth > self.max_chain_depth
                 ):
                     bad.add(cid)
+                elif (
+                    record.logical_nbytes
+                    != parent.logical_nbytes + record.payload_nbytes
+                ):
+                    bad.add(cid)
+            if (
+                record.parent_cid is None
+                and record.logical_nbytes != record.payload_nbytes
+            ):
+                bad.add(cid)
             seen = set()
             current = cid
             while current:
@@ -367,9 +470,13 @@ class SnapshotStore:
                     bad.add(cid)
                     changed = True
         for cid in bad:
-            record = self._records.pop(cid, None)
+            record = self._records.get(cid)
             if record is not None:
-                self._quarantine(record.path, "missing or cyclic parent chain")
+                self._blocked_cids.add(cid)
+                if self._quarantine(
+                    record.path, "invalid parent chain or logical byte count"
+                ):
+                    self._records.pop(cid, None)
 
     def _load_index_lru(self):
         path = self.directory / "index.json"
@@ -396,6 +503,7 @@ class SnapshotStore:
                 path.unlink()
             except FileNotFoundError:
                 pass
+            self._index_dirty = False
             return
         temp = self.directory / f"index.json.tmp-{uuid.uuid4().hex}"
         data = {
@@ -409,6 +517,7 @@ class SnapshotStore:
         os.chmod(temp, 0o600)
         os.replace(temp, path)
         os.chmod(path, 0o600)
+        self._index_dirty = False
 
     def _choose_parent(self, snapshot) -> Optional[SnapshotRecord]:
         best = None
@@ -425,13 +534,21 @@ class SnapshotStore:
         # longest chain reaches the cap, this write is a new whole root.
         return None if best is not None and best.depth >= self.max_chain_depth else best
 
+    @_owned_operation
     def save(self, snapshot: FrozenPrefixSnapshot) -> str:
         """Atomically save one RAM snapshot, delta-chained when profitable."""
+        self._assert_owner()
         cid = snapshot.cid
+        final = self.directory / f"{cid}.safetensors"
+        # The pathname is authoritative under the exclusive writer lock; a
+        # stale private index may never overwrite an already-visible cid.
+        if final.exists() and cid not in self._records:
+            self._records[cid] = self._parse_record(final)
         if cid in self._records:
             stored = self._restore(cid, record_hit=False, promote=False)
             if stored is None or not self._snapshots_equal(snapshot, stored):
-                raise ValueError(
+                self.quarantine_cid(cid, "same-cid KV payload mismatch")
+                raise SnapshotCorruptError(
                     f"snapshot content mismatch for existing cid {cid}; "
                     "the model key must change whenever weights change"
                 )
@@ -470,7 +587,6 @@ class SnapshotStore:
         # Keep the safetensors suffix: MLX otherwise appends one, which would
         # make the path passed to chmod/replace differ from the file written.
         temp = self.directory / f".{cid}.tmp-{uuid.uuid4().hex}.safetensors"
-        final = self.directory / f"{cid}.safetensors"
         try:
             mx.save_safetensors(str(temp), tensors, metadata)
             os.chmod(temp, 0o600)
@@ -483,7 +599,10 @@ class SnapshotStore:
         os.chmod(final, 0o600)
         record = self._parse_record(final)
         self._records[cid] = record
-        self._stats["demotions"] += 1
+        self._blocked_cids.discard(cid)
+        self._disk_ghosts = deque(
+            (ghost for ghost in self._disk_ghosts if ghost[2] != cid), maxlen=256
+        )
         self._write_index()
         self.gc()
         return cid
@@ -562,6 +681,7 @@ class SnapshotStore:
         ) as exc:
             raise SnapshotCorruptError(str(exc)) from exc
 
+    @_owned_operation
     def restore(self, cid: str) -> Optional[FrozenPrefixSnapshot]:
         """Walk and verify root→leaf, returning a materialized snapshot."""
         return self._restore(cid, record_hit=True, promote=True)
@@ -569,10 +689,8 @@ class SnapshotStore:
     def _restore(
         self, cid: str, *, record_hit: bool, promote: bool
     ) -> Optional[FrozenPrefixSnapshot]:
-        if cid in self._disk_ghosts:
-            self._stats["ghost_hits"] += 1
         record = self._records.get(cid)
-        if record is None:
+        if record is None or cid in self._blocked_cids:
             return None
         chain, seen = [], set()
         current = record
@@ -641,6 +759,9 @@ class SnapshotStore:
             self._stats["disk_hits"] += 1
         if promote:
             self._stats["promotions"] += 1
+            self._ram_ghosts = deque(
+                (ghost for ghost in self._ram_ghosts if ghost[2] != cid), maxlen=256
+            )
         snapshot = FrozenPrefixSnapshot(
             cid, record.model_key, record.tokens, keys, values
         )
@@ -650,9 +771,12 @@ class SnapshotStore:
 
     def _quarantine_chain(self, chain, reason):
         for record in chain:
-            self._records.pop(record.cid, None)
-            self._quarantine(record.path, reason)
-            if self.registry is not None:
+            self._blocked_cids.add(record.cid)
+            if self._quarantine(record.path, reason):
+                self._records.pop(record.cid, None)
+            if self.registry is not None and isinstance(
+                self.registry.get(record.cid), DiskBackedSnapshot
+            ):
                 self.registry.invalidate(record.cid)
         self._write_index()
         self.gc()
@@ -670,27 +794,61 @@ class SnapshotStore:
             [self._records[x] for x in poisoned if x in self._records], reason
         )
 
+    @_owned_operation
+    def quarantine_cid(self, cid: str, reason: str):
+        """Quarantine an ambiguous disk identity and force a full RAM miss."""
+        self._quarantine_descendants(cid, reason)
+        if self.registry is not None:
+            self.registry.invalidate(cid)
+
     def _touch(self, cid):
         record = self._records.pop(cid, None)
         if record is not None:
             record.last_use = time.time()
             self._records[cid] = record
+            self._index_dirty = True
 
-    def flush_registry(self, registry=None):
-        """Write every unsaved RAM snapshot; safe to call only while idle."""
+    @_owned_operation
+    def flush_registry(
+        self,
+        registry=None,
+        *,
+        max_snapshots=None,
+        max_bytes=None,
+        deadline=None,
+    ):
+        """Write a bounded batch of unsaved RAM snapshots while quiescent."""
+        self._assert_owner()
         registry = registry or self.registry
         if registry is None:
             return 0
         count = 0
+        spent = 0
         for snapshot in registry.snapshots():
+            if max_snapshots is not None and count >= max_snapshots:
+                break
+            if deadline is not None and time.monotonic() >= deadline:
+                break
             if (
                 isinstance(snapshot, FrozenPrefixSnapshot)
                 and snapshot.cid not in self._records
             ):
+                if max_bytes is not None and spent + snapshot.nbytes > max_bytes:
+                    continue
                 self.save(snapshot)
                 count += 1
+                spent += snapshot.nbytes
+        if self._index_dirty:
+            self._write_index()
         return count
 
+    @_owned_operation
+    def flush_index(self):
+        self._assert_owner()
+        if self._index_dirty:
+            self._write_index()
+
+    @_owned_operation
     def demote_from_ram(self, cid: str) -> bool:
         """Replace a discoverable RAM snapshot with its header-only proxy."""
         if self.registry is None:
@@ -706,36 +864,113 @@ class SnapshotStore:
             return False
         replaced = self.registry.replace_snapshot(DiskBackedSnapshot(self, record))
         if replaced:
-            self._ram_ghosts.append(cid)
-            if already_on_disk:
-                self._stats["demotions"] += 1
+            self._ram_ghosts.append((record.model_key, record.tokens, cid))
+            self._stats["demotions"] += 1
         return replaced
 
     def scrub_one(self) -> bool:
         """Verify one snapshot's complete per-layer payload, round-robin."""
-        if not self._records:
+        while self._records:
+            completed = self.scrub_increment(max_bytes=64 << 20)
+            if completed:
+                return True
+            if self._scrub_state is None:
+                return False
+        return False
+
+    @_owned_operation
+    def scrub_increment(self, *, max_bytes=8 << 20, deadline=None) -> bool:
+        """Hash at most ``max_bytes`` of one tensor and resume next tick."""
+        self._assert_owner()
+        if not self._records or max_bytes <= 0:
             return False
-        cids = list(self._records)
-        cid = cids[self._scrub_cursor % len(cids)]
-        self._scrub_cursor += 1
-        record = self._records[cid]
+        if self._scrub_state is None:
+            cids = list(self._records)
+            cid = cids[self._scrub_cursor % len(cids)]
+            self._scrub_state = {
+                "cid": cid,
+                "layer": 0,
+                "side": 0,
+                "position": None,
+                "hasher": hashlib.sha256(),
+            }
+        state = self._scrub_state
+        record = self._records.get(state["cid"])
+        if record is None:
+            self._scrub_state = None
+            return False
+        remaining = max_bytes
         try:
-            self._load_delta(record)
-            self._stats["scrubs"] += 1
-            return True
-        except SnapshotCorruptError as exc:
+            while remaining > 0 and (deadline is None or time.monotonic() < deadline):
+                start, end = record.tensor_offsets[state["layer"]][state["side"]]
+                position = state["position"] if state["position"] is not None else start
+                amount = min(1 << 20, remaining, end - position)
+                with record.path.open("rb") as handle:
+                    handle.seek(position)
+                    chunk = handle.read(amount)
+                if len(chunk) != amount:
+                    raise SnapshotCorruptError("truncated payload during scrub")
+                state["hasher"].update(chunk)
+                position += amount
+                remaining -= amount
+                state["position"] = position
+                if position == end:
+                    expected = record.digests[state["layer"]][state["side"]]
+                    if state["hasher"].hexdigest() != expected:
+                        raise SnapshotCorruptError(
+                            f"payload digest mismatch at layer {state['layer']}"
+                        )
+                    state["side"] += 1
+                    state["position"] = None
+                    state["hasher"] = hashlib.sha256()
+                    if state["side"] == 2:
+                        state["side"] = 0
+                        state["layer"] += 1
+                    if state["layer"] == len(record.digests):
+                        self._stats["scrubs"] += 1
+                        self._scrub_cursor += 1
+                        self._scrub_state = None
+                        return True
+        except (OSError, SnapshotCorruptError) as exc:
+            self._scrub_state = None
             self._quarantine_descendants(record.cid, str(exc))
-            return False
+        return False
 
     def note_ram_eviction(self, cid: str):
         """Record ARC-style RAM ghost telemetry (sizing remains static)."""
-        self._ram_ghosts.append(cid)
+        self._assert_owner()
+        if self._operation_lock.acquire(blocking=False):
+            try:
+                record = self._records.get(cid)
+                if record is not None:
+                    self._ram_ghosts.append((record.model_key, record.tokens, cid))
+            finally:
+                self._operation_lock.release()
 
-    def note_request_cid(self, cid: str):
-        """Count requests that would have hit either telemetry ghost list."""
-        if cid in self._ram_ghosts or cid in self._disk_ghosts:
-            self._stats["ghost_hits"] += 1
+    def note_ram_hit(self, cid: str):
+        """Keep disk LRU aligned with accesses served from promoted RAM."""
+        self._assert_owner()
+        if self._operation_lock.acquire(blocking=False):
+            try:
+                self._touch(cid)
+            finally:
+                self._operation_lock.release()
 
+    def note_request(self, model_key: str, tokens: List[int]):
+        """Count requests whose longest prefix was recently evicted."""
+        self._assert_owner()
+        if self._operation_lock.acquire(blocking=False):
+            try:
+                ghosts = list(self._ram_ghosts) + list(self._disk_ghosts)
+                if any(
+                    key == model_key and tuple(tokens[: len(prefix)]) == prefix
+                    for key, prefix, _ in ghosts
+                ):
+                    self._stats["ghost_hits"] += 1
+            finally:
+                self._operation_lock.release()
+
+    @_owned_operation
     def gc(self):
         """Enforce both caps, evicting least-recently-used leaves first."""
 
@@ -753,27 +988,37 @@ class SnapshotStore:
                 break
             # Rebuildable/transient artifacts never deserve eviction
             # protection over valid KV data.
-            candidates = [p for p in files if p.suffix != ".safetensors"]
+            known_paths = {record.path for record in self._records.values()}
+            candidates = [
+                p for p in files if p.suffix != ".safetensors" or p not in known_paths
+            ]
             if candidates:
                 victim = min(candidates, key=lambda p: p.stat().st_mtime)
                 try:
                     victim.unlink()
                     continue
-                except OSError:
-                    pass
+                except OSError as exc:
+                    raise RuntimeError(
+                        f"snapshot cap enforcement could not unlink {victim}"
+                    ) from exc
             parents = {r.parent_cid for r in self._records.values() if r.parent_cid}
             leaf = next(
                 (r for r in self._records.values() if r.cid not in parents), None
             )
             if leaf is not None:
-                self._records.pop(leaf.cid, None)
                 try:
                     leaf.path.unlink()
-                except OSError:
-                    pass
-                self._disk_ghosts.append(leaf.cid)
+                except OSError as exc:
+                    raise RuntimeError(
+                        f"snapshot cap enforcement could not unlink {leaf.path}"
+                    ) from exc
+                self._records.pop(leaf.cid, None)
+                self._index_dirty = True
+                self._disk_ghosts.append((leaf.model_key, leaf.tokens, leaf.cid))
                 self._stats["gc_files"] += 1
-                if self.registry is not None:
+                if self.registry is not None and isinstance(
+                    self.registry.get(leaf.cid), DiskBackedSnapshot
+                ):
                     self.registry.invalidate(leaf.cid)
                 continue
             break

--- a/mlx_lm/snapshot_store.py
+++ b/mlx_lm/snapshot_store.py
@@ -659,52 +659,55 @@ class SnapshotStore:
         return None if best is not None and best.depth >= self.max_chain_depth else best
 
     def _reserve_space(self, reservation: int, protected_cids=None):
-        """Make room for one transient/final file without evicting parents."""
+        """Plan then make room for one file without evicting parents."""
         protected_cids = set(protected_cids or ())
         if self.max_files < 1:
             raise RuntimeError("snapshot reservation requires max_files >= 1")
         if reservation > self.max_bytes:
             raise RuntimeError("snapshot reservation exceeds max_bytes")
+        if shutil.disk_usage(self.directory).free < reservation:
+            raise RuntimeError("insufficient free disk space for snapshot reservation")
 
-        def files():
-            return [
-                path
-                for path in self.directory.iterdir()
-                if path.is_file() and path.name != ".writer.lock"
-            ]
-
+        file_stats = {
+            path: path.stat()
+            for path in self.directory.iterdir()
+            if path.is_file() and path.name != ".writer.lock"
+        }
+        simulated_files = dict(file_stats)
+        simulated_records = dict(self._records)
+        victims = []
         while True:
-            live_files = files()
-            live_bytes = sum(path.stat().st_size for path in live_files)
+            live_bytes = sum(stat.st_size for stat in simulated_files.values())
             if (
-                len(live_files) + 1 <= self.max_files
+                len(simulated_files) + 1 <= self.max_files
                 and live_bytes + reservation <= self.max_bytes
             ):
                 break
-            known_paths = {record.path for record in self._records.values()}
+            known_paths = {record.path for record in simulated_records.values()}
             disposable = [
                 path
-                for path in live_files
+                for path in simulated_files
                 if path.suffix != ".safetensors" or path not in known_paths
             ]
             if disposable:
-                victim = min(disposable, key=lambda path: path.stat().st_mtime)
-                try:
-                    victim.unlink()
-                except OSError as exc:
-                    raise RuntimeError(
-                        f"snapshot reservation could not unlink {victim}"
-                    ) from exc
+                victim = min(
+                    disposable,
+                    key=lambda path: (simulated_files[path].st_mtime, path.name),
+                )
+                victims.append((victim, None))
+                simulated_files.pop(victim)
                 continue
             parents = {
                 record.parent_cid
-                for record in self._records.values()
+                for record in simulated_records.values()
                 if record.parent_cid
             }
             leaves = [
                 record
-                for record in self._records.values()
-                if record.cid not in parents and record.cid not in protected_cids
+                for record in simulated_records.values()
+                if record.path in simulated_files
+                and record.cid not in parents
+                and record.cid not in protected_cids
             ]
             leaf = min(
                 leaves,
@@ -715,22 +718,27 @@ class SnapshotStore:
                 raise RuntimeError(
                     "snapshot reservation exceeds cap with no evictable leaf"
                 )
+            victims.append((leaf.path, leaf))
+            simulated_files.pop(leaf.path)
+            simulated_records.pop(leaf.cid)
+
+        for path, record in victims:
             try:
-                leaf.path.unlink()
+                path.unlink()
             except OSError as exc:
                 raise RuntimeError(
-                    f"snapshot reservation could not unlink {leaf.path}"
+                    f"snapshot reservation could not unlink {path}"
                 ) from exc
-            self._records.pop(leaf.cid, None)
+            if record is None:
+                continue
+            self._records.pop(record.cid, None)
             self._index_dirty = True
-            self._disk_ghosts.append((leaf.model_key, leaf.tokens, leaf.cid))
+            self._disk_ghosts.append((record.model_key, record.tokens, record.cid))
             self._stats["gc_files"] += 1
             if self.registry is not None and isinstance(
-                self.registry.get(leaf.cid), DiskBackedSnapshot
+                self.registry.get(record.cid), DiskBackedSnapshot
             ):
-                self.registry.invalidate(leaf.cid)
-        if shutil.disk_usage(self.directory).free < reservation:
-            raise RuntimeError("insufficient free disk space for snapshot reservation")
+                self.registry.invalidate(record.cid)
 
     @_owned_operation
     def save(self, snapshot: FrozenPrefixSnapshot) -> str:
@@ -989,7 +997,8 @@ class SnapshotStore:
         ):
             self._quarantine_chain(chain, "restored length mismatch")
             return None
-        self._touch(cid)
+        if record_hit or promote:
+            self._touch(cid)
         if record_hit:
             self._stats["disk_hits"] += 1
         if promote:

--- a/mlx_lm/snapshot_store.py
+++ b/mlx_lm/snapshot_store.py
@@ -12,6 +12,12 @@ integrity doubt becomes quarantine plus a safe miss.
 Chain restore concatenates cumulative root-to-leaf state. At the default
 depth cap of eight this can transiently allocate several times the final KV
 size; representative-scale benchmarks must include that state-budget cost.
+
+Save is intentionally two-pass: a staged safetensors write establishes the
+canonical raw tensor bytes (including bfloat16), then the final atomic write
+embeds those digests. This costs roughly 2x write bandwidth and temporarily
+one extra snapshot file; both dot-temporary paths are cleaned on failure and
+startup and remain subject to directory-cap GC after the atomic commit.
 """
 
 import fcntl
@@ -32,7 +38,6 @@ from pathlib import Path
 from typing import Dict, List, Optional, Tuple
 
 import mlx.core as mx
-import numpy as np
 
 from .prefix_forks import FrozenPrefixSnapshot, compute_cid
 
@@ -56,8 +61,42 @@ def _owned_operation(method):
     return wrapped
 
 
-def _array_digest(array: mx.array) -> str:
-    return hashlib.sha256(np.asarray(array).tobytes(order="C")).hexdigest()
+def _tensor_hasher(dtype: str, shape: List[int]):
+    """Domain-separated canonical tensor digest, independent of PEP-3118."""
+    hasher = hashlib.sha256()
+    hasher.update(b"mlx-lm-snapshot-tensor-v1")
+    dtype_bytes = dtype.encode()
+    hasher.update(len(dtype_bytes).to_bytes(8, "big"))
+    hasher.update(dtype_bytes)
+    hasher.update(json.dumps(shape, separators=(",", ":")).encode())
+    return hasher
+
+
+def _file_tensor_digest(path: Path, tensor: dict, data_start: int) -> str:
+    hasher = _tensor_hasher(tensor["dtype"], tensor["shape"])
+    start, end = tensor["data_offsets"]
+    position = data_start + start
+    end = data_start + end
+    with path.open("rb") as handle:
+        handle.seek(position)
+        while position < end:
+            chunk = handle.read(min(4 << 20, end - position))
+            if not chunk:
+                raise SnapshotCorruptError("truncated tensor payload")
+            hasher.update(chunk)
+            position += len(chunk)
+    return hasher.hexdigest()
+
+
+def _payload_digests(path: Path, layers: int):
+    header, data_start = _read_header(path)
+    return tuple(
+        (
+            _file_tensor_digest(path, header[f"k.{layer}"], data_start),
+            _file_tensor_digest(path, header[f"v.{layer}"], data_start),
+        )
+        for layer in range(layers)
+    )
 
 
 def _read_header(path: Path) -> Tuple[dict, int]:
@@ -120,6 +159,9 @@ class SnapshotRecord:
     last_use: float
     digests: Tuple[Tuple[str, str], ...]
     tensor_offsets: Tuple[Tuple[Tuple[int, int], Tuple[int, int]], ...]
+    tensor_specs: Tuple[
+        Tuple[Tuple[str, Tuple[int, ...]], Tuple[str, Tuple[int, ...]]], ...
+    ]
 
 
 class DiskBackedSnapshot:
@@ -328,6 +370,7 @@ class SnapshotStore:
             raise SnapshotCorruptError("invalid parent cid")
         digests = []
         tensor_offsets = []
+        tensor_specs = []
         expected_names = {f"{side}.{layer}" for layer in range(layers) for side in "kv"}
         actual_names = {name for name in header if name != "__metadata__"}
         if actual_names != expected_names:
@@ -357,6 +400,12 @@ class SnapshotStore:
                     tuple(data_start + x for x in header[v_name]["data_offsets"]),
                 )
             )
+            tensor_specs.append(
+                (
+                    (header[k_name]["dtype"], tuple(header[k_name]["shape"])),
+                    (header[v_name]["dtype"], tuple(header[v_name]["shape"])),
+                )
+            )
         payload_nbytes = sum(
             end - start for pair in tensor_offsets for start, end in pair
         )
@@ -375,6 +424,7 @@ class SnapshotStore:
             last_use=created_at,
             digests=tuple(digests),
             tensor_offsets=tuple(tensor_offsets),
+            tensor_specs=tuple(tensor_specs),
         )
 
     def _quarantine(self, path: Path, reason: str) -> bool:
@@ -402,7 +452,7 @@ class SnapshotStore:
         self._blocked_cids.clear()
         # A temp is never authoritative.  A previous crash may leave one.
         for path in self.directory.iterdir():
-            if ".tmp-" in path.name:
+            if ".tmp-" in path.name or ".digest-" in path.name:
                 try:
                     path.unlink()
                     self._stats["temps_cleaned"] += 1
@@ -582,20 +632,34 @@ class SnapshotStore:
             mx.eval(key, value)
             tensors[f"k.{layer}"] = key
             tensors[f"v.{layer}"] = value
-            metadata[f"sha256_k_{layer}"] = _array_digest(key)
-            metadata[f"sha256_v_{layer}"] = _array_digest(value)
+            # Fixed-width placeholders keep the staged/final header geometry
+            # stable while canonical digests are derived from safetensors'
+            # exact contiguous payload bytes (works for bfloat16 and every
+            # supported MLX dtype without NumPy/PEP-3118 conversion).
+            metadata[f"sha256_k_{layer}"] = "0" * 64
+            metadata[f"sha256_v_{layer}"] = "0" * 64
         # Keep the safetensors suffix: MLX otherwise appends one, which would
         # make the path passed to chmod/replace differ from the file written.
         temp = self.directory / f".{cid}.tmp-{uuid.uuid4().hex}.safetensors"
+        stage = self.directory / f".{cid}.digest-{uuid.uuid4().hex}.safetensors"
         try:
+            mx.save_safetensors(str(stage), tensors, metadata)
+            os.chmod(stage, 0o600)
+            digests = _payload_digests(stage, len(keys))
+            for layer, (key_digest, value_digest) in enumerate(digests):
+                metadata[f"sha256_k_{layer}"] = key_digest
+                metadata[f"sha256_v_{layer}"] = value_digest
             mx.save_safetensors(str(temp), tensors, metadata)
             os.chmod(temp, 0o600)
+            if _payload_digests(temp, len(keys)) != digests:
+                raise SnapshotCorruptError("staged/final tensor payload mismatch")
             os.replace(temp, final)
         finally:
-            try:
-                temp.unlink()
-            except FileNotFoundError:
-                pass
+            for transient in (stage, temp):
+                try:
+                    transient.unlink()
+                except FileNotFoundError:
+                    pass
         os.chmod(final, 0o600)
         record = self._parse_record(final)
         self._records[cid] = record
@@ -645,9 +709,21 @@ class SnapshotStore:
 
     def _load_delta(self, record: SnapshotRecord):
         try:
+            observed_digests = _payload_digests(record.path, len(record.digests))
+            if observed_digests != record.digests:
+                bad_layer = next(
+                    layer
+                    for layer, (observed, expected) in enumerate(
+                        zip(observed_digests, record.digests)
+                    )
+                    if observed != expected
+                )
+                raise SnapshotCorruptError(
+                    f"payload digest mismatch at layer {bad_layer}"
+                )
             arrays, _ = mx.load(str(record.path), return_metadata=True)
             keys, values = [], []
-            for layer, (expected_k, expected_v) in enumerate(record.digests):
+            for layer in range(len(record.digests)):
                 key, value = arrays[f"k.{layer}"], arrays[f"v.{layer}"]
                 tail_length = len(record.tokens) - record.parent_length
                 if (
@@ -659,16 +735,9 @@ class SnapshotStore:
                     raise SnapshotCorruptError(
                         f"invalid tensor geometry at layer {layer}"
                     )
-                # Verification is layer-incremental and occurs only when this
-                # disk hit is materialized, never during startup indexing.
+                # Payload verification occurs only on this disk hit, never
+                # during startup indexing; MLX materialization stays per-layer.
                 mx.eval(key, value)
-                if (
-                    _array_digest(key) != expected_k
-                    or _array_digest(value) != expected_v
-                ):
-                    raise SnapshotCorruptError(
-                        f"payload digest mismatch at layer {layer}"
-                    )
                 keys.append(key)
                 values.append(value)
             return keys, values
@@ -892,7 +961,7 @@ class SnapshotStore:
                 "layer": 0,
                 "side": 0,
                 "position": None,
-                "hasher": hashlib.sha256(),
+                "hasher": None,
             }
         state = self._scrub_state
         record = self._records.get(state["cid"])
@@ -903,6 +972,9 @@ class SnapshotStore:
         try:
             while remaining > 0 and (deadline is None or time.monotonic() < deadline):
                 start, end = record.tensor_offsets[state["layer"]][state["side"]]
+                if state["hasher"] is None:
+                    dtype, shape = record.tensor_specs[state["layer"]][state["side"]]
+                    state["hasher"] = _tensor_hasher(dtype, list(shape))
                 position = state["position"] if state["position"] is not None else start
                 amount = min(1 << 20, remaining, end - position)
                 with record.path.open("rb") as handle:
@@ -922,7 +994,7 @@ class SnapshotStore:
                         )
                     state["side"] += 1
                     state["position"] = None
-                    state["hasher"] = hashlib.sha256()
+                    state["hasher"] = None
                     if state["side"] == 2:
                         state["side"] = 0
                         state["layer"] += 1

--- a/mlx_lm/snapshot_store.py
+++ b/mlx_lm/snapshot_store.py
@@ -1,0 +1,780 @@
+# Copyright © 2026 Apple Inc.
+
+"""Fail-closed disk tier for content-addressed prefix-fork snapshots.
+
+Snapshots can contain conversation content and are protected like logs:
+directories are mode 0700 and files are mode 0600.  Tier 1 is deliberately
+uncompressed because compression prevents ``mx.load`` from memory mapping the
+payload.  The store provides no repair, redundancy, lossy re-quantization,
+OS-sleep handling, or adaptive sizing: cached KV is recomputable, so every
+integrity doubt becomes quarantine plus a safe miss.
+"""
+
+import fcntl
+import hashlib
+import json
+import logging
+import math
+import os
+import time
+import uuid
+from collections import Counter, OrderedDict, deque
+from dataclasses import dataclass
+from numbers import Integral
+from pathlib import Path
+from typing import Dict, List, Optional, Tuple
+
+import mlx.core as mx
+import numpy as np
+
+from .prefix_forks import FrozenPrefixSnapshot, compute_cid
+
+FORMAT_VERSION = "1"
+KNOWN_FEATURES = frozenset({"delta-chain", "payload-sha256"})
+_PROCESS_LOCKS = {}
+
+
+class SnapshotCorruptError(RuntimeError):
+    """A snapshot cannot be trusted and must be treated as a miss."""
+
+
+def _array_digest(array: mx.array) -> str:
+    return hashlib.sha256(np.asarray(array).tobytes(order="C")).hexdigest()
+
+
+def _read_header(path: Path) -> Tuple[dict, int]:
+    """Read and validate only the safetensors JSON header."""
+    size = path.stat().st_size
+    with path.open("rb") as handle:
+        raw = handle.read(8)
+        if len(raw) != 8:
+            raise SnapshotCorruptError("truncated safetensors length")
+        header_size = int.from_bytes(raw, "little")
+        if header_size <= 0 or header_size > min(size - 8, 64 << 20):
+            raise SnapshotCorruptError("invalid safetensors header length")
+        try:
+            header = json.loads(handle.read(header_size))
+        except (UnicodeDecodeError, json.JSONDecodeError) as exc:
+            raise SnapshotCorruptError("invalid safetensors header JSON") from exc
+    if not isinstance(header, dict):
+        raise SnapshotCorruptError("safetensors header is not an object")
+    data_start = 8 + header_size
+    spans = []
+    for name, tensor in header.items():
+        if name == "__metadata__":
+            continue
+        try:
+            start, end = tensor["data_offsets"]
+        except (KeyError, TypeError, ValueError) as exc:
+            raise SnapshotCorruptError("invalid tensor offsets") from exc
+        if (
+            type(start) is not int
+            or type(end) is not int
+            or start < 0
+            or end < start
+            or end > size - data_start
+        ):
+            raise SnapshotCorruptError("tensor payload extends past file")
+        spans.append((start, end))
+    cursor = 0
+    for start, end in sorted(spans):
+        if start != cursor:
+            raise SnapshotCorruptError("gapped or overlapping tensor payload")
+        cursor = end
+    if cursor != size - data_start:
+        raise SnapshotCorruptError("trailing or truncated tensor payload")
+    return header, data_start
+
+
+@dataclass
+class SnapshotRecord:
+    cid: str
+    path: Path
+    model_key: str
+    tokens: Tuple[int, ...]
+    created_at: float
+    parent_cid: Optional[str]
+    parent_length: int
+    depth: int
+    logical_nbytes: int
+    file_bytes: int
+    last_use: float
+    digests: Tuple[Tuple[str, str], ...]
+
+
+class DiskBackedSnapshot:
+    """Header-only registry entry; KV payload is restored on first fork."""
+
+    def __init__(self, store: "SnapshotStore", record: SnapshotRecord):
+        self._store = store
+        self._record = record
+        self._forks = ()
+
+    @property
+    def cid(self):
+        return self._record.cid
+
+    @property
+    def model_key(self):
+        return self._record.model_key
+
+    @property
+    def tokens(self):
+        return self._record.tokens
+
+    @property
+    def nbytes(self):
+        return self._record.logical_nbytes
+
+    @property
+    def pinned(self):
+        return False
+
+    def __len__(self):
+        return len(self.tokens)
+
+    def fork(self):
+        snapshot = self._store.restore(self.cid)
+        return None if snapshot is None else snapshot.fork()
+
+
+class SnapshotStore:
+    """Content-addressed, delta-chained safetensors snapshot store."""
+
+    def __init__(
+        self,
+        directory,
+        *,
+        max_bytes: int = 32 << 30,
+        max_files: int = 4096,
+        max_chain_depth: int = 8,
+        registry=None,
+    ):
+        for name, value in (
+            ("max_bytes", max_bytes),
+            ("max_files", max_files),
+            ("max_chain_depth", max_chain_depth),
+        ):
+            if isinstance(value, bool) or not isinstance(value, Integral):
+                raise TypeError(f"{name} must be a non-negative integer")
+            if value < 0:
+                raise ValueError(f"{name} must be non-negative")
+        self.directory = Path(directory)
+        self.directory.mkdir(parents=True, exist_ok=True, mode=0o700)
+        os.chmod(self.directory, 0o700)
+        lock_key = str(self.directory.resolve())
+        lock_fd = _PROCESS_LOCKS.get(lock_key)
+        if lock_fd is None:
+            lock_path = self.directory / ".writer.lock"
+            lock_fd = os.open(lock_path, os.O_CREAT | os.O_RDWR, 0o600)
+            try:
+                fcntl.flock(lock_fd, fcntl.LOCK_EX | fcntl.LOCK_NB)
+            except OSError as exc:
+                os.close(lock_fd)
+                raise RuntimeError(
+                    f"snapshot directory already has a live writer: {self.directory}"
+                ) from exc
+            os.chmod(lock_path, 0o600)
+            _PROCESS_LOCKS[lock_key] = lock_fd
+        self._lock_fd = lock_fd
+        self.max_bytes = int(max_bytes)
+        self.max_files = int(max_files)
+        self.max_chain_depth = int(max_chain_depth)
+        self.registry = registry
+        self._records: "OrderedDict[str, SnapshotRecord]" = OrderedDict()
+        self._ram_ghosts = deque(maxlen=256)
+        self._disk_ghosts = deque(maxlen=256)
+        self._scrub_cursor = 0
+        self._stats = Counter()
+        self.rebuild(registry)
+
+    @property
+    def stats(self):
+        out = dict(self._stats)
+        out.update(
+            files=len(self._records),
+            bytes=sum(r.file_bytes for r in self._records.values()),
+        )
+        return out
+
+    def _parse_record(self, path: Path) -> SnapshotRecord:
+        os.chmod(path, 0o600)
+        header, _ = _read_header(path)
+        metadata = header.get("__metadata__")
+        if not isinstance(metadata, dict):
+            raise SnapshotCorruptError("missing metadata")
+        if metadata.get("format_version") != FORMAT_VERSION:
+            raise SnapshotCorruptError("unknown format version")
+        try:
+            raw_features = json.loads(metadata.get("features", "[]"))
+        except (TypeError, json.JSONDecodeError) as exc:
+            raise SnapshotCorruptError("invalid feature flags") from exc
+        if not isinstance(raw_features, list) or any(
+            not isinstance(feature, str) for feature in raw_features
+        ):
+            raise SnapshotCorruptError("invalid feature flags")
+        features = set(raw_features)
+        unknown = features - KNOWN_FEATURES
+        if unknown:
+            raise SnapshotCorruptError(f"unknown features: {sorted(unknown)}")
+        try:
+            model_key = metadata["model_key"]
+            tokens = tuple(json.loads(metadata["token_ids"]))
+            created_at = float(metadata["created_at"])
+            parent_cid = metadata.get("parent_cid") or None
+            parent_length = int(metadata.get("parent_length", "0"))
+            depth = int(metadata.get("chain_depth", "0"))
+            logical_nbytes = int(metadata["logical_nbytes"])
+            layers = int(metadata["layers"])
+        except (KeyError, TypeError, ValueError, json.JSONDecodeError) as exc:
+            raise SnapshotCorruptError("invalid snapshot metadata") from exc
+        if not isinstance(model_key, str) or any(type(t) is not int for t in tokens):
+            raise SnapshotCorruptError("invalid identity metadata")
+        if (
+            not math.isfinite(created_at)
+            or created_at < 0
+            or logical_nbytes < 0
+            or layers <= 0
+            or depth < 0
+        ):
+            raise SnapshotCorruptError("invalid numeric metadata")
+        cid = path.stem
+        if len(cid) != 64 or cid != compute_cid(model_key, tokens):
+            raise SnapshotCorruptError("filename/cid identity mismatch")
+        if parent_length < 0 or parent_length > len(tokens):
+            raise SnapshotCorruptError("invalid parent length")
+        if bool(parent_cid) != bool(parent_length):
+            raise SnapshotCorruptError("inconsistent parent metadata")
+        if parent_cid is not None and (
+            len(parent_cid) != 64
+            or any(char not in "0123456789abcdef" for char in parent_cid)
+        ):
+            raise SnapshotCorruptError("invalid parent cid")
+        digests = []
+        expected_names = {f"{side}.{layer}" for layer in range(layers) for side in "kv"}
+        actual_names = {name for name in header if name != "__metadata__"}
+        if actual_names != expected_names:
+            raise SnapshotCorruptError("unexpected or missing layer tensor")
+        for layer in range(layers):
+            k_name, v_name = f"k.{layer}", f"v.{layer}"
+            if k_name not in header or v_name not in header:
+                raise SnapshotCorruptError("missing layer tensor")
+            try:
+                pair = (
+                    metadata[f"sha256_k_{layer}"],
+                    metadata[f"sha256_v_{layer}"],
+                )
+            except KeyError as exc:
+                raise SnapshotCorruptError("missing payload digest") from exc
+            if any(
+                not isinstance(digest, str)
+                or len(digest) != 64
+                or any(char not in "0123456789abcdef" for char in digest)
+                for digest in pair
+            ):
+                raise SnapshotCorruptError("invalid payload digest")
+            digests.append(pair)
+        return SnapshotRecord(
+            cid=cid,
+            path=path,
+            model_key=model_key,
+            tokens=tokens,
+            created_at=created_at,
+            parent_cid=parent_cid,
+            parent_length=parent_length,
+            depth=depth,
+            logical_nbytes=logical_nbytes,
+            file_bytes=path.stat().st_size,
+            last_use=created_at,
+            digests=tuple(digests),
+        )
+
+    def _quarantine(self, path: Path, reason: str):
+        if not path.exists():
+            return
+        target = path.with_suffix(".quarantined")
+        if target.exists():
+            target = path.with_name(f"{path.stem}.{uuid.uuid4().hex}.quarantined")
+        try:
+            os.replace(path, target)
+            os.chmod(target, 0o600)
+        except OSError:
+            logging.warning("Snapshot quarantine failed for %s", path)
+        self._stats["quarantines"] += 1
+        logging.warning("Snapshot %s quarantined: %s", path.stem, reason)
+
+    def rebuild(self, registry=None):
+        """Header-only directory scan; tensor payloads remain untouched."""
+        if registry is not None:
+            self.registry = registry
+        self._records.clear()
+        # A temp is never authoritative.  A previous crash may leave one.
+        for path in self.directory.iterdir():
+            if ".tmp-" in path.name:
+                try:
+                    path.unlink()
+                    self._stats["temps_cleaned"] += 1
+                except OSError:
+                    pass
+        parsed = []
+        for path in self.directory.glob("*.safetensors"):
+            try:
+                parsed.append(self._parse_record(path))
+            except (OSError, SnapshotCorruptError) as exc:
+                self._quarantine(path, str(exc))
+        for record in sorted(parsed, key=lambda r: r.last_use):
+            self._records[record.cid] = record
+        self._poison_missing_or_cyclic()
+        self._load_index_lru()
+        if self.registry is not None:
+            for record in self._records.values():
+                self.registry.register_snapshot(DiskBackedSnapshot(self, record))
+        self._write_index()
+        self.gc()
+        return len(self._records)
+
+    def _poison_missing_or_cyclic(self):
+        bad = set()
+        for cid, record in list(self._records.items()):
+            if record.parent_cid is None:
+                if record.parent_length != 0 or record.depth != 0:
+                    bad.add(cid)
+            else:
+                parent = self._records.get(record.parent_cid)
+                if (
+                    parent is None
+                    or parent.model_key != record.model_key
+                    or record.parent_length != len(parent.tokens)
+                    or parent.tokens != record.tokens[: record.parent_length]
+                    or record.depth != parent.depth + 1
+                    or record.depth > self.max_chain_depth
+                ):
+                    bad.add(cid)
+            seen = set()
+            current = cid
+            while current:
+                if current in seen or current not in self._records:
+                    bad.add(cid)
+                    break
+                seen.add(current)
+                current = self._records[current].parent_cid
+        # Descendants of a bad node are bad too; repeat to a fixed point.
+        changed = True
+        while changed:
+            changed = False
+            for cid, record in self._records.items():
+                if record.parent_cid in bad and cid not in bad:
+                    bad.add(cid)
+                    changed = True
+        for cid in bad:
+            record = self._records.pop(cid, None)
+            if record is not None:
+                self._quarantine(record.path, "missing or cyclic parent chain")
+
+    def _load_index_lru(self):
+        path = self.directory / "index.json"
+        try:
+            data = json.loads(path.read_text())
+            lru = data.get("last_use", {})
+        except (OSError, json.JSONDecodeError, AttributeError):
+            return
+        for cid, stamp in lru.items():
+            if (
+                cid in self._records
+                and isinstance(stamp, (int, float))
+                and math.isfinite(stamp)
+            ):
+                self._records[cid].last_use = float(stamp)
+        self._records = OrderedDict(
+            sorted(self._records.items(), key=lambda item: item[1].last_use)
+        )
+
+    def _write_index(self):
+        path = self.directory / "index.json"
+        if self.max_files == 0 or self.max_bytes == 0:
+            try:
+                path.unlink()
+            except FileNotFoundError:
+                pass
+            return
+        temp = self.directory / f"index.json.tmp-{uuid.uuid4().hex}"
+        data = {
+            "format_version": FORMAT_VERSION,
+            "last_use": {cid: rec.last_use for cid, rec in self._records.items()},
+        }
+        with temp.open("w") as handle:
+            json.dump(data, handle, sort_keys=True)
+            handle.flush()
+            os.fsync(handle.fileno())
+        os.chmod(temp, 0o600)
+        os.replace(temp, path)
+        os.chmod(path, 0o600)
+
+    def _choose_parent(self, snapshot) -> Optional[SnapshotRecord]:
+        best = None
+        tokens = snapshot.tokens
+        for record in self._records.values():
+            if (
+                record.model_key == snapshot.model_key
+                and len(record.tokens) < len(tokens)
+                and tokens[: len(record.tokens)] == record.tokens
+                and (best is None or len(record.tokens) > len(best.tokens))
+            ):
+                best = record
+        # Do not silently fall back to a shorter ancestor: once the natural
+        # longest chain reaches the cap, this write is a new whole root.
+        return None if best is not None and best.depth >= self.max_chain_depth else best
+
+    def save(self, snapshot: FrozenPrefixSnapshot) -> str:
+        """Atomically save one RAM snapshot, delta-chained when profitable."""
+        cid = snapshot.cid
+        if cid in self._records:
+            stored = self._restore(cid, record_hit=False, promote=False)
+            if stored is None or not self._snapshots_equal(snapshot, stored):
+                raise ValueError(
+                    f"snapshot content mismatch for existing cid {cid}; "
+                    "the model key must change whenever weights change"
+                )
+            self._touch(cid)
+            return cid
+        parent = self._choose_parent(snapshot)
+        if parent is not None and not self._parent_matches(snapshot, parent):
+            # KV can be chunk- or implementation-dependent even for the same
+            # nominal weights/tokens.  Delta only when the actual bytes share
+            # the claimed prefix; otherwise self-root to prevent a false hit.
+            parent = None
+        parent_length = len(parent.tokens) if parent is not None else 0
+        keys = snapshot.keys
+        values = snapshot.values
+        tensors = {}
+        metadata = {
+            "format_version": FORMAT_VERSION,
+            "features": json.dumps(sorted(KNOWN_FEATURES)),
+            "model_key": snapshot.model_key,
+            "token_ids": json.dumps(list(snapshot.tokens), separators=(",", ":")),
+            "created_at": repr(time.time()),
+            "parent_cid": parent.cid if parent is not None else "",
+            "parent_length": str(parent_length),
+            "chain_depth": str(parent.depth + 1 if parent is not None else 0),
+            "logical_nbytes": str(snapshot.nbytes),
+            "layers": str(len(keys)),
+        }
+        for layer, (key, value) in enumerate(zip(keys, values)):
+            key = key[..., parent_length:, :]
+            value = value[..., parent_length:, :]
+            mx.eval(key, value)
+            tensors[f"k.{layer}"] = key
+            tensors[f"v.{layer}"] = value
+            metadata[f"sha256_k_{layer}"] = _array_digest(key)
+            metadata[f"sha256_v_{layer}"] = _array_digest(value)
+        # Keep the safetensors suffix: MLX otherwise appends one, which would
+        # make the path passed to chmod/replace differ from the file written.
+        temp = self.directory / f".{cid}.tmp-{uuid.uuid4().hex}.safetensors"
+        final = self.directory / f"{cid}.safetensors"
+        try:
+            mx.save_safetensors(str(temp), tensors, metadata)
+            os.chmod(temp, 0o600)
+            os.replace(temp, final)
+        finally:
+            try:
+                temp.unlink()
+            except FileNotFoundError:
+                pass
+        os.chmod(final, 0o600)
+        record = self._parse_record(final)
+        self._records[cid] = record
+        self._stats["demotions"] += 1
+        self._write_index()
+        self.gc()
+        return cid
+
+    def _parent_matches(self, snapshot, parent: SnapshotRecord) -> bool:
+        restored = self._restore(parent.cid, record_hit=False, promote=False)
+        if restored is None:
+            return False
+        child_keys, child_values = snapshot.keys, snapshot.values
+        if len(child_keys) != len(restored.keys) or len(child_values) != len(
+            restored.values
+        ):
+            return False
+        n = len(parent.tokens)
+        for child, old in zip(
+            child_keys + child_values, restored.keys + restored.values
+        ):
+            if (
+                child.ndim != old.ndim
+                or child.dtype != old.dtype
+                or child.shape[:2] + child.shape[3:] != old.shape[:2] + old.shape[3:]
+                or not bool(mx.array_equal(child[..., :n, :], old))
+            ):
+                return False
+        return True
+
+    @staticmethod
+    def _snapshots_equal(left, right) -> bool:
+        if (
+            left.model_key != right.model_key
+            or tuple(left.tokens) != tuple(right.tokens)
+            or len(left.keys) != len(right.keys)
+            or len(left.values) != len(right.values)
+        ):
+            return False
+        return all(
+            a.shape == b.shape and a.dtype == b.dtype and bool(mx.array_equal(a, b))
+            for a, b in zip(left.keys + left.values, right.keys + right.values)
+        )
+
+    def _load_delta(self, record: SnapshotRecord):
+        try:
+            arrays, _ = mx.load(str(record.path), return_metadata=True)
+            keys, values = [], []
+            for layer, (expected_k, expected_v) in enumerate(record.digests):
+                key, value = arrays[f"k.{layer}"], arrays[f"v.{layer}"]
+                tail_length = len(record.tokens) - record.parent_length
+                if (
+                    key.ndim != 4
+                    or value.ndim != 4
+                    or key.shape[:3] != value.shape[:3]
+                    or key.shape[2] != tail_length
+                ):
+                    raise SnapshotCorruptError(
+                        f"invalid tensor geometry at layer {layer}"
+                    )
+                # Verification is layer-incremental and occurs only when this
+                # disk hit is materialized, never during startup indexing.
+                mx.eval(key, value)
+                if (
+                    _array_digest(key) != expected_k
+                    or _array_digest(value) != expected_v
+                ):
+                    raise SnapshotCorruptError(
+                        f"payload digest mismatch at layer {layer}"
+                    )
+                keys.append(key)
+                values.append(value)
+            return keys, values
+        except (
+            OSError,
+            KeyError,
+            ValueError,
+            RuntimeError,
+            SnapshotCorruptError,
+        ) as exc:
+            raise SnapshotCorruptError(str(exc)) from exc
+
+    def restore(self, cid: str) -> Optional[FrozenPrefixSnapshot]:
+        """Walk and verify root→leaf, returning a materialized snapshot."""
+        return self._restore(cid, record_hit=True, promote=True)
+
+    def _restore(
+        self, cid: str, *, record_hit: bool, promote: bool
+    ) -> Optional[FrozenPrefixSnapshot]:
+        if cid in self._disk_ghosts:
+            self._stats["ghost_hits"] += 1
+        record = self._records.get(cid)
+        if record is None:
+            return None
+        chain, seen = [], set()
+        current = record
+        while current is not None:
+            if current.cid in seen or len(chain) > self.max_chain_depth:
+                self._quarantine_chain(chain + [current], "cyclic/deep chain")
+                return None
+            seen.add(current.cid)
+            chain.append(current)
+            current = (
+                self._records.get(current.parent_cid) if current.parent_cid else None
+            )
+            if chain[-1].parent_cid and current is None:
+                self._quarantine_chain(chain, "missing parent")
+                return None
+        keys = values = None
+        try:
+            for part in reversed(chain):
+                delta_keys, delta_values = self._load_delta(part)
+                if keys is None:
+                    keys, values = delta_keys, delta_values
+                else:
+                    if (
+                        not keys
+                        or len(keys) != len(delta_keys)
+                        or len(values) != len(delta_values)
+                    ):
+                        raise SnapshotCorruptError("incompatible layer counts in chain")
+                    for old_k, old_v, new_k, new_v in zip(
+                        keys, values, delta_keys, delta_values
+                    ):
+                        if (
+                            old_k.ndim != 4
+                            or old_v.ndim != 4
+                            or new_k.ndim != 4
+                            or new_v.ndim != 4
+                            or old_k.dtype != new_k.dtype
+                            or old_v.dtype != new_v.dtype
+                            or old_k.shape[:2] + old_k.shape[3:]
+                            != new_k.shape[:2] + new_k.shape[3:]
+                            or old_v.shape[:2] + old_v.shape[3:]
+                            != new_v.shape[:2] + new_v.shape[3:]
+                        ):
+                            raise SnapshotCorruptError(
+                                "incompatible tensor geometry in chain"
+                            )
+                    keys = [
+                        mx.concatenate([a, b], axis=2) for a, b in zip(keys, delta_keys)
+                    ]
+                    values = [
+                        mx.concatenate([a, b], axis=2)
+                        for a, b in zip(values, delta_values)
+                    ]
+            mx.eval(*keys, *values)
+        except SnapshotCorruptError as exc:
+            self._quarantine_descendants(part.cid, str(exc))
+            return None
+        if any(
+            key.shape[2] != len(record.tokens) or value.shape[2] != len(record.tokens)
+            for key, value in zip(keys, values)
+        ):
+            self._quarantine_chain(chain, "restored length mismatch")
+            return None
+        self._touch(cid)
+        if record_hit:
+            self._stats["disk_hits"] += 1
+        if promote:
+            self._stats["promotions"] += 1
+        snapshot = FrozenPrefixSnapshot(
+            cid, record.model_key, record.tokens, keys, values
+        )
+        if promote and self.registry is not None:
+            self.registry.replace_snapshot(snapshot)
+        return snapshot
+
+    def _quarantine_chain(self, chain, reason):
+        for record in chain:
+            self._records.pop(record.cid, None)
+            self._quarantine(record.path, reason)
+            if self.registry is not None:
+                self.registry.invalidate(record.cid)
+        self._write_index()
+        self.gc()
+
+    def _quarantine_descendants(self, cid, reason):
+        poisoned = {cid}
+        changed = True
+        while changed:
+            changed = False
+            for child, record in self._records.items():
+                if record.parent_cid in poisoned and child not in poisoned:
+                    poisoned.add(child)
+                    changed = True
+        self._quarantine_chain(
+            [self._records[x] for x in poisoned if x in self._records], reason
+        )
+
+    def _touch(self, cid):
+        record = self._records.pop(cid, None)
+        if record is not None:
+            record.last_use = time.time()
+            self._records[cid] = record
+
+    def flush_registry(self, registry=None):
+        """Write every unsaved RAM snapshot; safe to call only while idle."""
+        registry = registry or self.registry
+        if registry is None:
+            return 0
+        count = 0
+        for snapshot in registry.snapshots():
+            if (
+                isinstance(snapshot, FrozenPrefixSnapshot)
+                and snapshot.cid not in self._records
+            ):
+                self.save(snapshot)
+                count += 1
+        return count
+
+    def demote_from_ram(self, cid: str) -> bool:
+        """Replace a discoverable RAM snapshot with its header-only proxy."""
+        if self.registry is None:
+            return False
+        snapshot = self.registry.get(cid)
+        if not isinstance(snapshot, FrozenPrefixSnapshot):
+            return False
+        already_on_disk = cid in self._records
+        if not already_on_disk:
+            self.save(snapshot)
+        record = self._records.get(cid)
+        if record is None:
+            return False
+        replaced = self.registry.replace_snapshot(DiskBackedSnapshot(self, record))
+        if replaced:
+            self._ram_ghosts.append(cid)
+            if already_on_disk:
+                self._stats["demotions"] += 1
+        return replaced
+
+    def scrub_one(self) -> bool:
+        """Verify one snapshot's complete per-layer payload, round-robin."""
+        if not self._records:
+            return False
+        cids = list(self._records)
+        cid = cids[self._scrub_cursor % len(cids)]
+        self._scrub_cursor += 1
+        record = self._records[cid]
+        try:
+            self._load_delta(record)
+            self._stats["scrubs"] += 1
+            return True
+        except SnapshotCorruptError as exc:
+            self._quarantine_descendants(record.cid, str(exc))
+            return False
+
+    def note_ram_eviction(self, cid: str):
+        """Record ARC-style RAM ghost telemetry (sizing remains static)."""
+        self._ram_ghosts.append(cid)
+
+    def note_request_cid(self, cid: str):
+        """Count requests that would have hit either telemetry ghost list."""
+        if cid in self._ram_ghosts or cid in self._disk_ghosts:
+            self._stats["ghost_hits"] += 1
+
+    def gc(self):
+        """Enforce both caps, evicting least-recently-used leaves first."""
+
+        def all_files():
+            return [
+                p
+                for p in self.directory.iterdir()
+                if p.is_file() and p.name != ".writer.lock"
+            ]
+
+        while True:
+            files = all_files()
+            total = sum(p.stat().st_size for p in files)
+            if len(files) <= self.max_files and total <= self.max_bytes:
+                break
+            # Rebuildable/transient artifacts never deserve eviction
+            # protection over valid KV data.
+            candidates = [p for p in files if p.suffix != ".safetensors"]
+            if candidates:
+                victim = min(candidates, key=lambda p: p.stat().st_mtime)
+                try:
+                    victim.unlink()
+                    continue
+                except OSError:
+                    pass
+            parents = {r.parent_cid for r in self._records.values() if r.parent_cid}
+            leaf = next(
+                (r for r in self._records.values() if r.cid not in parents), None
+            )
+            if leaf is not None:
+                self._records.pop(leaf.cid, None)
+                try:
+                    leaf.path.unlink()
+                except OSError:
+                    pass
+                self._disk_ghosts.append(leaf.cid)
+                self._stats["gc_files"] += 1
+                if self.registry is not None:
+                    self.registry.invalidate(leaf.cid)
+                continue
+            break
+        return len(self._records)

--- a/mlx_lm/snapshot_store.py
+++ b/mlx_lm/snapshot_store.py
@@ -14,10 +14,10 @@ depth cap of eight this can transiently allocate several times the final KV
 size; representative-scale benchmarks must include that state-budget cost.
 
 Save is intentionally two-pass: a staged safetensors write establishes the
-canonical raw tensor bytes (including bfloat16), then the final atomic write
-embeds those digests. This costs roughly 2x write bandwidth and temporarily
-one extra snapshot file; both dot-temporary paths are cleaned on failure and
-startup and remain subject to directory-cap GC after the atomic commit.
+canonical raw tensor bytes (including bfloat16), then it is removed before the
+final atomic write embeds those digests. This costs roughly 2x write bandwidth
+but only one extra snapshot file at a time; reservation uses leaf-safe LRU
+eviction without deleting the incoming delta's parent chain.
 """
 
 import fcntl
@@ -27,6 +27,7 @@ import json
 import logging
 import math
 import os
+import shutil
 import threading
 import time
 import uuid
@@ -41,8 +42,28 @@ import mlx.core as mx
 
 from .prefix_forks import FrozenPrefixSnapshot, compute_cid
 
-FORMAT_VERSION = "1"
-KNOWN_FEATURES = frozenset({"delta-chain", "payload-sha256"})
+FORMAT_VERSION = "2"
+CANONICAL_DIGEST_FEATURE = "canonical-tensor-sha256-v2"
+DIGEST_DOMAIN = b"mlx-lm-snapshot-tensor-v2"
+KNOWN_FEATURES = frozenset({"delta-chain", CANONICAL_DIGEST_FEATURE})
+_DTYPE_BYTES = {
+    "BOOL": 1,
+    "I8": 1,
+    "U8": 1,
+    "I16": 2,
+    "U16": 2,
+    "I32": 4,
+    "U32": 4,
+    "I64": 8,
+    "U64": 8,
+    "F8_E4M3": 1,
+    "F8_E5M2": 1,
+    "F16": 2,
+    "BF16": 2,
+    "F32": 4,
+    "F64": 8,
+    "C64": 8,
+}
 _PROCESS_OWNERS = {}
 _OWNERS_LOCK = threading.Lock()
 
@@ -63,8 +84,12 @@ def _owned_operation(method):
 
 def _tensor_hasher(dtype: str, shape: List[int]):
     """Domain-separated canonical tensor digest, independent of PEP-3118."""
+    if dtype not in _DTYPE_BYTES or not isinstance(shape, (list, tuple)):
+        raise SnapshotCorruptError("invalid tensor digest descriptor")
+    if any(type(dimension) is not int or dimension < 0 for dimension in shape):
+        raise SnapshotCorruptError("invalid tensor digest shape")
     hasher = hashlib.sha256()
-    hasher.update(b"mlx-lm-snapshot-tensor-v1")
+    hasher.update(DIGEST_DOMAIN)
     dtype_bytes = dtype.encode()
     hasher.update(len(dtype_bytes).to_bytes(8, "big"))
     hasher.update(dtype_bytes)
@@ -73,8 +98,11 @@ def _tensor_hasher(dtype: str, shape: List[int]):
 
 
 def _file_tensor_digest(path: Path, tensor: dict, data_start: int) -> str:
-    hasher = _tensor_hasher(tensor["dtype"], tensor["shape"])
-    start, end = tensor["data_offsets"]
+    try:
+        hasher = _tensor_hasher(tensor["dtype"], tensor["shape"])
+        start, end = tensor["data_offsets"]
+    except (KeyError, TypeError, ValueError, AttributeError) as exc:
+        raise SnapshotCorruptError("invalid tensor digest descriptor") from exc
     position = data_start + start
     end = data_start + end
     with path.open("rb") as handle:
@@ -90,13 +118,31 @@ def _file_tensor_digest(path: Path, tensor: dict, data_start: int) -> str:
 
 def _payload_digests(path: Path, layers: int):
     header, data_start = _read_header(path)
-    return tuple(
-        (
-            _file_tensor_digest(path, header[f"k.{layer}"], data_start),
-            _file_tensor_digest(path, header[f"v.{layer}"], data_start),
+    try:
+        return tuple(
+            (
+                _file_tensor_digest(path, header[f"k.{layer}"], data_start),
+                _file_tensor_digest(path, header[f"v.{layer}"], data_start),
+            )
+            for layer in range(layers)
         )
-        for layer in range(layers)
-    )
+    except (KeyError, TypeError, ValueError, AttributeError) as exc:
+        raise SnapshotCorruptError("invalid tensor payload descriptors") from exc
+
+
+def _remove_transient(path: Path):
+    """Best-effort retry for temp cleanup; startup/GC remain the backstop."""
+    last_error = None
+    for _ in range(2):
+        try:
+            path.unlink()
+            return True
+        except FileNotFoundError:
+            return True
+        except OSError as exc:
+            last_error = exc
+    logging.warning("Could not remove snapshot transient %s: %s", path, last_error)
+    return False
 
 
 def _read_header(path: Path) -> Tuple[dict, int]:
@@ -111,7 +157,7 @@ def _read_header(path: Path) -> Tuple[dict, int]:
             raise SnapshotCorruptError("invalid safetensors header length")
         try:
             header = json.loads(handle.read(header_size))
-        except (UnicodeDecodeError, json.JSONDecodeError) as exc:
+        except (UnicodeDecodeError, ValueError, RecursionError) as exc:
             raise SnapshotCorruptError("invalid safetensors header JSON") from exc
     if not isinstance(header, dict):
         raise SnapshotCorruptError("safetensors header is not an object")
@@ -120,10 +166,25 @@ def _read_header(path: Path) -> Tuple[dict, int]:
     for name, tensor in header.items():
         if name == "__metadata__":
             continue
+        if not isinstance(name, str) or not isinstance(tensor, dict):
+            raise SnapshotCorruptError("invalid tensor descriptor")
         try:
+            dtype = tensor["dtype"]
+            shape = tensor["shape"]
             start, end = tensor["data_offsets"]
         except (KeyError, TypeError, ValueError) as exc:
-            raise SnapshotCorruptError("invalid tensor offsets") from exc
+            raise SnapshotCorruptError("incomplete tensor descriptor") from exc
+        if not isinstance(dtype, str) or dtype not in _DTYPE_BYTES:
+            raise SnapshotCorruptError("unsupported tensor dtype")
+        if (
+            not isinstance(shape, list)
+            or len(shape) > 64
+            or any(
+                type(dimension) is not int or dimension < 0 or dimension > (1 << 63) - 1
+                for dimension in shape
+            )
+        ):
+            raise SnapshotCorruptError("invalid tensor shape")
         if (
             type(start) is not int
             or type(end) is not int
@@ -132,6 +193,9 @@ def _read_header(path: Path) -> Tuple[dict, int]:
             or end > size - data_start
         ):
             raise SnapshotCorruptError("tensor payload extends past file")
+        elements = math.prod(shape)
+        if end - start != elements * _DTYPE_BYTES[dtype]:
+            raise SnapshotCorruptError("tensor shape does not match payload span")
         spans.append((start, end))
     cursor = 0
     for start, end in sorted(spans):
@@ -321,11 +385,17 @@ class SnapshotStore:
         metadata = header.get("__metadata__")
         if not isinstance(metadata, dict):
             raise SnapshotCorruptError("missing metadata")
-        if metadata.get("format_version") != FORMAT_VERSION:
+        format_version = metadata.get("format_version")
+        if format_version == "1":
+            raise SnapshotCorruptError(
+                "legacy format v1 payload digests are intentionally unsupported; "
+                "safe miss requires re-prefill"
+            )
+        if format_version != FORMAT_VERSION:
             raise SnapshotCorruptError("unknown format version")
         try:
             raw_features = json.loads(metadata.get("features", "[]"))
-        except (TypeError, json.JSONDecodeError) as exc:
+        except (TypeError, ValueError, RecursionError) as exc:
             raise SnapshotCorruptError("invalid feature flags") from exc
         if not isinstance(raw_features, list) or any(
             not isinstance(feature, str) for feature in raw_features
@@ -335,6 +405,8 @@ class SnapshotStore:
         unknown = features - KNOWN_FEATURES
         if unknown:
             raise SnapshotCorruptError(f"unknown features: {sorted(unknown)}")
+        if CANONICAL_DIGEST_FEATURE not in features:
+            raise SnapshotCorruptError("missing canonical tensor digest feature")
         try:
             model_key = metadata["model_key"]
             tokens = tuple(json.loads(metadata["token_ids"]))
@@ -344,8 +416,9 @@ class SnapshotStore:
             depth = int(metadata.get("chain_depth", "0"))
             logical_nbytes = int(metadata["logical_nbytes"])
             layers = int(metadata["layers"])
-        except (KeyError, TypeError, ValueError, json.JSONDecodeError) as exc:
+        except (KeyError, TypeError, ValueError, RecursionError) as exc:
             raise SnapshotCorruptError("invalid snapshot metadata") from exc
+        tensor_count = len(header) - int("__metadata__" in header)
         if not isinstance(model_key, str) or any(type(t) is not int for t in tokens):
             raise SnapshotCorruptError("invalid identity metadata")
         if (
@@ -353,6 +426,7 @@ class SnapshotStore:
             or created_at < 0
             or logical_nbytes < 0
             or layers <= 0
+            or layers * 2 != tensor_count
             or depth < 0
         ):
             raise SnapshotCorruptError("invalid numeric metadata")
@@ -533,7 +607,7 @@ class SnapshotStore:
         try:
             data = json.loads(path.read_text())
             lru = data.get("last_use", {})
-        except (OSError, json.JSONDecodeError, AttributeError):
+        except (OSError, ValueError, RecursionError, AttributeError):
             return
         for cid, stamp in lru.items():
             if (
@@ -583,6 +657,80 @@ class SnapshotStore:
         # Do not silently fall back to a shorter ancestor: once the natural
         # longest chain reaches the cap, this write is a new whole root.
         return None if best is not None and best.depth >= self.max_chain_depth else best
+
+    def _reserve_space(self, reservation: int, protected_cids=None):
+        """Make room for one transient/final file without evicting parents."""
+        protected_cids = set(protected_cids or ())
+        if self.max_files < 1:
+            raise RuntimeError("snapshot reservation requires max_files >= 1")
+        if reservation > self.max_bytes:
+            raise RuntimeError("snapshot reservation exceeds max_bytes")
+
+        def files():
+            return [
+                path
+                for path in self.directory.iterdir()
+                if path.is_file() and path.name != ".writer.lock"
+            ]
+
+        while True:
+            live_files = files()
+            live_bytes = sum(path.stat().st_size for path in live_files)
+            if (
+                len(live_files) + 1 <= self.max_files
+                and live_bytes + reservation <= self.max_bytes
+            ):
+                break
+            known_paths = {record.path for record in self._records.values()}
+            disposable = [
+                path
+                for path in live_files
+                if path.suffix != ".safetensors" or path not in known_paths
+            ]
+            if disposable:
+                victim = min(disposable, key=lambda path: path.stat().st_mtime)
+                try:
+                    victim.unlink()
+                except OSError as exc:
+                    raise RuntimeError(
+                        f"snapshot reservation could not unlink {victim}"
+                    ) from exc
+                continue
+            parents = {
+                record.parent_cid
+                for record in self._records.values()
+                if record.parent_cid
+            }
+            leaves = [
+                record
+                for record in self._records.values()
+                if record.cid not in parents and record.cid not in protected_cids
+            ]
+            leaf = min(
+                leaves,
+                key=lambda record: (record.last_use, record.cid),
+                default=None,
+            )
+            if leaf is None:
+                raise RuntimeError(
+                    "snapshot reservation exceeds cap with no evictable leaf"
+                )
+            try:
+                leaf.path.unlink()
+            except OSError as exc:
+                raise RuntimeError(
+                    f"snapshot reservation could not unlink {leaf.path}"
+                ) from exc
+            self._records.pop(leaf.cid, None)
+            self._index_dirty = True
+            self._disk_ghosts.append((leaf.model_key, leaf.tokens, leaf.cid))
+            self._stats["gc_files"] += 1
+            if self.registry is not None and isinstance(
+                self.registry.get(leaf.cid), DiskBackedSnapshot
+            ):
+                self.registry.invalidate(leaf.cid)
+        if shutil.disk_usage(self.directory).free < reservation:
+            raise RuntimeError("insufficient free disk space for snapshot reservation")
 
     @_owned_operation
     def save(self, snapshot: FrozenPrefixSnapshot) -> str:
@@ -638,6 +786,21 @@ class SnapshotStore:
             # supported MLX dtype without NumPy/PEP-3118 conversion).
             metadata[f"sha256_k_{layer}"] = "0" * 64
             metadata[f"sha256_v_{layer}"] = "0" * 64
+        payload_bytes = sum(tensor.nbytes for tensor in tensors.values())
+        metadata_bytes = len(json.dumps(metadata, sort_keys=True).encode())
+        reservation = (
+            payload_bytes + 4 * metadata_bytes + 1024 * len(tensors) + (64 << 10)
+        )
+        protected = set()
+        current_parent = parent
+        while current_parent is not None:
+            protected.add(current_parent.cid)
+            current_parent = (
+                self._records.get(current_parent.parent_cid)
+                if current_parent.parent_cid
+                else None
+            )
+        self._reserve_space(reservation, protected)
         # Keep the safetensors suffix: MLX otherwise appends one, which would
         # make the path passed to chmod/replace differ from the file written.
         temp = self.directory / f".{cid}.tmp-{uuid.uuid4().hex}.safetensors"
@@ -645,21 +808,24 @@ class SnapshotStore:
         try:
             mx.save_safetensors(str(stage), tensors, metadata)
             os.chmod(stage, 0o600)
+            if stage.stat().st_size > reservation:
+                raise RuntimeError("snapshot stage exceeded reserved disk bytes")
             digests = _payload_digests(stage, len(keys))
+            if not _remove_transient(stage):
+                raise RuntimeError("could not release staged snapshot reservation")
             for layer, (key_digest, value_digest) in enumerate(digests):
                 metadata[f"sha256_k_{layer}"] = key_digest
                 metadata[f"sha256_v_{layer}"] = value_digest
             mx.save_safetensors(str(temp), tensors, metadata)
             os.chmod(temp, 0o600)
+            if temp.stat().st_size > reservation:
+                raise RuntimeError("snapshot final exceeded reserved disk bytes")
             if _payload_digests(temp, len(keys)) != digests:
                 raise SnapshotCorruptError("staged/final tensor payload mismatch")
             os.replace(temp, final)
         finally:
             for transient in (stage, temp):
-                try:
-                    transient.unlink()
-                except FileNotFoundError:
-                    pass
+                _remove_transient(transient)
         os.chmod(final, 0o600)
         record = self._parse_record(final)
         self._records[cid] = record

--- a/tests/test_prefix_forks.py
+++ b/tests/test_prefix_forks.py
@@ -1,0 +1,311 @@
+# Copyright © 2026 Apple Inc.
+
+import copy
+import unittest
+
+import mlx.core as mx
+
+from mlx_lm.generate import generate_step
+from mlx_lm.models.cache import KVCache, RotatingKVCache, make_prompt_cache
+from mlx_lm.prefix_forks import (
+    ForkedKVCache,
+    FrozenPrefixSnapshot,
+    PrefixForkRegistry,
+    compute_cid,
+)
+from mlx_lm.utils import load
+
+HF_MODEL_PATH = "mlx-community/Qwen1.5-0.5B-Chat-4bit"
+
+
+def _random_kv(n, dims=(1, 2, 8)):
+    B, H, D = dims
+    k = mx.random.normal((B, H, n, D)).astype(mx.float16)
+    v = mx.random.normal((B, H, n, D)).astype(mx.float16)
+    mx.eval(k, v)
+    return k, v
+
+
+def _prime_cache(tokens, n_layers=2, dims=(1, 2, 8)):
+    """A KVCache stack filled with len(tokens) of random KV."""
+    cache = [KVCache() for _ in range(n_layers)]
+    for c in cache:
+        k, v = _random_kv(len(tokens), dims)
+        c.update_and_fetch(k, v)
+    mx.eval(*(x for c in cache for x in c.state))
+    return cache
+
+
+class TestForkedKVCache(unittest.TestCase):
+    """Pure-array tests: a ForkedKVCache must be observationally identical to
+    a plain KVCache fed the same KV stream."""
+
+    def test_update_and_fetch_matches_kvcache(self):
+        mx.random.seed(0)
+        prefix_len = 300  # crosses the step=256 boundary and is not a multiple
+        full = KVCache()
+        pk, pv = _random_kv(prefix_len)
+        full.update_and_fetch(pk, pv)
+
+        snapshot = FrozenPrefixSnapshot(
+            "cid", "m", tuple(range(prefix_len)), [mx.array(pk)], [mx.array(pv)]
+        )
+        fork = snapshot.fork()[0]
+
+        # Mixed prefill/decode chunks; total tail crosses another step boundary
+        for n in (1, 7, 1, 1, 256, 1, 40):
+            k, v = _random_kv(n)
+            fk, fv = full.update_and_fetch(k, v)
+            gk, gv = fork.update_and_fetch(k, v)
+            self.assertEqual(fork.offset, full.offset)
+            self.assertEqual(fork.size(), full.size())
+            self.assertTrue(mx.array_equal(fk, gk))
+            self.assertTrue(mx.array_equal(fv, gv))
+
+        # state is the joined exact-length view
+        sk, sv = fork.state
+        self.assertTrue(mx.array_equal(sk, full.state[0]))
+        self.assertTrue(mx.array_equal(sv, full.state[1]))
+
+        # detaching gives an equal, independent KVCache
+        detached = fork.to_kv_cache()
+        self.assertIsInstance(detached, KVCache)
+        self.assertEqual(detached.offset, full.offset)
+        self.assertTrue(mx.array_equal(detached.state[0], full.state[0]))
+
+    def test_trim_is_clamped_to_tail(self):
+        pk, pv = _random_kv(64)
+        fork = ForkedKVCache(pk, pv)
+        k, v = _random_kv(10)
+        fork.update_and_fetch(k, v)
+        self.assertEqual(fork.offset, 74)
+        # Trim deeper than the tail: only the 10 private tokens go
+        self.assertTrue(fork.is_trimmable())
+        self.assertEqual(fork.trim(30), 10)
+        self.assertEqual(fork.offset, 64)
+        self.assertEqual(fork.trim(5), 0)
+
+    def test_nbytes_counts_private_tail_only(self):
+        pk, pv = _random_kv(128)
+        fork = ForkedKVCache(pk, pv)
+        self.assertEqual(fork.nbytes, 0)  # fork creation costs no private bytes
+        self.assertEqual(fork.shared_nbytes, pk.nbytes + pv.nbytes)
+        k, v = _random_kv(4)
+        fork.update_and_fetch(k, v)
+        self.assertEqual(fork.nbytes, fork.tail.nbytes)
+        self.assertGreater(fork.nbytes, 0)
+
+    def test_make_mask_matches_kvcache(self):
+        pk, pv = _random_kv(32)
+        fork = ForkedKVCache(pk, pv)
+        k, v = _random_kv(8)
+        fork.update_and_fetch(k, v)
+        ref = KVCache()
+        rk, rv = _random_kv(40)
+        ref.update_and_fetch(rk, rv)
+        for N, kwargs in [
+            (1, dict(return_array=False, window_size=None)),
+            (5, dict(return_array=False, window_size=None)),
+            (5, dict(return_array=True, window_size=None)),
+            (5, dict(return_array=False, window_size=16)),
+        ]:
+            a = fork.make_mask(N, **kwargs)
+            b = ref.make_mask(N, **kwargs)
+            if isinstance(b, (str, type(None))):
+                self.assertEqual(a, b)
+            else:
+                self.assertTrue(mx.array_equal(a, b))
+
+    def test_state_is_read_only(self):
+        pk, pv = _random_kv(8)
+        fork = ForkedKVCache(pk, pv)
+        with self.assertRaises(ValueError):
+            fork.state = (pk, pv)
+
+    def test_parent_arrays_untouched_by_tail_writes(self):
+        prefix_len = 260
+        pk, pv = _random_kv(prefix_len)
+        before_k, before_v = mx.array(pk), mx.array(pv)
+        mx.eval(before_k, before_v)
+        fork = ForkedKVCache(pk, pv)
+        for _ in range(300):  # force several tail buffer growths
+            k, v = _random_kv(1)
+            fork.update_and_fetch(k, v)
+        mx.eval(*fork.state)
+        self.assertTrue(mx.array_equal(pk, before_k))
+        self.assertTrue(mx.array_equal(pv, before_v))
+
+
+class TestPrefixForkRegistry(unittest.TestCase):
+
+    def test_freeze_rejects_unsupported_caches(self):
+        registry = PrefixForkRegistry()
+        tokens = list(range(16))
+        # Wrong cache type
+        rot = [RotatingKVCache(max_size=8)]
+        k, v = _random_kv(16)
+        rot[0].update_and_fetch(k, v)
+        self.assertIsNone(registry.freeze("m", tokens, rot))
+        # Offset mismatch
+        cache = _prime_cache(tokens)
+        self.assertIsNone(registry.freeze("m", tokens + [1, 2], cache))
+        # Empty
+        self.assertIsNone(registry.freeze("m", [], []))
+        self.assertEqual(len(registry), 0)
+
+    def test_cid_dedup(self):
+        registry = PrefixForkRegistry()
+        tokens = list(range(32))
+        mx.random.seed(3)
+        cache_a = _prime_cache(tokens)
+        mx.random.seed(4)
+        cache_b = _prime_cache(tokens)
+
+        cid_a = registry.freeze("m", tokens, cache_a)
+        nbytes = registry.nbytes
+        cid_b = registry.freeze("m", tokens, cache_b)
+        # Same content (model, tokens) -> same cid, ONE snapshot, bytes once
+        self.assertEqual(cid_a, cid_b)
+        self.assertEqual(len(registry), 1)
+        self.assertEqual(registry.nbytes, nbytes)
+
+        # Different tokens or model namespace -> different cid
+        self.assertNotEqual(compute_cid("m", tokens), compute_cid("m", tokens[:-1]))
+        self.assertNotEqual(compute_cid("m", tokens), compute_cid("m2", tokens))
+
+    def test_fetch_longest_prefix_and_false_miss(self):
+        registry = PrefixForkRegistry()
+        short, long_ = list(range(8)), list(range(20))
+        registry.freeze("m", short, _prime_cache(short))
+        cid_long = registry.freeze("m", long_, _prime_cache(long_))
+
+        request = long_ + [99, 100]
+        forks, remaining = registry.fetch_fork("m", request)
+        self.assertIsNotNone(forks)
+        self.assertEqual(remaining, [99, 100])  # longest match won
+        self.assertEqual(forks[0].prefix_length, len(long_))
+
+        # A snapshot that only EXTENDS the request is a deliberate miss
+        forks2, remaining2 = registry.fetch_fork("m", long_[:15])
+        self.assertIsNotNone(forks2)  # falls back to the shorter snapshot
+        self.assertEqual(forks2[0].prefix_length, len(short))
+
+        # Unknown model / tokens: miss returns the tokens unchanged
+        forks3, remaining3 = registry.fetch_fork("other", request)
+        self.assertIsNone(forks3)
+        self.assertEqual(remaining3, request)
+
+        # Invalidation errs toward false MISS: fetch misses afterwards...
+        self.assertTrue(registry.invalidate(cid_long))
+        self.assertFalse(registry.invalidate(cid_long))
+        forks4, _ = registry.fetch_fork("m", request)
+        self.assertEqual(forks4[0].prefix_length, len(short))
+        # ...but live forks made earlier still hold their arrays
+        k, v = _random_kv(1)
+        out_k, _ = forks[0].update_and_fetch(k, v)
+        mx.eval(out_k)
+        self.assertEqual(out_k.shape[2], len(long_) + 1)
+
+    def test_lru_eviction(self):
+        registry = PrefixForkRegistry(max_snapshots=2)
+        toks = [list(range(i, i + 8)) for i in (0, 100, 200)]
+        cids = [registry.freeze("m", t, _prime_cache(t)) for t in toks]
+        self.assertEqual(len(registry), 2)
+        # Oldest evicted -> miss; newer ones still hit
+        self.assertIsNone(registry.get(cids[0]))
+        self.assertIsNone(registry.fetch_fork("m", toks[0])[0])
+        self.assertIsNotNone(registry.fetch_fork("m", toks[1])[0])
+        self.assertIsNotNone(registry.fetch_fork("m", toks[2])[0])
+
+
+class TestPrefixForksWithModel(unittest.TestCase):
+    """End-to-end correctness against the real model used by the prompt-cache
+    suite. Bar: a fork must be indistinguishable (greedy, token-exact) from a
+    full deepcopy of the same cache, while never touching the parent."""
+
+    @classmethod
+    def setUpClass(cls):
+        cls.model, cls.tokenizer = load(HF_MODEL_PATH)
+        text = (
+            "The lighthouse keeper counted ships every morning. " * 40
+            + "One day the fog rolled in and"
+        )
+        cls.tokens = cls.tokenizer.encode(text)
+        assert len(cls.tokens) > 300  # prefix must cross the step=256 boundary
+        cls.prefix = cls.tokens[:-1]
+        cls.cache = make_prompt_cache(cls.model)
+        cls.model(mx.array(cls.prefix)[None], cache=cls.cache)
+        mx.eval(*(x for c in cls.cache for x in c.state))
+
+    def _greedy(self, tokens, cache, n):
+        out = []
+        for token, _ in generate_step(
+            mx.array(tokens), self.model, prompt_cache=cache, max_tokens=n
+        ):
+            out.append(int(token))
+        return out
+
+    def test_fork_generation_matches_deepcopy(self):
+        registry = PrefixForkRegistry()
+        cid = registry.freeze(self.model, self.prefix, self.cache)
+        self.assertIsNotNone(cid)
+        snapshot = registry.get(cid)
+
+        # Fork creation must be O(tail): no prefix-sized materialization
+        mx.eval(*(a for s in [snapshot] for a in s.keys + s.values))
+        base_mem = mx.get_active_memory()
+        forks, remaining = registry.fetch_fork(self.model, self.tokens)
+        fork_mem = mx.get_active_memory() - base_mem
+        self.assertIsNotNone(forks)
+        self.assertEqual(remaining, [self.tokens[-1]])
+        self.assertLess(fork_mem, max(1 << 20, snapshot.nbytes // 20))
+        self.assertEqual(sum(f.nbytes for f in forks), 0)
+
+        # Snapshot state before anyone generates
+        before = [mx.array(a) for a in snapshot.keys + snapshot.values]
+        mx.eval(*before)
+
+        # (1) Token-exact equivalence with a full deepcopy continuation
+        ref_cache = copy.deepcopy(self.cache)
+        ref = self._greedy(remaining, ref_cache, 110)
+        got = self._greedy(remaining, forks, 110)
+        self.assertEqual(ref, got)
+
+        # (2) Parent immutability after 110 generated tokens
+        for arr, prev in zip(snapshot.keys + snapshot.values, before):
+            self.assertTrue(mx.array_equal(arr, prev))
+
+        # The original primed cache is also untouched (freeze copied it)
+        self.assertEqual(self.cache[0].offset, len(self.prefix))
+
+    def test_sibling_forks_do_not_contaminate(self):
+        registry = PrefixForkRegistry()
+        cid = registry.freeze(self.model, self.prefix, self.cache)
+        snapshot = registry.get(cid)
+
+        suffix_a = [self.tokens[-1]]
+        suffix_b = self.tokenizer.encode(" thunder shook the")
+
+        forks_a, _ = registry.fetch_fork(self.model, self.prefix + suffix_a)
+        forks_b, _ = registry.fetch_fork(self.model, self.prefix + suffix_b)
+
+        # Independent single-user references for both continuations
+        ref_a = self._greedy(suffix_a, copy.deepcopy(self.cache), 40)
+        ref_b = self._greedy(suffix_b, copy.deepcopy(self.cache), 40)
+
+        # Generate on A first, then B: if A's writes leaked into the shared
+        # prefix (or into B), B would diverge from its clean reference.
+        got_a = self._greedy(suffix_a, forks_a, 40)
+        got_b = self._greedy(suffix_b, forks_b, 40)
+        self.assertEqual(ref_a, got_a)
+        self.assertEqual(ref_b, got_b)
+        self.assertNotEqual(got_a, got_b)  # sanity: they really diverged
+
+        # And the shared parent still froze exactly the prefix
+        self.assertEqual(len(snapshot), len(self.prefix))
+        for f_a, f_b in zip(forks_a, forks_b):
+            self.assertIs(f_a._prefix_keys, f_b._prefix_keys)  # truly shared
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_prefix_forks.py
+++ b/tests/test_prefix_forks.py
@@ -100,6 +100,13 @@ class TestForkedKVCache(unittest.TestCase):
         self.assertEqual(fork.offset, 70)  # untouched by the failed trim
         self.assertEqual(fork.trim(0), 0)
 
+        # A negative rollback must not flow through to KVCache.trim(), where
+        # subtracting a negative value grows the logical offset into
+        # uninitialised capacity.
+        with self.assertRaises(ValueError):
+            fork.trim(-1)
+        self.assertEqual(fork.offset, 70)
+
     def test_trim_prompt_cache_fails_loudly_not_skewed(self):
         # F1 regression (reviewer's exact scenario): a fork inside the
         # trim-longer path of a request-level cache. trim_prompt_cache used
@@ -189,6 +196,35 @@ class TestForkedKVCache(unittest.TestCase):
         self.assertTrue(mx.array_equal(snapshot.keys[0], before))
         self.assertTrue(mx.array_equal(fork.state[0], before))
 
+    def test_registry_snapshot_views_cannot_corrupt_future_forks(self):
+        # registry.get() is a public boundary too.  Mutating an array obtained
+        # from it must not rewrite the snapshot used by forks created later.
+        tokens = list(range(16))
+        registry = PrefixForkRegistry()
+        cid = registry.freeze("m", tokens, _prime_cache(tokens))
+        snapshot = registry.get(cid)
+        before = mx.array(snapshot.keys[0])
+        mx.eval(before)
+
+        exposed = snapshot.keys[0]
+        exposed[..., 0, :] = 777.0
+        mx.eval(exposed)
+
+        future = registry.fetch_fork("m", tokens)[0][0]
+        self.assertTrue(mx.array_equal(future.state[0], before))
+
+        # Registry bookkeeping metadata is part of the immutable snapshot too.
+        for name, value in (
+            ("cid", "wrong"),
+            ("model_key", "wrong"),
+            ("tokens", (999,)),
+            ("nbytes", 0),
+        ):
+            with self.assertRaises(AttributeError):
+                setattr(snapshot, name, value)
+        self.assertTrue(registry.invalidate(cid))
+        self.assertEqual(registry.nbytes, 0)
+
     def test_meta_state_and_save_refuse(self):
         # N4: save_prompt_cache would write a file load_prompt_cache cannot
         # reconstruct (class lookup is models/cache.py globals); refuse loudly.
@@ -215,6 +251,25 @@ class TestForkedKVCache(unittest.TestCase):
 
 
 class TestPrefixForkRegistry(unittest.TestCase):
+
+    def test_cid_framing_separates_model_key_from_tokens(self):
+        # Without length/domain framing these serialize to the same bytes:
+        # b"m" + b"\\0" + b"1" + b"\\0" + b"2".
+        self.assertNotEqual(
+            compute_cid("m", [1, 2]), compute_cid("m\x001", [2])
+        )
+        self.assertEqual(len(compute_cid("m", [1, 2])), 64)
+
+    def test_token_identity_rejects_lossy_coercions(self):
+        registry = PrefixForkRegistry()
+        cache = _prime_cache([1])
+        for bad in ([1.9], ["1"], [True]):
+            with self.assertRaises(TypeError):
+                compute_cid("m", bad)
+            with self.assertRaises(TypeError):
+                registry.freeze("m", bad, cache)
+            with self.assertRaises(TypeError):
+                registry.fetch_fork("m", bad)
 
     def test_model_key_must_be_str(self):
         # B1 regression: id()-derived and object keys are forbidden. An
@@ -284,6 +339,24 @@ class TestPrefixForkRegistry(unittest.TestCase):
         with self.assertRaises(ValueError):
             registry.freeze("m@v1", tokens, altered)
 
+    def test_dedup_value_only_mismatch_raises(self):
+        # A V-projection-only change can leave every key bit-identical.  The
+        # advertised KV-content check must inspect values on every layer too.
+        registry = PrefixForkRegistry()
+        tokens = list(range(40))
+        mx.random.seed(41)
+        registry.freeze("m@v1", tokens, _prime_cache(tokens))
+
+        mx.random.seed(41)
+        altered = _prime_cache(tokens)
+        _, v1 = altered[1].state
+        v1_mod = mx.array(v1)
+        v1_mod[..., -1, :] = 321.0
+        altered[1].values[..., : altered[1].offset, :] = v1_mod
+        mx.eval(altered[1].values)
+        with self.assertRaises(ValueError):
+            registry.freeze("m@v1", tokens, altered)
+
     def test_dedup_content_mismatch_raises(self):
         # F3 regression: same key + tokens but DIFFERENT KV content (weights
         # changed under a stale key) must raise, not silently dedup.
@@ -310,6 +383,19 @@ class TestPrefixForkRegistry(unittest.TestCase):
         # Empty
         self.assertIsNone(registry.freeze("m", [], []))
         self.assertEqual(len(registry), 0)
+
+    def test_existing_cid_does_not_turn_unsupported_freeze_into_success(self):
+        registry = PrefixForkRegistry()
+        tokens = list(range(16))
+        cid = registry.freeze("m", tokens, _prime_cache(tokens))
+
+        rotating = RotatingKVCache(max_size=32)
+        rotating.update_and_fetch(*_random_kv(len(tokens)))
+        self.assertIsNone(registry.freeze("m", tokens, [rotating]))
+
+        wrong_offset = _prime_cache(tokens[:-1])
+        self.assertIsNone(registry.freeze("m", tokens, wrong_offset))
+        self.assertEqual(registry.get(cid).cid, cid)
 
     def test_cid_dedup(self):
         registry = PrefixForkRegistry()
@@ -396,6 +482,48 @@ class TestPrefixForkRegistry(unittest.TestCase):
         del forks
         gc.collect()
         self.assertEqual(registry.pinned_nbytes, 0)
+
+    def test_pinned_nbytes_survives_same_cid_reinsertion(self):
+        registry = PrefixForkRegistry()
+        tokens = list(range(40))
+        cache = _prime_cache(tokens)
+        cid = registry.freeze("m", tokens, cache)
+        old_bytes = registry.get(cid).nbytes
+        old_forks, _ = registry.fetch_fork("m", tokens)
+        registry.invalidate(cid)
+
+        # Reinserting the same CID must not overwrite tracking for the older,
+        # still-live snapshot held by old_forks.
+        self.assertEqual(registry.freeze("m", tokens, cache), cid)
+        self.assertEqual(registry.pinned_nbytes, old_bytes)
+        del old_forks
+        gc.collect()
+        self.assertEqual(registry.pinned_nbytes, 0)
+
+    def test_max_bytes_is_a_strict_discoverable_cap(self):
+        registry = PrefixForkRegistry(max_bytes=1)
+        tokens = list(range(8))
+        cid = registry.freeze("m", tokens, _prime_cache(tokens))
+        self.assertGreater(cid is not None, 0)
+        self.assertEqual(registry.nbytes, 0)
+        self.assertEqual(len(registry), 0)
+        self.assertIsNone(registry.fetch_fork("m", tokens)[0])
+
+    def test_registry_limits_reject_negative_values_and_allow_zero(self):
+        with self.assertRaises(ValueError):
+            PrefixForkRegistry(max_snapshots=-1)
+        with self.assertRaises(ValueError):
+            PrefixForkRegistry(max_bytes=-1)
+        for bad in (True, 1.5, float("nan"), "1"):
+            with self.assertRaises(TypeError):
+                PrefixForkRegistry(max_snapshots=bad)
+            with self.assertRaises(TypeError):
+                PrefixForkRegistry(max_bytes=bad)
+        registry = PrefixForkRegistry(max_snapshots=0, max_bytes=0)
+        tokens = list(range(8))
+        registry.freeze("m", tokens, _prime_cache(tokens))
+        self.assertEqual(len(registry), 0)
+        self.assertEqual(registry.nbytes, 0)
 
 
 class TestPrefixForksWithModel(unittest.TestCase):

--- a/tests/test_prefix_forks.py
+++ b/tests/test_prefix_forks.py
@@ -263,6 +263,27 @@ class TestPrefixForkRegistry(unittest.TestCase):
         self.assertIsNone(forks)
         self.assertEqual(remaining, tokens)
 
+    def test_dedup_mismatch_beyond_layer0_raises(self):
+        """A layer-1-only KV difference (layer 0 bit-identical — the
+        realistic LoRA-that-skips-early-layers shape) must be caught by
+        the all-layer dedup spot-check."""
+        registry = PrefixForkRegistry()
+        tokens = list(range(40))
+        mx.random.seed(31)
+        base = _prime_cache(tokens)
+        registry.freeze("m@v1", tokens, base)
+
+        # Rebuild with layer 0 bit-identical and layer 1 perturbed only
+        mx.random.seed(31)
+        altered = _prime_cache(tokens)  # same seed -> same content
+        k1, v1 = altered[1].state
+        k1_mod = mx.array(k1)
+        k1_mod[..., -1, :] = 123.0
+        altered[1].keys[..., : altered[1].offset, :] = k1_mod
+        mx.eval(altered[1].keys)
+        with self.assertRaises(ValueError):
+            registry.freeze("m@v1", tokens, altered)
+
     def test_dedup_content_mismatch_raises(self):
         # F3 regression: same key + tokens but DIFFERENT KV content (weights
         # changed under a stale key) must raise, not silently dedup.

--- a/tests/test_prefix_forks.py
+++ b/tests/test_prefix_forks.py
@@ -1,12 +1,21 @@
 # Copyright © 2026 Apple Inc.
 
 import copy
+import gc
+import os
+import tempfile
 import unittest
 
 import mlx.core as mx
 
 from mlx_lm.generate import generate_step
-from mlx_lm.models.cache import KVCache, RotatingKVCache, make_prompt_cache
+from mlx_lm.models.cache import (
+    KVCache,
+    RotatingKVCache,
+    make_prompt_cache,
+    save_prompt_cache,
+    trim_prompt_cache,
+)
 from mlx_lm.prefix_forks import (
     ForkedKVCache,
     FrozenPrefixSnapshot,
@@ -73,17 +82,36 @@ class TestForkedKVCache(unittest.TestCase):
         self.assertEqual(detached.offset, full.offset)
         self.assertTrue(mx.array_equal(detached.state[0], full.state[0]))
 
-    def test_trim_is_clamped_to_tail(self):
+    def test_trim_within_tail_and_raises_beyond(self):
         pk, pv = _random_kv(64)
         fork = ForkedKVCache(pk, pv)
         k, v = _random_kv(10)
         fork.update_and_fetch(k, v)
         self.assertEqual(fork.offset, 74)
-        # Trim deeper than the tail: only the 10 private tokens go
         self.assertTrue(fork.is_trimmable())
-        self.assertEqual(fork.trim(30), 10)
-        self.assertEqual(fork.offset, 64)
-        self.assertEqual(fork.trim(5), 0)
+        # Rollback within the private tail works like KVCache
+        self.assertEqual(fork.trim(4), 4)
+        self.assertEqual(fork.offset, 70)
+        # Trimming into the frozen prefix must FAIL LOUDLY (F1): callers of
+        # trim_prompt_cache ignore the return value, so a silent clamp would
+        # leave generation running against skewed KV.
+        with self.assertRaises(ValueError):
+            fork.trim(30)
+        self.assertEqual(fork.offset, 70)  # untouched by the failed trim
+        self.assertEqual(fork.trim(0), 0)
+
+    def test_trim_prompt_cache_fails_loudly_not_skewed(self):
+        # F1 regression (reviewer's exact scenario): a fork inside the
+        # trim-longer path of a request-level cache. trim_prompt_cache used
+        # to under-trim silently (offset skew); now it raises.
+        tokens = list(range(300))
+        registry = PrefixForkRegistry()
+        registry.freeze("m", tokens, _prime_cache(tokens))
+        forks, _ = registry.fetch_fork("m", tokens)
+        for f in forks:
+            f.update_and_fetch(*_random_kv(10))
+        with self.assertRaises(ValueError):
+            trim_prompt_cache(forks, 50)  # 50 > tail of 10
 
     def test_nbytes_counts_private_tail_only(self):
         pk, pv = _random_kv(128)
@@ -122,6 +150,56 @@ class TestForkedKVCache(unittest.TestCase):
         with self.assertRaises(ValueError):
             fork.state = (pk, pv)
 
+    def test_empty_tail_state_is_sealed(self):
+        # F2 regression: .state with an EMPTY tail must never hand out the
+        # raw frozen array objects — a consumer __setitem__ would corrupt
+        # the snapshot and every sibling fork.
+        tokens = list(range(32))
+        registry = PrefixForkRegistry()
+        cid = registry.freeze("m", tokens, _prime_cache(tokens))
+        snapshot = registry.get(cid)
+        fork_a = registry.fetch_fork("m", tokens)[0]
+        fork_b = registry.fetch_fork("m", tokens)[0]
+        before_k = mx.array(snapshot.keys[0])
+        before_v = mx.array(snapshot.values[0])
+        mx.eval(before_k, before_v)
+
+        k, v = fork_a[0].state  # tail empty
+        self.assertIsNot(k, snapshot.keys[0])
+        k[..., 0, :] = 999.0  # hostile consumer edits .state in place
+        v[..., 0, :] = -999.0
+        mx.eval(k, v)
+
+        self.assertTrue(mx.array_equal(snapshot.keys[0], before_k))
+        self.assertTrue(mx.array_equal(snapshot.values[0], before_v))
+        kb, vb = fork_b[0].state  # sibling unaffected
+        self.assertTrue(mx.array_equal(kb, before_k))
+        self.assertTrue(mx.array_equal(vb, before_v))
+
+    def test_snapshot_init_seals_caller_arrays(self):
+        # F2 (defensive): a caller that retains its arrays and later mutates
+        # them via __setitem__ must not reach the snapshot's stored nodes.
+        pk, pv = _random_kv(16)
+        before = mx.array(pk)
+        mx.eval(before)
+        snapshot = FrozenPrefixSnapshot("cid", "m", tuple(range(16)), [pk], [pv])
+        fork = ForkedKVCache(pk, pv)
+        pk[..., 0, :] = 123.0  # caller scribbles its own reference
+        mx.eval(pk)
+        self.assertTrue(mx.array_equal(snapshot.keys[0], before))
+        self.assertTrue(mx.array_equal(fork.state[0], before))
+
+    def test_meta_state_and_save_refuse(self):
+        # N4: save_prompt_cache would write a file load_prompt_cache cannot
+        # reconstruct (class lookup is models/cache.py globals); refuse loudly.
+        pk, pv = _random_kv(8)
+        forks = [ForkedKVCache(pk, pv)]
+        with self.assertRaises(ValueError):
+            _ = forks[0].meta_state
+        path = os.path.join(tempfile.mkdtemp(), "fork.safetensors")
+        with self.assertRaises(ValueError):
+            save_prompt_cache(path, forks)
+
     def test_parent_arrays_untouched_by_tail_writes(self):
         prefix_len = 260
         pk, pv = _random_kv(prefix_len)
@@ -137,6 +215,65 @@ class TestForkedKVCache(unittest.TestCase):
 
 
 class TestPrefixForkRegistry(unittest.TestCase):
+
+    def test_model_key_must_be_str(self):
+        # B1 regression: id()-derived and object keys are forbidden. An
+        # in-place weight swap keeps the same object, and CPython recycles
+        # addresses of dead objects — both turned into stale-KV false HITs.
+        registry = PrefixForkRegistry()
+        tokens = list(range(8))
+        cache = _prime_cache(tokens)
+
+        class FakeModel:
+            pass
+
+        for bad in (FakeModel(), ("path", "adapter", None), 42, None, b"key"):
+            with self.assertRaises(TypeError):
+                registry.freeze(bad, tokens, cache)
+            with self.assertRaises(TypeError):
+                registry.fetch_fork(bad, tokens)
+            with self.assertRaises(TypeError):
+                compute_cid(bad, tokens)
+        self.assertEqual(len(registry), 0)
+
+    def test_distinct_string_keys_never_collide(self):
+        registry = PrefixForkRegistry()
+        tokens = list(range(16))
+        mx.random.seed(11)
+        cache_a = _prime_cache(tokens)
+        mx.random.seed(12)
+        cache_b = _prime_cache(tokens)
+        cid_a = registry.freeze("org/model@rev1", tokens, cache_a)
+        cid_b = registry.freeze("org/model@rev2", tokens, cache_b)
+        self.assertNotEqual(cid_a, cid_b)
+        self.assertEqual(len(registry), 2)
+        got_a = registry.fetch_fork("org/model@rev1", tokens)[0]
+        got_b = registry.fetch_fork("org/model@rev2", tokens)[0]
+        self.assertTrue(mx.array_equal(got_a[0].state[0], cache_a[0].state[0]))
+        self.assertTrue(mx.array_equal(got_b[0].state[0], cache_b[0].state[0]))
+
+    def test_key_contract_weight_swap_misses(self):
+        # B1 contract, documented: the key MUST change when the weights
+        # change (adapter load). The caller changing the key converts what
+        # was a deterministic stale-KV HIT into a safe MISS.
+        registry = PrefixForkRegistry()
+        tokens = list(range(24))
+        registry.freeze("org/model@base", tokens, _prime_cache(tokens))
+        forks, remaining = registry.fetch_fork("org/model@base+adapterX", tokens)
+        self.assertIsNone(forks)
+        self.assertEqual(remaining, tokens)
+
+    def test_dedup_content_mismatch_raises(self):
+        # F3 regression: same key + tokens but DIFFERENT KV content (weights
+        # changed under a stale key) must raise, not silently dedup.
+        registry = PrefixForkRegistry()
+        tokens = list(range(32))
+        mx.random.seed(21)
+        registry.freeze("org/model@base", tokens, _prime_cache(tokens))
+        mx.random.seed(22)
+        post_adapter = _prime_cache(tokens)
+        with self.assertRaises(ValueError):
+            registry.freeze("org/model@base", tokens, post_adapter)
 
     def test_freeze_rejects_unsupported_caches(self):
         registry = PrefixForkRegistry()
@@ -156,20 +293,19 @@ class TestPrefixForkRegistry(unittest.TestCase):
     def test_cid_dedup(self):
         registry = PrefixForkRegistry()
         tokens = list(range(32))
-        mx.random.seed(3)
         cache_a = _prime_cache(tokens)
-        mx.random.seed(4)
-        cache_b = _prime_cache(tokens)
+        cache_b = copy.deepcopy(cache_a)  # same content, different arrays
 
         cid_a = registry.freeze("m", tokens, cache_a)
         nbytes = registry.nbytes
         cid_b = registry.freeze("m", tokens, cache_b)
-        # Same content (model, tokens) -> same cid, ONE snapshot, bytes once
+        # Same content (model key, tokens, KV) -> same cid, ONE snapshot,
+        # bytes counted once
         self.assertEqual(cid_a, cid_b)
         self.assertEqual(len(registry), 1)
         self.assertEqual(registry.nbytes, nbytes)
 
-        # Different tokens or model namespace -> different cid
+        # Different tokens or model key -> different cid
         self.assertNotEqual(compute_cid("m", tokens), compute_cid("m", tokens[:-1]))
         self.assertNotEqual(compute_cid("m", tokens), compute_cid("m2", tokens))
 
@@ -190,7 +326,7 @@ class TestPrefixForkRegistry(unittest.TestCase):
         self.assertIsNotNone(forks2)  # falls back to the shorter snapshot
         self.assertEqual(forks2[0].prefix_length, len(short))
 
-        # Unknown model / tokens: miss returns the tokens unchanged
+        # Unknown model key / tokens: miss returns the tokens unchanged
         forks3, remaining3 = registry.fetch_fork("other", request)
         self.assertIsNone(forks3)
         self.assertEqual(remaining3, request)
@@ -217,11 +353,38 @@ class TestPrefixForkRegistry(unittest.TestCase):
         self.assertIsNotNone(registry.fetch_fork("m", toks[1])[0])
         self.assertIsNotNone(registry.fetch_fork("m", toks[2])[0])
 
+    def test_pinned_nbytes_tracks_live_forks(self):
+        # F4 regression: nbytes drops on invalidate while live forks still
+        # pin the snapshot's memory. pinned_nbytes reports that residency.
+        registry = PrefixForkRegistry()
+        tokens = list(range(400))
+        cid = registry.freeze("m", tokens, _prime_cache(tokens))
+        snap_bytes = registry.get(cid).nbytes
+        self.assertEqual(registry.nbytes, snap_bytes)
+        self.assertEqual(registry.pinned_nbytes, 0)  # no forks yet
+
+        forks, _ = registry.fetch_fork("m", tokens)
+        self.assertEqual(registry.pinned_nbytes, snap_bytes)
+
+        registry.invalidate(cid)
+        # Discoverability gone, residency not: max_bytes bounds the
+        # discoverable set only.
+        self.assertEqual(registry.nbytes, 0)
+        self.assertEqual(registry.pinned_nbytes, snap_bytes)
+
+        del forks
+        gc.collect()
+        self.assertEqual(registry.pinned_nbytes, 0)
+
 
 class TestPrefixForksWithModel(unittest.TestCase):
     """End-to-end correctness against the real model used by the prompt-cache
     suite. Bar: a fork must be indistinguishable (greedy, token-exact) from a
     full deepcopy of the same cache, while never touching the parent."""
+
+    # The stable weight-identity string the registry requires (see the
+    # MODEL-KEY CONTRACT in prefix_forks.py).
+    MODEL_KEY = HF_MODEL_PATH + "@main"
 
     @classmethod
     def setUpClass(cls):
@@ -232,7 +395,11 @@ class TestPrefixForksWithModel(unittest.TestCase):
         )
         cls.tokens = cls.tokenizer.encode(text)
         assert len(cls.tokens) > 300  # prefix must cross the step=256 boundary
-        cls.prefix = cls.tokens[:-1]
+        # Multi-token suffix: N>1 prefill through the fork exercises the
+        # causal mask / position handling (a flipped prefix/tail concat is
+        # invisible to N=1 decode, which is permutation-invariant over keys).
+        cls.prefix = cls.tokens[:-4]
+        cls.suffix = cls.tokens[-4:]
         cls.cache = make_prompt_cache(cls.model)
         cls.model(mx.array(cls.prefix)[None], cache=cls.cache)
         mx.eval(*(x for c in cls.cache for x in c.state))
@@ -247,17 +414,20 @@ class TestPrefixForksWithModel(unittest.TestCase):
 
     def test_fork_generation_matches_deepcopy(self):
         registry = PrefixForkRegistry()
-        cid = registry.freeze(self.model, self.prefix, self.cache)
+        cid = registry.freeze(self.MODEL_KEY, self.prefix, self.cache)
         self.assertIsNotNone(cid)
         snapshot = registry.get(cid)
 
-        # Fork creation must be O(tail): no prefix-sized materialization
+        # Fork creation must be O(tail): no prefix-sized materialization.
+        # Measure AFTER evaluating everything the fork exposes, so a lazy
+        # O(prefix) copy cannot hide behind deferred execution.
         mx.eval(*(a for s in [snapshot] for a in s.keys + s.values))
         base_mem = mx.get_active_memory()
-        forks, remaining = registry.fetch_fork(self.model, self.tokens)
-        fork_mem = mx.get_active_memory() - base_mem
+        forks, remaining = registry.fetch_fork(self.MODEL_KEY, self.tokens)
         self.assertIsNotNone(forks)
-        self.assertEqual(remaining, [self.tokens[-1]])
+        self.assertEqual(remaining, self.suffix)
+        mx.eval(*(a for f in forks for a in f.state))
+        fork_mem = mx.get_active_memory() - base_mem
         self.assertLess(fork_mem, max(1 << 20, snapshot.nbytes // 20))
         self.assertEqual(sum(f.nbytes for f in forks), 0)
 
@@ -265,7 +435,8 @@ class TestPrefixForksWithModel(unittest.TestCase):
         before = [mx.array(a) for a in snapshot.keys + snapshot.values]
         mx.eval(*before)
 
-        # (1) Token-exact equivalence with a full deepcopy continuation
+        # (1) Token-exact equivalence with a full deepcopy continuation,
+        # through an N>1 prefill (position-sensitive) then 110 decode steps
         ref_cache = copy.deepcopy(self.cache)
         ref = self._greedy(remaining, ref_cache, 110)
         got = self._greedy(remaining, forks, 110)
@@ -280,14 +451,14 @@ class TestPrefixForksWithModel(unittest.TestCase):
 
     def test_sibling_forks_do_not_contaminate(self):
         registry = PrefixForkRegistry()
-        cid = registry.freeze(self.model, self.prefix, self.cache)
+        cid = registry.freeze(self.MODEL_KEY, self.prefix, self.cache)
         snapshot = registry.get(cid)
 
-        suffix_a = [self.tokens[-1]]
+        suffix_a = self.suffix
         suffix_b = self.tokenizer.encode(" thunder shook the")
 
-        forks_a, _ = registry.fetch_fork(self.model, self.prefix + suffix_a)
-        forks_b, _ = registry.fetch_fork(self.model, self.prefix + suffix_b)
+        forks_a, _ = registry.fetch_fork(self.MODEL_KEY, self.prefix + suffix_a)
+        forks_b, _ = registry.fetch_fork(self.MODEL_KEY, self.prefix + suffix_b)
 
         # Independent single-user references for both continuations
         ref_a = self._greedy(suffix_a, copy.deepcopy(self.cache), 40)
@@ -301,10 +472,12 @@ class TestPrefixForksWithModel(unittest.TestCase):
         self.assertEqual(ref_b, got_b)
         self.assertNotEqual(got_a, got_b)  # sanity: they really diverged
 
-        # And the shared parent still froze exactly the prefix
+        # And the shared parent still froze exactly the prefix, with both
+        # forks referencing the SAME snapshot (no per-fork copies)
         self.assertEqual(len(snapshot), len(self.prefix))
         for f_a, f_b in zip(forks_a, forks_b):
-            self.assertIs(f_a._prefix_keys, f_b._prefix_keys)  # truly shared
+            self.assertIs(f_a._snapshot, f_b._snapshot)
+            self.assertIs(f_a._snapshot, snapshot)
 
 
 if __name__ == "__main__":

--- a/tests/test_snapshot_store.py
+++ b/tests/test_snapshot_store.py
@@ -1,8 +1,13 @@
 # Copyright © 2026 Apple Inc.
 
+import copy
 import json
 import os
+import socket
+import subprocess
+import sys
 import tempfile
+import time
 import unittest
 from argparse import Namespace
 from pathlib import Path
@@ -10,10 +15,25 @@ from unittest.mock import patch
 
 import mlx.core as mx
 
-from mlx_lm.models.cache import KVCache
+from mlx_lm.generate import generate_step
+from mlx_lm.models.cache import KVCache, LRUPromptCache, make_prompt_cache
 from mlx_lm.prefix_forks import FrozenPrefixSnapshot, PrefixForkRegistry, compute_cid
-from mlx_lm.server import PersistentPromptCache, ResponseGenerator
-from mlx_lm.snapshot_store import SnapshotStore, _array_digest, _read_header
+from mlx_lm.server import (
+    PersistentPromptCache,
+    ResponseGenerator,
+    _persistent_model_key,
+    _run_http_server,
+    run,
+)
+from mlx_lm.snapshot_store import (
+    SnapshotCorruptError,
+    SnapshotStore,
+    _array_digest,
+    _read_header,
+)
+from mlx_lm.utils import load
+
+HF_MODEL_PATH = "mlx-community/Qwen1.5-0.5B-Chat-4bit"
 
 
 def _cache(length, seed=1, layers=2):
@@ -110,7 +130,7 @@ class TestSnapshotStore(unittest.TestCase):
         store.save(first)
         second_registry = PrefixForkRegistry()
         mismatch = _freeze(second_registry, "m@r", list(range(8)), seed=2)
-        with self.assertRaises(ValueError):
+        with self.assertRaises(SnapshotCorruptError):
             store.save(mismatch)
 
     def test_rebuild_is_header_only_until_fetch(self):
@@ -151,6 +171,7 @@ class TestSnapshotStore(unittest.TestCase):
         original = self.path / f"{snapshot.cid}.safetensors"
         wrong = self.path / ("f" * 64 + ".safetensors")
         os.replace(original, wrong)
+        store.close()
         SnapshotStore(self.path)
         self.assertTrue(any(p.suffix == ".quarantined" for p in self.path.iterdir()))
 
@@ -181,6 +202,7 @@ class TestSnapshotStore(unittest.TestCase):
             byte = handle.read(1)
             handle.seek(offset)
             handle.write(bytes([byte[0] ^ 1]))
+        store.close()
         restarted = PrefixForkRegistry()
         corrupt = SnapshotStore(self.path, registry=restarted)
         forks, rest = restarted.fetch_fork("m@r", list(range(16)))
@@ -201,6 +223,36 @@ class TestSnapshotStore(unittest.TestCase):
             handle.write(bytes([byte[0] ^ 1]))
         self.assertFalse(clean_store.scrub_one())
         self.assertFalse(clean_path.exists())
+
+    def test_quarantine_rename_failure_blocks_proxy_without_losing_record(self):
+        registry = PrefixForkRegistry()
+        snapshot = _freeze(registry, "m@r", list(range(8)))
+        store = SnapshotStore(self.path)
+        store.save(snapshot)
+        path = self.path / f"{snapshot.cid}.safetensors"
+        header, data_start = _read_header(path)
+        offset = data_start + header["k.0"]["data_offsets"][0]
+        with path.open("r+b") as handle:
+            handle.seek(offset)
+            byte = handle.read(1)
+            handle.seek(offset)
+            handle.write(bytes([byte[0] ^ 1]))
+        store.close()
+        restarted = PrefixForkRegistry()
+        reopened = SnapshotStore(self.path, registry=restarted)
+        original = os.replace
+
+        def refuse(source, target):
+            if Path(source) == path:
+                raise PermissionError("injected")
+            return original(source, target)
+
+        with patch("mlx_lm.snapshot_store.os.replace", side_effect=refuse):
+            forks, _ = restarted.fetch_fork("m@r", list(range(8)))
+        self.assertIsNone(forks)
+        self.assertTrue(path.exists())
+        self.assertIn(snapshot.cid, reopened._records)
+        self.assertIsNone(restarted.get(snapshot.cid))
 
     def test_gc_is_lru_leaves_first_and_resave_works(self):
         registry = PrefixForkRegistry()
@@ -225,6 +277,7 @@ class TestSnapshotStore(unittest.TestCase):
         store.save(root)
         store.save(child)
         (self.path / f"{root.cid}.safetensors").unlink()
+        store.close()
         restarted = PrefixForkRegistry()
         SnapshotStore(self.path, registry=restarted)
         forks, _ = restarted.fetch_fork("m@r", list(range(16)))
@@ -245,6 +298,7 @@ class TestSnapshotStore(unittest.TestCase):
         arrays, metadata = mx.load(str(path), return_metadata=True)
         metadata["parent_cid"] = other.cid
         mx.save_safetensors(str(path), arrays, metadata)
+        store.close()
         SnapshotStore(self.path)
         self.assertFalse(path.exists())
 
@@ -260,12 +314,31 @@ class TestSnapshotStore(unittest.TestCase):
         arrays["k.0"] = mx.zeros((1, 3, 8, 4))
         metadata["sha256_k_0"] = _array_digest(arrays["k.0"])
         mx.save_safetensors(str(path), arrays, metadata)
+        store.close()
         restarted = PrefixForkRegistry()
         rebuilt = SnapshotStore(self.path, registry=restarted)
         forks, rest = restarted.fetch_fork("m@r", list(range(16)))
-        self.assertIsNone(forks)
-        self.assertEqual(rest, list(range(16)))
+        # Corrupt child is gone; the valid root remains a safe shorter hit.
+        self.assertIsNotNone(forks)
+        self.assertEqual(forks[0].prefix_length, 8)
+        self.assertEqual(rest, list(range(8, 16)))
         self.assertGreaterEqual(rebuilt.stats["quarantines"], 1)
+
+    def test_forged_logical_nbytes_quarantined(self):
+        registry = PrefixForkRegistry()
+        snapshot = _freeze(registry, "m@r", list(range(8)))
+        store = SnapshotStore(self.path)
+        store.save(snapshot)
+        path = self.path / f"{snapshot.cid}.safetensors"
+        arrays, metadata = mx.load(str(path), return_metadata=True)
+        metadata["logical_nbytes"] = str(1 << 40)
+        mx.save_safetensors(str(path), arrays, metadata)
+        store.close()
+        restarted = PrefixForkRegistry()
+        reopened = SnapshotStore(self.path, registry=restarted)
+        self.assertEqual(len(restarted), 0)
+        self.assertFalse(path.exists())
+        reopened.close()
 
     def test_permissions_and_ghost_telemetry(self):
         registry = PrefixForkRegistry()
@@ -278,8 +351,111 @@ class TestSnapshotStore(unittest.TestCase):
             0o600,
         )
         store.note_ram_eviction(snapshot.cid)
-        store.note_request_cid(snapshot.cid)
+        store.note_request("m@r", list(range(8)) + [9])
         self.assertEqual(store.stats["ghost_hits"], 1)
+
+    def test_single_owner_close_and_reopen(self):
+        store = SnapshotStore(self.path)
+        with self.assertRaises(RuntimeError):
+            SnapshotStore(self.path)
+        child = subprocess.run(
+            [
+                sys.executable,
+                "-c",
+                "from mlx_lm.snapshot_store import SnapshotStore; "
+                f"SnapshotStore({str(self.path)!r})",
+            ],
+            env={**os.environ, "PYTHONPATH": "."},
+            capture_output=True,
+            text=True,
+        )
+        self.assertNotEqual(child.returncode, 0)
+        self.assertIn("live writer", child.stderr)
+        if hasattr(os, "fork"):
+            pid = os.fork()
+            if pid == 0:
+                try:
+                    SnapshotStore(self.path)
+                except RuntimeError:
+                    os._exit(0)
+                os._exit(1)
+            _, status = os.waitpid(pid, 0)
+            self.assertEqual(os.waitstatus_to_exitcode(status), 0)
+        store.close()
+        reopened = SnapshotStore(self.path)
+        reopened.close()
+
+    def test_disk_proxy_freeze_materializes_cleanly(self):
+        registry = PrefixForkRegistry()
+        tokens = list(range(8))
+        snapshot = _freeze(registry, "m@r", tokens)
+        store = SnapshotStore(self.path)
+        store.save(snapshot)
+        store.close()
+        restarted = PrefixForkRegistry()
+        reopened = SnapshotStore(self.path, registry=restarted)
+        self.assertEqual(restarted.freeze("m@r", tokens, _cache(8)), snapshot.cid)
+        reopened.close()
+
+    def test_gc_unlink_failure_retains_bookkeeping(self):
+        registry = PrefixForkRegistry()
+        snapshot = _freeze(registry, "m@r", list(range(8)))
+        store = SnapshotStore(self.path)
+        store.save(snapshot)
+        path = self.path / f"{snapshot.cid}.safetensors"
+        store.max_bytes = path.stat().st_size - 1
+        original = Path.unlink
+
+        def refuse(target, *args, **kwargs):
+            if target == path:
+                raise PermissionError("injected")
+            return original(target, *args, **kwargs)
+
+        with patch.object(Path, "unlink", refuse), self.assertRaises(RuntimeError):
+            store.gc()
+        self.assertTrue(path.exists())
+        self.assertIn(snapshot.cid, store._records)
+
+    def test_orphan_safetensors_is_gc_candidate(self):
+        store = SnapshotStore(self.path)
+        orphan = self.path / ("f" * 64 + ".safetensors")
+        orphan.write_bytes(b"x" * 4096)
+        store.max_bytes = 1
+        store.gc()
+        self.assertFalse(orphan.exists())
+
+    def test_hit_lru_persists_on_flush_index(self):
+        registry = PrefixForkRegistry()
+        a = _freeze(registry, "m@r", list(range(8)), seed=1)
+        b = _freeze(registry, "m@r", list(range(100, 108)), seed=2)
+        store = SnapshotStore(self.path)
+        store.save(a)
+        store.save(b)
+        store.restore(a.cid)
+        runtime = list(store._records)
+        store.flush_index()
+        store.close()
+        rebooted = SnapshotStore(self.path)
+        self.assertEqual(list(rebooted._records), runtime)
+
+    def test_mmap_survives_unlink_before_touch(self):
+        path = self.path / "mmap.safetensors"
+        mx.save_safetensors(str(path), {"x": mx.arange(4096)}, {})
+        arrays = mx.load(str(path))
+        path.unlink()
+        self.assertEqual(int(mx.sum(arrays["x"]).item()), sum(range(4096)))
+
+    def test_flush_and_scrub_respect_byte_budgets(self):
+        registry = PrefixForkRegistry()
+        store = SnapshotStore(self.path, registry=registry)
+        snapshot = _freeze(registry, "m@r", list(range(64)))
+        self.assertEqual(
+            store.flush_registry(registry, max_snapshots=1, max_bytes=1), 0
+        )
+        self.assertFalse(list(self.path.glob("*.safetensors")))
+        store.save(snapshot)
+        self.assertFalse(store.scrub_increment(max_bytes=17))
+        self.assertIsNotNone(store._scrub_state)
 
     def test_cid_filename_contract(self):
         self.assertEqual(
@@ -306,7 +482,8 @@ class TestPersistentServerBridge(unittest.TestCase):
             4, self.store_dir, max_bytes=1 << 20, max_files=32
         )
         first.insert_cache(model, tokens, _prefix_cache(8))
-        self.assertEqual(first.flush_persistent(scrub=False), 1)
+        self.assertEqual(first.flush_persistent(scrub=False, shutdown=True), 1)
+        first.close()
 
         restarted = PersistentPromptCache(
             4, self.store_dir, max_bytes=1 << 20, max_files=32
@@ -322,6 +499,21 @@ class TestPersistentServerBridge(unittest.TestCase):
                 for snapshot in restarted._registry.snapshots()
             )
         )
+        restarted.close()
+
+    def test_local_identity_hashes_content_not_size_or_mtime(self):
+        weights = self.model_dir / "weights.safetensors"
+        weights.write_bytes(b"A" * 4096)
+        stamp = weights.stat().st_mtime_ns
+        first = _persistent_model_key((str(self.model_dir), None, None))
+        weights.write_bytes(b"B" * 4096)
+        os.utime(weights, ns=(stamp, stamp))
+        second = _persistent_model_key((str(self.model_dir), None, None))
+        self.assertNotEqual(first, second)
+
+    def test_unresolved_hf_identity_fails_closed(self):
+        with self.assertRaises(ValueError):
+            _persistent_model_key(("org/not-loader-resolved", None, None))
 
     def test_opt_in_disables_incompatible_batch_path_only(self):
         provider = type(
@@ -339,6 +531,19 @@ class TestPersistentServerBridge(unittest.TestCase):
         provider.cli_args.prompt_cache_persist_dir = None
         self.assertTrue(generator._is_batchable(args))
 
+    def test_off_switch_constructs_plain_cache_and_no_files(self):
+        provider = type(
+            "Provider",
+            (),
+            {"cli_args": Namespace(prompt_cache_size=3)},
+        )()
+        with patch("mlx_lm.server.ResponseGenerator") as response, patch(
+            "mlx_lm.server._run_http_server"
+        ):
+            run("127.0.0.1", 0, provider)
+        self.assertIsInstance(response.call_args.args[1], LRUPromptCache)
+        self.assertFalse(self.store_dir.exists())
+
     def test_unsupported_cache_falls_back_without_disk_file(self):
         class Unsupported:
             offset = 4
@@ -354,6 +559,7 @@ class TestPersistentServerBridge(unittest.TestCase):
         cache.insert_cache((str(self.model_dir), None, None), list(range(4)), [item])
         self.assertEqual(len(cache._fallback), 1)
         self.assertFalse(list(self.store_dir.glob("*.safetensors")))
+        cache.close()
 
     def test_ram_cap_demotes_and_disk_hit_repromotes_safely(self):
         model = (str(self.model_dir), None, None)
@@ -373,6 +579,95 @@ class TestPersistentServerBridge(unittest.TestCase):
         self.assertEqual(rest, [9])
         self.assertGreaterEqual(cache.persistent_stats["promotions"], 1)
         self.assertGreaterEqual(cache.persistent_stats["demotions"], 2)
+        cache.close()
+
+    def test_maintenance_failure_is_contained(self):
+        cache = PersistentPromptCache(
+            4, self.store_dir, max_bytes=1 << 20, max_files=32
+        )
+        with patch.object(
+            cache, "_maintenance_tick", side_effect=RuntimeError("disk full")
+        ):
+            cache.flush_persistent()
+            while not cache._maintenance_future.done():
+                time.sleep(0.001)
+            self.assertEqual(cache.flush_persistent(), 0)
+        cache.close()
+
+    def test_idle_maintenance_never_blocks_request_thread(self):
+        cache = PersistentPromptCache(
+            4, self.store_dir, max_bytes=1 << 20, max_files=32
+        )
+        with patch.object(
+            cache, "_maintenance_tick", side_effect=lambda _: time.sleep(0.2)
+        ):
+            start = time.monotonic()
+            cache.flush_persistent()
+            self.assertLess(time.monotonic() - start, 0.05)
+        cache.close()
+
+    def test_non_keyboard_server_exit_always_stops_generator(self):
+        class Generator:
+            stopped = False
+
+            def stop_and_join(self):
+                self.stopped = True
+
+        class BoomServer:
+            address_family = socket.AF_INET
+
+            def __init__(self, *args, **kwargs):
+                pass
+
+            def serve_forever(self):
+                raise RuntimeError("injected")
+
+            def shutdown(self):
+                pass
+
+        generator = Generator()
+        with patch(
+            "mlx_lm.server.socket.getaddrinfo",
+            return_value=[(socket.AF_INET, None, None, None, ("127.0.0.1", 0))],
+        ), self.assertRaises(RuntimeError):
+            _run_http_server("127.0.0.1", 0, generator, server_class=BoomServer)
+        self.assertTrue(generator.stopped)
+
+
+class TestPersistentRoundTripWithModel(unittest.TestCase):
+    def test_restart_continuation_matches_never_persisted(self):
+        model, tokenizer = load(HF_MODEL_PATH)
+        tokens = tokenizer.encode("The careful archivist checked every page. " * 12)
+        prefix, suffix = tokens[:-3], tokens[-3:]
+        cache = make_prompt_cache(model)
+        model(mx.array(prefix)[None], cache=cache)
+        mx.eval(*(array for layer in cache for array in layer.state))
+        baseline = copy.deepcopy(cache)
+        registry = PrefixForkRegistry()
+        cid = registry.freeze(HF_MODEL_PATH + "@resolved-test", prefix, cache)
+        with tempfile.TemporaryDirectory() as directory:
+            store = SnapshotStore(directory)
+            store.save(registry.get(cid))
+            store.close()
+            restarted = PrefixForkRegistry()
+            reopened = SnapshotStore(directory, registry=restarted)
+            forks, remaining = restarted.fetch_fork(
+                HF_MODEL_PATH + "@resolved-test", tokens
+            )
+            expected = [
+                int(token)
+                for token, _ in generate_step(
+                    mx.array(suffix), model, prompt_cache=baseline, max_tokens=8
+                )
+            ]
+            actual = [
+                int(token)
+                for token, _ in generate_step(
+                    mx.array(remaining), model, prompt_cache=forks, max_tokens=8
+                )
+            ]
+            self.assertEqual(actual, expected)
+            reopened.close()
 
 
 if __name__ == "__main__":

--- a/tests/test_snapshot_store.py
+++ b/tests/test_snapshot_store.py
@@ -511,6 +511,27 @@ class TestPersistentServerBridge(unittest.TestCase):
         second = _persistent_model_key((str(self.model_dir), None, None))
         self.assertNotEqual(first, second)
 
+    def test_hf_snapshot_identity_opens_no_payload_and_tracks_revision(self):
+        repo = Path(self.temp.name) / "models--org--model" / "snapshots"
+        revision_a = "a" * 40
+        revision_b = "b" * 40
+        snapshot_a = repo / revision_a
+        snapshot_b = repo / revision_b
+        snapshot_a.mkdir(parents=True)
+        snapshot_b.mkdir()
+        (snapshot_a / "weights.safetensors").write_bytes(b"A" * 4096)
+        (snapshot_b / "weights.safetensors").write_bytes(b"A" * 4096)
+        with patch.object(
+            Path,
+            "open",
+            side_effect=AssertionError("HF payload must not be opened for identity"),
+        ):
+            identity_a = _persistent_model_key((str(snapshot_a), None, None))
+            identity_b = _persistent_model_key((str(snapshot_b), None, None))
+        self.assertNotEqual(identity_a, identity_b)
+        self.assertIn(revision_a, identity_a)
+        self.assertIn(revision_b, identity_b)
+
     def test_unresolved_hf_identity_fails_closed(self):
         with self.assertRaises(ValueError):
             _persistent_model_key(("org/not-loader-resolved", None, None))

--- a/tests/test_snapshot_store.py
+++ b/tests/test_snapshot_store.py
@@ -672,6 +672,113 @@ class TestSnapshotStore(unittest.TestCase):
         self.assertIn(existing.cid, store._records)
         self.assertFalse((file_cap_path / f"{incoming.cid}.safetensors").exists())
 
+    def test_infeasible_child_reservation_preserves_all_existing_state(self):
+        source = PrefixForkRegistry()
+        root = source.get(source.freeze("m@r", list(range(8)), _prefix_cache(8)))
+        child = source.get(source.freeze("m@r", list(range(16)), _prefix_cache(16)))
+        unrelated = source.get(
+            source.freeze("other@r", list(range(100, 108)), _prefix_cache(8))
+        )
+        first = SnapshotStore(self.path)
+        first.save(root)
+        first.save(unrelated)
+        first.close()
+
+        registry = PrefixForkRegistry()
+        store = SnapshotStore(self.path, registry=registry)
+        captured = {}
+
+        class ReservationProbe(RuntimeError):
+            pass
+
+        def capture_reservation(reservation, protected_cids=None):
+            captured["reservation"] = reservation
+            captured["protected"] = set(protected_cids or ())
+            raise ReservationProbe
+
+        with patch.object(
+            store, "_reserve_space", side_effect=capture_reservation
+        ), self.assertRaises(ReservationProbe):
+            store.save(child)
+        self.assertEqual(captured["protected"], {root.cid})
+        store.max_bytes = captured["reservation"]
+
+        low_free_files = {
+            path.name: path.read_bytes()
+            for path in self.path.iterdir()
+            if path.is_file()
+        }
+        low_free_records = copy.deepcopy(tuple(store._records.items()))
+        low_free_ghosts = tuple(store._disk_ghosts)
+        low_free_stats = store.stats
+        low_free_index_dirty = store._index_dirty
+        with patch(
+            "mlx_lm.snapshot_store.shutil.disk_usage",
+            return_value=Namespace(total=100, used=100, free=0),
+        ), self.assertRaisesRegex(RuntimeError, "insufficient free disk space"):
+            store._reserve_space(captured["reservation"], {root.cid})
+        self.assertEqual(
+            {
+                path.name: path.read_bytes()
+                for path in self.path.iterdir()
+                if path.is_file()
+            },
+            low_free_files,
+        )
+        self.assertEqual(tuple(store._records.items()), low_free_records)
+        self.assertEqual(tuple(store._disk_ghosts), low_free_ghosts)
+        self.assertEqual(store.stats, low_free_stats)
+        self.assertEqual(store._index_dirty, low_free_index_dirty)
+
+        files_before = {
+            path.name: path.read_bytes()
+            for path in self.path.iterdir()
+            if path.is_file()
+        }
+        records_before = copy.deepcopy(tuple(store._records.items()))
+        proxies_before = {cid: registry.get(cid) for cid in (root.cid, unrelated.cid)}
+        index_before = (self.path / "index.json").read_bytes()
+        ghosts_before = tuple(store._disk_ghosts)
+        stats_before = store.stats
+        index_dirty_before = store._index_dirty
+
+        original_reserve = store._reserve_space
+
+        def reserve_at_exact_cap(reservation, protected_cids=None):
+            store.max_bytes = reservation
+            return original_reserve(reservation, protected_cids)
+
+        with patch.object(
+            store, "_reserve_space", side_effect=reserve_at_exact_cap
+        ), self.assertRaisesRegex(RuntimeError, "no evictable leaf"):
+            store.save(child)
+
+        self.assertEqual(
+            {
+                path.name: path.read_bytes()
+                for path in self.path.iterdir()
+                if path.is_file()
+            },
+            files_before,
+        )
+        self.assertEqual(tuple(store._records.items()), records_before)
+        for cid, proxy in proxies_before.items():
+            self.assertIs(registry.get(cid), proxy)
+        self.assertEqual((self.path / "index.json").read_bytes(), index_before)
+        self.assertEqual(tuple(store._disk_ghosts), ghosts_before)
+        self.assertEqual(store.stats, stats_before)
+        self.assertEqual(store._index_dirty, index_dirty_before)
+        self.assertNotIn(child.cid, store._records)
+        self.assertFalse((self.path / f"{child.cid}.safetensors").exists())
+        self.assertFalse(
+            [
+                path
+                for path in self.path.iterdir()
+                if ".digest-" in path.name or ".tmp-" in path.name
+            ]
+        )
+        store.close()
+
     def test_reservation_protects_incoming_parent_chain(self):
         registry = PrefixForkRegistry()
         root = registry.get(registry.freeze("m@r", list(range(8)), _prefix_cache(8)))

--- a/tests/test_snapshot_store.py
+++ b/tests/test_snapshot_store.py
@@ -1,6 +1,7 @@
 # Copyright © 2026 Apple Inc.
 
 import copy
+import hashlib
 import json
 import os
 import socket
@@ -71,6 +72,49 @@ def _save_with_payload_digests(path, arrays, metadata):
         metadata[f"sha256_k_{layer}"] = key_digest
         metadata[f"sha256_v_{layer}"] = value_digest
     mx.save_safetensors(str(path), arrays, metadata)
+
+
+def _rewrite_header(path, mutate):
+    raw = path.read_bytes()
+    header_size = int.from_bytes(raw[:8], "little")
+    header = json.loads(raw[8 : 8 + header_size])
+    payload = raw[8 + header_size :]
+    mutate(header)
+    encoded = json.dumps(header, separators=(",", ":")).encode()
+    padding = (-len(encoded)) % 8
+    encoded += b" " * padding
+    path.write_bytes(len(encoded).to_bytes(8, "little") + encoded + payload)
+
+
+def _save_legacy_v1(path, snapshot):
+    tensors = {}
+    metadata = {
+        "format_version": "1",
+        "features": json.dumps(["delta-chain", "payload-sha256"]),
+        "model_key": snapshot.model_key,
+        "token_ids": json.dumps(list(snapshot.tokens), separators=(",", ":")),
+        "created_at": "1.0",
+        "parent_cid": "",
+        "parent_length": "0",
+        "chain_depth": "0",
+        "logical_nbytes": str(snapshot.nbytes),
+        "layers": str(len(snapshot.keys)),
+    }
+    for layer, (key, value) in enumerate(zip(snapshot.keys, snapshot.values)):
+        tensors[f"k.{layer}"] = key
+        tensors[f"v.{layer}"] = value
+        metadata[f"sha256_k_{layer}"] = "0" * 64
+        metadata[f"sha256_v_{layer}"] = "0" * 64
+    mx.save_safetensors(str(path), tensors, metadata)
+    header, data_start = _read_header(path)
+    raw = path.read_bytes()
+    for layer in range(len(snapshot.keys)):
+        for side in "kv":
+            start, end = header[f"{side}.{layer}"]["data_offsets"]
+            metadata[f"sha256_{side}_{layer}"] = hashlib.sha256(
+                raw[data_start + start : data_start + end]
+            ).hexdigest()
+    mx.save_safetensors(str(path), tensors, metadata)
 
 
 def _freeze(registry, model_key, tokens, seed=1):
@@ -175,6 +219,149 @@ class TestSnapshotStore(unittest.TestCase):
         self.assertFalse(path.exists())
         self.assertEqual(len(restarted), 0)
 
+    def test_two_pass_failure_windows_leave_no_visible_or_transient_snapshot(self):
+        registry = PrefixForkRegistry()
+        snapshot = _freeze(registry, "m@r", list(range(8)))
+        original_save = mx.save_safetensors
+        original_digests = _payload_digests
+        original_replace = os.replace
+
+        def exercise(label, save_effect=None, digest_effect=None, replace_effect=None):
+            directory = self.path / label
+            store = SnapshotStore(directory)
+            save_calls = 0
+            digest_calls = 0
+
+            def save_wrapper(*args, **kwargs):
+                nonlocal save_calls
+                save_calls += 1
+                if save_effect is not None:
+                    save_effect(save_calls)
+                return original_save(*args, **kwargs)
+
+            def digest_wrapper(*args, **kwargs):
+                nonlocal digest_calls
+                digest_calls += 1
+                result = original_digests(*args, **kwargs)
+                return digest_effect(digest_calls, result) if digest_effect else result
+
+            def replace_wrapper(source, target):
+                if replace_effect is not None:
+                    replace_effect(Path(source), Path(target))
+                return original_replace(source, target)
+
+            with patch(
+                "mlx_lm.snapshot_store.mx.save_safetensors", side_effect=save_wrapper
+            ), patch(
+                "mlx_lm.snapshot_store._payload_digests",
+                side_effect=digest_wrapper,
+            ), patch(
+                "mlx_lm.snapshot_store.os.replace", side_effect=replace_wrapper
+            ), self.assertRaises(
+                (OSError, RuntimeError, SnapshotCorruptError)
+            ):
+                store.save(snapshot)
+            self.assertFalse((directory / f"{snapshot.cid}.safetensors").exists())
+            self.assertNotIn(snapshot.cid, store._records)
+            self.assertFalse(
+                [
+                    path
+                    for path in directory.iterdir()
+                    if ".digest-" in path.name or ".tmp-" in path.name
+                ]
+            )
+            store.close()
+
+        exercise(
+            "stage-save",
+            save_effect=lambda call: (
+                (_ for _ in ()).throw(RuntimeError("stage")) if call == 1 else None
+            ),
+        )
+        exercise(
+            "stage-digest",
+            digest_effect=lambda call, result: (
+                (_ for _ in ()).throw(SnapshotCorruptError("stage digest"))
+                if call == 1
+                else result
+            ),
+        )
+        exercise(
+            "final-save",
+            save_effect=lambda call: (
+                (_ for _ in ()).throw(RuntimeError("final")) if call == 2 else None
+            ),
+        )
+
+        def mismatch(call, result):
+            if call != 2:
+                return result
+            altered = [list(pair) for pair in result]
+            altered[0][0] = "f" * 64
+            return tuple(tuple(pair) for pair in altered)
+
+        exercise("final-digest", digest_effect=mismatch)
+        exercise(
+            "final-digest-error",
+            digest_effect=lambda call, result: (
+                (_ for _ in ()).throw(SnapshotCorruptError("final digest"))
+                if call == 2
+                else result
+            ),
+        )
+        exercise(
+            "replace",
+            replace_effect=lambda source, target: (
+                (_ for _ in ()).throw(OSError("replace"))
+                if ".tmp-" in source.name
+                else None
+            ),
+        )
+
+    def test_transient_unlink_retry_cleans_stage(self):
+        registry = PrefixForkRegistry()
+        snapshot = _freeze(registry, "m@r", list(range(8)))
+        store = SnapshotStore(self.path)
+        original = Path.unlink
+        failures = 0
+
+        def flaky(path, *args, **kwargs):
+            nonlocal failures
+            if ".digest-" in path.name and failures == 0:
+                failures += 1
+                raise PermissionError("retry me")
+            return original(path, *args, **kwargs)
+
+        with patch.object(Path, "unlink", flaky):
+            store.save(snapshot)
+        self.assertEqual(failures, 1)
+        self.assertFalse([p for p in self.path.iterdir() if ".digest-" in p.name])
+
+    def test_persistent_transient_unlink_failure_is_cleaned_on_restart(self):
+        registry = PrefixForkRegistry()
+        snapshot = _freeze(registry, "m@r", list(range(8)))
+        store = SnapshotStore(self.path)
+        original = Path.unlink
+
+        def refuse_stage(path, *args, **kwargs):
+            if ".digest-" in path.name:
+                raise PermissionError("persistent injected failure")
+            return original(path, *args, **kwargs)
+
+        with patch.object(Path, "unlink", refuse_stage), self.assertRaises(
+            RuntimeError
+        ):
+            store.save(snapshot)
+        self.assertFalse((self.path / f"{snapshot.cid}.safetensors").exists())
+        self.assertNotIn(snapshot.cid, store._records)
+        self.assertEqual(len(list(self.path.glob("*.digest-*.safetensors"))), 1)
+        store.close()
+
+        restarted = SnapshotStore(self.path)
+        self.assertFalse(list(self.path.glob("*.digest-*.safetensors")))
+        self.assertEqual(restarted.stats["temps_cleaned"], 1)
+        restarted.close()
+
     def test_filename_mismatch_and_unknown_feature_quarantine(self):
         registry = PrefixForkRegistry()
         snapshot = _freeze(registry, "m@r", list(range(8)))
@@ -192,7 +379,7 @@ class TestSnapshotStore(unittest.TestCase):
             str(other),
             {"k.0": mx.zeros((1, 1, 8, 1)), "v.0": mx.zeros((1, 1, 8, 1))},
             {
-                "format_version": "1",
+                "format_version": "2",
                 "features": json.dumps(["future-feature"]),
                 "model_key": "m@r",
                 "token_ids": json.dumps(list(range(8))),
@@ -200,6 +387,110 @@ class TestSnapshotStore(unittest.TestCase):
         )
         SnapshotStore(self.path)
         self.assertFalse(other.exists())
+
+    def test_legacy_v1_old_writer_is_deliberate_safe_miss(self):
+        registry = PrefixForkRegistry()
+        tokens = list(range(8))
+        snapshot = _freeze(registry, "legacy@r", tokens)
+        path = self.path / f"{snapshot.cid}.safetensors"
+        _save_legacy_v1(path, snapshot)
+        restarted = PrefixForkRegistry()
+        store = SnapshotStore(self.path, registry=restarted)
+        forks, remaining = restarted.fetch_fork("legacy@r", tokens)
+        self.assertIsNone(forks)
+        self.assertEqual(remaining, tokens)
+        self.assertFalse(path.exists())
+        self.assertGreaterEqual(store.stats["quarantines"], 1)
+
+    def test_malformed_descriptors_quarantine_at_startup_and_restore(self):
+        registry = PrefixForkRegistry()
+        snapshot = _freeze(registry, "m@r", list(range(8)))
+        store = SnapshotStore(self.path)
+        store.save(snapshot)
+        path = self.path / f"{snapshot.cid}.safetensors"
+        store.close()
+        _rewrite_header(path, lambda header: header["k.0"].pop("dtype"))
+        restarted = PrefixForkRegistry()
+        reopened = SnapshotStore(self.path, registry=restarted)
+        self.assertEqual(len(restarted), 0)
+        self.assertFalse(path.exists())
+        reopened.close()
+
+        registry = PrefixForkRegistry()
+        snapshot = _freeze(registry, "bad-dtype@r", list(range(8)))
+        store = SnapshotStore(self.path)
+        store.save(snapshot)
+        path = self.path / f"{snapshot.cid}.safetensors"
+        store.close()
+        _rewrite_header(path, lambda header: header["k.0"].update(dtype=7))
+        restarted = PrefixForkRegistry()
+        reopened = SnapshotStore(self.path, registry=restarted)
+        self.assertEqual(len(restarted), 0)
+        self.assertFalse(path.exists())
+        reopened.close()
+
+        registry = PrefixForkRegistry()
+        snapshot = _freeze(registry, "m2@r", list(range(8)))
+        store = SnapshotStore(self.path)
+        store.save(snapshot)
+        path = self.path / f"{snapshot.cid}.safetensors"
+        store.close()
+        restarted = PrefixForkRegistry()
+        reopened = SnapshotStore(self.path, registry=restarted)
+        _rewrite_header(path, lambda header: header["v.0"].update(shape=[1, 2, 9, 4]))
+        forks, remaining = restarted.fetch_fork("m2@r", list(range(8)))
+        self.assertIsNone(forks)
+        self.assertEqual(remaining, list(range(8)))
+        self.assertFalse(path.exists())
+        reopened.close()
+
+        registry = PrefixForkRegistry()
+        snapshot = _freeze(registry, "bad-layers@r", list(range(8)))
+        store = SnapshotStore(self.path)
+        store.save(snapshot)
+        path = self.path / f"{snapshot.cid}.safetensors"
+        store.close()
+        _rewrite_header(
+            path,
+            lambda header: header["__metadata__"].update(layers="1000000000"),
+        )
+        restarted = PrefixForkRegistry()
+        reopened = SnapshotStore(self.path, registry=restarted)
+        self.assertEqual(len(restarted), 0)
+        self.assertFalse(path.exists())
+        reopened.close()
+
+        registry = PrefixForkRegistry()
+        snapshot = _freeze(registry, "bad-shape@r", list(range(8)))
+        store = SnapshotStore(self.path)
+        store.save(snapshot)
+        path = self.path / f"{snapshot.cid}.safetensors"
+        store.close()
+        restarted = PrefixForkRegistry()
+        reopened = SnapshotStore(self.path, registry=restarted)
+        _rewrite_header(path, lambda header: header["v.0"].update(shape="oops"))
+        forks, remaining = restarted.fetch_fork("bad-shape@r", list(range(8)))
+        self.assertIsNone(forks)
+        self.assertEqual(remaining, list(range(8)))
+        self.assertFalse(path.exists())
+        reopened.close()
+
+    def test_over_limit_json_integer_is_normalized_to_corruption(self):
+        path = self.path / "malicious.safetensors"
+        encoded = (
+            b'{"x":{"dtype":"F32","shape":[' + b"9" * 5000 + b'],"data_offsets":[0,0]}}'
+        )
+        path.write_bytes(len(encoded).to_bytes(8, "little") + encoded)
+
+        with self.assertRaises(SnapshotCorruptError):
+            _read_header(path)
+
+        nested = self.path / "deeply-nested.safetensors"
+        depth = 2000
+        encoded = b"[" * depth + b"0" + b"]" * depth
+        nested.write_bytes(len(encoded).to_bytes(8, "little") + encoded)
+        with self.assertRaises(SnapshotCorruptError):
+            _read_header(nested)
 
     def test_digest_guard_on_fetch_and_scrub(self):
         registry = PrefixForkRegistry()
@@ -328,7 +619,81 @@ class TestSnapshotStore(unittest.TestCase):
         store.gc()
         self.assertIn(root.cid, store._records)
         self.assertNotIn(child.cid, store._records)
+        store.max_bytes = 32 << 30
         self.assertEqual(store.save(child), child.cid)
+
+    def test_reservation_evicts_deterministic_lru_leaf(self):
+        registry = PrefixForkRegistry()
+        older = _freeze(registry, "older@r", list(range(8)), seed=1)
+        newer = _freeze(registry, "newer@r", list(range(100, 108)), seed=2)
+        incoming = _freeze(registry, "incoming@r", list(range(200, 208)), seed=3)
+        store = SnapshotStore(self.path)
+        store.save(older)
+        store.save(newer)
+        # Make recency disagree with insertion order so this detects a
+        # first-eligible implementation instead of explicit LRU selection.
+        store._records[older.cid].last_use = 2.0
+        store._records[newer.cid].last_use = 1.0
+        store.max_files = 2
+
+        store.save(incoming)
+
+        self.assertIn(older.cid, store._records)
+        self.assertNotIn(newer.cid, store._records)
+        self.assertIn(incoming.cid, store._records)
+
+    def test_impossible_reservation_does_not_evict_existing_snapshot(self):
+        registry = PrefixForkRegistry()
+        existing = _freeze(registry, "existing@r", list(range(8)), seed=1)
+        incoming = _freeze(registry, "incoming@r", list(range(100, 108)), seed=2)
+        store = SnapshotStore(self.path)
+        store.save(existing)
+        existing_path = self.path / f"{existing.cid}.safetensors"
+        store.max_bytes = 1
+
+        with self.assertRaisesRegex(RuntimeError, "exceeds max_bytes"):
+            store.save(incoming)
+
+        self.assertTrue(existing_path.exists())
+        self.assertIn(existing.cid, store._records)
+        self.assertFalse((self.path / f"{incoming.cid}.safetensors").exists())
+
+        store.close()
+        file_cap_path = self.path / "file-cap"
+        store = SnapshotStore(file_cap_path)
+        store.save(existing)
+        existing_path = file_cap_path / f"{existing.cid}.safetensors"
+        store.max_files = 0
+
+        with self.assertRaisesRegex(RuntimeError, "max_files >= 1"):
+            store.save(incoming)
+
+        self.assertTrue(existing_path.exists())
+        self.assertIn(existing.cid, store._records)
+        self.assertFalse((file_cap_path / f"{incoming.cid}.safetensors").exists())
+
+    def test_reservation_protects_incoming_parent_chain(self):
+        registry = PrefixForkRegistry()
+        root = registry.get(registry.freeze("m@r", list(range(8)), _prefix_cache(8)))
+        child = registry.get(registry.freeze("m@r", list(range(16)), _prefix_cache(16)))
+        store = SnapshotStore(self.path)
+        store.save(root)
+        root_path = self.path / f"{root.cid}.safetensors"
+        store.max_files = 1
+
+        with self.assertRaisesRegex(RuntimeError, "no evictable leaf"):
+            store.save(child)
+
+        self.assertTrue(root_path.exists())
+        self.assertIn(root.cid, store._records)
+        self.assertNotIn(child.cid, store._records)
+        self.assertFalse(
+            [
+                path
+                for path in self.path.iterdir()
+                if ".digest-" in path.name or ".tmp-" in path.name
+            ]
+        )
 
     def test_missing_parent_poisons_descendant(self):
         registry = PrefixForkRegistry()

--- a/tests/test_snapshot_store.py
+++ b/tests/test_snapshot_store.py
@@ -522,7 +522,9 @@ class TestPersistentServerBridge(unittest.TestCase):
         snapshot_b.mkdir()
         (snapshot_a / "weights.safetensors").write_bytes(b"A" * 4096)
         (snapshot_b / "weights.safetensors").write_bytes(b"A" * 4096)
-        with patch.object(
+        with patch(
+            "mlx_lm.server.hf_constants.HF_HUB_CACHE", str(Path(self.temp.name))
+        ), patch.object(
             Path,
             "open",
             side_effect=AssertionError("HF payload must not be opened for identity"),
@@ -534,15 +536,25 @@ class TestPersistentServerBridge(unittest.TestCase):
         self.assertIn(revision_b, identity_b)
 
     def test_local_snapshots_lookalike_still_hashes_bytes(self):
-        lookalike = Path(self.temp.name) / "ordinary-local" / "snapshots" / ("c" * 40)
+        lookalike = (
+            Path(self.temp.name)
+            / "ordinary-local"
+            / "models--org--model"
+            / "snapshots"
+            / ("c" * 40)
+        )
         lookalike.mkdir(parents=True)
+        (lookalike.parent.parent / "blobs").mkdir()
         weights = lookalike / "adapter.safetensors"
         weights.write_bytes(b"A" * 4096)
         stamp = weights.stat().st_mtime_ns
-        first = _persistent_model_key((str(lookalike), None, None))
-        weights.write_bytes(b"B" * 4096)
-        os.utime(weights, ns=(stamp, stamp))
-        second = _persistent_model_key((str(lookalike), None, None))
+        trusted_root = Path(self.temp.name) / "configured-hf-cache"
+        trusted_root.mkdir()
+        with patch("mlx_lm.server.hf_constants.HF_HUB_CACHE", str(trusted_root)):
+            first = _persistent_model_key((str(lookalike), None, None))
+            weights.write_bytes(b"B" * 4096)
+            os.utime(weights, ns=(stamp, stamp))
+            second = _persistent_model_key((str(lookalike), None, None))
         self.assertNotEqual(first, second)
 
     def test_unresolved_hf_identity_fails_closed(self):

--- a/tests/test_snapshot_store.py
+++ b/tests/test_snapshot_store.py
@@ -513,6 +513,7 @@ class TestPersistentServerBridge(unittest.TestCase):
 
     def test_hf_snapshot_identity_opens_no_payload_and_tracks_revision(self):
         repo = Path(self.temp.name) / "models--org--model" / "snapshots"
+        (repo.parent / "blobs").mkdir(parents=True)
         revision_a = "a" * 40
         revision_b = "b" * 40
         snapshot_a = repo / revision_a
@@ -531,6 +532,18 @@ class TestPersistentServerBridge(unittest.TestCase):
         self.assertNotEqual(identity_a, identity_b)
         self.assertIn(revision_a, identity_a)
         self.assertIn(revision_b, identity_b)
+
+    def test_local_snapshots_lookalike_still_hashes_bytes(self):
+        lookalike = Path(self.temp.name) / "ordinary-local" / "snapshots" / ("c" * 40)
+        lookalike.mkdir(parents=True)
+        weights = lookalike / "adapter.safetensors"
+        weights.write_bytes(b"A" * 4096)
+        stamp = weights.stat().st_mtime_ns
+        first = _persistent_model_key((str(lookalike), None, None))
+        weights.write_bytes(b"B" * 4096)
+        os.utime(weights, ns=(stamp, stamp))
+        second = _persistent_model_key((str(lookalike), None, None))
+        self.assertNotEqual(first, second)
 
     def test_unresolved_hf_identity_fails_closed(self):
         with self.assertRaises(ValueError):

--- a/tests/test_snapshot_store.py
+++ b/tests/test_snapshot_store.py
@@ -1,0 +1,379 @@
+# Copyright © 2026 Apple Inc.
+
+import json
+import os
+import tempfile
+import unittest
+from argparse import Namespace
+from pathlib import Path
+from unittest.mock import patch
+
+import mlx.core as mx
+
+from mlx_lm.models.cache import KVCache
+from mlx_lm.prefix_forks import FrozenPrefixSnapshot, PrefixForkRegistry, compute_cid
+from mlx_lm.server import PersistentPromptCache, ResponseGenerator
+from mlx_lm.snapshot_store import SnapshotStore, _array_digest, _read_header
+
+
+def _cache(length, seed=1, layers=2):
+    mx.random.seed(seed)
+    out = []
+    for _ in range(layers):
+        cache = KVCache()
+        key = mx.random.normal((1, 2, length, 4))
+        value = mx.random.normal((1, 2, length, 4))
+        cache.update_and_fetch(key, value)
+        out.append(cache)
+    mx.eval(*(array for cache in out for array in cache.state))
+    return out
+
+
+def _prefix_cache(length):
+    cache = KVCache()
+    positions = mx.arange(length, dtype=mx.float32)[None, None, :, None]
+    heads = mx.arange(2, dtype=mx.float32)[None, :, None, None] * 100
+    dims = mx.arange(4, dtype=mx.float32)[None, None, None, :]
+    key = mx.broadcast_to(positions + heads + dims, (1, 2, length, 4))
+    value = key + 1000
+    cache.update_and_fetch(key, value)
+    mx.eval(*cache.state)
+    return [cache]
+
+
+def _freeze(registry, model_key, tokens, seed=1):
+    cid = registry.freeze(model_key, tokens, _cache(len(tokens), seed=seed))
+    return registry.get(cid)
+
+
+class TestSnapshotStore(unittest.TestCase):
+    def setUp(self):
+        self.temp = tempfile.TemporaryDirectory()
+        self.path = Path(self.temp.name)
+
+    def tearDown(self):
+        self.temp.cleanup()
+
+    def test_round_trip_restart_and_model_key_guard(self):
+        registry = PrefixForkRegistry()
+        tokens = list(range(16))
+        snapshot = _freeze(registry, "model@rev-a", tokens)
+        before = snapshot.keys + snapshot.values
+        SnapshotStore(self.path).save(snapshot)
+
+        restarted = PrefixForkRegistry()
+        store = SnapshotStore(self.path, registry=restarted)
+        forks, rest = restarted.fetch_fork("model@rev-a", tokens + [99])
+        self.assertEqual(rest, [99])
+        self.assertEqual(store.stats["disk_hits"], 1)
+        for got, expected in zip(
+            [array for fork in forks for array in fork.state],
+            [item for pair in zip(before[:2], before[2:]) for item in pair],
+        ):
+            self.assertTrue(mx.array_equal(got, expected))
+        miss, rest = restarted.fetch_fork("model@rev-b", tokens)
+        self.assertIsNone(miss)
+        self.assertEqual(rest, tokens)
+
+    def test_chain_round_trip_and_depth_cap_self_roots(self):
+        registry = PrefixForkRegistry()
+        root = registry.get(registry.freeze("m@r", list(range(8)), _prefix_cache(8)))
+        child = registry.get(registry.freeze("m@r", list(range(16)), _prefix_cache(16)))
+        grand = registry.get(registry.freeze("m@r", list(range(24)), _prefix_cache(24)))
+        store = SnapshotStore(self.path, max_chain_depth=1)
+        store.save(root)
+        store.save(child)
+        store.save(grand)
+        self.assertIsNone(store._records[root.cid].parent_cid)
+        self.assertEqual(store._records[child.cid].parent_cid, root.cid)
+        self.assertIsNone(store._records[grand.cid].parent_cid)
+        restored = store.restore(child.cid)
+        self.assertEqual(restored.tokens, child.tokens)
+        for got, expected in zip(
+            restored.keys + restored.values, child.keys + child.values
+        ):
+            self.assertTrue(mx.array_equal(got, expected))
+
+    def test_delta_refuses_mismatched_kv_prefix(self):
+        registry = PrefixForkRegistry()
+        root = _freeze(registry, "m@r", list(range(8)), seed=1)
+        mismatch = _freeze(registry, "m@r", list(range(16)), seed=2)
+        store = SnapshotStore(self.path)
+        store.save(root)
+        store.save(mismatch)
+        self.assertIsNone(store._records[mismatch.cid].parent_cid)
+
+    def test_existing_cid_rejects_mismatched_payload(self):
+        first_registry = PrefixForkRegistry()
+        first = _freeze(first_registry, "m@r", list(range(8)), seed=1)
+        store = SnapshotStore(self.path)
+        store.save(first)
+        second_registry = PrefixForkRegistry()
+        mismatch = _freeze(second_registry, "m@r", list(range(8)), seed=2)
+        with self.assertRaises(ValueError):
+            store.save(mismatch)
+
+    def test_rebuild_is_header_only_until_fetch(self):
+        registry = PrefixForkRegistry()
+        snapshot = _freeze(registry, "m@r", list(range(64)))
+        SnapshotStore(self.path).save(snapshot)
+        restarted = PrefixForkRegistry()
+        with patch("mlx_lm.snapshot_store.mx.load") as load:
+            SnapshotStore(self.path, registry=restarted)
+            load.assert_not_called()
+        self.assertEqual(len(restarted), 1)
+
+    def test_temp_cleaned_and_truncated_quarantined(self):
+        (self.path / ".dead.tmp-crash.safetensors").write_bytes(b"partial")
+        (self.path / ("a" * 64 + ".safetensors")).write_bytes(b"short")
+        store = SnapshotStore(self.path)
+        self.assertFalse(any("tmp-crash" in p.name for p in self.path.iterdir()))
+        self.assertTrue(any(p.suffix == ".quarantined" for p in self.path.iterdir()))
+        self.assertEqual(store.stats["quarantines"], 1)
+
+    def test_header_valid_truncated_payload_quarantined_at_rebuild(self):
+        registry = PrefixForkRegistry()
+        snapshot = _freeze(registry, "m@r", list(range(8)))
+        SnapshotStore(self.path).save(snapshot)
+        path = self.path / f"{snapshot.cid}.safetensors"
+        with path.open("r+b") as handle:
+            handle.truncate(path.stat().st_size - 1)
+        restarted = PrefixForkRegistry()
+        SnapshotStore(self.path, registry=restarted)
+        self.assertFalse(path.exists())
+        self.assertEqual(len(restarted), 0)
+
+    def test_filename_mismatch_and_unknown_feature_quarantine(self):
+        registry = PrefixForkRegistry()
+        snapshot = _freeze(registry, "m@r", list(range(8)))
+        store = SnapshotStore(self.path)
+        store.save(snapshot)
+        original = self.path / f"{snapshot.cid}.safetensors"
+        wrong = self.path / ("f" * 64 + ".safetensors")
+        os.replace(original, wrong)
+        SnapshotStore(self.path)
+        self.assertTrue(any(p.suffix == ".quarantined" for p in self.path.iterdir()))
+
+        other = self.path / f"{snapshot.cid}.safetensors"
+        mx.save_safetensors(
+            str(other),
+            {"k.0": mx.zeros((1, 1, 8, 1)), "v.0": mx.zeros((1, 1, 8, 1))},
+            {
+                "format_version": "1",
+                "features": json.dumps(["future-feature"]),
+                "model_key": "m@r",
+                "token_ids": json.dumps(list(range(8))),
+            },
+        )
+        SnapshotStore(self.path)
+        self.assertFalse(other.exists())
+
+    def test_digest_guard_on_fetch_and_scrub(self):
+        registry = PrefixForkRegistry()
+        snapshot = _freeze(registry, "m@r", list(range(16)))
+        store = SnapshotStore(self.path)
+        store.save(snapshot)
+        path = self.path / f"{snapshot.cid}.safetensors"
+        header, data_start = _read_header(path)
+        offset = data_start + header["k.0"]["data_offsets"][0]
+        with path.open("r+b") as handle:
+            handle.seek(offset)
+            byte = handle.read(1)
+            handle.seek(offset)
+            handle.write(bytes([byte[0] ^ 1]))
+        restarted = PrefixForkRegistry()
+        corrupt = SnapshotStore(self.path, registry=restarted)
+        forks, rest = restarted.fetch_fork("m@r", list(range(16)))
+        self.assertIsNone(forks)
+        self.assertEqual(rest, list(range(16)))
+        self.assertGreaterEqual(corrupt.stats["quarantines"], 1)
+
+        clean_dir = self.path / "clean"
+        clean_store = SnapshotStore(clean_dir)
+        clean_store.save(snapshot)
+        clean_path = clean_dir / f"{snapshot.cid}.safetensors"
+        header, data_start = _read_header(clean_path)
+        offset = data_start + header["v.0"]["data_offsets"][0]
+        with clean_path.open("r+b") as handle:
+            handle.seek(offset)
+            byte = handle.read(1)
+            handle.seek(offset)
+            handle.write(bytes([byte[0] ^ 1]))
+        self.assertFalse(clean_store.scrub_one())
+        self.assertFalse(clean_path.exists())
+
+    def test_gc_is_lru_leaves_first_and_resave_works(self):
+        registry = PrefixForkRegistry()
+        root = registry.get(registry.freeze("m@r", list(range(8)), _prefix_cache(8)))
+        child = registry.get(registry.freeze("m@r", list(range(16)), _prefix_cache(16)))
+        store = SnapshotStore(self.path)
+        store.save(root)
+        store.save(child)
+        child_size = store._records[child.cid].file_bytes
+        root_size = store._records[root.cid].file_bytes
+        store.max_bytes = root_size + child_size - 1
+        store.gc()
+        self.assertIn(root.cid, store._records)
+        self.assertNotIn(child.cid, store._records)
+        self.assertEqual(store.save(child), child.cid)
+
+    def test_missing_parent_poisons_descendant(self):
+        registry = PrefixForkRegistry()
+        root = registry.get(registry.freeze("m@r", list(range(8)), _prefix_cache(8)))
+        child = registry.get(registry.freeze("m@r", list(range(16)), _prefix_cache(16)))
+        store = SnapshotStore(self.path)
+        store.save(root)
+        store.save(child)
+        (self.path / f"{root.cid}.safetensors").unlink()
+        restarted = PrefixForkRegistry()
+        SnapshotStore(self.path, registry=restarted)
+        forks, _ = restarted.fetch_fork("m@r", list(range(16)))
+        self.assertIsNone(forks)
+
+    def test_forged_parent_identity_quarantines_child(self):
+        registry = PrefixForkRegistry()
+        root = registry.get(registry.freeze("m@r", list(range(8)), _prefix_cache(8)))
+        child = registry.get(registry.freeze("m@r", list(range(16)), _prefix_cache(16)))
+        other = registry.get(
+            registry.freeze("m@r", list(range(100, 108)), _prefix_cache(8))
+        )
+        store = SnapshotStore(self.path)
+        store.save(root)
+        store.save(other)
+        store.save(child)
+        path = self.path / f"{child.cid}.safetensors"
+        arrays, metadata = mx.load(str(path), return_metadata=True)
+        metadata["parent_cid"] = other.cid
+        mx.save_safetensors(str(path), arrays, metadata)
+        SnapshotStore(self.path)
+        self.assertFalse(path.exists())
+
+    def test_incompatible_chain_geometry_quarantines_descendant(self):
+        registry = PrefixForkRegistry()
+        root = registry.get(registry.freeze("m@r", list(range(8)), _prefix_cache(8)))
+        child = registry.get(registry.freeze("m@r", list(range(16)), _prefix_cache(16)))
+        store = SnapshotStore(self.path)
+        store.save(root)
+        store.save(child)
+        path = self.path / f"{child.cid}.safetensors"
+        arrays, metadata = mx.load(str(path), return_metadata=True)
+        arrays["k.0"] = mx.zeros((1, 3, 8, 4))
+        metadata["sha256_k_0"] = _array_digest(arrays["k.0"])
+        mx.save_safetensors(str(path), arrays, metadata)
+        restarted = PrefixForkRegistry()
+        rebuilt = SnapshotStore(self.path, registry=restarted)
+        forks, rest = restarted.fetch_fork("m@r", list(range(16)))
+        self.assertIsNone(forks)
+        self.assertEqual(rest, list(range(16)))
+        self.assertGreaterEqual(rebuilt.stats["quarantines"], 1)
+
+    def test_permissions_and_ghost_telemetry(self):
+        registry = PrefixForkRegistry()
+        snapshot = _freeze(registry, "m@r", list(range(8)))
+        store = SnapshotStore(self.path)
+        store.save(snapshot)
+        self.assertEqual(self.path.stat().st_mode & 0o777, 0o700)
+        self.assertEqual(
+            (self.path / f"{snapshot.cid}.safetensors").stat().st_mode & 0o777,
+            0o600,
+        )
+        store.note_ram_eviction(snapshot.cid)
+        store.note_request_cid(snapshot.cid)
+        self.assertEqual(store.stats["ghost_hits"], 1)
+
+    def test_cid_filename_contract(self):
+        self.assertEqual(
+            compute_cid("m@r", list(range(8))),
+            compute_cid("m@r", list(range(8))),
+        )
+
+
+class TestPersistentServerBridge(unittest.TestCase):
+    def setUp(self):
+        self.temp = tempfile.TemporaryDirectory()
+        self.model_dir = Path(self.temp.name) / "model"
+        self.store_dir = Path(self.temp.name) / "store"
+        self.model_dir.mkdir()
+        (self.model_dir / "config.json").write_text("{}")
+
+    def tearDown(self):
+        self.temp.cleanup()
+
+    def test_insert_flush_restart_fetch_and_promote(self):
+        model = (str(self.model_dir), None, None)
+        tokens = list(range(8))
+        first = PersistentPromptCache(
+            4, self.store_dir, max_bytes=1 << 20, max_files=32
+        )
+        first.insert_cache(model, tokens, _prefix_cache(8))
+        self.assertEqual(first.flush_persistent(scrub=False), 1)
+
+        restarted = PersistentPromptCache(
+            4, self.store_dir, max_bytes=1 << 20, max_files=32
+        )
+        forks, rest = restarted.fetch_nearest_cache(model, tokens + [9])
+        self.assertIsNotNone(forks)
+        self.assertEqual(rest, [9])
+        self.assertEqual(restarted.persistent_stats["disk_hits"], 1)
+        # The disk proxy was re-promoted to an in-RAM immutable snapshot.
+        self.assertTrue(
+            any(
+                isinstance(snapshot, FrozenPrefixSnapshot)
+                for snapshot in restarted._registry.snapshots()
+            )
+        )
+
+    def test_opt_in_disables_incompatible_batch_path_only(self):
+        provider = type(
+            "Provider",
+            (),
+            {
+                "is_batchable": True,
+                "cli_args": Namespace(prompt_cache_persist_dir=str(self.store_dir)),
+            },
+        )()
+        generator = ResponseGenerator.__new__(ResponseGenerator)
+        generator.model_provider = provider
+        args = Namespace(seed=None)
+        self.assertFalse(generator._is_batchable(args))
+        provider.cli_args.prompt_cache_persist_dir = None
+        self.assertTrue(generator._is_batchable(args))
+
+    def test_unsupported_cache_falls_back_without_disk_file(self):
+        class Unsupported:
+            offset = 4
+            nbytes = 0
+
+            def is_trimmable(self):
+                return False
+
+        cache = PersistentPromptCache(
+            4, self.store_dir, max_bytes=1 << 20, max_files=32
+        )
+        item = Unsupported()
+        cache.insert_cache((str(self.model_dir), None, None), list(range(4)), [item])
+        self.assertEqual(len(cache._fallback), 1)
+        self.assertFalse(list(self.store_dir.glob("*.safetensors")))
+
+    def test_ram_cap_demotes_and_disk_hit_repromotes_safely(self):
+        model = (str(self.model_dir), None, None)
+        cache = PersistentPromptCache(
+            0, self.store_dir, max_bytes=1 << 20, max_files=32
+        )
+        tokens = list(range(8))
+        cache.insert_cache(model, tokens, _prefix_cache(8))
+        self.assertFalse(
+            any(
+                isinstance(snapshot, FrozenPrefixSnapshot)
+                for snapshot in cache._registry.snapshots()
+            )
+        )
+        forks, rest = cache.fetch_nearest_cache(model, tokens + [9])
+        self.assertIsNotNone(forks)
+        self.assertEqual(rest, [9])
+        self.assertGreaterEqual(cache.persistent_stats["promotions"], 1)
+        self.assertGreaterEqual(cache.persistent_stats["demotions"], 2)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_snapshot_store.py
+++ b/tests/test_snapshot_store.py
@@ -28,7 +28,7 @@ from mlx_lm.server import (
 from mlx_lm.snapshot_store import (
     SnapshotCorruptError,
     SnapshotStore,
-    _array_digest,
+    _payload_digests,
     _read_header,
 )
 from mlx_lm.utils import load
@@ -49,16 +49,28 @@ def _cache(length, seed=1, layers=2):
     return out
 
 
-def _prefix_cache(length):
+def _prefix_cache(length, dtype=mx.float32):
     cache = KVCache()
     positions = mx.arange(length, dtype=mx.float32)[None, None, :, None]
     heads = mx.arange(2, dtype=mx.float32)[None, :, None, None] * 100
     dims = mx.arange(4, dtype=mx.float32)[None, None, None, :]
-    key = mx.broadcast_to(positions + heads + dims, (1, 2, length, 4))
+    key = mx.broadcast_to(positions + heads + dims, (1, 2, length, 4)).astype(dtype)
     value = key + 1000
     cache.update_and_fetch(key, value)
     mx.eval(*cache.state)
     return [cache]
+
+
+def _save_with_payload_digests(path, arrays, metadata):
+    layers = int(metadata["layers"])
+    for layer in range(layers):
+        metadata[f"sha256_k_{layer}"] = "0" * 64
+        metadata[f"sha256_v_{layer}"] = "0" * 64
+    mx.save_safetensors(str(path), arrays, metadata)
+    for layer, (key_digest, value_digest) in enumerate(_payload_digests(path, layers)):
+        metadata[f"sha256_k_{layer}"] = key_digest
+        metadata[f"sha256_v_{layer}"] = value_digest
+    mx.save_safetensors(str(path), arrays, metadata)
 
 
 def _freeze(registry, model_key, tokens, seed=1):
@@ -224,6 +236,55 @@ class TestSnapshotStore(unittest.TestCase):
         self.assertFalse(clean_store.scrub_one())
         self.assertFalse(clean_path.exists())
 
+    def test_bfloat16_round_trip_corruption_and_incremental_scrub(self):
+        registry = PrefixForkRegistry()
+        tokens = list(range(8))
+        cid = registry.freeze("bf16@r", tokens, _prefix_cache(8, mx.bfloat16))
+        snapshot = registry.get(cid)
+        store = SnapshotStore(self.path)
+        store.save(snapshot)
+        while not store.scrub_increment(max_bytes=13):
+            self.assertIsNotNone(store._scrub_state)
+        store.close()
+
+        restarted = PrefixForkRegistry()
+        reopened = SnapshotStore(self.path, registry=restarted)
+        forks, rest = restarted.fetch_fork("bf16@r", tokens + [9])
+        self.assertEqual(rest, [9])
+        self.assertEqual(forks[0].state[0].dtype, mx.bfloat16)
+        self.assertTrue(mx.array_equal(forks[0].state[0], snapshot.keys[0]))
+        reopened.demote_from_ram(cid)
+        path = self.path / f"{cid}.safetensors"
+        header, data_start = _read_header(path)
+        offset = data_start + header["v.0"]["data_offsets"][0]
+        with path.open("r+b") as handle:
+            handle.seek(offset)
+            byte = handle.read(1)
+            handle.seek(offset)
+            handle.write(bytes([byte[0] ^ 1]))
+        corrupt, remaining = restarted.fetch_fork("bf16@r", tokens)
+        self.assertIsNone(corrupt)
+        self.assertEqual(remaining, tokens)
+
+    def test_payload_digest_distinguishes_dtype_with_same_zero_bytes(self):
+        bf_registry = PrefixForkRegistry()
+        u16_registry = PrefixForkRegistry()
+        tokens = list(range(8))
+        bf_cache = _prefix_cache(8, mx.bfloat16)
+        u16_cache = _prefix_cache(8, mx.uint16)
+        # Force identical all-zero payload bytes; only dtype metadata differs.
+        for cache in bf_cache + u16_cache:
+            cache.keys = mx.zeros_like(cache.keys)
+            cache.values = mx.zeros_like(cache.values)
+        bf_cid = bf_registry.freeze("bf@r", tokens, bf_cache)
+        u16_cid = u16_registry.freeze("u16@r", tokens, u16_cache)
+        store = SnapshotStore(self.path)
+        store.save(bf_registry.get(bf_cid))
+        store.save(u16_registry.get(u16_cid))
+        self.assertNotEqual(
+            store._records[bf_cid].digests, store._records[u16_cid].digests
+        )
+
     def test_quarantine_rename_failure_blocks_proxy_without_losing_record(self):
         registry = PrefixForkRegistry()
         snapshot = _freeze(registry, "m@r", list(range(8)))
@@ -312,8 +373,7 @@ class TestSnapshotStore(unittest.TestCase):
         path = self.path / f"{child.cid}.safetensors"
         arrays, metadata = mx.load(str(path), return_metadata=True)
         arrays["k.0"] = mx.zeros((1, 3, 8, 4))
-        metadata["sha256_k_0"] = _array_digest(arrays["k.0"])
-        mx.save_safetensors(str(path), arrays, metadata)
+        _save_with_payload_digests(path, arrays, metadata)
         store.close()
         restarted = PrefixForkRegistry()
         rebuilt = SnapshotStore(self.path, registry=restarted)


### PR DESCRIPTION
# Warm-restart persistence tier for prefix-fork KV snapshots

*Branch `pr/fork-persistence`, based on `pr/cow-prefix-forks` @ `15b344b1`. Code
tip `f3e0d9c`.*

> **DRAFT — stacked on #1547.** This tier is built on the COW prefix-fork registry
> from #1547, which is not yet merged. Because GitHub cannot base a PR on a fork
> branch, the diff below currently includes **#1547's 4 commits** underneath this
> feature's **8 persistence commits**. Please review only the persistence commits
> (everything on top of `pr/cow-prefix-forks`); the base commits will drop out of
> this diff automatically once #1547 merges. Filed as a draft for early visibility
> and to be re-based/re-targeted cleanly after #1547 lands.

## Motivation

The COW prefix-fork registry keeps frozen prefix snapshots in RAM so N agents
sharing a long system/repo prefix pay to prefill it once. That warmth dies with
the process: a server restart, a launchd bounce, a deploy, or a crash discards
every cached prefix, and the next request re-prefills from scratch.

This is **not** about OS suspend. MLX arrays are plain unified process memory, so
system sleep preserves them transparently — there is nothing to do there. What
destroys warmth is **process death**. On Qwen3-Coder-30B-A3B the KV cost is
~98 KB/token, so a long agent/repo context incurs a measured multi-second
re-prefill after *every* restart (4.90 s at 16k in the representative run).

Because `mx.load` memory-maps safetensors, restoring a snapshot is an index scan
plus lazy page-in, not a decode. This PR adds a content-addressed **disk tier**
under the existing registry: the first request after a restart pays milliseconds
of page-in instead of a full re-prefill.

The feature is **opt-in** and off by default (`--prompt-cache-persist-dir`). With
the flag absent, no new files are written and there is zero behavior change
(regression-pinned).

### What actually gets accelerated — read this before the numbers

`fetch_fork` is a **prefix-of-request matcher**: a stored snapshot serves a
request only when the snapshot's tokens are a prefix of (shorter-or-equal to) the
request; a longer-only stored prefix is a **deliberate MISS** ("a frozen prefix
cannot be trimmed"). Because the frozen prefix includes the assistant's generated
tokens, re-sending the *bare* original prompt (shorter than the snapshot) is a
deliberate miss. Persistence therefore accelerates a **continuation** that
*extends* the frozen prefix — an agent or multi-turn loop whose context grows
across restarts — **not** an identical prompt re-send. This is the §1 value case
(agent/repo context), and it is exactly what the server-path corroboration below
exercises (`cached_tokens=14416`, the entire frozen prefix restored, feeding a
superset request).

## Design: adopt ZFS's integrity/structure, reject its durability

A KV cache is fundamentally different from the data ZFS protects: it is
*recomputable* from `(weights, tokens)`. That inverts the design. We adopt ZFS's
**integrity and structure** machinery and reject its **durability** machinery,
because for recomputable data the correct response to any doubt is to throw the
file away and re-prefill — never to repair.

| ZFS mechanism | Decision | How it maps here |
|---|---|---|
| Copy-on-write, atomic publish | **Adopt** | temp file + `os.replace`; a visible file is always complete |
| Merkle/block checksums | **Adopt** | per-layer SHA-256 payload digests, verified lazily on first materialization + idle scrub |
| ARC tiering | **Adopt** | RAM-tier eviction demotes to disk; disk hit re-promotes to RAM; ghost-list telemetry |
| Incremental send (`send -i`) | **Adopt** | delta chaining — a child stores only its tail past the parent |
| Feature flags | **Adopt** | unknown feature string ⇒ quarantine (miss), never crash or guess |
| RAID / mirror / repair / ZIL | **Reject** | data is recomputable; every integrity doubt ⇒ discard → fail-closed MISS → re-prefill |

The invariant throughout: **never repair, never trust a questionable file.** A
missing, truncated, mis-addressed, digest-failing, or unknown-feature file is a
MISS that falls back to a normal prefill — the correct result, just without the
warm-boot speedup.

## On-disk format v2

- **One file per snapshot**, `<dir>/<cid>.safetensors`, written atomically (temp
  file in the same directory + `os.replace`). Idempotent by cid.
- **Content addressing**: `cid = sha256(model_key || token_ids)`, identical to the
  RAM registry's cid so the two tiers agree. `model_key` is the registry's
  stable-string contract (model path + adapter + resolved revision) — never
  `id()`-derived.
- **Per-file metadata** in the safetensors metadata dict: `format_version` (`"2"`),
  `features` list (ZFS feature flags, including the digest feature
  `canonical-tensor-sha256-v2`), `model_key`, full `token_ids` (needed to rebuild
  the prefix trie at startup), `created_at`, nullable `parent_cid` +
  `parent_length` for delta chaining, and per-layer payload digests.
- **Version discipline.** The payload-digest scheme changed when the bf16 bug was
  fixed (see below), so the format is bumped to **v2**. A file written by the old
  **v1** scheme is **not** trusted under the new digest semantics — it is a
  **safe MISS** (records raise `SnapshotCorruptError` → quarantine → re-prefill),
  never a silent false-HIT under mismatched digest rules. An unknown
  `format_version` is likewise a MISS.
- **Sidecar `index.json`** is a rebuildable cache of the files — never the
  authority. On any disagreement, a directory rescan wins.
- **Security**: directory mode `0700`, files `0600`. Snapshots can contain
  conversation content and are treated like logs; this is stated in the module
  docstring and here.

## Payload digests: raw-safetensors bytes, dtype-agnostic (the bf16 fix)

The cid authenticates *identity* (which model/tokens the file claims to be), not
the KV *bytes*. Without payload digests a bit-flip would restore silently-corrupt
KV with no diagnosis path. So each layer's K and V carry a SHA-256 digest.

The digest is computed over the **raw safetensors payload bytes** of each tensor,
with a **domain-separated dtype+shape prefix** framed into the hash — it is *not*
computed via `numpy`. This matters: an earlier revision digested KV via
`np.asarray(array).tobytes()`, which **throws on bfloat16** (numpy has no bf16
dtype) — the common case for every 7B+ port. That bug was found and fixed here;
the raw-byte path is correct for every MLX dtype including bfloat16, verified by a
bf16 round-trip (save → close → reopen → restore bit-exact, dtype preserved) and a
bf16-model two-process restart producing an identical greedy continuation token.

- **At restore**: digests are verified **lazily, per layer, on first
  materialization**, preserving mmap laziness (ZFS verifies per-block on read). A
  mismatch quarantines the file, misses, and logs one WARNING (cid, layer).
- **Scrub**: on the idle hook, one snapshot's digests are verified per tick
  (round-robin, time-boxed). Scrub never repairs — quarantine only.
- **Quarantine** = rename to `<cid>.quarantined`, kept for post-mortem, excluded
  from the index, and GC'd by the byte cap like any other file.
- **Malformed descriptors fail closed**: a hostile or non-JSON dtype/shape/offsets
  descriptor raises `SnapshotCorruptError` (quarantine), never escapes as a raw
  exception or a partial read.

## Delta chaining (ZFS `send -i`)

Whole-file storage duplicates shared prefixes: 8 agents behind an 8k shared system
prefix would store 8 copies of it. The registry trie already knows the parent
relationships, and the disk layout mirrors them:

- A child snapshot stores **only the tail delta** `[parent_length : length)` per
  layer, plus `parent_cid`.
- Restore walks root→leaf and concatenates, reusing the fork concat geometry.
  `max_chain_depth` (default 8) bounds restore cost; deeper writes self-root.
- **Refcounted GC**: a file that is some live file's `parent_cid` is never deleted.
  LRU eviction operates over *leaves*; a parent becomes eligible only when its last
  child goes.
- A missing/quarantined parent **poisons all descendants → MISS** (they are
  recomputable).

## Store lifecycle

- **Caps**: `max_bytes` (default 32 GiB) + `max_files`, enforced at save and by GC.
  Every quarantine/temp/orphan path is bounded by the caps.
- **Reservation atomicity.** Before a save evicts anything to make room, the store
  computes the **complete victim plan and proves it fits** — honoring protected
  ancestry (parents of live children) and *current physical free space* (not
  trusting APFS async reclaim) — **before any `unlink` or state mutation**. An
  infeasible save destroys nothing (every existing byte preserved); a feasible one
  evicts only the oldest eligible LRU leaves. This closes the class where a
  partial eviction discards warm state and then discovers the new save still cannot
  fit.
- **Eviction**: LRU by last-use, timestamps in the sidecar index (bumped on hit —
  filesystem atime is not trusted), leaves-first.
- **Startup**: scan the directory, parse safetensors *headers only*, validate
  `format_version`/`features`/cid-filename match, and register disk-backed proxy
  entries into the registry. **Rebuild never materializes KV bytes** — it is a
  header scan; a multi-MB store rebuilds at ~0 active-memory delta (asserted by
  test, and observed in the bench: `rebuild_mx_load_calls == 0`).
- **Write-back (ARC demote)**: RAM-tier eviction saves to disk instead of
  discarding; a disk hit re-promotes to RAM.
- **Ghost lists**: small deques of recently-evicted (RAM) and recently-GC'd (disk)
  cids; a request that would have hit a ghost bumps a counter. v1 = telemetry only,
  no adaptive sizing.
- **Flush policy**: batched on the idle hook + graceful shutdown. There is no
  journal — content-addressed writes are idempotent, and a crash loses only unsaved
  (recomputable) snapshots. SIGKILL semantics are documented.
- **No compression in tier 1**: it would break `mx.load` mmap. Restart latency is
  scarce, disk is not. Explicit non-goal.

### mmap-unlink safety (verified empirically on APFS)

GC deletes files purely by LRU/byte-cap policy without consulting live mappings,
which is only safe if an mmap'd file survives `unlink`. We verified this
empirically rather than assuming it: a 302 MB safetensors lazily mapped via
`mx.load` (0 pages touched) stayed byte-exact after `unlink` across 3/3
same-process reps and the cross-process case (another process unlinks while a child
holds the untouched mapping), 12/12 SHA-256 checks each; `lsof` confirmed the
deleted-but-open vnode. **POSIX behavior holds on local APFS.** Caveat: space
reclamation is asynchronous (guaranteed at last close — which is why the
reservation check uses current physical free space, not a projection), and the
property is local-APFS only; network filesystems (NFS/SMB) are out of scope.

## Server wiring (opt-in)

- `--prompt-cache-persist-dir PATH` turns the tier on; `--prompt-cache-persist-bytes`
  and `--prompt-cache-persist-files` size the caps. Absent = feature fully off, zero
  behavior change.
- Startup builds the store, rebuilds the index, and logs
  `N snapshots / M GiB indexed (no data loaded)`.
- On request completion, `insert_cache` freezes the prefix (`full prompt + generated
  tokens`) into the `PrefixForkRegistry`; the disk tier persists it on the quiescent
  generation-thread tick and, guaranteed, on graceful shutdown
  (`SIGTERM → KeyboardInterrupt → close() → flush_persistent(shutdown=True)`).
- The idle hook flushes unsaved snapshots then runs one scrub increment,
  generation-thread-only and quiescent-only.
- Persistence uses the **sequential server generation path**: the COW base registry
  has no batched merge for `ForkedKVCache`, so the persistent tier rides the
  sequential path (documented limitation; batched merge is a named follow-up).

## Measured

Provenance: Apple **M5 Max**, 128 GB; mlx **0.32.0.dev20260705** (`+47b16bbe`);
interpreter `.venv-mlxlatest`; worktree `mlx-lm-fork-persist @ f3e0d9c`. Method:
controls-first, counterbalanced cold/warm interleave, **median of 3 reps**, fresh
subprocess per measurement (model reloaded each run — neither path gets a warm-GPU
edge), **TTFT excludes model load**. Pre/post process sweeps clean; benches ran
uninterrupted. The server-path observations (below) are single-shot per context and
do not retain an exact driver or raw request logs; they are directional
corroboration, not a second rigorous timing harness.

**Equal-context definition (the correctness basis).** Both arms decode from the
identical N-token context. The snapshot is frozen at the first **N−1** tokens; the
real Nth token is fed to both arms. **cold** = fresh `make_prompt_cache` + full
N-token prefill → first token. **warm** = reopen `SnapshotStore` from disk +
`fetch_fork` (restore the N−1 prefix KV) + feed the Nth token → first token. The
delta between them is the prefix re-prefill the feature saves on restart. (An
earlier run compared unequal contexts and was discarded; these numbers rest on an
offset-asserted equal-context harness, independently reviewed and then focused-
re-reviewed after the cache-step fix.)

**Label: WARM-CACHE PROCESS-RESTART.** The warm restore is page-cache-hot — it
models a launchd bounce / server restart / deploy (the §1 "process death" value
case), **not** a cold-disk post-reboot restore.

### Representative scale — `mlx-community/Qwen3-Coder-30B-A3B-Instruct-8bit` (bfloat16 KV)

| prefix | cold TTFT (median) | warm TTFT (median) | **speedup** | snapshot on disk | peak transient disk |
|---:|---:|---:|:---:|---:|---:|
| 8k  | 1.828 s | 0.337 s | **5.42×** | 786 MB | ~786 MB (≈1×) |
| 16k | 4.897 s | 0.669 s | **7.32×** | 1.57 GB | ~1.57 GB (≈1×) |

All assertions green at both sizes: **warm greedy first token == cold greedy first
token** (token 279 @ 8k, 323 @ 16k; no logits/distribution digest was captured);
**restored KV digest == pre-save digest** (bit-exact, every rep);
**restore is lazy** (`rebuild_mx_load_calls == 0`, payload memory-mapped on first
fetch); **warm disk-hit** (`disk_hits == 1` every rep — the real disk path, not a
RAM hit). Reps are tight (8k warm 0.337/0.335/0.348 s — no thermal drift). The
speedup **widens with context**: restore + page-in grows far slower than prefill.

**Save cost.** Save is two-pass (staged safetensors write to establish canonical
raw bytes, then final atomic write embedding the digests): 0.76 s @ 8k, 1.36 s @
16k. Peak *transient disk* is ≈1× the snapshot (the stage file is removed before
the final write), so the store never holds two full copies at rest; the ~2× figure
is **write bandwidth** only (est. 1.57 GB @ 8k, 3.15 GB @ 16k moved).

### Correctness scale — `mlx-community/Qwen1.5-0.5B-Chat-4bit` (fp16 KV)

| prefix | speedup |
|---:|:---:|
| 2k  | 0.55× |
| 8k  | 0.65× |
| 32k | 1.33× |

Honest reading: break-even is where `prefill(prefix) ≈ disk-restore cost`. On a
0.5B model prefill is so cheap that restoring the 200–800 MB fp16-KV file costs
more than re-prefilling, so warm only wins at long prefixes (1.33× @ 32k). A larger
model (costlier prefill, same-order disk restore) moves the crossover to much
shorter prefixes — exactly the 30B regime above and the regime the feature targets.
We report both so the crossover is not hidden.

### Independent server-path corroboration (real production HTTP path)

Corroborated through the actual `mlx_lm.server --prompt-cache-persist-dir` path
(genuinely different code from the timing harness), `mlx-community/Qwen1.5-0.5B-Chat-4bit`,
greedy: a snapshot written on server-1 shutdown was re-indexed lazily by server-2
(`1 snapshots / 1.32 GiB indexed (no data loaded)`), and a **continuation** request
(the frozen prefix + a follow-up turn) restored the entire frozen prefix off disk —
`disk_hits: 1`, `usage.cached_tokens = 14416` — producing **byte-identical output**
to a from-scratch cold reference on a separate empty-dir
server. This double-confirms correctness across two independent code paths.
(Directional latency on this tiny prefill-cheap model shows the same crossover: a
1.32 GiB disk restore costs more first-touch than re-prefilling 14.4k tokens; the
RAM-promoted reuse is ~2.3× faster than cold — consistent with the 0.5B table.)

The same server path was then run **at 30B**:
byte-identical warm/cold output at both 8k and 16k, `cached_tokens` = 7840 / 15863 (the
full frozen prefix restored off disk, cold reference 0), and whole-request wall-clock
cold-vs-warm of **3.94× @8k** and **5.54× @16k**. This is an *independent 30B*
confirmation of both correctness and the speedup **direction/shape** — the same
grows-with-context curve the harness reports (5.42→7.32×), through a different code
path. The server magnitude is lower than the harness because whole-request HTTP
wall-clock is not pure TTFT (the follow-up decode + round-trip sit in both terms,
pulling the ratio toward 1); the harness TTFT remains the precise figure. (Measurement
note for future benchers: the server's `/health` returns 200 *before* the lazy model
load completes, so an un-warmed first request absorbs model-load time — warm up before
timing.)

The 30B server observations are **single-shot per context** and the exact driver and
raw request logs were not retained. They support correctness and direction only;
the counterbalanced three-rep harness supplies the precise TTFT values.

## Assumptions and limitations

- **Timing rests on one rigorous harness** (one independent review plus focused
  re-review after the cache-step fix,
  offset-asserted, all assertions green) **plus independent server-path corroboration
  at both 0.5B and 30B** (byte-identical output, correct disk-hit, same grows-with-context
  speedup direction: server 3.94→5.54× vs harness 5.42→7.32×). A planned second
  independent *precise-TTFT* harness did not land, so the exact TTFT multipliers are
  single-harness (server-corroborated for correctness+direction) — not
  dual-harness-confirmed. Correctness *is* double-confirmed at both scales (harness
  digest+greedy-token asserts and server e2e byte-identical output).
- **Representative scale validated at one config** (30B, 8k/16k). The mechanism is
  model-size-independent in kind, but a wider sweep is future work.
- **HF fast-identity trust boundary.** For a model resolved under the configured
  `HF_HUB_CACHE` (honoring `HF_HOME`), identity uses the immutable snapshot
  revision/path without reading weight bytes. Recognition is restricted to real
  `models--…/snapshots/<rev>` cache ancestry under the configured root, with
  symlink-safe resolution; a full-layout lookalike *outside* the root falls back to
  byte authentication (regression-tested). This trusts HF cache containment — an
  attacker-writable HF cache shares that trust boundary, as would a blob symlink
  escaping the cache root.
- **Local (non-HF) model dirs** hash all weight bytes on first identity — a one-time
  cost, off the hot path.
- **Sequential server path only** (see wiring): the COW base lacks a batched merge
  for `ForkedKVCache`.
- **Tier 1 is uncompressed** (mmap requirement).

## Non-goals (stated in code and here)

OS-sleep handling (unified memory survives sleep); tier-1 compression (breaks mmap);
lossy re-quantization for storage; repair/redundancy of any kind (recomputable ⇒
discard on doubt); adaptive sizing from ghost stats (v1 = telemetry only).

## Named follow-ups (documented, not built)

- **Tier-2 cold archive**: packed *quantized* snapshots, bit-exact to the quantized
  cache, benched zstd-first before any custom codec.
- **Quantized-KV fork snapshots** (gates the tier-2 archive).
- **Cross-machine snapshot shipping** (the `zfs send` analogy).
- **Batched-path persistence**: in-place batched merge for `ForkedKVCache` so the
  tier composes with the batched server path.

## Change surface

4 files, **2988 insertions / 19 deletions**: `mlx_lm/snapshot_store.py` (new,
1272 L), `mlx_lm/prefix_forks.py` (91 changed), `mlx_lm/server.py` (opt-in wiring,
392), `tests/test_snapshot_store.py` (new, 1252 L; 103 focused tests green, static
clean). With `--prompt-cache-persist-dir` absent, the default path is unchanged
(regression-pinned).
