### PR TITLE
Fix internlm3 dynamic-NTK RoPE: wrong seq axis, scale/factor conflation

### DIFF
--- a/mlx_lm/models/internlm3.py
+++ b/mlx_lm/models/internlm3.py
@@ -53,6 +53,8 @@ class DynamicNTKScalingRoPE(nn.Module):
         traditional: bool = False,
         base: float = 10000,
         scale: float = 1.0,
+        rope_type: str = "default",
+        ntk_factor: float = 1.0,
     ):
         super().__init__()
         self.max_position_embeddings = max_position_embeddings
@@ -60,15 +62,23 @@ class DynamicNTKScalingRoPE(nn.Module):
         self.dims = dims
         self.traditional = traditional
         self.scale = scale
+        self.rope_type = rope_type
+        self.ntk_factor = ntk_factor
 
     def extra_repr(self):
-        return f"{self.dims}, traditional={self.traditional}, max_position_embeddings={self.max_position_embeddings}, scaling_factor={self.scaling_factor}"
+        return f"{self.dims}, traditional={self.traditional}, max_position_embeddings={self.max_position_embeddings}, rope_type={self.rope_type}"
 
     def __call__(self, x, offset: int = 0):
-        seq_len = x.shape[1] + offset
-        if seq_len > self.max_position_embeddings:
+        # x is [B, n_heads, L, head_dim] by the time it reaches rope() -- the
+        # sequence axis is 2, not 1.
+        seq_len = x.shape[2] + offset
+        # Only "dynamic" NTK recomputes the base, and only off the config
+        # factor -- self.scale is the *position* scale (only nonzero for
+        # "linear"), a different knob from the NTK base-growth factor.
+        if self.rope_type == "dynamic" and seq_len > self.max_position_embeddings:
             base = self.original_base * (
-                (self.scale * seq_len / self.max_position_embeddings) - (self.scale - 1)
+                (self.ntk_factor * seq_len / self.max_position_embeddings)
+                - (self.ntk_factor - 1)
             ) ** (self.dims / (self.dims - 2))
         else:
             base = self.original_base
@@ -101,12 +111,14 @@ class Attention(nn.Module):
         self.v_proj = nn.Linear(dim, n_kv_heads * head_dim, bias=qkv_bias)
         self.o_proj = nn.Linear(n_heads * head_dim, dim, bias=qkv_bias)
 
-        rope_scale = (
-            1 / args.rope_scaling["factor"]
-            if args.rope_scaling is not None
-            and args.rope_scaling["rope_type"] == "linear"
-            else 2.0
+        rope_type = (
+            args.rope_scaling["rope_type"] if args.rope_scaling is not None else None
         )
+        # Position scale: only "linear" mode scales positions (1/factor).
+        # "dynamic" mode leaves positions alone and instead grows the base
+        # (see DynamicNTKScalingRoPE.__call__).
+        rope_scale = 1 / args.rope_scaling["factor"] if rope_type == "linear" else 1.0
+        ntk_factor = args.rope_scaling["factor"] if rope_type == "dynamic" else 1.0
 
         self.rope = DynamicNTKScalingRoPE(
             head_dim,
@@ -114,6 +126,8 @@ class Attention(nn.Module):
             traditional=args.rope_traditional,
             base=args.rope_theta,
             scale=rope_scale,
+            rope_type=rope_type or "default",
+            ntk_factor=ntk_factor,
         )
 
     def __call__(

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -1930,6 +1930,81 @@ class TestModels(unittest.TestCase):
             model, args.model_type, args.vocab_size, args.num_hidden_layers
         )
 
+    def test_internlm3_dynamic_ntk_rope(self):
+        # Regression test for #1545: dynamic-NTK RoPE conflated the position
+        # scale with the NTK base-growth factor, defaulted the position scale
+        # to 2.0 whenever scaling wasn't "linear", and read the sequence
+        # length off the wrong axis (post-transpose, seq is axis 2, not 1).
+        from mlx_lm.models import internlm3
+
+        def make_attn(rope_scaling):
+            args = internlm3.ModelArgs(
+                model_type="internlm3",
+                hidden_size=64,
+                num_hidden_layers=1,
+                intermediate_size=64,
+                num_attention_heads=4,
+                rms_norm_eps=1e-5,
+                vocab_size=100,
+                max_position_embeddings=32768,
+                rope_scaling=rope_scaling,
+            )
+            return internlm3.Attention(args)
+
+        # No scaling config at all: positions must be left unscaled (was 2.0).
+        self.assertEqual(make_attn(None).rope.scale, 1.0)
+
+        # Dynamic: positions unscaled, and the config factor reaches the NTK
+        # base formula as `ntk_factor` (was silently discarded / hard-coded).
+        dyn = make_attn({"factor": 6.0, "rope_type": "dynamic"})
+        self.assertEqual(dyn.rope.scale, 1.0)
+        self.assertEqual(dyn.rope.ntk_factor, 6.0)
+
+        # Linear: only the position scale (1/factor) applies.
+        lin = make_attn({"factor": 4.0, "rope_type": "linear"})
+        self.assertEqual(lin.rope.scale, 0.25)
+
+        # Sequence length must come from the post-transpose axis (2), so a
+        # long prompt actually triggers the dynamic NTK recompute even though
+        # the head-count axis (1) is small. Detect the recompute by its
+        # effect: a rotated non-zero vector changes when the base changes.
+        mx.random.seed(0)
+        x = mx.random.normal((1, 4, 100, 8))  # n_heads=4 < 64, real seq_len=100 > 64
+
+        def make_rope(max_position_embeddings, rope_type, ntk_factor):
+            return internlm3.DynamicNTKScalingRoPE(
+                dims=8,
+                max_position_embeddings=max_position_embeddings,
+                base=10000.0,
+                scale=1.0,
+                rope_type=rope_type,
+                ntk_factor=ntk_factor,
+            )
+
+        recomputed = make_rope(64, "dynamic", 6.0)(x)  # 100 > 64 -> base grows
+        static = make_rope(1_000_000, "dynamic", 6.0)(x)  # 100 < 1e6 -> base unchanged
+        self.assertFalse(mx.array_equal(recomputed, static))
+
+        # Linear mode must never rewrite the base, even past
+        # max_position_embeddings -- only the position scale applies there.
+        lin_short = internlm3.DynamicNTKScalingRoPE(
+            dims=8,
+            max_position_embeddings=1_000_000,
+            base=10000.0,
+            scale=0.25,
+            rope_type="linear",
+            ntk_factor=1.0,
+        )(x)
+        lin_long = internlm3.DynamicNTKScalingRoPE(
+            dims=8,
+            max_position_embeddings=8,  # real seq_len=100 > 8
+            base=10000.0,
+            scale=0.25,
+            rope_type="linear",
+            ntk_factor=1.0,
+        )(x)
+        self.assertTrue(mx.array_equal(lin_short, lin_long))
+
     def test_iquestloopcoder(self):
         from mlx_lm.models import iquestloopcoder
 


### PR DESCRIPTION
## Fix internlm3 dynamic-NTK RoPE: wrong seq axis, scale/factor conflation

### Summary

Fixes #1545. Credit to @magicnight for the full root-cause diagnosis in the issue (checked against InternLM's reference `modeling_internlm3.py`) — this PR independently verifies each of the four defects against the real code and adds regression tests.

Four related bugs in `internlm3.py`'s `DynamicNTKScalingRoPE` and its construction in `Attention.__init__`:

1. **Position scale defaulted to 2.0 whenever scaling wasn't `"linear"`** — including the common case of no `rope_scaling` at all — doubling every position index fed into `mx.fast.rope`. Only `"linear"` should scale positions (`1/factor`); the default should be `1.0`.
2. **The dynamic-NTK base formula reused that same wrong 2.0** instead of the config's `factor`, so a real config (e.g. `factor=6.0`) never reached the base recomputation.
3. **`seq_len` was read from `x.shape[1]`** — the head-count axis post-transpose (`[B, n_heads, L, head_dim]`) — not the sequence axis (`shape[2]`). The dynamic recompute could never fire at prefill regardless of prompt length (head count is typically far below `max_position_embeddings`).
4. **The base recompute wasn't gated on `rope_type`** — `"linear"` scaling also rewrote the base once past `max_position_embeddings`, when it should stay static and only the position scale should apply.

### Fix

- Split the single conflated `scale` into `scale` (position scale, `mx.fast.rope`'s `scale=`) and a new `ntk_factor` (the config `factor`, used only in the base-growth formula).
- `rope_type` is now threaded into `DynamicNTKScalingRoPE` and gates the base recompute (`if self.rope_type == "dynamic" and seq_len > self.max_position_embeddings`).
- `seq_len = x.shape[2] + offset` instead of `x.shape[1]`.

Total change: +23/−9 in `mlx_lm/models/internlm3.py`.

### Verification

Falsified all four defects against the pre-fix code directly (no checkpoint needed — these are pure position-math bugs reproducible with tiny synthetic tensors), then verified each is fixed:

- No `rope_scaling` → `self.rope.scale` was `2.0`, now `1.0`.
- `{"factor": 6.0, "rope_type": "dynamic"}` → `self.rope.scale` was `2.0` (factor discarded), now `scale=1.0` / `ntk_factor=6.0`.
- A tensor shaped `(1, 4, 100, 8)` (4 heads, 100 real sequence positions, `max_position_embeddings=64`) — pre-fix, `seq_len` read as `4` and the dynamic recompute never fired; post-fix, `seq_len=100` correctly triggers it.
- `"linear"` mode with `real seq_len=50 > max_position_embeddings=8` — pre-fix, the base was rewritten anyway; post-fix, output is identical to a run where `max_position_embeddings` is never exceeded (base provably stayed static).
- End-to-end: full `internlm3.Model` (tiny synthetic config, `rope_scaling={"factor": 4.0, "rope_type": "dynamic"}`), prefill past `max_position_embeddings` then several decode steps — runs cleanly.

### Test plan

- [x] New regression test `test_internlm3_dynamic_ntk_rope` — covers all four defects (scale defaults, factor threading, correct seq axis via an actual-effect comparison rather than just checking it doesn't crash, and linear-mode base staying static). Confirmed it fails on pre-fix code (`2.0 != 1.0`) and passes post-fix.
- [x] Full suite: `python -m unittest discover tests/` — pre-existing unrelated import errors only (`datasets`/`lm_eval`/`requests`, optional deps not installed locally).
- [x] `pre-commit run --files mlx_lm/models/internlm3.py tests/test_models.py` — clean.

### Note

`internlm2.py` has an identical copy-pasted `DynamicNTKScalingRoPE` with the same four bugs. Filing that as a separate PR against that file rather than bundling it here, to keep this one scoped to the reported issue.
