### PR TITLE
Fix internlm2 dynamic-NTK RoPE: wrong seq axis, scale/factor conflation

### DIFF
--- a/mlx_lm/models/internlm2.py
+++ b/mlx_lm/models/internlm2.py
@@ -52,6 +52,8 @@ class DynamicNTKScalingRoPE(nn.Module):
         traditional: bool = False,
         base: float = 10000,
         scale: float = 1.0,
+        rope_type: str = "default",
+        ntk_factor: float = 1.0,
     ):
         super().__init__()
         self.max_position_embeddings = max_position_embeddings
@@ -59,15 +61,23 @@ class DynamicNTKScalingRoPE(nn.Module):
         self.dims = dims
         self.traditional = traditional
         self.scale = scale
+        self.rope_type = rope_type
+        self.ntk_factor = ntk_factor
 
     def extra_repr(self):
-        return f"{self.dims}, traditional={self.traditional}, max_position_embeddings={self.max_position_embeddings}, scaling_factor={self.scaling_factor}"
+        return f"{self.dims}, traditional={self.traditional}, max_position_embeddings={self.max_position_embeddings}, rope_type={self.rope_type}"
 
     def __call__(self, x, offset: int = 0):
-        seq_len = x.shape[1] + offset
-        if seq_len > self.max_position_embeddings:
+        # x is [B, n_heads, L, head_dim] by the time it reaches rope() -- the
+        # sequence axis is 2, not 1.
+        seq_len = x.shape[2] + offset
+        # Only "dynamic" NTK recomputes the base, and only off the config
+        # factor -- self.scale is the *position* scale (only nonzero for
+        # "linear"), a different knob from the NTK base-growth factor.
+        if self.rope_type == "dynamic" and seq_len > self.max_position_embeddings:
             base = self.original_base * (
-                (self.scale * seq_len / self.max_position_embeddings) - (self.scale - 1)
+                (self.ntk_factor * seq_len / self.max_position_embeddings)
+                - (self.ntk_factor - 1)
             ) ** (self.dims / (self.dims - 2))
         else:
             base = self.original_base
@@ -99,11 +109,12 @@ class Attention(nn.Module):
         )
         self.wo = nn.Linear(n_heads * head_dim, dim, bias=args.bias)
 
-        rope_scale = (
-            1 / args.rope_scaling["factor"]
-            if args.rope_scaling is not None and args.rope_scaling["type"] == "linear"
-            else 2.0
-        )
+        rope_type = args.rope_scaling["type"] if args.rope_scaling is not None else None
+        # Position scale: only "linear" mode scales positions (1/factor).
+        # "dynamic" mode leaves positions alone and instead grows the base
+        # (see DynamicNTKScalingRoPE.__call__).
+        rope_scale = 1 / args.rope_scaling["factor"] if rope_type == "linear" else 1.0
+        ntk_factor = args.rope_scaling["factor"] if rope_type == "dynamic" else 1.0
 
         self.rope = DynamicNTKScalingRoPE(
             head_dim,
@@ -111,6 +122,8 @@ class Attention(nn.Module):
             traditional=args.rope_traditional,
             base=args.rope_theta,
             scale=rope_scale,
+            rope_type=rope_type or "default",
+            ntk_factor=ntk_factor,
         )
 
     def __call__(

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -1339,6 +1339,82 @@ class TestModels(unittest.TestCase):
             model, args.model_type, args.vocab_size, args.num_hidden_layers
         )
 
+    def test_internlm2_dynamic_ntk_rope(self):
+        # Same defect class as #1545 (internlm3): dynamic-NTK RoPE conflated
+        # the position scale with the NTK base-growth factor, defaulted the
+        # position scale to 2.0 whenever scaling wasn't "linear", and read
+        # the sequence length off the wrong axis (post-transpose, seq is
+        # axis 2, not 1). internlm2.py has an identical copy-pasted class.
+        from mlx_lm.models import internlm2
+
+        def make_attn(rope_scaling):
+            args = internlm2.ModelArgs(
+                model_type="internlm2",
+                hidden_size=64,
+                num_hidden_layers=1,
+                intermediate_size=64,
+                num_attention_heads=4,
+                rms_norm_eps=1e-5,
+                vocab_size=100,
+                max_position_embeddings=32768,
+                rope_scaling=rope_scaling,
+            )
+            return internlm2.Attention(args)
+
+        # No scaling config at all: positions must be left unscaled (was 2.0).
+        self.assertEqual(make_attn(None).rope.scale, 1.0)
+
+        # Dynamic: positions unscaled, and the config factor reaches the NTK
+        # base formula as `ntk_factor` (was silently discarded / hard-coded).
+        dyn = make_attn({"factor": 6.0, "type": "dynamic"})
+        self.assertEqual(dyn.rope.scale, 1.0)
+        self.assertEqual(dyn.rope.ntk_factor, 6.0)
+
+        # Linear: only the position scale (1/factor) applies.
+        lin = make_attn({"factor": 4.0, "type": "linear"})
+        self.assertEqual(lin.rope.scale, 0.25)
+
+        # Sequence length must come from the post-transpose axis (2), so a
+        # long prompt actually triggers the dynamic NTK recompute even though
+        # the head-count axis (1) is small. Detect the recompute by its
+        # effect: a rotated non-zero vector changes when the base changes.
+        mx.random.seed(0)
+        x = mx.random.normal((1, 4, 100, 8))  # n_heads=4 < 64, real seq_len=100 > 64
+
+        def make_rope(max_position_embeddings, rope_type, ntk_factor):
+            return internlm2.DynamicNTKScalingRoPE(
+                dims=8,
+                max_position_embeddings=max_position_embeddings,
+                base=10000.0,
+                scale=1.0,
+                rope_type=rope_type,
+                ntk_factor=ntk_factor,
+            )
+
+        recomputed = make_rope(64, "dynamic", 6.0)(x)  # 100 > 64 -> base grows
+        static = make_rope(1_000_000, "dynamic", 6.0)(x)  # 100 < 1e6 -> unchanged
+        self.assertFalse(mx.array_equal(recomputed, static))
+
+        # Linear mode must never rewrite the base, even past
+        # max_position_embeddings -- only the position scale applies there.
+        lin_short = internlm2.DynamicNTKScalingRoPE(
+            dims=8,
+            max_position_embeddings=1_000_000,
+            base=10000.0,
+            scale=0.25,
+            rope_type="linear",
+            ntk_factor=1.0,
+        )(x)
+        lin_long = internlm2.DynamicNTKScalingRoPE(
+            dims=8,
+            max_position_embeddings=8,  # real seq_len=100 > 8
+            base=10000.0,
+            scale=0.25,
+            rope_type="linear",
+            ntk_factor=1.0,
+        )(x)
+        self.assertTrue(mx.array_equal(lin_short, lin_long))
+
     def test_llama3_1(self):
         from mlx_lm.models import llama
 


### PR DESCRIPTION
## Fix internlm2 dynamic-NTK RoPE: wrong seq axis, scale/factor conflation

### Summary

Twin of #1552's sibling PR for internlm3 (#1545 / this repo's #1553): while fixing internlm3's `DynamicNTKScalingRoPE`, I found `internlm2.py` has an identical copy-pasted class with the same four bugs. No separate issue was filed for internlm2 specifically, so this PR describes and fixes it directly, scoped to that one file, rather than bundling it into #1553.

Four related bugs in `DynamicNTKScalingRoPE` and its construction in `Attention.__init__` (config key is `"type"` here, vs `"rope_type"` in internlm3 — otherwise identical):

1. **Position scale defaulted to 2.0 whenever scaling wasn't `"linear"`** — including no `rope_scaling` at all — doubling every position index fed into `mx.fast.rope`. Only `"linear"` should scale positions (`1/factor`); default should be `1.0`.
2. **The dynamic-NTK base formula reused that same wrong 2.0** instead of the config's `factor`, so a real config (e.g. `factor=6.0`) never reached the base recomputation.
3. **`seq_len` was read from `x.shape[1]`** — the head-count axis post-transpose (`[B, n_heads, L, head_dim]`) — not the sequence axis (`shape[2]`). The dynamic recompute could never fire at prefill regardless of prompt length.
4. **The base recompute wasn't gated on `rope_type`** — `"linear"` scaling also rewrote the base once past `max_position_embeddings`, when it should stay static and only the position scale should apply.

### Fix

Same shape as #1553: split `scale` (position scale) from a new `ntk_factor` (config `factor`, used only in the base-growth formula), thread `rope_type` through to gate the recompute, and read `seq_len` from `x.shape[2]`.

Total change: +22/−9 in `mlx_lm/models/internlm2.py`.

### Verification

Falsified all four defects against the pre-fix code directly (pure position-math bugs, reproducible with tiny synthetic tensors, no checkpoint needed), then verified each is fixed — same method as #1553:

- No `rope_scaling` → `scale` was `2.0`, now `1.0`.
- `{"factor": 6.0, "type": "dynamic"}` → `scale` was `2.0` (factor discarded), now `scale=1.0` / `ntk_factor=6.0`.
- A tensor shaped `(1, 4, 100, 8)` (4 heads, real seq_len=100, `max_position_embeddings=64`) — pre-fix, `seq_len` read as `4` and the recompute never fired; post-fix it correctly fires on `100`.
- `"linear"` mode past `max_position_embeddings` — pre-fix, base was rewritten anyway; post-fix, output is bit-identical to a run where `max_position_embeddings` is never exceeded.

### Test plan

- [x] New regression test `test_internlm2_dynamic_ntk_rope`, mirroring `test_internlm3_dynamic_ntk_rope` from #1553. Confirmed it fails on pre-fix code (`2.0 != 1.0`) and passes post-fix.
- [x] Full suite: `python -m unittest discover tests/` — pre-existing unrelated import errors only (`datasets`/`lm_eval`/`requests`).
- [x] `pre-commit run --files mlx_lm/models/internlm2.py tests/test_models.py` — clean.
