### PR TITLE
Hadamard-rotated KV-cache quantization for low-bit KV

### DIFF
--- a/benchmarks/kv_rotation_ppl.py
+++ b/benchmarks/kv_rotation_ppl.py
@@ -1,0 +1,89 @@
+"""Perplexity: plain-affine vs Hadamard-rotated quantized KV cache.
+
+Demonstrates the failure mode that `--kv-bits` (PR #1476) exposes to server
+users — plain affine low-bit KV degrades sharply — and the fix: a self-inverse
+orthonormal Hadamard rotation of K (in the cache) + Q (at attention), which
+keeps every q·k inner product identical while making the stored keys quantize
+cleanly. The effect grows with head_dim (more quant groups) and at lower bits.
+
+Run on Apple silicon:
+
+    python benchmarks/kv_rotation_ppl.py \
+        --model mlx-community/Qwen3-1.7B-bf16 --bits 8 4 3 2
+"""
+
+import argparse
+import math
+
+import mlx.core as mx
+
+from mlx_lm import load
+from mlx_lm.models.cache import QuantizedKVCache, make_prompt_cache
+
+# A few hundred tokens of varied, non-repetitive prose so the KV cache is
+# genuinely exercised over a real context (repetition would flatter ppl).
+TEXT = (
+    "The gongfu tea ceremony is a choreographed ritual of preparing and serving "
+    "tea, valued for attention, restraint, and the quiet reading of small signs. "
+    "A small clay pot is warmed, rinsed, and filled with tightly rolled oolong. "
+    "Hot water is poured in a high thin stream to agitate the leaves, the lid is "
+    "set back, and the first brief steeping is discarded to awaken the leaf. "
+    "Later infusions grow longer, and the host judges each by colour and aroma "
+    "before decanting into a pitcher so every cup is of equal strength. When a "
+    "guest wants more hot water, the lid is tipped ajar and rested on the rim — "
+    "a silent signal read across a crowded room without a word.\n\n"
+    "Cities encode similar signals in their streets. A raised hand at the kerb, "
+    "a folded newspaper on a cafe table, a lantern left burning past midnight: "
+    "each is a small protocol, learned rather than written, that lets strangers "
+    "coordinate without speaking. Markets run on such conventions too. A trader's "
+    "open palm, a nod across a pit, a chalk mark on a crate — these once moved "
+    "fortunes faster than any ledger, and the ledger only caught up afterward.\n\n"
+    "Machines are late to this game. A camera can be taught to notice the tipped "
+    "lid, the raised hand, the lantern — but only if it attends to the right "
+    "region at the right moment and ignores the thousand irrelevant motions of a "
+    "busy room. Attention, in that sense, is the whole problem: deciding which "
+    "of the many things in view actually carry a message, and which are noise to "
+    "be discarded before they crowd out the signal that matters. The art is old; "
+    "the apparatus is new; the difficulty is exactly the same as it ever was."
+)
+
+
+def perplexity(model, ids, cache):
+    logits = model(ids[None], cache=cache)[0, :-1].astype(mx.float32)
+    targets = ids[1:]
+    logp = logits - mx.logsumexp(logits, axis=-1, keepdims=True)
+    nll = -mx.take_along_axis(logp, targets[:, None], axis=-1)[:, 0]
+    return math.exp(mx.mean(nll).item())
+
+
+def quant_caches(model, bits, group_size, rotate):
+    n = len(make_prompt_cache(model))
+    return [
+        QuantizedKVCache(group_size=group_size, bits=bits, rotate=rotate)
+        for _ in range(n)
+    ]
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--model", default="mlx-community/Qwen3-1.7B-bf16")
+    ap.add_argument("--bits", type=int, nargs="+", default=[8, 4, 3, 2])
+    ap.add_argument("--group-size", type=int, default=64)
+    args = ap.parse_args()
+
+    model, tok = load(args.model)
+    ids = mx.array(tok.encode(TEXT))
+    fp16 = perplexity(model, ids, make_prompt_cache(model))
+    print(f"model={args.model}  tokens={ids.size}  group_size={args.group_size}")
+    print(f"  fp16 KV                       ppl = {fp16:10.2f}")
+    print(f"  {'bits':>4}  {'affine':>12}  {'rotated':>12}  {'gap recovered':>14}")
+    for b in args.bits:
+        affine = perplexity(model, ids, quant_caches(model, b, args.group_size, False))
+        rotated = perplexity(model, ids, quant_caches(model, b, args.group_size, True))
+        gap = max(affine - fp16, 1e-9)
+        pct = (affine - rotated) / gap * 100
+        print(f"  {b:>4}  {affine:>12.2f}  {rotated:>12.2f}  {pct:>13.0f}%")
+
+
+if __name__ == "__main__":
+    main()

--- a/mlx_lm/generate.py
+++ b/mlx_lm/generate.py
@@ -199,6 +199,13 @@ def setup_arg_parser():
         default=DEFAULT_QUANTIZED_KV_START,
     )
     parser.add_argument(
+        "--kv-rotate",
+        action="store_true",
+        help="Hadamard-rotate the KV cache before quantization, keeping low-bit "
+        "--kv-bits near full precision (scores are preserved; head_dim must be a "
+        "supported Hadamard size).",
+    )
+    parser.add_argument(
         "--draft-model",
         type=str,
         help="A model to be used for speculative decoding.",
@@ -287,12 +294,16 @@ class GenerationResponse:
     finish_reason: Optional[str] = None
 
 
-def maybe_quantize_kv_cache(prompt_cache, quantized_kv_start, kv_group_size, kv_bits):
+def maybe_quantize_kv_cache(
+    prompt_cache, quantized_kv_start, kv_group_size, kv_bits, kv_rotate=False
+):
     if kv_bits is None:
         return
     for e, c in enumerate(prompt_cache):
         if hasattr(c, "to_quantized") and c.offset >= quantized_kv_start:
-            prompt_cache[e] = c.to_quantized(group_size=kv_group_size, bits=kv_bits)
+            prompt_cache[e] = c.to_quantized(
+                group_size=kv_group_size, bits=kv_bits, rotate=kv_rotate
+            )
 
 
 def generate_step(
@@ -308,6 +319,7 @@ def generate_step(
     kv_bits: Optional[int] = None,
     kv_group_size: int = 64,
     quantized_kv_start: int = 0,
+    kv_rotate: bool = False,
     prompt_progress_callback: Optional[Callable[[int, int], None]] = None,
     input_embeddings: Optional[mx.array] = None,
 ) -> Generator[Tuple[mx.array, mx.array], None, None]:
@@ -372,6 +384,7 @@ def generate_step(
         quantized_kv_start=quantized_kv_start,
         kv_group_size=kv_group_size,
         kv_bits=kv_bits,
+        kv_rotate=kv_rotate,
     )
 
     sampler = sampler or (lambda x: mx.argmax(x, axis=-1))
@@ -475,6 +488,7 @@ def speculative_generate_step(
     kv_bits: Optional[int] = None,
     kv_group_size: int = 64,
     quantized_kv_start: int = 0,
+    kv_rotate: bool = False,
 ) -> Generator[Tuple[mx.array, mx.array, bool], None, None]:
     """
     A generator producing token ids based on the given prompt from the model.
@@ -520,7 +534,7 @@ def speculative_generate_step(
     if not cache.can_trim_prompt_cache(model_cache):
         types = {type(c).__name__ for c in model_cache if not c.is_trimmable()}
         raise ValueError(
-            f"Speculative decoding requires a trimmable prompt cache " f"(got {types})."
+            f"Speculative decoding requires a trimmable prompt cache (got {types})."
         )
 
     sampler = sampler or (lambda x: mx.argmax(x, axis=-1))
@@ -530,6 +544,7 @@ def speculative_generate_step(
         quantized_kv_start=quantized_kv_start,
         kv_group_size=kv_group_size,
         kv_bits=kv_bits,
+        kv_rotate=kv_rotate,
     )
 
     def _process_and_sample(tokens, logits):
@@ -2179,6 +2194,7 @@ def main():
         kv_bits=args.kv_bits,
         kv_group_size=args.kv_group_size,
         quantized_kv_start=args.quantized_kv_start,
+        kv_rotate=args.kv_rotate,
         draft_model=draft_model,
         num_draft_tokens=args.num_draft_tokens,
     )

--- a/mlx_lm/models/base.py
+++ b/mlx_lm/models/base.py
@@ -1,11 +1,36 @@
 # Copyright © 2023-2024 Apple Inc.
 
 import inspect
+import math
 from dataclasses import dataclass
 from typing import Any, Optional
 
 import mlx.core as mx
 from mlx.utils import tree_map
+
+_HADAMARD_BASES = (1, 12, 20, 28)
+
+
+def hadamard_size_ok(n: int) -> bool:
+    """True if ``mx.hadamard_transform`` supports a last-dim of size ``n``
+    (i.e. ``n = m * 2**k`` for ``m`` in {1, 12, 20, 28})."""
+    for m in _HADAMARD_BASES:
+        if n % m == 0 and ((n // m) & (n // m - 1)) == 0:
+            return True
+    return False
+
+
+def rotate_last(x: mx.array) -> mx.array:
+    """Orthonormal Walsh–Hadamard transform along the last axis.
+
+    Normalized by ``1/sqrt(D)`` so the transform is orthonormal (``R^T R = I``).
+    Applying it to *both* queries and keys leaves every ``q·k`` inner product —
+    and hence the attention scores — unchanged in exact arithmetic, while
+    spreading per-channel outliers into a near-Gaussian marginal that low-bit
+    affine quantization handles far more gracefully. Only orthonormality is
+    relied on here; the transform is additionally self-inverse only for
+    power-of-two ``D``."""
+    return mx.hadamard_transform(x, scale=1.0 / math.sqrt(x.shape[-1]))
 
 
 @dataclass
@@ -119,6 +144,11 @@ def scaled_dot_product_attention(
     if hasattr(cache, "bits"):
         if sinks is not None:
             raise ValueError("Quantized SDPA does not support attention sinks.")
+        # Rotated KV: keys were Hadamard-rotated before quantization, so rotate
+        # the queries by the same orthonormal transform. (R q)·(R k) = q·k, so
+        # scores are preserved while the stored keys quantize far more cleanly.
+        if getattr(cache, "rotate", False) and hadamard_size_ok(queries.shape[-1]):
+            queries = rotate_last(queries)
         return quantized_scaled_dot_product_attention(
             queries,
             keys,

--- a/mlx_lm/models/cache.py
+++ b/mlx_lm/models/cache.py
@@ -9,7 +9,7 @@ import mlx.core as mx
 import mlx.nn as nn
 from mlx.utils import tree_flatten, tree_map, tree_reduce, tree_unflatten
 
-from .base import create_causal_mask
+from .base import create_causal_mask, hadamard_size_ok, rotate_last
 
 
 def make_prompt_cache(
@@ -232,12 +232,13 @@ class ConcatenateKVCache(_BaseCache):
 class QuantizedKVCache(_BaseCache):
     step = 256
 
-    def __init__(self, group_size: int = 64, bits: int = 8):
+    def __init__(self, group_size: int = 64, bits: int = 8, rotate: bool = False):
         self.keys = None
         self.values = None
         self.offset = 0
         self.group_size = group_size
         self.bits = bits
+        self.rotate = rotate
 
     def update_and_fetch(self, keys, values):
         B, n_kv_heads, num_steps, k_head_dim = keys.shape
@@ -274,6 +275,8 @@ class QuantizedKVCache(_BaseCache):
 
         self.offset += num_steps
 
+        if self.rotate and hadamard_size_ok(keys.shape[-1]):
+            keys = rotate_last(keys)
         keys = mx.quantize(keys, group_size=self.group_size, bits=self.bits)
         values = mx.quantize(values, group_size=self.group_size, bits=self.bits)
         for i in range(len(self.keys)):
@@ -297,11 +300,16 @@ class QuantizedKVCache(_BaseCache):
 
     @property
     def meta_state(self):
-        return tuple(map(str, (self.offset, self.group_size, self.bits)))
+        return tuple(
+            map(str, (self.offset, self.group_size, self.bits, int(self.rotate)))
+        )
 
     @meta_state.setter
     def meta_state(self, v):
-        self.offset, self.group_size, self.bits = map(int, v)
+        vals = list(map(int, v))
+        self.offset, self.group_size, self.bits = vals[:3]
+        # Backward compatible with caches saved before `rotate` existed.
+        self.rotate = bool(vals[3]) if len(vals) > 3 else False
 
     def is_trimmable(self):
         return True
@@ -380,11 +388,16 @@ class KVCache(_BaseCache):
         self.offset -= n
         return n
 
-    def to_quantized(self, group_size: int = 64, bits: int = 4) -> QuantizedKVCache:
-        quant_cache = QuantizedKVCache(group_size=group_size, bits=bits)
+    def to_quantized(
+        self, group_size: int = 64, bits: int = 4, rotate: bool = False
+    ) -> QuantizedKVCache:
+        quant_cache = QuantizedKVCache(group_size=group_size, bits=bits, rotate=rotate)
         quant_cache.offset = self.offset
         if self.keys is not None:
-            quant_cache.keys = mx.quantize(self.keys, group_size=group_size, bits=bits)
+            keys = self.keys
+            if rotate and hadamard_size_ok(keys.shape[-1]):
+                keys = rotate_last(keys)
+            quant_cache.keys = mx.quantize(keys, group_size=group_size, bits=bits)
             quant_cache.values = mx.quantize(
                 self.values, group_size=group_size, bits=bits
             )

--- a/tests/test_kv_rotate.py
+++ b/tests/test_kv_rotate.py
@@ -1,0 +1,124 @@
+# Copyright © 2024 Apple Inc.
+
+import os
+import tempfile
+import unittest
+
+import mlx.core as mx
+
+from mlx_lm.generate import generate_step
+from mlx_lm.models.base import hadamard_size_ok, rotate_last
+from mlx_lm.models.cache import (
+    QuantizedKVCache,
+    load_prompt_cache,
+    make_prompt_cache,
+    save_prompt_cache,
+)
+from mlx_lm.utils import load
+
+HF_MODEL_PATH = "mlx-community/Qwen1.5-0.5B-Chat-4bit"
+
+
+class TestKVRotate(unittest.TestCase):
+    """Coverage for the Hadamard-rotated quantized KV cache (``--kv-rotate``)."""
+
+    @classmethod
+    def setUpClass(cls):
+        cls.model, cls.tokenizer = load(HF_MODEL_PATH)
+
+    def setUp(self):
+        self.test_dir_fid = tempfile.TemporaryDirectory()
+        self.test_dir = self.test_dir_fid.name
+
+    def tearDown(self):
+        self.test_dir_fid.cleanup()
+
+    def test_rotate_last_preserves_scores_across_head_dims(self):
+        # Broadened head_dim coverage: the Hadamard rotation is orthonormal, so
+        # rotating both Q and K leaves the full q.k score matrix unchanged for
+        # every supported head_dim -- the invariant the quantized-SDPA fast path
+        # relies on. Covers the sizes verified in the PR (64, 80, 96, 128).
+        for d in (64, 80, 96, 128):
+            self.assertTrue(hadamard_size_ok(d))
+            q = mx.random.normal(shape=(2, 4, 3, d))
+            k = mx.random.normal(shape=(2, 4, 5, d))
+            s0 = q @ mx.swapaxes(k, -1, -2)
+            s1 = rotate_last(q) @ mx.swapaxes(rotate_last(k), -1, -2)
+            self.assertTrue(mx.allclose(s0, s1, atol=1e-3, rtol=1e-3))
+            # orthonormal => per-vector L2 norm is preserved
+            self.assertTrue(
+                mx.allclose(
+                    mx.sum(q * q, axis=-1),
+                    mx.sum(rotate_last(q) * rotate_last(q), axis=-1),
+                    atol=1e-3,
+                    rtol=1e-3,
+                )
+            )
+        # Unsupported sizes are rejected, so rotation is skipped rather than
+        # silently applying a non-orthonormal transform (e.g. MLA's 576 latent).
+        for d in (17, 100, 130, 576):
+            self.assertFalse(hadamard_size_ok(d))
+
+    def test_cache_to_quantized_rotated(self):
+        # Dedicated coverage for the --quantized-kv-start rotation path:
+        # KVCache.to_quantized(rotate=True) rotates the cached keys and the
+        # quantized-SDPA fast path rotates Q, so at 8-bit (tiny quant error) the
+        # rotated quantized cache still tracks the fp reference -- the rotation is
+        # correct and neutral at high bits, exactly as intended (win is at 4-bit).
+        model, tokenizer = self.model, self.tokenizer
+        prompt = tokenizer.encode("this is a prompt", return_tensors="mlx")[0]
+        results = zip(range(4), generate_step(prompt, model))
+        toks, all_logits = zip(*(r[1] for r in results))
+
+        prompt_cache = make_prompt_cache(model)
+        i = 0
+        for _, (tok, logits) in zip(
+            range(2), generate_step(prompt, model, prompt_cache=prompt_cache)
+        ):
+            self.assertEqual(tok, toks[i])
+            i += 1
+
+        prompt_cache = [
+            c.to_quantized(bits=8, group_size=32, rotate=True) for c in prompt_cache
+        ]
+        for c in prompt_cache:
+            self.assertIsInstance(c, QuantizedKVCache)
+            self.assertTrue(c.rotate)
+            # rotate flag is carried in meta_state (4 fields, not the legacy 3)
+            self.assertEqual(len(c.meta_state), 4)
+
+        for _, (tok, logits) in zip(
+            range(1),
+            generate_step(mx.array([toks[i]]), model, prompt_cache=prompt_cache),
+        ):
+            i += 1
+            self.assertEqual(tok, toks[i])
+            # 8-bit rotation is neutral: it preserves the argmax and stays near
+            # fp, but redistributes quant error, so it sits a hair looser than
+            # affine's 4e-2 (measured max-rel ~0.04 on this model) -- 6e-2 keeps
+            # the assertion tight while non-flaky.
+            self.assertTrue(mx.allclose(logits, all_logits[i], rtol=6e-2))
+
+    def test_quantized_cache_rotate_roundtrip(self):
+        # The rotate flag survives save/load, and a legacy 3-field meta_state
+        # (written before rotate existed) loads as rotate=False.
+        cache = [QuantizedKVCache(bits=4, group_size=32, rotate=True) for _ in range(2)]
+        for c in cache:
+            x = mx.random.uniform(shape=(1, 8, 10, 64))
+            c.update_and_fetch(x, x)
+        cache_file = os.path.join(self.test_dir, "rotate_cache.safetensors")
+        save_prompt_cache(cache_file, cache)
+        loaded = load_prompt_cache(cache_file)
+        for c, lc in zip(cache, loaded):
+            self.assertTrue(lc.rotate)
+            self.assertEqual(lc.meta_state, c.meta_state)
+        # Backward compatibility: pre-rotate 3-field meta_state -> rotate=False.
+        legacy = QuantizedKVCache()
+        legacy.meta_state = ("7", "32", "4")
+        self.assertFalse(legacy.rotate)
+        self.assertEqual(legacy.offset, 7)
+        self.assertEqual(legacy.bits, 4)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

`--kv-bits 4` currently produces an **unusable** KV cache on many models: plain affine quantization of the keys collapses because a few outlier channels blow up each quantization group's range. This PR adds an optional **orthonormal Hadamard rotation** of the keys before quantization (and the matching rotation of the queries at attention time). Because the rotation is orthonormal it leaves every `q·k` inner product — and therefore the attention scores — **unchanged in exact arithmetic**, while spreading the outliers into a near-Gaussian marginal that low-bit affine quantization handles cleanly.

Enable with a new `--kv-rotate` flag (composes with `--kv-bits`).

**Scope of the claim** (sharpened by [independent validation below](#independent-validation)): rotation effectively **lowers the usable K-bits floor by about one bit** on outlier-prone models. It rescues 4-bit KV from collapse (near-fp16 at short context, small but visible ppl cost at 4k context); it does not make 4-bit free at long context, and 3-bit still collapses. The strongest practical configuration is rotated keys combined with asymmetric K/V bits — see *Recommended configurations*.

## Results

`benchmarks/kv_rotation_ppl.py` (included), teacher-forced perplexity, `mlx-community/Qwen3-1.7B-bf16` (head_dim 128), 349-token context, `group_size=64`, on an M3 Max (mlx 0.32.0):

| KV bits | affine ppl | rotated ppl | gap to fp16 recovered |
|--------:|-----------:|------------:|----------------------:|
| fp16    | —          | **41.23**   | —                     |
| 8       | 40.91      | 41.33       | neutral (both ≈ fp16) |
| **4**   | **560.44** | **57.57**   | **97%**               |
| 3       | 2047.31    | 570.02      | 74%                   |
| 2       | 44802.84   | 9780.67     | 78%                   |

At the practically important **4-bit** setting, affine KV is ~14× worse than fp16 and effectively broken; rotation restores near-fp16 at this context length. 8-bit is already fine (rotation is neutral there, so `--kv-rotate` is intended for `kv_bits ≤ 4`). Models with `head_dim == group_size` (e.g. Llama-3.2-1B, head_dim 64 = a single group) show a much smaller effect — the win scales with the number of quant groups per head.

**Coherence** (same model, greedy, 4-bit KV) — affine collapses into repetition, rotation stays correct:

```
[affine  4-bit] The sky appears blue because the atmosphere is not transparent. The atmosphere
                is not transparent, it is not transparent. The atmosphere is not transparent...
[rotated 4-bit] The sky appears blue because of Rayleigh scattering. The sun emits light of
                different wavelengths, and the atmosphere scatters the shorter wavelengths more...
```

## Independent validation

[pierre427 reproduced the headline result and extended it to 4k context and a second model](https://github.com/ml-explore/mlx-lm/pull/1555#issuecomment-4958414613) — key datapoints from the thread:

- **Repro** (Qwen3-1.7B-4bit, M5): kv4 affine 554.9 → rotated 57.7 vs fp16 45.3 — matches the table above on a 4-bit-weight checkpoint.
- **4k context** (teacher-forced ppl): fp16 22.39; K4/V4 affine 515.18; K4/V4 rotated 28.82 (+29%); K3 rotated still collapses. So at long context rotation moves the usable-K floor down ~1 bit (K5–K6 rotated are clean) rather than making K4 free.
- **Model dependence**: on a 152B MoE (Hunyuan-3-REAP50 4-bit, GQA 64/8), affine K4/V4 is already fine (+2% ppl) — no key-outlier pathology, rotation neutral. The win depends on the checkpoint's key statistics; `--kv-rotate` is a per-model call, not a proposed default.

## Recommended configurations

Because rotation only touches K, it composes directly with separate K/V bit-widths (#1550). On the outlier-prone model at 4k context (pierre427's numbers):

| config | avg bits | ppl |
|---|---:|---:|
| fp16 | 16 | 22.39 |
| K5/V4 affine | 4.5 | 31.10 |
| **K5/V4 rotated** | **4.5** | **23.15** |
| **K6/V3 rotated** | **4.5** | **22.98** |

Rotated keys + low-bit values reach a **4.5-bit-average cache at ~+3% ppl** — a point neither symmetric rotation nor asymmetric affine reaches alone.

## How it works

- **`QuantizedKVCache`** rotates the keys with a normalized Walsh–Hadamard transform (`scale = 1/sqrt(D)`, **orthonormal**: `R^T R = I`) *before* `mx.quantize`. Values are **not** rotated — they don't enter the `Q Kᵀ` inner product.
- **`scaled_dot_product_attention`** rotates the queries by the same transform before the quantized SDPA when `cache.rotate` is set. `(Rq)·(Rk) = q·k` (orthonormality), so scores are preserved.
- Reuses `mx.hadamard_transform`; a `hadamard_size_ok(head_dim)` guard falls back to plain affine on unsupported dims (`n = m·2^k`, `m ∈ {1,12,20,28}`). Verified numerically that `(Rq)·(Rk) − q·k` is ~1e-6 for head_dim ∈ {64, 80, 96, 128}.

Cost is one `hadamard_transform` on K per store and on Q per step — `O(D log D)`. Measured decode overhead ≈ **2%** (rotated 4-bit 81.9 vs affine 83.4 tok/s, M3 Max).

## Changes

- `models/base.py` — `hadamard_size_ok` / `rotate_last` helpers; rotate Q in the quantized-SDPA dispatch.
- `models/cache.py` — rotate K in `QuantizedKVCache`; `rotate` flag; `to_quantized(rotate=…)`; `meta_state` carries `rotate` (backward-compatible with caches saved before this field).
- `generate.py` — thread `kv_rotate` through `maybe_quantize_kv_cache`, `generate_step`, `speculative_generate_step`; add `--kv-rotate` to the `mlx_lm.generate` CLI.

## Usage

```bash
python -m mlx_lm.generate --model mlx-community/Qwen3-1.7B-bf16 \
    --kv-bits 4 --kv-rotate --prompt "…"
```

## Scope / follow-ups

- Implements the **rotation (MSE) regime** of TurboQuant ([arXiv:2504.19874](https://arxiv.org/abs/2504.19874)). The paper's **+1-bit QJL residual** was the obvious next step for usable 3-bit KV, so I prototyped it on top of this rather than assuming: wikitext-2, 1024 tokens, Qwen3-1.7B — fp16 **10.66**, rotated-4-bit **12.81**, rotated-3-bit **160.4**, rotated-3-bit + QJL **27.14**. QJL recovers ~89% of the 3-bit gap, but 3-bit + QJL still loses badly to plain 4-bit rotation, so it is **not** proposed as a feature. 4-bit rotation is the sweet spot for affine KV; 3-bit isn't competitive with or without the residual.
- **MLA / absorbed-form caches** (e.g. `deepseek_v2` latent path): the cached last dim is `kv_lora_rank + qk_rope_head_dim` = 576 = 2⁶·9, which `hadamard_size_ok` rejects, so `--kv-rotate` is a **silent no-op** there (correctly — the guard is symmetric on Q and K). Rotating only the 512-dim latent slice works mechanically but **does not pay**, on three checkpoints measured independently: Moonlight-16B-A3B (wikitext — fp16 6.64 / kv4 affine 6.80 / kv4 rotated 7.04) and [pierre427's DeepSeek-V2-Lite-Chat and Sarvam-105B](https://github.com/ml-explore/mlx-lm/pull/1555#issuecomment-5047452039) (neutral at kv8, slightly worse at kv4). MLA latents don't carry the key-outlier structure the rotation exploits, so there is no collapse to rescue. Recorded here so it isn't re-derived.
- Kept self-contained to the `mlx_lm.generate` CLI. `mlx_lm.server` support is a one-line addition (`kv_rotate=args.kv_rotate` into the server's `maybe_quantize_kv_cache` call + a `--kv-rotate` flag) that lands naturally with the in-flight server KV-quant work (#1476); left out here to keep this diff focused.

## Test plan

- [x] `benchmarks/kv_rotation_ppl.py` reproduces the table above.
- [x] `tests/test_prompt_cache.py` (22) and `tests/test_generate.py` (26) pass on the patched tree.
- [x] `rotate=False` (default) leaves existing behavior unchanged; `meta_state` round-trips and loads pre-existing (3-field) caches as `rotate=False`.
- [x] Independent reproduction on M5 (Qwen3-1.7B-4bit) + 4k-context scoping + second architecture (152B MoE) — see *Independent validation*.
- [x] `--quantized-kv-start` (KVCache→`to_quantized(rotate=True)`) rotation path — covered by `test_cache_to_quantized_rotated` (tests/test_kv_rotate.py).
- [x] Broaden model/head_dim coverage — `test_rotate_last_preserves_scores_across_head_dims` sweeps head_dim ∈ {64, 80, 96, 128} on the orthonormal invariant + `hadamard_size_ok` accept/reject.
