### PR TITLE
Commit-steering: a content-blind controller for reasoning run-on

### DIFF
--- a/mlx_lm/__init__.py
+++ b/mlx_lm/__init__.py
@@ -1,4 +1,4 @@
-# Copyright © 2023-2024 Apple Inc.
+# Copyright © 2023-2026 Apple Inc.
 
 import os
 
@@ -8,6 +8,7 @@ os.environ["TRANSFORMERS_NO_ADVISORY_WARNINGS"] = "1"
 
 from .convert import convert
 from .generate import batch_generate, generate, stream_generate
+from .steer import CommitSteerer
 from .utils import load
 
 __all__ = [
@@ -16,5 +17,6 @@ __all__ = [
     "batch_generate",
     "generate",
     "stream_generate",
+    "CommitSteerer",
     "load",
 ]

--- a/mlx_lm/examples/commit_steer.py
+++ b/mlx_lm/examples/commit_steer.py
@@ -1,0 +1,126 @@
+# Copyright © 2026 Apple Inc.
+
+"""End-to-end example: extract a commit direction, then steer generation.
+
+Step 1 (offline, once per model) records a handful of greedy reasoning traces on
+checkable problems and extracts the commit direction by difference-of-means.
+Step 2 (runtime, content-blind) generates with the two-mode CommitSteerer and
+prints the token counts with and without it.
+
+    python -m mlx_lm.examples.commit_steer --model mlx-community/Qwen3-8B-4bit
+"""
+
+import argparse
+
+import mlx.core as mx
+import numpy as np
+
+from mlx_lm import load
+from mlx_lm.generate import generate_step
+from mlx_lm.steer import CommitSteerer, extract_commit_direction
+
+# A few checkable problems to elicit reasoning traces for extraction.
+PROBLEMS = [
+    "What is 23 times 4? Show your reasoning, then give the final answer.",
+    "A bat and a ball cost $1.10. The bat costs $1.00 more than the ball. "
+    "How much is the ball?",
+    "What is 37 times 43? Reason step by step, then answer.",
+    "Find the smallest positive integer x with x = 2 (mod 3) and x = 3 (mod 5).",
+]
+
+
+def greedy_trace(model, tok, prompt, max_tokens=2048):
+    ids = mx.array(
+        tok.encode(
+            tok.apply_chat_template(
+                [{"role": "user", "content": prompt}],
+                tokenize=False,
+                add_generation_prompt=True,
+            )
+        )
+    )
+    out = []
+    for t, _ in generate_step(ids, model, max_tokens=max_tokens):
+        t = int(t)
+        out.append(t)
+        if t == tok.eos_token_id:
+            break
+    return out
+
+
+def run(model, tok, prompt, steerer=None, max_tokens=2048):
+    ids = mx.array(
+        tok.encode(
+            tok.apply_chat_template(
+                [{"role": "user", "content": prompt}],
+                tokenize=False,
+                add_generation_prompt=True,
+            )
+        )
+    )
+    close_id = tok.encode("</think>", add_special_tokens=False)
+    close_id = close_id[0] if len(close_id) == 1 else -1
+    procs = [steerer.logits_processor] if steerer else None
+    ctx = steerer if steerer else _null()
+    n = think = 0
+    closed = False
+    with ctx:
+        for t, _ in generate_step(
+            ids, model, max_tokens=max_tokens, logits_processors=procs
+        ):
+            t = int(t)
+            n += 1
+            if t == close_id:
+                closed = True
+            elif not closed:
+                think += 1
+            if t == tok.eos_token_id:
+                break
+    return n, think
+
+
+class _null:
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *a):
+        return False
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--model", required=True)
+    ap.add_argument("--layer", type=int, default=None, help="commit locus (default ~57%)")
+    ap.add_argument("--alpha-bias", type=float, default=0.2)
+    ap.add_argument("--alpha-hammer", type=float, default=0.8)
+    ap.add_argument("--hammer-budget", type=int, default=900)
+    ap.add_argument("--test-prompt", default="Is 91 a prime number? Explain, then answer.")
+    args = ap.parse_args()
+
+    model, tok = load(args.model)
+    n_layers = len(model.model.layers)
+    layer = args.layer if args.layer is not None else round(0.57 * n_layers)
+    span = sorted({max(2, min(n_layers - 1, round(f * n_layers)))
+                   for f in (0.43, 0.5, 0.57, 0.64)})
+
+    print(f"[1/2] extracting commit direction on {len(PROBLEMS)} traces ...")
+    traces = [greedy_trace(model, tok, p) for p in PROBLEMS]
+    vecs = extract_commit_direction(model, tok, traces, span)
+    v_hat, rms = vecs[layer]
+    print(f"      layer {layer}/{n_layers}  ||v||={np.linalg.norm(v_hat):.3f}  rms={rms:.1f}")
+
+    steerer = CommitSteerer(
+        model, tok, v_hat, rms, layer=layer,
+        alpha_bias=args.alpha_bias, alpha_hammer=args.alpha_hammer,
+        hammer_budget=args.hammer_budget,
+    )
+    print(f"[2/2] generating '{args.test_prompt}'")
+    n_off, think_off = run(model, tok, args.test_prompt, steerer=None)
+    n_on, think_on = run(model, tok, args.test_prompt, steerer=steerer)
+    cut = (1 - think_on / max(think_off, 1)) * 100
+    print(f"      OFF: {n_off} tokens ({think_off} thinking)")
+    print(f"      ON : {n_on} tokens ({think_on} thinking)  -> {cut:.0f}% fewer think tokens")
+
+
+if __name__ == "__main__":
+    main()

--- a/mlx_lm/steer.py
+++ b/mlx_lm/steer.py
@@ -1,0 +1,421 @@
+# Copyright © 2026 Apple Inc.
+
+"""Commit-steering: a content-blind controller for reasoning run-on.
+
+Reasoning models often *have* the answer well before they stop deliberating —
+they re-derive, second-guess, and re-check long after the result is formed. This
+"run-on" is largely a **suppressed stop token** (the exit is high-rank but held
+down by a logit margin), not confusion. The behavior of committing/terminating
+is a direction in the residual stream; nudging the hidden state along that
+direction at the layer where the model decides to wrap up releases the answer
+sooner.
+
+The direction is learned **offline** by difference-of-means — the mean hidden
+state over commitment spans minus the mean over reflection spans
+(:func:`extract_commit_direction`). At inference the controller is
+**content-blind**: it never reads the generated text, it only adds a fixed
+vector at one decoder layer while the model is inside its think channel.
+
+Two-mode controller (:class:`CommitSteerer`):
+
+* an always-on low-dose **bias** while inside the think channel, and
+* a late hard **hammer** if the model is still thinking past a token budget.
+
+Integration is non-invasive. :class:`CommitSteerer` is a context manager that
+taps one decoder layer, and exposes a :meth:`~CommitSteerer.logits_processor`
+that plugs into the existing ``generate_step(..., logits_processors=[...])``
+API. The processor never changes the sampled logits — it only updates which
+steering vector the *next* forward injects, from the committed-token prefix.
+
+Example::
+
+    from mlx_lm import load
+    from mlx_lm.generate import generate_step
+    from mlx_lm.steer import CommitSteerer
+    import numpy as np
+
+    model, tok = load("mlx-community/Qwen3-8B-4bit")
+    z = np.load("commit_vectors_qwen3-8b.npz")          # from extract_commit_direction
+    steerer = CommitSteerer(model, tok, z["v_20"], z["rms_20"], layer=20)
+
+    ids = mx.array(tok.encode(prompt))
+    with steerer:
+        for tok_id, _ in generate_step(
+            ids, model, max_tokens=2048,
+            logits_processors=[steerer.logits_processor],
+        ):
+            ...
+"""
+
+from __future__ import annotations
+
+import re
+from contextlib import contextmanager
+from typing import Any, Dict, List, Optional, Tuple
+
+import mlx.core as mx
+import numpy as np
+
+__all__ = [
+    "CommitSteerer",
+    "steer_layer",
+    "build_vector",
+    "extract_commit_direction",
+]
+
+
+# --------------------------------------------------------------------------- #
+# Layer tap
+# --------------------------------------------------------------------------- #
+class _SteerTap:
+    """Wraps one decoder layer: adds a (mutable) steering vector to its residual
+    output and/or captures that output, delegating everything else — attention
+    mask, cache, sinks, hybrid routing, ``is_linear``, ... — to the real layer.
+
+    Because it runs the real layer's own forward, it works across architectures
+    (dense, MoE, sliding-window/sink attention, latent-attention, GDN/SSM
+    hybrids) without re-implementing any of them.
+
+    ``holder[0]`` is the current steering vector (or ``None`` for a no-op).
+    ``sink`` (optional) is a one-element list that receives the layer output for
+    offline capture.
+    """
+
+    def __init__(self, inner, holder, sink=None):
+        object.__setattr__(self, "_inner", inner)
+        object.__setattr__(self, "_holder", holder)
+        object.__setattr__(self, "_sink", sink)
+
+    def __call__(self, *args, **kwargs):
+        h = self._inner(*args, **kwargs)
+        vec = self._holder[0]
+        if vec is not None:
+            h = h + vec
+        if self._sink is not None:
+            self._sink[0] = h
+        return h
+
+    def __getattr__(self, name):
+        return getattr(object.__getattribute__(self, "_inner"), name)
+
+
+@contextmanager
+def steer_layer(model, layer_index: int, holder: List[Optional[mx.array]], sink=None):
+    """Temporarily tap decoder layer ``layer_index``.
+
+    While the context is open, ``holder[0]`` (if not ``None``) is added to the
+    layer's residual output on every forward, and — if ``sink`` is given — the
+    output is stashed into ``sink[0]``. The original layer is always restored on
+    exit. Requires ``model.model.layers`` to be the decoder-layer list, which is
+    the standard mlx-lm decoder layout.
+    """
+    layers = model.model.layers
+    original = layers[layer_index]
+    layers[layer_index] = _SteerTap(original, holder, sink)
+    try:
+        yield
+    finally:
+        layers[layer_index] = original
+
+
+def build_vector(v_hat, rms: float, alpha: float) -> Optional[mx.array]:
+    """Return ``alpha * rms * v_hat`` as a float16 array, or ``None`` if the
+    direction is degenerate (non-finite or ~zero norm).
+
+    Returning ``None`` makes a missing or invalid axis a safe no-op: a model with
+    no extractable commit direction (e.g. a non-thinking model) simply runs
+    unchanged instead of having ``NaN`` injected into its residual stream.
+    """
+    v = np.asarray(v_hat, dtype=np.float64)
+    rms = float(rms)
+    if (
+        not np.isfinite(rms)
+        or not np.all(np.isfinite(v))
+        or float(np.linalg.norm(v)) < 1e-6
+    ):
+        return None
+    return mx.array((alpha * rms * v).astype(np.float16))
+
+
+def _single_token_id(tokenizer, text: str) -> int:
+    """Token id for ``text`` if it encodes to exactly one token, else ``-1``
+    (which never matches a real token). Non-thinking tokenizers that split
+    ``</think>`` across tokens therefore yield ``-1`` and disable phase tracking.
+    """
+    try:
+        ids = tokenizer.encode(text, add_special_tokens=False)
+    except Exception:
+        return -1
+    return ids[0] if len(ids) == 1 else -1
+
+
+# --------------------------------------------------------------------------- #
+# Runtime controller
+# --------------------------------------------------------------------------- #
+class CommitSteerer:
+    """Two-mode commit-steering controller for a reasoning model.
+
+    Args:
+        model: an mlx-lm model exposing ``model.model.layers``.
+        tokenizer: used only to resolve the reasoning-channel tag ids; the
+          controller is content-blind otherwise.
+        v_hat: unit commit direction at ``layer`` (length = hidden size).
+        rms: typical residual norm at ``layer`` (scales the injected vector).
+        layer (int): decoder layer to inject at. ~55-60% relative depth is a
+          good default across models.
+        alpha_bias (float): standing low-dose bias while inside the think
+          channel. Default: ``0.2``.
+        alpha_hammer (float): late hard dose if still thinking past
+          ``hammer_budget``. Default: ``0.8``.
+        hammer_budget (int): think-token count after which the hammer engages.
+          Set to ``0``/``None`` for bias only. Default: ``900``.
+        close_tag, open_tag (str): reasoning-channel tags. Defaults
+          ``"</think>"`` / ``"<think>"``.
+
+    If the commit direction is degenerate (:func:`build_vector` returns
+    ``None``) the controller is disabled and behaves as a pure no-op.
+
+    Use as a context manager and pass :meth:`logits_processor` to
+    ``generate_step`` (see the module docstring for a full example).
+    """
+
+    def __init__(
+        self,
+        model,
+        tokenizer,
+        v_hat,
+        rms,
+        *,
+        layer: int,
+        alpha_bias: float = 0.2,
+        alpha_hammer: float = 0.8,
+        hammer_budget: Optional[int] = 900,
+        close_tag: str = "</think>",
+        open_tag: str = "<think>",
+    ):
+        self.model = model
+        self.layer = layer
+        self._bias = build_vector(v_hat, rms, alpha_bias)
+        self._hammer = (
+            build_vector(v_hat, rms, alpha_hammer) if hammer_budget else None
+        )
+        self.hammer_budget = int(hammer_budget or 0)
+        self._close_id = _single_token_id(tokenizer, close_tag)
+        self._open_id = _single_token_id(tokenizer, open_tag)
+        # a degenerate axis (or no resolvable close tag) => pure no-op
+        self.disabled = self._bias is None or self._close_id < 0
+        # runtime state
+        self._holder: List[Optional[mx.array]] = [None]
+        self._in_think = True  # chat templates typically pre-open the channel
+        self._think_count = 0
+        self._seen = 0
+        self._cm = None
+
+    # -- context management: patch/unpatch the layer --------------------------
+    def __enter__(self) -> "CommitSteerer":
+        self.reset()
+        if not self.disabled:
+            self._cm = steer_layer(self.model, self.layer, self._holder)
+            self._cm.__enter__()
+        return self
+
+    def __exit__(self, *exc) -> bool:
+        if self._cm is not None:
+            self._cm.__exit__(*exc)
+            self._cm = None
+        self._holder[0] = None
+        return False
+
+    def reset(self) -> None:
+        """Reset the think-channel state for a fresh generation."""
+        self._in_think = True
+        self._think_count = 0
+        self._seen = 0
+        self._holder[0] = None
+
+    # -- schedule -------------------------------------------------------------
+    def _select(self) -> Optional[mx.array]:
+        if self.disabled or not self._in_think:
+            return None
+        if (
+            self.hammer_budget
+            and self._think_count >= self.hammer_budget
+            and self._hammer is not None
+        ):
+            return self._hammer
+        return self._bias
+
+    def logits_processor(self, tokens: mx.array, logits: mx.array) -> mx.array:
+        """State-updater for the ``logits_processors`` list.
+
+        Reads the committed-token prefix, updates the think-channel state, and
+        sets the vector the *next* forward will inject. Returns ``logits``
+        unchanged — steering happens mid-network, not on the sampled logits, so
+        this composes with samplers and other logits processors.
+        """
+        if self.disabled:
+            return logits
+        n = int(tokens.shape[-1])
+        if self._seen == 0:
+            # first call: `tokens` is the prompt. Derive the think state from its
+            # tail; do not count prompt tokens toward the hammer budget. Leave
+            # the holder at None so prefill and the first decode step are
+            # unsteered (steering begins one decode token in).
+            for t in tokens[max(0, n - 64):].tolist():
+                if t == self._open_id:
+                    self._in_think = True
+                elif t == self._close_id:
+                    self._in_think = False
+        else:
+            for t in tokens[self._seen:].tolist():
+                if t == self._open_id:
+                    self._in_think = True
+                elif t == self._close_id:
+                    self._in_think = False
+                elif self._in_think:
+                    self._think_count += 1
+            self._holder[0] = self._select()
+        self._seen = n
+        return logits
+
+
+# --------------------------------------------------------------------------- #
+# Offline extraction (content labels are used here only, never at runtime)
+# --------------------------------------------------------------------------- #
+# Lexical markers used *offline* to label reflection vs commitment spans. These
+# are a convenience for English self-correcting reasoners; a position-based
+# labeling (early-think vs the tokens just before </think>) generalizes to
+# models that reason more linearly.
+REFLECT_RE = re.compile(
+    r"\b(Wait|But wait|Hmm|However|Actually|Alternatively|Hold on|"
+    r"Let me (?:double-?check|re-?check|verify|check|reconsider))\b",
+    re.IGNORECASE,
+)
+COMMIT_RE = re.compile(
+    r"\b(Therefore|Thus|So the answer is|The answer is|the final answer|"
+    r"final answer is|So the result|I'?m confident|answer:)\b",
+    re.IGNORECASE,
+)
+
+
+def _hidden_dim(model) -> int:
+    for attr in ("hidden_size", "model_dim", "d_model", "n_embd", "dim"):
+        d = getattr(model.args, attr, None)
+        if isinstance(d, int) and d > 0:
+            return d
+    return int(model.model.embed_tokens.weight.shape[-1])
+
+
+@contextmanager
+def _tap_layers(model, layers, holder, sinks):
+    """Tap several layers at once (shared no-op ``holder``, per-layer ``sinks``),
+    restoring all of them on exit."""
+    layer_list = model.model.layers
+    original = {L: layer_list[L] for L in layers}
+    try:
+        for L in layers:
+            layer_list[L] = _SteerTap(layer_list[L], holder, sinks[L])
+        yield
+    finally:
+        for L, layer in original.items():
+            layer_list[L] = layer
+
+
+def _capture_layers(model, ids: List[int], layers: List[int]) -> Dict[int, np.ndarray]:
+    """One forward over ``ids`` (fresh cache), returning each layer's residual
+    output as a (seq, hidden) numpy array."""
+    from mlx_lm.models.cache import make_prompt_cache
+
+    holder: List[Optional[mx.array]] = [None]
+    sinks = {L: [None] for L in layers}
+    with _tap_layers(model, layers, holder, sinks):
+        model(mx.array(ids)[None], cache=make_prompt_cache(model))
+    mx.eval(*[sinks[L][0] for L in layers])
+    return {L: np.array(sinks[L][0][0].astype(mx.float32)) for L in layers}
+
+
+def extract_commit_direction(
+    model,
+    tokenizer,
+    traces: List[List[int]],
+    layers: List[int],
+    *,
+    close_tag: str = "</think>",
+    span_after: int = 6,
+    commit_tail: int = 8,
+) -> Dict[int, Tuple[np.ndarray, float]]:
+    """Offline: extract the commit direction per layer by difference-of-means.
+
+    Args:
+        model, tokenizer: the model to extract from.
+        traces: greedy reasoning traces, each a list of generated token ids.
+        layers: decoder layers to extract at.
+        close_tag: reasoning-channel close tag (its span end anchors commitment).
+        span_after: tokens taken after each lexical marker as its span.
+        commit_tail: in-think tokens just before ``</think>`` counted as commit.
+
+    Returns ``{layer: (v_hat, rms)}`` where ``v_hat`` is the unit commit
+    direction and ``rms`` the mean residual norm at that layer. Reflection and
+    commitment spans are labeled by lexical markers here (offline only — the
+    runtime controller in :class:`CommitSteerer` is content-blind).
+
+    Cross-trace consistency of ``v_hat`` (mean pairwise cosine of the per-trace
+    directions) is a good sanity check: a real axis is strongly positive
+    (~+0.5 to +0.86 across the models we tested); near zero means no usable
+    direction.
+    """
+    D = _hidden_dim(model)
+    sums = {L: {"reflect": np.zeros(D), "commit": np.zeros(D)} for L in layers}
+    counts = {"reflect": 0, "commit": 0}
+    rms = {L: [] for L in layers}
+
+    def _positions(text, starts, rx, limit):
+        out: List[int] = []
+        for m in rx.finditer(text[:limit] if limit else text):
+            t0 = next((i for i, s in enumerate(starts) if s >= m.start()), None)
+            if t0 is not None:
+                out.extend(range(t0, min(t0 + span_after, len(starts))))
+        return sorted(set(out))
+
+    for ids in traces:
+        # incremental detokenization gives clean text + per-token char offsets
+        det = tokenizer.detokenizer
+        det.reset()
+        starts: List[int] = []
+        for t in ids:
+            starts.append(len(det.text))
+            det.add_token(t)
+        det.finalize()
+        text = det.text
+
+        close_char = text.find(close_tag)
+        limit = close_char if close_char >= 0 else len(text)
+        p_ref = _positions(text, starts, REFLECT_RE, limit)
+        p_com = _positions(text, starts, COMMIT_RE, limit)
+        if close_char >= 0:
+            ct = next(
+                (i for i, s in enumerate(starts) if s >= close_char), len(starts)
+            )
+            p_com = sorted(set(p_com) | set(range(max(0, ct - commit_tail), ct)))
+        p_ref = [p for p in p_ref if p not in set(p_com)]
+        if not p_ref or not p_com:
+            continue
+
+        H = _capture_layers(model, ids, layers)  # one forward, all layers
+        for L in layers:
+            hr = H[L][[p for p in p_ref if p < len(H[L])]]
+            hc = H[L][[p for p in p_com if p < len(H[L])]]
+            sums[L]["reflect"] += hr.sum(0)
+            sums[L]["commit"] += hc.sum(0)
+            rms[L].append(float(np.linalg.norm(H[L], axis=1).mean()))
+        counts["reflect"] += len(p_ref)
+        counts["commit"] += len(p_com)
+
+    out: Dict[int, Tuple[np.ndarray, float]] = {}
+    for L in layers:
+        v = sums[L]["commit"] / max(counts["commit"], 1) - sums[L][
+            "reflect"
+        ] / max(counts["reflect"], 1)
+        vhat = v / (np.linalg.norm(v) + 1e-8)
+        out[L] = (vhat.astype(np.float32), float(np.mean(rms[L]) if rms[L] else 0.0))
+    return out

--- a/tests/test_steer.py
+++ b/tests/test_steer.py
@@ -1,0 +1,148 @@
+# Copyright © 2026 Apple Inc.
+
+import unittest
+
+import mlx.core as mx
+import mlx.nn as nn
+import numpy as np
+
+from mlx_lm.steer import CommitSteerer, build_vector, steer_layer
+
+
+class _Layer(nn.Module):
+    """Identity decoder layer with a distinguishing attribute, matching the
+    ``layer(x, ...) -> x`` calling convention taps rely on."""
+
+    def __init__(self):
+        super().__init__()
+        self.is_linear = False
+
+    def __call__(self, x, *args, **kwargs):
+        return x
+
+
+class _Inner(nn.Module):
+    def __init__(self, n_layers=4, dim=8):
+        super().__init__()
+        self.embed_tokens = nn.Embedding(32, dim)
+        self.layers = [_Layer() for _ in range(n_layers)]
+
+    def __call__(self, ids, cache=None):
+        h = self.embed_tokens(ids)
+        for layer in self.layers:
+            h = layer(h)
+        return h
+
+
+class _Model(nn.Module):
+    def __init__(self, dim=8):
+        super().__init__()
+        self.model = _Inner(dim=dim)
+        self.args = type("A", (), {"hidden_size": dim})()
+
+    def __call__(self, ids, cache=None):
+        return self.model(ids, cache=cache)
+
+
+class _Tok:
+    """Minimal tokenizer: </think> and <think> are single ids 2 and 1."""
+
+    def encode(self, text, add_special_tokens=False):
+        return {"<think>": [1], "</think>": [2]}.get(text, [9, 9])
+
+
+class TestBuildVector(unittest.TestCase):
+    def test_scales(self):
+        v = build_vector(np.array([1.0, 0.0, 0.0]), rms=10.0, alpha=0.2)
+        self.assertAlmostEqual(float(mx.sum(v)), 2.0, places=2)
+
+    def test_degenerate_is_none(self):
+        self.assertIsNone(build_vector(np.zeros(3), 10.0, 0.2))          # zero norm
+        self.assertIsNone(build_vector(np.array([np.nan, 0, 0]), 1.0, 0.2))  # nan
+        self.assertIsNone(build_vector(np.array([1.0, 0, 0]), np.nan, 0.2))  # nan rms
+
+
+class TestSteerLayer(unittest.TestCase):
+    def test_injects_and_restores(self):
+        model = _Model(dim=4)
+        ids = mx.array([[3, 4, 5]])
+        base = model(ids)
+        holder = [mx.array([1.0, 1.0, 1.0, 1.0])]
+        original = model.model.layers[2]
+        with steer_layer(model, 2, holder):
+            steered = model(ids)
+        # every position shifted by exactly the vector (three identity layers
+        # after the tap pass it through unchanged)
+        self.assertTrue(
+            mx.allclose(steered, base + holder[0], atol=1e-4).item()
+        )
+        # None holder is a no-op
+        holder[0] = None
+        with steer_layer(model, 2, holder):
+            noop = model(ids)
+        self.assertTrue(mx.allclose(noop, base, atol=1e-5).item())
+        # layer object restored
+        self.assertIs(model.model.layers[2], original)
+
+    def test_delegates_attributes(self):
+        model = _Model()
+        holder = [None]
+        with steer_layer(model, 1, holder):
+            # the loop reads layer.is_linear on some hybrid archs; must resolve
+            self.assertFalse(model.model.layers[1].is_linear)
+
+
+class TestCommitSteererSchedule(unittest.TestCase):
+    def _steerer(self, **kw):
+        model = _Model()
+        v = np.ones(8) / np.sqrt(8)
+        return CommitSteerer(model, _Tok(), v, rms=10.0, layer=1, **kw)
+
+    def test_bias_then_hammer_then_off(self):
+        s = self._steerer(alpha_bias=0.2, alpha_hammer=0.8, hammer_budget=3)
+        s.reset()
+        # first call: prompt (pre-opened think). Holder stays off during prefill.
+        s.logits_processor(mx.array([1, 5, 5]), mx.zeros((1, 32)))
+        self.assertIsNone(s._holder[0])
+        # decode tokens accumulate; under budget => bias
+        toks = [1, 5, 5]
+        for extra in (5, 5):  # 2 think tokens (count 1, 2)
+            toks.append(extra)
+            s.logits_processor(mx.array(toks), mx.zeros((1, 32)))
+        self.assertTrue(mx.allclose(s._holder[0], s._bias).item())
+        # cross the hammer budget (count reaches 3) => hammer
+        toks.append(5)
+        s.logits_processor(mx.array(toks), mx.zeros((1, 32)))
+        self.assertTrue(mx.allclose(s._holder[0], s._hammer).item())
+        # closing the think channel => steering off
+        toks.append(2)  # </think>
+        s.logits_processor(mx.array(toks), mx.zeros((1, 32)))
+        self.assertIsNone(s._holder[0])
+
+    def test_disabled_on_degenerate_axis(self):
+        s = self._steerer()
+        s._bias = None  # simulate a null direction
+        s.disabled = True
+        out = s.logits_processor(mx.array([1, 5]), mx.ones((1, 32)))
+        self.assertTrue(mx.allclose(out, mx.ones((1, 32))).item())
+        self.assertIsNone(s._holder[0])
+
+    def test_no_close_tag_disables(self):
+        model = _Model()
+
+        class _NoThink:
+            def encode(self, text, add_special_tokens=False):
+                return [7, 8]  # </think> is multi-token => -1 => disabled
+
+        s = CommitSteerer(model, _NoThink(), np.ones(8) / np.sqrt(8), 10.0, layer=1)
+        self.assertTrue(s.disabled)
+
+    def test_logits_never_modified(self):
+        s = self._steerer()
+        logits = mx.random.normal((1, 32))
+        out = s.logits_processor(mx.array([1, 5, 5, 5]), logits)
+        self.assertTrue(mx.array_equal(out, logits).item())
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Commit-steering: a content-blind controller for reasoning run-on

Reasoning models often *have* the answer well before they stop talking. They re-derive it, second-guess, re-check the arithmetic a third time, and finally emit `</think>` thousands of tokens after the result was already formed. That deliberation is real compute you pay for and usually don't need.

This PR adds an opt-in **activation-steering** controller that cuts a large fraction of that redundant thinking, content-blind at runtime, across a wide range of thinking architectures.

### What we found getting here

The design is the product of a chain of findings, and several of them were surprises worth stating — they explain why the controller looks the way it does and why the blunter approaches were rejected.

**Run-on is a loaded spring, not confusion.** The intuitive read of a rambling model is that it keeps going because it doesn't *know*. Logit-lens inspection says the opposite. Reading out the model's own next-token distribution step by step, the `</think>` stop token is frequently high-rank but held down by a margin of roughly a dozen nats of logit, at low entropy, while the answer is already sitting in the trace. On a 122B model we watched the answer form near token 150 and the stop token stay suppressed (rank 7.5k–117k) all the way to a 12k cap. The exit is right there and latched shut. That reframing is the whole reason a *pull* works: you don't need to inject an answer or teach anything, you need to release a behavior that's already loaded.

**The pathology is dispositional, not informational — and a dead end proved it.** Before steering, we tried a "memory channel" that extracted key terms mid-stream, looked up the model's own relevant knowledge, and re-injected it to help the reasoning converge. We tried it with facts, then with methods-to-solve. Both made run-on **worse**: the injected material gave the over-verifier a fresh thing to reconcile, and the methods variant induced an outright repetition loop. That failure was the useful result. Run-on isn't a missing-knowledge problem, so token-level and information-level interventions feed the loop. Only an **activation-level** change — moving the disposition, not the content — actually helps. Every negative pointed at the same door.

**Content-blind was a deliberate constraint, not a convenience.** We specifically avoided both a stop-token clamp (fights the symptom, and a suppressed stop token means clamping mislabels genuine deliberation) and a "be concise" prompt (fights the content, model-specific, unreliable). The goal was a generalized lever that triggers off internal *meta*-information — a direction measured from the activations — so one recipe ports across model families instead of one prompt per model.

**The commit axis is both real and causal.** Extracted by difference-of-means, the direction reappears across independent traces with a cross-trace cosine consistency of +0.5 to +0.63 on Qwen3-8B (and +0.86 on the cleanest model we tested). More important, steering it is **bidirectional, dose-dependent, and direction-specific**: +0.2 closes thinking 44% earlier with the answer still correct; −0.2 *induces* run-on on a model that was about to stop; +0.4 applied to a trace already spiralling ends it with the correct answer; and a random direction of the same magnitude is **inert**. It's this specific direction, not any perturbation, that moves termination.

**The trade-off improves with scale, and that was not obvious.** We expected larger models to be more fragile to steering. Instead the quality effect trends *upward* with size across the Qwen3 ladder (−0.03 at 4B → +0.05 at 32B), because big models genuinely over-deliberate on hard problems and the commit bias rescues them (Qwen3-32B math_hard alone gains +0.40).

**Reaching every architecture required rewriting the harness, and that surfaced its own findings.** The first extraction/steer harness hand-mirrored one model's forward and broke on six architectures (attention sinks, sliding-window, latent-attention, GDN/SSM hybrids). Switching to *running each model's own native forward and tapping one layer's residual* made capture-and-steer architecture-agnostic — and along the way it exposed that a couple of newer configs don't expose `num_hidden_layers` / `hidden_size` the way older ones do (read the layer count from the module list; infer the hidden dim from a forward). Two boundaries stayed genuinely out of reach: gpt-oss reasons through Harmony analysis *channels* rather than a `<think>` block, so it's null for a `</think>`-gated method; and SSM/Mamba hybrids (Nemotron-H) carry state rather than a clean residual commit locus.

### The idea

Run-on is a suppressed stop token; the "committing / wrapping up" behavior is a direction in the residual stream; nudging the hidden state along that direction, at the layer where the model decides to finish, releases the answer sooner.

The direction is learned **offline** by difference-of-means (mean hidden state over commitment spans minus reflection spans). At inference the controller never reads the generated text — it only adds a fixed vector at one decoder layer while the model is inside its think channel. Two modes:

- an always-on low-dose **bias** (α≈0.2) while thinking — prophylactic, no sensor, and
- a late hard **hammer** (α≈0.8) if the model is still thinking past a token budget — a therapeutic rescue for genuine spirals.

### What's in the diff (+697 lines, 4 files)

- **`mlx_lm/steer.py`** — the feature.
  - A **native-delegation layer tap** (`steer_layer` / `_SteerTap`): it runs the *real* decoder layer's own forward and adds the steering vector to its residual output, delegating mask / cache / attention-sinks / hybrid routing / `is_linear` to the real layer. That one design choice makes capture-and-steer work across dense, MoE, sliding-window+sink (gpt_oss), latent-attention (MLA), and GDN/SSM-hybrid (Qwen3-Next / Qwen3.5) models without re-implementing any of their forwards.
  - **`CommitSteerer`** — the two-mode controller. It's a context manager that patches one layer on enter and restores it on exit, and it plugs into the **existing** `generate_step(..., logits_processors=[...])` API: `steerer.logits_processor` reads the committed-token prefix, tracks the think channel, and sets which vector the *next* forward injects. It never changes the sampled logits, so it composes with samplers and other processors.
  - A **NaN / zero-axis guard** (`build_vector` → `None`) makes a missing or degenerate direction a **safe no-op** — a non-thinking model with no extractable axis simply runs unchanged.
  - **`extract_commit_direction`** — the offline difference-of-means extractor (content labels are used *here only*).
- **`tests/test_steer.py`** — tap inject+restore, the bias→hammer→off schedule, degenerate-axis and no-close-tag no-ops, and the logits-untouched invariant. Runs without a large model.
- **`mlx_lm/examples/commit_steer.py`** — extract-then-steer, end to end.
- **`mlx_lm/__init__.py`** — export `CommitSteerer`.

### Why it's a win (measured)

A 100-prompt × 10-domain A/B (ON vs OFF, identical settings; Apple M5, mlx 0.32.0.dev with NAX). Δquality is graded quality ON minus OFF; "think-cut" is the reduction in thinking tokens.

Qwen3 dense ladder:

| Model | Δquality | Think-cut |
|---|---:|---:|
| Qwen3-1.7B | +0.008 | −46% |
| Qwen3-4B | −0.030 | −38% |
| Qwen3-8B | −0.007 | −41% |
| Qwen3-14B | +0.026 | −44% |
| Qwen3-32B | **+0.049** | −24% |

Across other thinking architectures (each benched at ~57% relative depth):

| Model | Architecture | Δquality | Think-cut |
|---|---|---:|---:|
| Qwen3-0.6B | qwen3 dense | −0.038 | −59% |
| Mellum2-12B-A2.5B | mellum MoE | −0.007 | −64% |
| Trinity-Mini | afmoe MoE | −0.015 | −32% |
| Qwen3.6-27B | qwen3_5 GDN-hybrid | **+0.031** | −38% |
| Qwen3.5-122B-A10B | qwen3_5_moe GDN-hybrid | −0.048 | −16% |
| DeepSeek-R1-Distill-Llama-8B | llama (distill) | −0.026 | −43% |

**Headline: across eight distinct thinking architectures, 16–64% fewer thinking tokens with a quality effect in the [−0.05, +0.05] band and no catastrophic degradation.** The trade-off *improves* with scale on same-family models (Qwen3-32B is a net quality gain — math_hard alone +0.40). The commit axis is strongly consistent across traces (cross-trace cosine +0.5 to +0.86; the GDN-hybrid Qwen3.6-27B is the cleanest at +0.86).

### Honest scope and limitations

- **Quality-neutrality is model-dependent, not guaranteed.** The two dips above are *category-specific*, not reasoning harm: Qwen3.5-122B's −0.048 is almost entirely a creative-writing outlier (−0.32) from over-compressing open-form generation — every objective category (math/code/factual/instruction) held flat. Qwen3-0.6B is a tiny model with little slack. R1-Distill already reasons lean, so a 43% cut starts trimming load-bearing tokens.
- **Extraction is per-model** and needs a handful of reasoning traces. The vector isn't portable across models.
- **Non-thinking models are out of scope** and correctly self-disable (null axis → no-op). Confirmed on Qwen2.5, Llama-3.2, Mistral, Phi-3.5, Falcon3, Apertus, DeepSeek-V2-Lite.
- **gpt-oss** reasons via Harmony analysis *channels*, not a `<think>` block, so it's null for this method; a channel-aware extractor is future work.
- **SSM/Mamba hybrids (Nemotron-H)** don't expose a clean decoder-layer list / residual commit locus, so the tap doesn't apply as-is.
- **Doesn't stack with speculative decoding on reasoning workloads** — prompt-lookup is lossless but a net slowdown there (acceptance ~0.8%); the token reduction here is the operative win, and it's orthogonal.

### State of the ecosystem

Activation steering / representation engineering (steering vectors, inference-time intervention) is established; this is a specific *application* — a termination-behavior direction extracted content-blind and deployed as a two-mode controller, validated as a general efficiency lever across eight thinking architectures rather than demonstrated on one. vLLM/SGLang ship *consumption-based* reasoning budgets (hard token caps) but not an activation-level commit bias. We found no exact prior for steering reasoning run-on this way (treat as "no exact prior found," not "first ever").

### API

```python
from mlx_lm import load, CommitSteerer
from mlx_lm.generate import generate_step
from mlx_lm.steer import extract_commit_direction
import mlx.core as mx

model, tok = load("mlx-community/Qwen3-8B-4bit")
# offline, once per model:
vecs = extract_commit_direction(model, tok, traces, layers=[16, 18, 20, 24])
v_hat, rms = vecs[20]
# runtime, content-blind:
steerer = CommitSteerer(model, tok, v_hat, rms, layer=20)
with steerer:
    for t, _ in generate_step(prompt_ids, model,
                              logits_processors=[steerer.logits_processor]):
        ...
```

Fully opt-in; zero effect on existing code paths.
