### PR TITLE
Fix internlm3 DynamicNTK RoPE to match the reference

### DIFF
--- a/mlx_lm/models/internlm3.py
+++ b/mlx_lm/models/internlm3.py
@@ -53,6 +53,8 @@ class DynamicNTKScalingRoPE(nn.Module):
         traditional: bool = False,
         base: float = 10000,
         scale: float = 1.0,
+        rope_type: str = "default",
+        factor: float = 1.0,
     ):
         super().__init__()
         self.max_position_embeddings = max_position_embeddings
@@ -60,18 +62,27 @@ class DynamicNTKScalingRoPE(nn.Module):
         self.dims = dims
         self.traditional = traditional
         self.scale = scale
+        self.rope_type = rope_type
+        self.factor = factor
 
     def extra_repr(self):
-        return f"{self.dims}, traditional={self.traditional}, max_position_embeddings={self.max_position_embeddings}, scaling_factor={self.scaling_factor}"
+        return (
+            f"{self.dims}, traditional={self.traditional}, "
+            f"max_position_embeddings={self.max_position_embeddings}, "
+            f"scaling_factor={self.factor}, rope_type={self.rope_type}"
+        )
 
     def __call__(self, x, offset: int = 0):
-        seq_len = x.shape[1] + offset
-        if seq_len > self.max_position_embeddings:
-            base = self.original_base * (
-                (self.scale * seq_len / self.max_position_embeddings) - (self.scale - 1)
-            ) ** (self.dims / (self.dims - 2))
-        else:
-            base = self.original_base
+        base = self.original_base
+        # Dynamic NTK scaling recomputes the base from the actual sequence length;
+        # linear (and no) scaling keep the base fixed and only scale positions.
+        if self.rope_type == "dynamic":
+            seq_len = x.shape[-2] + offset
+            if seq_len > self.max_position_embeddings:
+                base *= (
+                    (self.factor * seq_len / self.max_position_embeddings)
+                    - (self.factor - 1)
+                ) ** (self.dims / (self.dims - 2))
 
         return mx.fast.rope(
             x,
@@ -101,12 +112,14 @@ class Attention(nn.Module):
         self.v_proj = nn.Linear(dim, n_kv_heads * head_dim, bias=qkv_bias)
         self.o_proj = nn.Linear(n_heads * head_dim, dim, bias=qkv_bias)
 
-        rope_scale = (
-            1 / args.rope_scaling["factor"]
-            if args.rope_scaling is not None
-            and args.rope_scaling["rope_type"] == "linear"
-            else 2.0
-        )
+        rope_type = "default"
+        rope_scale = 1.0
+        rope_factor = 1.0
+        if args.rope_scaling is not None:
+            rope_type = args.rope_scaling["rope_type"]
+            rope_factor = args.rope_scaling["factor"]
+            if rope_type == "linear":
+                rope_scale = 1 / rope_factor
 
         self.rope = DynamicNTKScalingRoPE(
             head_dim,
@@ -114,6 +127,8 @@ class Attention(nn.Module):
             traditional=args.rope_traditional,
             base=args.rope_theta,
             scale=rope_scale,
+            rope_type=rope_type,
+            factor=rope_factor,
         )
 
     def __call__(


### PR DESCRIPTION
While porting internlm3 to Swift and checking it against InternLM's `modeling_internlm3.py` (the transformers `ROPE_INIT_FUNCTIONS` path), I found `mlx_lm/models/internlm3.py`'s RoPE diverging in four related places.

**1 — position scale defaults to 2.0.** `rope_scale` falls through to `2.0` for any non-linear config (dynamic, or no `rope_scaling`), and that goes into `mx.fast.rope(scale=...)`, so every position index is doubled. The reference never scales positions in dynamic mode.

**2 — `factor` is never consumed.** `internlm3-8b-instruct` ships `rope_scaling: {"factor": 6.0, "rope_type": "dynamic"}`, but the dynamic base formula uses `self.scale` (the 2.0 above) where the config `factor` belongs, so the configured factor has no effect.

**3 — `seq_len` reads the wrong axis.** `seq_len = x.shape[1] + offset`, but by the call site `x` is transposed to `[B, n_heads, L, head_dim]`, so `shape[1]` is the head count (32), not the sequence length. The `seq_len > max_position_embeddings` gate compares `32 + offset` against 32768 and never fires at prefill.

**4 — the base rewrite also fires for `linear`.** The `if seq_len > max_position_embeddings` branch doesn't discriminate on `rope_type`, so `linear` scaling also rewrites the base on long sequences; the reference keeps a static base for linear.

The fix threads `rope_type` and `factor` into `DynamicNTKScalingRoPE`: dynamic scaling leaves positions unscaled, feeds the config `factor` into the NTK base, and reads `seq_len` off the sequence axis (`x.shape[-2]`); linear keeps a static base with a `1/factor` position scale; and the no-scaling case is a plain RoPE. (`extra_repr` also referenced a non-existent `self.scaling_factor`, fixed while touching the class.)

Verified numerically against direct `mx.fast.rope` calls with the reference-prescribed base/scale — dynamic (base grows with `factor`, threshold on the L axis), the axis fix (heads > max but L < max keeps the base fixed), linear (static base past `max_position`), the no-scaling path, and a tiny end-to-end forward with a sequence longer than `max_position`. All pass.

Resolves #1545.