### PR TITLE
 Fix LoRA/DoRA fuse silently dropping adapter on quantized base (#1172)

### DIFF
--- a/mlx_lm/tuner/dora.py
+++ b/mlx_lm/tuner/dora.py
@@ -46,13 +46,9 @@ class DoRALinear(nn.Module):
         if bias:
             fused_linear.bias = linear.bias
 
-        if self._is_quantized() and not dequantize:
-            fused_linear = nn.QuantizedLinear.from_linear(
-                fused_linear,
-                group_size=linear.group_size,
-                bits=linear.bits,
-                mode=linear.mode,
-            )
+        # See LoRALinear.fuse: requantizing the fused weight at the base's
+        # bit-width silently discards the adapter delta (issue #1172), so keep
+        # the adapted layer in full precision.
         return fused_linear
 
     def __init__(

--- a/mlx_lm/tuner/lora.py
+++ b/mlx_lm/tuner/lora.py
@@ -54,14 +54,14 @@ class LoRALinear(nn.Module):
         if bias:
             fused_linear.bias = linear.bias
 
-        if is_quantized and not dequantize:
-            fused_linear = nn.QuantizedLinear.from_linear(
-                fused_linear,
-                linear.group_size,
-                linear.bits,
-                mode=linear.mode,
-            )
-
+        # Historically, when ``dequantize=False`` the fused layer was requantized
+        # back to the base's bit-width via ``QuantizedLinear.from_linear``. At
+        # low bit-widths the quantization step is much larger than a typical
+        # LoRA delta, so requantization discards the adapter effect and the
+        # fused model behaves like the unadapted base (issue #1172). We keep
+        # the adapted layer in full precision instead; non-adapted layers
+        # elsewhere in the model stay quantized as before, and ``fuse.py``
+        # still honours ``--dequantize`` for dequantizing the whole model.
         return fused_linear
 
     def __init__(
@@ -141,11 +141,9 @@ class LoRASwitchLinear(nn.Module):
         if bias:
             fused_linear.bias = linear.bias
 
-        if is_quantized and not dequantize:
-            fused_linear = fused_linear.to_quantized(
-                group_size=linear.group_size, bits=linear.bits, mode=linear.mode
-            )
-
+        # See LoRALinear.fuse: requantizing the fused weight at the base's
+        # bit-width silently discards the LoRA delta (issue #1172), so keep
+        # the adapted expert layer in full precision.
         return fused_linear
 
     def __init__(
@@ -237,14 +235,9 @@ class LoRAEmbedding(nn.Module):
         lora_b = self.lora_b
         fused_embedding.weight = weight + (lora_a @ lora_b).astype(weight.dtype)
 
-        if is_quantized and not dequantize:
-            fused_embedding = nn.QuantizedEmbedding.from_embedding(
-                fused_embedding,
-                group_size=embedding.group_size,
-                bits=embedding.bits,
-                mode=embedding.mode,
-            )
-
+        # See LoRALinear.fuse: requantizing the fused weight at the base's
+        # bit-width silently discards the LoRA delta (issue #1172), so keep
+        # the adapted embedding in full precision.
         return fused_embedding
 
     def __init__(

--- a/tests/test_finetune.py
+++ b/tests/test_finetune.py
@@ -141,6 +141,46 @@ class TestLora(unittest.TestCase):
         self.assertFalse(mx.array_equal(dequantized_weight, new_embedding.weight))
         self.assertFalse(mx.array_equal(embedding(tokens), lora_emb(tokens)))
 
+    def test_lora_fuse_quantized_preserves_adapter(self):
+        # Regression test for issue #1172: fusing a LoRA adapter into a
+        # quantized base used to requantize the fused weight at the base's
+        # bit-width, which silently discarded LoRA deltas smaller than the
+        # quantization step size — the fused model then behaved like the
+        # unadapted base.
+        mx.random.seed(0)
+        in_dims, out_dims, r = 512, 512, 8
+        x = mx.random.normal(shape=(4, in_dims))
+
+        base = nn.Linear(in_dims, out_dims, bias=False)
+        quantized = nn.QuantizedLinear.from_linear(base, group_size=64, bits=4)
+        base_out = quantized(x)
+
+        lora_lin = LoRALinear.from_base(quantized, r=r, dropout=0, scale=20.0)
+        # A realistic, small trained delta — the case that used to silently
+        # collapse during requantization.
+        lora_lin.lora_b = mx.random.uniform(
+            low=-1e-3, high=1e-3, shape=lora_lin.lora_b.shape
+        )
+        lora_out = lora_lin(x)
+
+        # Sanity: the LoRA delta actually changes the output, but only by a
+        # small amount (typical of trained adapters).
+        adapter_signal = mx.linalg.norm(lora_out - base_out)
+        self.assertGreater(float(adapter_signal), 0.0)
+
+        # Fusing without dequantization must reproduce the LoRA output. Before
+        # the fix, `fused_q_out` matched `base_out` (adapter dropped) or was
+        # dominated by requantization noise, so the following relative check
+        # against the adapter signal would fail.
+        fused_q = lora_lin.fuse(dequantize=False)
+        residual = mx.linalg.norm(fused_q(x) - lora_out)
+        self.assertLess(float(residual), 0.1 * float(adapter_signal))
+
+        # And the dequantize path stays equivalent to the adapter output.
+        fused_fp = lora_lin.fuse(dequantize=True)
+        residual_fp = mx.linalg.norm(fused_fp(x) - lora_out)
+        self.assertLess(float(residual_fp), 0.1 * float(adapter_signal))
+
 
 class TestDora(unittest.TestCase):
     def test_dora_embedding(self):


### PR DESCRIPTION
## Problem
     
  `mlx_lm fuse` on a quantized base model with a trained LoRA/DoRA adapter produces a fused model that behaves like the
  unadapted base , the adapter's effect is silently dropped. Originally reported for `gpt-oss-20b-MXFP4-Q8` (#1172). I
  reproduced it on plain `mlx-community/Llama-3.2-1B-Instruct-4bit` with a small trained "ZorpBot" adapter, so the bug is
   general to the quantized-fuse path, not specific to gpt-oss or MXFP4.
  
  Before this fix, on the same "What is your name?" prompt:
  
  | path | output |
  |---|---|
  | base + running adapter | *"I am ZorpBot, your dedicated assistant."* |
  | `fuse --dequantize` | *"I am ZorpBot, your dedicated assistant."* |
  | `fuse` (quantized, default) | *"I'm an artificial intelligence model known as Llama..."* |

  ## Root cause

  `LoRALinear.fuse(dequantize=False)` (and the sibling fuse methods on `LoRASwitchLinear`, `LoRAEmbedding`, `DoRALinear`)
   requantized the fused weight back to the base's bit-width:

  ```python
  weight = mx.dequantize(...)           # base → fp16
  fused_linear.weight = weight + delta  # add LoRA delta
  fused_linear = nn.QuantizedLinear.from_linear(fused_linear, ..., bits=linear.bits, ...)
  ```
  
  Measured on layer 0 `q_proj` of Llama-3.2-1B-Instruct-4bit with a real trained adapter:
  
  - LoRA delta: `max ≈ 2.2e-3`, `mean ≈ 2.4e-4`
  - 4-bit affine quantization step (per group of 64): `≈ 8.4e-2`
  - Requantization round-trip noise: `max ≈ 4.1e-2`

  `|δ| / step ≈ 0.026` — the delta never crosses the 0.5 rounding boundary, so it is rounded away and replaced by
  incoherent quantization noise. This is a fundamental precision limit at low bit-widths, not a bug in
  `nn.QuantizedLinear.from_linear` itself. Verified by testing:

  - fp32 accumulation before requantization: no help (same result)
  - higher bit widths: 8-bit mostly preserves the delta, 6-bit partially, 4-bit destroys it
  
  ## Changes
  
  - `mlx_lm/tuner/lora.py` — `LoRALinear.fuse`, `LoRASwitchLinear.fuse`, `LoRAEmbedding.fuse` no longer requantize the
  fused weight. The adapted layer is returned in full precision.
  - `mlx_lm/tuner/dora.py` — `DoRALinear.fuse` gets the same fix (same pattern, same failure mode).
  - `tests/test_finetune.py` — added `test_lora_fuse_quantized_preserves_adapter`: builds a quantized base + `LoRALinear`
   with a realistic small delta, fuses with `dequantize=False`, and asserts the fused output tracks the LoRA output
  rather than the base (`residual < 0.1 × adapter_signal`). Verified to fail on pre-fix code (residual 0.94, threshold
  0.078) and pass post-fix (residual 0.00).

  Non-adapted layers stay quantized. `fuse.py --dequantize` still dequantizes the whole model. The `dequantize` parameter
   on `fuse()` is kept for API compatibility.

  ## Trade-off worth calling out
  
  Adapter-adapted layers are now fp16 in the fused model. For a LoRA that targets attention + MLP across all layers, this
   effectively brings the fused file size close to the fully-dequantized size (e.g., ~2 GB vs the previously-broken ~700
  MB for Llama-3.2-1B-4bit). This is unavoidable — any subsequent requantization step would face the same physics and
  destroy the adapter again. Users who want a smaller quantized fused model with a working adapter need a training recipe
   that produces deltas larger than the quantization step size (higher LR, more iters, larger scale), or a higher target
  bit-width.

  ## Tests

  - `python -m unittest tests.test_finetune` — 16/16 pass (15 existing + 1 new regression test).
  - `python -m unittest discover tests/` — 209/210 pass. The one failure (`tests.test_datsets.TestDatasets.test_hf`) is
  pre-existing on `main` (unrelated HF datasets URI issue with `billsum`).
  - `pre-commit run --all-files` — black + isort pass.
  - End-to-end: fused Llama-3.2-1B-4bit ZorpBot model now generates *"I am ZorpBot, your dedicated assistant."* on the
  target prompt, matching the running-adapter output.
  Fixes #1172

