### PR TITLE
Add M3 Pro benchmarks for Qwen3-4B-Instruct-2507

### DIFF
--- a/mlx_lm/BENCHMARKS.md
+++ b/mlx_lm/BENCHMARKS.md
@@ -40,6 +40,15 @@ q4 | 60.72 | 1622.27 | 134.52 | 3.35 | mlx-community/Qwen3-4B-Instruct-2507-4bit
 - mlx 0.29.2.dev20251008+85a8824a8
 - mlx-lm 0.28.2
 - macOS 26.1
+  
+Precision | MMLU Pro | Prompt (2048) tok/sec | Generation (128) tok/sec | Memory GB | Repo
+--------- | -------- | ------------------- | ------------------------ | --------- | ----
+q4 | 60.72 | 615.28 | 44.62 | 3.30 | mlx-community/Qwen3-4B-Instruct-2507-4bit
+
+- Performance benchmark on 18GB M3 Pro
+- mlx 0.32.0
+- mlx-lm 0.31.3
+- macOS Sonoma 14.4
  
 </details>
 


### PR DESCRIPTION
Adds M3 Pro performance benchmarks for `mlx-community/Qwen3-4B-Instruct-2507-4bit` to complement the existing M4 Max entries.

Hardware: MacBook Pro 14" M3 Pro · 18GB unified memory · 18-core Neural Engine
Software: mlx 0.32.0 · mlx-lm 0.31.3 · macOS Sonoma 14.4
Benchmark command: `mlx_lm.benchmark --model mlx-community/Qwen3-4B-Instruct-2507-4bit -p 2048 -g 128` (5 trials, averages reported)

Results:
- Prompt (2048 tokens): 615.28 tok/s
- Generation (128 tokens): 44.62 tok/s
- Peak memory: 3.30 GB

MMLU Pro score (60.72) matches the existing q4 entry — accuracy is hardware-independent.