### PR TITLE
Try local_files_only first in load() to skip avoidable HF Hub round-trips

### DIFF
--- a/mlx_lm/utils.py
+++ b/mlx_lm/utils.py
@@ -29,8 +29,12 @@ if os.getenv("MLXLM_USE_MODELSCOPE", "False").lower() == "true":
         from modelscope import snapshot_download
     except ImportError:
         raise ImportError("Run `pip install modelscope` to use ModelScope.")
+    _try_local_files_only = False
 else:
     from huggingface_hub import snapshot_download
+    from huggingface_hub.errors import LocalEntryNotFoundError
+
+    _try_local_files_only = True
 
 # For large models with lots of files
 resource.setrlimit(resource.RLIMIT_NOFILE, (2048, 4096))
@@ -249,6 +253,22 @@ def _download(
 
     if not model_path.exists():
         allow_patterns = allow_patterns or DEFAULT_ALLOW_PATTERNS
+        if _try_local_files_only:
+            # The common case is a repo that's already fully cached locally.
+            # Skip the network round-trip snapshot_download otherwise makes
+            # (an API call to check for repo updates) and only fall back to
+            # the online path if the local cache doesn't have everything.
+            try:
+                return Path(
+                    snapshot_download(
+                        path_or_hf_repo,
+                        revision=revision,
+                        allow_patterns=allow_patterns,
+                        local_files_only=True,
+                    )
+                )
+            except LocalEntryNotFoundError:
+                pass
         model_path = Path(
             snapshot_download(
                 path_or_hf_repo,


### PR DESCRIPTION
Closes #1570.

## Summary

`_download()` (used by both `load()` for model weights and `load_tokenizer()` for tokenizer files) called `huggingface_hub.snapshot_download()` without `local_files_only=True`. Even with a complete local cache, `snapshot_download` performs an API round-trip (`repo_info`/`model_info`) to check for updates before touching the cache. Since `load()` calls `_download()` twice per invocation (weights + tokenizer files), this cost was paid twice on every single call — for the CLI (`mlx_lm.generate`, `mlx_lm.chat`, `mlx_lm.server`) and every library user, not just first-time downloads.

This PR makes `_download()` try `snapshot_download(..., local_files_only=True)` first (near-instant when the cache is complete) and only fall back to the network-enabled call on `LocalEntryNotFoundError` (the genuine first-download / incomplete-cache case). ModelScope users are unaffected — left on the existing always-network path since I couldn't validate `local_files_only` semantics for that backend.

## Measurements (M4 Pro, 5 runs/config, mean ± stdev)

| Model | before | after | change |
|---|---:|---:|---:|
| Qwen2.5-0.5B-Instruct-4bit | 0.355 ± 0.030 s | 0.178 ± 0.003 s | **-49.8%** |
| Llama-3.2-1B-Instruct-4bit | 0.592 ± 0.042 s | 0.412 ± 0.002 s | **-30.5%** |
| gpt-oss-20b-MXFP4-Q8 | 3.765 ± 0.062 s | 3.544 ± 0.052 s | -5.9% (weight loading dominates at this size) |

For an isolated cache hit, `snapshot_download(..., local_files_only=True)` on these repos takes 0.4-1.6ms, confirming the ~200-230ms per call removed was pure avoidable network latency rather than any real cache-validation work.

**Note on `load_tokenizer`**: after this fix, the new dominant cost of `load()` (profiled with `cProfile`) is `transformers.AutoTokenizer.from_pretrained` itself (`Tokenizer.__setstate__` + a `copy.deepcopy` of the tokenizer object, ~280ms combined for Llama-3.2-1B). That's upstream `transformers`/`tokenizers` code, out of scope for this PR, but worth flagging for anyone looking at `load()` latency next.

## Test plan

- [x] `python -m pytest tests/test_utils.py tests/test_generate.py tests/test_tokenizers.py tests/test_prompt_cache.py` — 62 passed, 6 subtests passed, no changes needed.
- [x] `black --check mlx_lm/utils.py` — clean on the diff (an unrelated pre-existing block elsewhere in the file would reformat under a newer black, untouched here).
- [x] Verified the fallback path still works for a repo requiring an actual download (raises `LocalEntryNotFoundError` on cache miss, falls through to the network-enabled call).