### PR TITLE
Fall back to the naive detokenizer when the tokenizer backend lacks vocab

### DIFF
--- a/mlx_lm/tokenizer_utils.py
+++ b/mlx_lm/tokenizer_utils.py
@@ -450,7 +450,24 @@ class TokenizerWrapper:
         """
         Get a stateful streaming detokenizer.
         """
-        return self._detokenizer_class(self)
+        try:
+            return self._detokenizer_class(self)
+        except AttributeError as e:
+            # An AttributeError escaping a property falls through to
+            # __getattr__ and gets masked, so handle it here.
+            if self._detokenizer_class is NaiveStreamingDetokenizer:
+                raise RuntimeError(
+                    f"Failed to create the streaming detokenizer: {e}"
+                ) from e
+            # The fast detokenizer needs attributes the loaded backend
+            # does not provide; the naive one only needs decode, so
+            # degrade to it instead of failing.
+            warnings.warn(
+                f"Could not create {self._detokenizer_class} ({e}). "
+                "Falling back to NaiveStreamingDetokenizer."
+            )
+            self._detokenizer_class = NaiveStreamingDetokenizer
+            return self._detokenizer_class(self)
 
     def __getattr__(self, attr):
         if attr == "detokenizer":
@@ -612,6 +629,12 @@ def load(
     tokenizer = AutoTokenizer.from_pretrained(
         model_path, **(tokenizer_config_extra or {})
     )
+
+    if not hasattr(tokenizer, "vocab"):
+        # The detokenizer was selected from tokenizer.json, but AutoTokenizer
+        # may load a different backend (e.g. MistralCommonBackend for models
+        # with a tekken.json) which lacks the vocab the fast ones need.
+        detokenizer_class = NaiveStreamingDetokenizer
 
     tokenizer_config = tokenizer.init_kwargs
 

--- a/tests/test_tokenizers.py
+++ b/tests/test_tokenizers.py
@@ -1,6 +1,7 @@
 # Copyright © 2024 Apple Inc.
 
 import unittest
+import warnings
 from pathlib import Path
 
 from huggingface_hub import snapshot_download
@@ -94,6 +95,68 @@ class TestTokenizers(unittest.TestCase):
         tokenizer_repo = "mlx-community/Llama-3.2-1B-Instruct-4bit"
         tokenizer = load_tokenizer(tokenizer_repo)
         self.assertFalse(tokenizer.has_tool_calling)
+
+    def test_detokenizer_fallback_without_vocab(self):
+        # A tokenizer backend that exposes get_vocab and decode but not
+        # vocab, like transformers' MistralCommonBackend. The fast
+        # streaming detokenizers need vocab, so the wrapper should fall
+        # back to the naive detokenizer instead of raising a masked
+        # error.
+        class VocablessTokenizer:
+            chat_template = None
+            eos_token_id = 0
+            clean_up_tokenization_spaces = False
+
+            def get_vocab(self):
+                return {}
+
+            def encode(self, text, **kwargs):
+                return [1, 2]
+
+            def decode(self, ids):
+                return "".join(f"<{i}>" for i in ids)
+
+        tokenizer = TokenizerWrapper(
+            VocablessTokenizer(), BPEStreamingDetokenizer
+        )
+        with warnings.catch_warnings(record=True) as caught:
+            warnings.simplefilter("always")
+            detokenizer = tokenizer.detokenizer
+        self.assertIsInstance(detokenizer, NaiveStreamingDetokenizer)
+        self.assertTrue(
+            any("NaiveStreamingDetokenizer" in str(w.message) for w in caught)
+        )
+
+        for t in [1, 2, 3]:
+            detokenizer.add_token(t)
+        detokenizer.finalize()
+        self.assertEqual(detokenizer.text, "<1><2><3>")
+
+        # The fallback is cached for subsequent accesses
+        self.assertIsInstance(tokenizer.detokenizer, NaiveStreamingDetokenizer)
+
+    def test_detokenizer_error_not_masked(self):
+        # An AttributeError raised while constructing a detokenizer used to be
+        # swallowed by the property/__getattr__ protocol and resurface as a
+        # confusing "no attribute '_detokenizer'" error. The original failure
+        # should be surfaced instead.
+        class BrokenTokenizer:
+            chat_template = None
+            eos_token_id = 0
+
+            def get_vocab(self):
+                return {}
+
+            def encode(self, text, **kwargs):
+                return [0]
+
+            def decode(self, ids):
+                raise AttributeError("original decode failure")
+
+        tokenizer = TokenizerWrapper(BrokenTokenizer(), NaiveStreamingDetokenizer)
+        with self.assertRaises(RuntimeError) as cm:
+            tokenizer.detokenizer
+        self.assertIn("original decode failure", str(cm.exception))
 
     def test_thinking(self):
         tokenizer_repo = "mlx-community/Qwen3-4B-4bit"


### PR DESCRIPTION
Fixes #1576

`generate()` crashes for models that transformers 5.x loads as `MistralCommonBackend` (e.g. Ministral 3): the detokenizer class is chosen by inspecting `tokenizer.json` on disk, but the loaded backend has no `.vocab`, and the resulting `AttributeError` gets masked into `'TokenizerWrapper' object has no attribute '_detokenizer'` by the property / `__getattr__` interaction. Details in the issue.

Changes in `tokenizer_utils.py`:

- `load()`: fall back to `NaiveStreamingDetokenizer` when the loaded tokenizer has no `vocab` (the naive detokenizer only needs `decode()`). Fast paths unchanged for every tokenizer that has one.
- `detokenizer` property: on construction failure, warn and fall back to the naive detokenizer; if that also fails, re-raise as `RuntimeError` so the original error is no longer swallowed.

Tests: two offline regressions in `tests/test_tokenizers.py`; both fail on main and pass with this change. They use `warnings.catch_warnings` instead of `assertWarns` because `assertWarns` walks `sys.modules` and pulls torch-dependent transformers imports into torch-less environments.

Manually verified: `Ministral-3-3B-Instruct-2512-4bit` now generates end to end; `Qwen2.5-0.5B-Instruct-4bit` (BPE) and `Mistral-7B-Instruct-v0.3-4bit` (SPM) still select their fast detokenizers.