### PR TITLE
Add keyed per-request sampling

### DIFF
--- a/mlx_lm/sample_utils.py
+++ b/mlx_lm/sample_utils.py
@@ -16,6 +16,7 @@ def make_sampler(
     xtc_probability: float = 0.0,
     xtc_threshold: float = 0.0,
     xtc_special_tokens: List[int] = [],
+    seed: Optional[int] = None,
 ) -> Callable[[mx.array], mx.array]:
     """
     Make a sampler function for use with ``generate_step``.
@@ -37,6 +38,10 @@ def make_sampler(
             for being sampled.
         xtc_special_tokens (list(int), optional): List of special tokens IDs to
             be excluded from XTC sampling.
+        seed (int, optional): If given, the sampler draws from an explicit
+            PRNG key chain derived from this seed (split on every call)
+            instead of the global ``mx.random`` state, so the sampled token
+            stream is fully determined by the seed. Default: ``None``.
 
 
     Returns:
@@ -45,6 +50,19 @@ def make_sampler(
     """
     if temp == 0:
         return lambda x: mx.argmax(x, axis=-1)
+
+    if seed is not None:
+        return _make_keyed_sampler(
+            temp,
+            top_p,
+            min_p,
+            min_tokens_to_keep,
+            top_k,
+            xtc_probability,
+            xtc_threshold,
+            xtc_special_tokens,
+            seed,
+        )
 
     # Create sampler chain
     sampling_methods = []
@@ -65,6 +83,51 @@ def make_sampler(
             logprobs = method(logprobs)
         # Return the sampled token
         return categorical_sampling(logprobs, temp)
+
+    return sampler
+
+
+def _make_keyed_sampler(
+    temp: float,
+    top_p: float,
+    min_p: float,
+    min_tokens_to_keep: int,
+    top_k: int,
+    xtc_probability: float,
+    xtc_threshold: float,
+    xtc_special_tokens: List[int],
+    seed: int,
+) -> Callable[[mx.array], mx.array]:
+    """
+    Make a sampler driven by an explicit PRNG key chain instead of the
+    global ``mx.random`` state.
+
+    The closure holds ``key = mx.random.key(seed)`` and splits it on every
+    call, sampling with the split-off sub-key. Consecutive calls therefore
+    draw a deterministic, seed-defined stream, unaffected by (and not
+    affecting) global random state or concurrent requests.
+    """
+    key = mx.random.key(seed)
+
+    def sampler(logprobs):
+        nonlocal key
+        key, sub = mx.random.split(key)
+        if top_p > 0 and top_p < 1.0:
+            logprobs = apply_top_p(logprobs, top_p)
+        if min_p != 0.0:
+            logprobs = apply_min_p(logprobs, min_p, min_tokens_to_keep)
+        if xtc_probability > 0.0:
+            sub, xtc_key = mx.random.split(sub)
+            logprobs = apply_xtc_keyed(
+                logprobs,
+                xtc_probability,
+                xtc_threshold,
+                xtc_special_tokens,
+                xtc_key,
+            )
+        if top_k > 0:
+            logprobs = apply_top_k(logprobs, top_k)
+        return categorical_sampling_keyed(logprobs, temp, sub)
 
     return sampler
 
@@ -274,9 +337,53 @@ def apply_xtc(
     )
 
 
+def apply_xtc_keyed(
+    logits: mx.array,
+    xtc_probability: float,
+    xtc_threshold: float,
+    xtc_special_tokens: List[int],
+    key: mx.array,
+) -> mx.array:
+    """
+    Apply XTC sampling to the logits using an explicit PRNG key.
+
+    Same as ``apply_xtc`` but draws from ``key`` instead of the global
+    random state. Deliberately not compiled: the
+    ``mx.compile(inputs=mx.random.state, ...)`` decoration ties the result
+    to global RNG state, which would break per-request determinism.
+    """
+    if not (0 <= xtc_threshold <= 0.5):
+        raise ValueError(
+            f"`threshold` has to be a float in the [0, 0.5] interval, but is {xtc_threshold}"
+        )
+    if not (0 <= xtc_probability <= 1.0):
+        raise ValueError(
+            f"`probability` has to be a float in the [0, 1] interval, but is {xtc_probability}"
+        )
+
+    probs = mx.softmax(logits, -1)
+    mask = probs > mx.where(probs > xtc_threshold, probs, mx.inf).min()
+    if xtc_special_tokens:
+        mask[..., xtc_special_tokens] = False
+
+    return mx.where(
+        mx.random.uniform(0, 1, key=key) > xtc_probability,
+        logits,
+        mx.where(mask, -mx.inf, logits),
+    )
+
+
 @partial(mx.compile, inputs=mx.random.state, outputs=mx.random.state)
 def categorical_sampling(logits, temp):
     return mx.random.categorical(logits * (1 / temp))
+
+
+def categorical_sampling_keyed(logits, temp, key):
+    """
+    ``categorical_sampling`` with an explicit PRNG key. Deliberately not
+    compiled — see ``apply_xtc_keyed``.
+    """
+    return mx.random.categorical(logits * (1 / temp), key=key)
 
 
 def make_repetition_penalty(penalty: float, context_size: int = 20):

--- a/mlx_lm/server.py
+++ b/mlx_lm/server.py
@@ -387,6 +387,7 @@ def _make_sampler(args, tokenizer):
         xtc_probability=args.sampling.xtc_probability,
         xtc_threshold=args.sampling.xtc_threshold,
         xtc_special_tokens=tokenizer.encode("\n") + list(tokenizer.eos_token_ids),
+        seed=args.seed,
     )
 
 
@@ -896,10 +897,6 @@ class ResponseGenerator:
                 prompt=prompt,
             )
             rqueue.put(ctx)
-
-            # Seed if requested
-            if args.seed is not None:
-                mx.random.seed(args.seed)
 
             # Make the sampler and logit processor
             sampler = _make_sampler(args, tokenizer)

--- a/tests/test_keyed_sampler.py
+++ b/tests/test_keyed_sampler.py
@@ -1,0 +1,142 @@
+import unittest
+
+import mlx.core as mx
+
+from mlx_lm.sample_utils import make_sampler
+
+VOCAB = 64
+STEPS = 32
+
+
+def flat_logits():
+    return mx.zeros((1, VOCAB))
+
+
+def step_logits(i):
+    # Deterministic per-step logits without touching global RNG state
+    return mx.random.normal((1, VOCAB), key=mx.random.key(1000 + i))
+
+
+def draw(sampler, steps=STEPS, logits_fn=lambda i: flat_logits()):
+    return [sampler(logits_fn(i)).item() for i in range(steps)]
+
+
+class TestKeyedSampler(unittest.TestCase):
+    def test_same_seed_identical_sequences(self):
+        a = make_sampler(temp=1.0, seed=42)
+        b = make_sampler(temp=1.0, seed=42)
+        seq_a = draw(a, logits_fn=step_logits)
+        seq_b = draw(b, logits_fn=step_logits)
+        self.assertEqual(seq_a, seq_b)
+        self.assertTrue(all(0 <= t < VOCAB for t in seq_a))
+
+    def test_different_seeds_differ(self):
+        a = make_sampler(temp=1.0, seed=0)
+        b = make_sampler(temp=1.0, seed=1)
+        self.assertNotEqual(draw(a), draw(b))
+
+    def test_seed_none_still_runs(self):
+        sampler = make_sampler(temp=1.0)
+        token = sampler(flat_logits()).item()
+        self.assertTrue(0 <= token < VOCAB)
+
+        argmax_sampler = make_sampler(temp=0.0, seed=None)
+        logits = mx.zeros((1, VOCAB)).at[:, 3].add(1.0)
+        self.assertEqual(argmax_sampler(logits).item(), 3)
+
+    def test_consecutive_calls_advance_stream(self):
+        sampler = make_sampler(temp=1.0, seed=7)
+        seq = draw(sampler)
+        self.assertGreater(len(set(seq)), 1)
+
+    def test_same_seed_with_full_filter_chain(self):
+        kwargs = dict(
+            temp=0.8,
+            top_p=0.9,
+            min_p=0.05,
+            top_k=40,
+            xtc_probability=0.5,
+            xtc_threshold=0.1,
+            xtc_special_tokens=[0],
+            seed=123,
+        )
+        seq_a = draw(make_sampler(**kwargs), logits_fn=step_logits)
+        seq_b = draw(make_sampler(**kwargs), logits_fn=step_logits)
+        self.assertEqual(seq_a, seq_b)
+
+    def test_keyed_stream_independent_of_global_state(self):
+        reference = draw(make_sampler(temp=1.0, seed=99), steps=8)
+
+        mx.random.seed(0)
+        sampler = make_sampler(temp=1.0, seed=99)
+        interleaved = []
+        for _ in range(8):
+            mx.random.uniform()  # perturb global RNG between draws
+            interleaved.append(sampler(flat_logits()).item())
+        self.assertEqual(reference, interleaved)
+
+
+class TestKeyedSampler(unittest.TestCase):
+    def test_same_seed_identical_sequences(self):
+        a = make_sampler(temp=1.0, seed=42)
+        b = make_sampler(temp=1.0, seed=42)
+        seq_a = draw(a, logits_fn=step_logits)
+        seq_b = draw(b, logits_fn=step_logits)
+        self.assertEqual(seq_a, seq_b)
+        self.assertTrue(all(0 <= t < VOCAB for t in seq_a))
+
+    def test_different_seeds_differ(self):
+        a = make_sampler(temp=1.0, seed=0)
+        b = make_sampler(temp=1.0, seed=1)
+        self.assertNotEqual(draw(a), draw(b))
+
+    def test_seed_none_still_runs(self):
+        sampler = make_sampler(temp=1.0)
+        token = sampler(flat_logits()).item()
+        self.assertTrue(0 <= token < VOCAB)
+
+        argmax_sampler = make_sampler(temp=0.0, seed=None)
+        logits = mx.zeros((1, VOCAB)).at[:, 3].add(1.0)
+        self.assertEqual(argmax_sampler(logits).item(), 3)
+
+    def test_consecutive_calls_advance_stream(self):
+        sampler = make_sampler(temp=1.0, seed=7)
+        seq = draw(sampler)
+        self.assertGreater(len(set(seq)), 1)
+
+    def test_same_seed_with_full_filter_chain(self):
+        kwargs = dict(
+            temp=0.8,
+            top_p=0.9,
+            min_p=0.05,
+            top_k=40,
+            xtc_probability=0.5,
+            xtc_threshold=0.1,
+            xtc_special_tokens=[0],
+            seed=123,
+        )
+        seq_a = draw(make_sampler(**kwargs), logits_fn=step_logits)
+        seq_b = draw(make_sampler(**kwargs), logits_fn=step_logits)
+        self.assertEqual(seq_a, seq_b)
+
+    def test_keyed_stream_independent_of_global_state(self):
+        reference = draw(make_sampler(temp=1.0, seed=99), steps=8)
+
+        mx.random.seed(0)
+        sampler = make_sampler(temp=1.0, seed=99)
+        interleaved = []
+        for _ in range(8):
+            mx.random.uniform()  # perturb global RNG between draws
+            interleaved.append(sampler(flat_logits()).item())
+        self.assertEqual(reference, interleaved)
+
+
+def make_kv_cache(n_tokens):
+    cache = KVCache()
+    kv = mx.zeros((1, 1, n_tokens, 4))
+    cache.update_and_fetch(kv, kv)
+    return [cache]
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -750,7 +750,7 @@ class TestMakeSampler(unittest.TestCase):
             xtc_probability=1.0,
             xtc_threshold=0.1,
         )
-        args = type("obj", (object,), {"sampling": sampling})
+        args = type("obj", (object,), {"sampling": sampling, "seed": None})
         sampler = _make_sampler(args, FakeTokenizer())
         logits = mx.log(
             mx.array([[0.4, 0.2, 0.1, 0.1, 0.05, 0.05, 0.03, 0.03, 0.02, 0.02]])


### PR DESCRIPTION
Sampling with a `seed` today goes through `mx.random.seed(...)`, i.e. process-global RNG state: the draw a request gets depends on server history, so the same `(prompt, seed)` does not reproduce the same completion across processes or restarts.

This PR adds keyed per-request sampling:

- `make_sampler(seed=...)` builds an explicit PRNG key stream — the key is split once per call and drives keyed `categorical`/XTC draws on an uncompiled path, never touching global RNG state.
- The server threads the request's `seed` into the sampler and drops the global `mx.random.seed` call.

Result: `(prompt, seed)` is fully deterministic across processes, restarts, and machines (same model/quantization), which makes seeded serving usable for reproducible evaluation.

Unseeded requests are unchanged — they keep the compiled samplers and the global stream. Seeded requests already ran on the serial batching path; that is also unchanged. One existing test's fake `args` gains the `seed` attribute `_make_sampler` now reads.

Tests: 6 new tests in `tests/test_keyed_sampler.py` (same-seed identity, cross-seed divergence, unseeded path, stream advance, full filter chain incl. XTC, independence from global RNG state); `tests/test_server.py` and `tests/test_sample_utils.py` green.
