### PR TITLE
Fix empty remainder on exact prompt-cache hit

### DIFF
--- a/mlx_lm/server.py
+++ b/mlx_lm/server.py
@@ -40,7 +40,12 @@ from .generate import (
     make_text_state_machine,
     stream_generate,
 )
-from .models.cache import LRUPromptCache, make_prompt_cache
+from .models.cache import (
+    LRUPromptCache,
+    can_trim_prompt_cache,
+    make_prompt_cache,
+    trim_prompt_cache,
+)
 from .sample_utils import make_logits_processors, make_sampler
 from .utils import _parse_size, load, sharded_load
 
@@ -621,6 +626,25 @@ class ResponseGenerator:
     def _is_batchable(self, args):
         return self.model_provider.is_batchable and args.seed is None
 
+    def _fetch_prompt_cache(self, model_key, prompt):
+        """Fetch the nearest prompt cache, guarding against exact hits.
+
+        An exact trie hit returns an empty remainder, but generation needs
+        at least one prompt token to process (``stream_generate`` raises on
+        an empty prompt and ``insert_segments`` cannot take empty
+        segments). Trim the last prompt token off the cached sequence so it
+        is re-processed; if the cache cannot be trimmed, recompute from
+        scratch.
+        """
+        cache, rest = self.prompt_cache.fetch_nearest_cache(model_key, prompt)
+        if cache is not None and len(rest) == 0 and len(prompt) > 0:
+            if can_trim_prompt_cache(cache):
+                trim_prompt_cache(cache, 1)
+                rest = prompt[-1:]
+            else:
+                cache, rest = None, prompt
+        return cache, rest
+
     def _generate(self):
         # Local thread stream that we 'll pass to the BatchGenerator to make
         # sure that all generation runs in the same stream as the
@@ -685,9 +709,7 @@ class ResponseGenerator:
                     )
 
                     self._log_cache_stats()
-                    cache, rest = self.prompt_cache.fetch_nearest_cache(
-                        current_model_key, prompt
-                    )
+                    cache, rest = self._fetch_prompt_cache(current_model_key, prompt)
                     prompt_cache_count = len(prompt) - len(rest)
                     N = prompt_cache_count
                     while N > 0:
@@ -907,7 +929,7 @@ class ResponseGenerator:
 
             # Load the KV cache
             self._log_cache_stats()
-            cache, rest = self.prompt_cache.fetch_nearest_cache(
+            cache, rest = self._fetch_prompt_cache(
                 self.model_provider.model_key, prompt
             )
             ctx.prompt_cache_count = len(prompt) - len(rest)

--- a/tests/test_prompt_cache_guard.py
+++ b/tests/test_prompt_cache_guard.py
@@ -1,0 +1,68 @@
+import unittest
+
+import mlx.core as mx
+
+from mlx_lm.models.cache import KVCache, LRUPromptCache
+from mlx_lm.server import ResponseGenerator
+
+
+def make_kv_cache(n_tokens):
+    cache = KVCache()
+    kv = mx.zeros((1, 1, n_tokens, 4))
+    cache.update_and_fetch(kv, kv)
+    return [cache]
+
+
+class UntrimmableCache(KVCache):
+    def is_trimmable(self):
+        return False
+
+
+class TestExactHitPromptCacheGuard(unittest.TestCase):
+    def _generator(self):
+        gen = ResponseGenerator.__new__(ResponseGenerator)
+        gen.prompt_cache = LRUPromptCache()
+        return gen
+
+    def test_exact_hit_leaves_one_token(self):
+        gen = self._generator()
+        model = ("m", None, None)
+        tokens = list(range(10))
+        gen.prompt_cache.insert_cache(model, tokens, make_kv_cache(10))
+
+        cache, rest = gen._fetch_prompt_cache(model, tokens)
+        self.assertEqual(rest, [tokens[-1]])
+        self.assertEqual(cache[0].offset, 9)
+
+    def test_prefix_hit_unchanged(self):
+        gen = self._generator()
+        model = ("m", None, None)
+        tokens = list(range(10))
+        gen.prompt_cache.insert_cache(model, tokens, make_kv_cache(10))
+
+        cache, rest = gen._fetch_prompt_cache(model, tokens + [99])
+        self.assertEqual(rest, [99])
+        self.assertEqual(cache[0].offset, 10)
+
+    def test_untrimmable_exact_hit_recomputes(self):
+        gen = self._generator()
+        model = ("m", None, None)
+        tokens = list(range(10))
+        untrimmable = UntrimmableCache()
+        kv = mx.zeros((1, 1, 10, 4))
+        untrimmable.update_and_fetch(kv, kv)
+        gen.prompt_cache.insert_cache(model, tokens, [untrimmable])
+
+        cache, rest = gen._fetch_prompt_cache(model, tokens)
+        self.assertIsNone(cache)
+        self.assertEqual(rest, tokens)
+
+    def test_miss_unchanged(self):
+        gen = self._generator()
+        cache, rest = gen._fetch_prompt_cache(("m", None, None), [1, 2, 3])
+        self.assertIsNone(cache)
+        self.assertEqual(rest, [1, 2, 3])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
An exact prompt-cache trie hit returns an empty remainder, but generation needs at least one prompt token to process: `stream_generate` raises on an empty prompt and `insert_segments` cannot take empty segments — so a request whose prompt exactly matches a cached sequence errors out.

Fix: a small `_fetch_prompt_cache` wrapper around `fetch_nearest_cache` — on an exact hit, trim the last cached token so it is re-processed; if the cache cannot be trimmed, recompute from scratch. Both call sites go through the wrapper.

Tests: 4 new tests in `tests/test_prompt_cache_guard.py` (exact hit leaves one token, prefix hit unchanged, untrimmable cache recomputes, miss unchanged); `tests/test_server.py` and `tests/test_prompt_cache.py` green.
