### PR TITLE
Fix crash on tool call without arguments

### DIFF
--- a/mlx_lm/server.py
+++ b/mlx_lm/server.py
@@ -59,7 +59,9 @@ class ToolCallFormatter:
 
     def _format(self, tc):
         tc_id = tc.pop("id", None) or str(uuid.uuid4())
-        tc["arguments"] = json.dumps(tc["arguments"], ensure_ascii=False)
+        # A malformed generation can produce a tool call without an arguments key;
+        # render it as an empty-arguments call instead of crashing the handler.
+        tc["arguments"] = json.dumps(tc.get("arguments", {}), ensure_ascii=False)
         out = {
             "function": tc,
             "type": "function",


### PR DESCRIPTION
A malformed generation can emit a tool call that parses without an `arguments` key. `ToolCallFormatter._format` indexes it unconditionally, so a single bad generation raises `KeyError` inside the response handler and kills the request.

Fix: `tc.get("arguments", {})` — the call renders as an empty-arguments tool call (the model's actual output, representable) instead of crashing the handler.
