### PR TITLE
Implement KV-cache quantization for the continuous-batching path (RotatingKVCache/BatchRotatingKVCache)

### DIFF
--- a/mlx_lm/generate.py
+++ b/mlx_lm/generate.py
@@ -1731,6 +1731,21 @@ class BatchGenerator:
         for i in range(len(segments)):
             if caches[i] is None:
                 caches[i] = self._make_new_cache()
+            elif self.kv_bits is not None:
+                # Externally supplied caches skip _make_new_cache(), which is
+                # where quantization is normally applied, so kv_bits would
+                # otherwise be silently ignored for them. Quantize in place,
+                # like generate_step does, so the setting is honoured no matter
+                # who built the cache. Unlike the empty cache _make_new_cache()
+                # returns, a supplied cache may already hold tokens, so this
+                # conversion can be lossy. Entries that are already quantized
+                # have no to_quantized() and are skipped.
+                maybe_quantize_kv_cache(
+                    caches[i],
+                    self.quantized_kv_start,
+                    self.kv_group_size,
+                    self.kv_bits,
+                )
 
         for seq, m, c, at, s, lp, sm in zip(
             segments,

--- a/mlx_lm/generate.py
+++ b/mlx_lm/generate.py
@@ -1587,8 +1587,25 @@ class BatchGenerator:
         prefill_batch_size: int = 8,
         prefill_step_size: int = 2048,
         max_kv_size: Optional[int] = None,
+        kv_bits: Optional[int] = None,
+        kv_group_size: int = 64,
+        quantized_kv_start: int = 0,
         stream=None,
     ):
+        if kv_bits is not None and quantized_kv_start != 0:
+            # Validated before any state is set, so a rejected config never
+            # leaves a partially-constructed instance behind (__del__ calls
+            # close(), which needs self._old_wired_limit to already exist).
+            # Per-job caches are created once, empty (offset=0), at insertion
+            # time via _make_new_cache() — maybe_quantize_kv_cache's
+            # offset-threshold gate would never trigger later for a nonzero
+            # quantized_kv_start, since there's no per-step re-check in the
+            # batching path. Only immediate quantization is supported here.
+            raise NotImplementedError(
+                "BatchGenerator only supports quantized_kv_start=0 with kv_bits "
+                "set — delayed/threshold quantization is not implemented for "
+                "the continuous-batching path."
+            )
         self.model = model
         self.max_tokens = max_tokens
         self.sampler = sampler or (lambda x: mx.argmax(x, axis=-1))
@@ -1598,6 +1615,9 @@ class BatchGenerator:
         self.prefill_batch_size = prefill_batch_size
         self.completion_batch_size = max(completion_batch_size, prefill_batch_size)
         self.max_kv_size = max_kv_size
+        self.kv_bits = kv_bits
+        self.kv_group_size = kv_group_size
+        self.quantized_kv_start = quantized_kv_start
 
         self._stream = stream or generation_stream
 
@@ -1631,7 +1651,10 @@ class BatchGenerator:
         return self._stream
 
     def close(self):
-        if self._old_wired_limit is not None:
+        # getattr guards against __del__ firing on an instance whose __init__
+        # raised before this attribute was ever set (e.g. an invalid kv_bits
+        # config) — a bare self._old_wired_limit would AttributeError there.
+        if getattr(self, "_old_wired_limit", None) is not None:
             mx.synchronize(self._stream)
             mx.set_wired_limit(self._old_wired_limit)
             self._old_wired_limit = None
@@ -1732,16 +1755,27 @@ class BatchGenerator:
 
     def _make_new_cache(self):
         if self.max_kv_size is None:
-            return cache.make_prompt_cache(self.model)
+            new_cache = cache.make_prompt_cache(self.model)
+        else:
+            new_cache = [
+                (
+                    RotatingKVCache(max_size=self.max_kv_size)
+                    if isinstance(ci, KVCache)
+                    else ci
+                )
+                for ci in cache.make_prompt_cache(self.model)
+            ]
 
-        return [
-            (
-                RotatingKVCache(max_size=self.max_kv_size)
-                if isinstance(ci, KVCache)
-                else ci
+        if self.kv_bits is not None:
+            # quantized_kv_start is always 0 here (enforced in __init__), so this
+            # quantizes every layer immediately — the cache is empty (offset=0),
+            # so there's no precision to lose. All subsequent update_and_fetch
+            # calls go through the quantized cache classes from this point on;
+            # no further re-quantization is needed anywhere else.
+            maybe_quantize_kv_cache(
+                new_cache, self.quantized_kv_start, self.kv_group_size, self.kv_bits
             )
-            for ci in cache.make_prompt_cache(self.model)
-        ]
+        return new_cache
 
     def _find_uids(self, uids):
         uids = set(uids)

--- a/mlx_lm/generate.py
+++ b/mlx_lm/generate.py
@@ -291,7 +291,15 @@ def maybe_quantize_kv_cache(prompt_cache, quantized_kv_start, kv_group_size, kv_
     if kv_bits is None:
         return
     for e, c in enumerate(prompt_cache):
-        if hasattr(c, "to_quantized") and c.offset >= quantized_kv_start:
+        if isinstance(c, CacheList):
+            # Hybrid attention/recurrent models (baichuan_m1, falcon_h1,
+            # deepseek_v32, longcat_flash*) hold their KV cache one level down.
+            # The wrapper defines no to_quantized(), so without recursing here
+            # the nested KV leaves silently ignore kv_bits.
+            leaves = list(c.caches)
+            maybe_quantize_kv_cache(leaves, quantized_kv_start, kv_group_size, kv_bits)
+            c.caches = tuple(leaves)
+        elif hasattr(c, "to_quantized") and c.offset >= quantized_kv_start:
             prompt_cache[e] = c.to_quantized(group_size=kv_group_size, bits=kv_bits)
 
 
@@ -1746,6 +1754,30 @@ class BatchGenerator:
                     self.kv_group_size,
                     self.kv_bits,
                 )
+
+            if self.kv_bits is not None:
+                # Both lanes, not just supplied caches: _make_new_cache() wraps
+                # only top-level KVCache entries for max_kv_size and does not
+                # descend into CacheList, so a fresh job on a hybrid model can
+                # carry a nested leaf that quantizes to a non-mergeable class
+                # too. Checked here rather than inside maybe_quantize_kv_cache
+                # because that helper is shared with generate_step, where a
+                # merge-less QuantizedKVCache is the normal, correct result.
+                for c in caches[i]:
+                    # CacheList.merge merges leaf-wise, but _merge_caches only
+                    # inspects the wrapper — which does have merge() — so a
+                    # non-mergeable nested leaf would otherwise slip past and
+                    # fail as an AttributeError inside CacheList.merge once the
+                    # batch forms. Check the leaves, not the wrapper.
+                    for leaf in c.caches if isinstance(c, CacheList) else (c,):
+                        if not hasattr(leaf, "merge"):
+                            raise ValueError(
+                                "kv_bits is set but the cache for this job "
+                                f"quantizes to {type(leaf).__name__}, which does "
+                                "not support batching. Batched KV-cache "
+                                "quantization currently requires rotating "
+                                "caches, so set max_kv_size."
+                            )
 
         for seq, m, c, at, s, lp, sm in zip(
             segments,

--- a/mlx_lm/models/cache.py
+++ b/mlx_lm/models/cache.py
@@ -1996,7 +1996,10 @@ class BatchRotatingQuantizedKVCache(_BaseCache):
     @meta_state.setter
     def meta_state(self, v):
         self.max_size, self._offset, self._idx = map(int, v[:3])
-        self.rotated = bool(v[3])
+        # meta_state stringifies, so v[3] is "True"/"False" and bool() would
+        # make both truthy. Compare instead. Same slip as BatchRotatingKVCache
+        # (see ml-explore/mlx-lm#1250).
+        self.rotated = v[3] == "True"
         self.group_size, self.bits = map(int, v[4:6])
 
     def is_trimmable(self):

--- a/mlx_lm/models/cache.py
+++ b/mlx_lm/models/cache.py
@@ -229,6 +229,19 @@ class ConcatenateKVCache(_BaseCache):
         return self.keys.nbytes + self.values.nbytes
 
 
+def _empty_quantized(B, n_kv_heads, n_steps, head_dim, group_size, bits, dtype):
+    """Allocate a zero-filled quantized (packed, scales, biases) triple, matching
+    the layout `mx.quantize` produces — used to grow quantized cache buffers in
+    fixed-size chunks (mirrors QuantizedKVCache.update_and_fetch's init_quant)."""
+    el_per_int = 8 * mx.uint32.size // bits
+    shape = (B, n_kv_heads, n_steps)
+    return (
+        mx.zeros((*shape, head_dim // el_per_int), dtype=mx.uint32),
+        mx.zeros((*shape, head_dim // group_size), dtype=dtype),
+        mx.zeros((*shape, head_dim // group_size), dtype=dtype),
+    )
+
+
 class QuantizedKVCache(_BaseCache):
     step = 256
 
@@ -548,8 +561,24 @@ class RotatingKVCache(_BaseCache):
         self._idx -= n
         return n
 
-    def to_quantized(self, group_size: int = 64, bits: int = 4) -> QuantizedKVCache:
-        raise NotImplementedError("RotatingKVCache Quantization NYI")
+    def to_quantized(
+        self, group_size: int = 64, bits: int = 4
+    ) -> "RotatingQuantizedKVCache":
+        if self.keep > 0:
+            raise NotImplementedError(
+                "Quantizing a RotatingKVCache with keep tokens is not supported."
+            )
+        quant_cache = RotatingQuantizedKVCache(
+            self.max_size, keep=self.keep, group_size=group_size, bits=bits
+        )
+        quant_cache.offset = self.offset
+        quant_cache._idx = self._idx
+        if self.keys is not None:
+            quant_cache.keys = mx.quantize(self.keys, group_size=group_size, bits=bits)
+            quant_cache.values = mx.quantize(
+                self.values, group_size=group_size, bits=bits
+            )
+        return quant_cache
 
     def make_mask(
         self, N: int, window_size: Optional[int] = None, return_array: bool = False
@@ -589,6 +618,234 @@ class RotatingKVCache(_BaseCache):
         if self.keys is None:
             return 0
         return self.keys.nbytes + self.values.nbytes
+
+
+class RotatingQuantizedKVCache(_BaseCache):
+    """Quantized counterpart of RotatingKVCache. `keys`/`values` are each a
+    (packed, scales, biases) triple as produced by `mx.quantize`, rather than a
+    single float array. Does not support `keep` (sink) tokens — batching
+    (BatchRotatingKVCache) never supports them either, and mira-mlx never
+    configures them, so this restriction costs nothing in practice."""
+
+    step = 256
+
+    def __init__(self, max_size, keep=0, group_size: int = 64, bits: int = 4):
+        if keep > 0:
+            raise NotImplementedError(
+                "RotatingQuantizedKVCache does not support keep tokens."
+            )
+        self.keep = keep
+        self.keys = None
+        self.values = None
+        self.offset = 0
+        self.max_size = max_size
+        self._idx = 0
+        self.group_size = group_size
+        self.bits = bits
+
+    def _quantize(self, x):
+        return mx.quantize(x, group_size=self.group_size, bits=self.bits)
+
+    def _trim(self, trim_size, v, append=None):
+        if trim_size > 0:
+            v = tree_map(lambda a: a[..., trim_size:, :], v)
+        if append is not None:
+            v = tree_map(lambda a, b: mx.concatenate([a, b], axis=2), v, append)
+        return v
+
+    def _temporal_order(self, v):
+        """
+        Rearrange the cache into temporal order, slicing off the end if unused.
+        """
+        if self._idx == v[0].shape[2]:
+            return v
+        elif self._idx < self.offset:
+            return tree_map(
+                lambda a: mx.concatenate(
+                    [a[..., self._idx :, :], a[..., : self._idx, :]], axis=2
+                ),
+                v,
+            )
+        else:
+            return tree_map(lambda a: a[..., : self._idx, :], v)
+
+    def _update_concat(self, keys, values):
+        qkeys = self._quantize(keys)
+        qvalues = self._quantize(values)
+        if self.keys is None:
+            self.keys = qkeys
+            self.values = qvalues
+        else:
+            # Put the keys/values in temporal order to preserve context
+            self.keys = self._temporal_order(self.keys)
+            self.values = self._temporal_order(self.values)
+            self._idx = self.keys[0].shape[2]
+
+            # The largest size is self.max_size + S - 1 to ensure
+            # every token gets at least self.max_size context
+            trim_size = self._idx - self.max_size + 1
+            self.keys = self._trim(trim_size, self.keys, qkeys)
+            self.values = self._trim(trim_size, self.values, qvalues)
+        self.offset += keys.shape[2]
+        self._idx = self.keys[0].shape[2]
+        return self.keys, self.values
+
+    def _update_in_place(self, keys, values):
+        # May not have hit the max size yet, so potentially keep growing the cache
+        B, n_kv_heads, S, k_head_dim = keys.shape
+        v_head_dim = values.shape[3]
+        prev = self.offset
+        cur_size = self.keys[0].shape[2] if self.keys is not None else 0
+        if self.keys is None or (prev >= cur_size and cur_size < self.max_size):
+            new_size = min(self.step, self.max_size - prev)
+            new_k = _empty_quantized(
+                B,
+                n_kv_heads,
+                new_size,
+                k_head_dim,
+                self.group_size,
+                self.bits,
+                keys.dtype,
+            )
+            new_v = _empty_quantized(
+                B,
+                n_kv_heads,
+                new_size,
+                v_head_dim,
+                self.group_size,
+                self.bits,
+                values.dtype,
+            )
+            if self.keys is not None:
+                self.keys = tree_map(
+                    lambda a, b: mx.concatenate([a, b], axis=2), self.keys, new_k
+                )
+                self.values = tree_map(
+                    lambda a, b: mx.concatenate([a, b], axis=2), self.values, new_v
+                )
+            else:
+                self.keys, self.values = new_k, new_v
+            self._idx = prev
+
+        # Trim if needed
+        trim_size = self.keys[0].shape[2] - self.max_size
+        if trim_size > 0:
+            self.keys = self._trim(trim_size, self.keys)
+            self.values = self._trim(trim_size, self.values)
+            self._idx = self.max_size
+
+        # Rotate
+        if self._idx == self.max_size:
+            self._idx = self.keep  # always 0, keep>0 rejected in __init__
+
+        # Assign (quantize the incoming chunk, then slice-write like QuantizedKVCache)
+        qkeys = self._quantize(keys)
+        qvalues = self._quantize(values)
+        for i in range(3):
+            self.keys[i][..., self._idx : self._idx + S, :] = qkeys[i]
+            self.values[i][..., self._idx : self._idx + S, :] = qvalues[i]
+        self.offset += S
+        self._idx += S
+
+        # If the buffer is not full, slice off the end
+        if self.offset < self.max_size:
+            return (
+                tree_map(lambda a: a[..., : self.offset, :], self.keys),
+                tree_map(lambda a: a[..., : self.offset, :], self.values),
+            )
+        return self.keys, self.values
+
+    def update_and_fetch(self, keys, values):
+        if keys.shape[2] == 1:
+            return self._update_in_place(keys, values)
+        return self._update_concat(keys, values)
+
+    def size(self):
+        return min(self.offset, self.max_size)
+
+    @property
+    def state(self):
+        if self.offset < self.keys[0].shape[2]:
+            return (
+                tree_map(lambda a: a[..., : self.offset, :], self.keys),
+                tree_map(lambda a: a[..., : self.offset, :], self.values),
+            )
+        else:
+            return self.keys, self.values
+
+    @state.setter
+    def state(self, v):
+        self.keys, self.values = v
+
+    @property
+    def meta_state(self):
+        return tuple(
+            map(
+                str,
+                (
+                    self.keep,
+                    self.max_size,
+                    self.offset,
+                    self._idx,
+                    self.group_size,
+                    self.bits,
+                ),
+            )
+        )
+
+    @meta_state.setter
+    def meta_state(self, v):
+        self.keep, self.max_size, self.offset, self._idx, self.group_size, self.bits = (
+            map(int, v)
+        )
+
+    def is_trimmable(self):
+        return self.offset < self.max_size
+
+    def trim(self, n):
+        n = min(self.offset, n)
+        self.offset -= n
+        self._idx -= n
+        return n
+
+    def make_mask(
+        self, N: int, window_size: Optional[int] = None, return_array: bool = False
+    ):
+        # Identical bookkeeping to RotatingKVCache.make_mask — no array access.
+        if N > 1:
+            window_size = window_size or self.max_size
+            offset = min(self.max_size - 1, self.offset)
+            if offset + N > window_size or return_array:
+                return create_causal_mask(N, offset, window_size=window_size)
+            else:
+                return "causal"
+        else:
+            if window_size is None:
+                return None
+            if self.offset >= window_size and self.max_size > window_size:
+                idx = self._idx
+                if idx >= self.max_size:
+                    idx = 0
+                if self.offset < self.max_size:
+                    mask_size = self.offset + 1
+                else:
+                    mask_size = self.max_size
+                mask = mx.arange(mask_size) >= (mask_size - window_size)
+                mask = mx.roll(mask, shift=idx + 1)
+                return mask
+
+    @classmethod
+    def merge(_, caches):
+        return BatchRotatingQuantizedKVCache.merge(caches)
+
+    def empty(self):
+        return self.keys is None
+
+    @property
+    def nbytes(self):
+        if self.keys is None:
+            return 0
+        return tree_reduce(lambda a, x: a + x.nbytes, (self.keys, self.values), 0)
 
 
 class ArraysCache(_BaseCache):
@@ -1324,8 +1581,22 @@ class BatchRotatingKVCache(_BaseCache):
         self.offset -= n
         return n
 
-    def to_quantized(self, group_size: int = 64, bits: int = 4) -> QuantizedKVCache:
-        raise NotImplementedError("BatchRotatingKVCache Quantization NYI")
+    def to_quantized(
+        self, group_size: int = 64, bits: int = 4
+    ) -> "BatchRotatingQuantizedKVCache":
+        quant_cache = BatchRotatingQuantizedKVCache(
+            self.max_size, self.left_padding.tolist(), group_size=group_size, bits=bits
+        )
+        quant_cache.offset = self.offset
+        quant_cache._idx = self._idx
+        quant_cache._offset = self._offset
+        quant_cache.rotated = self.rotated
+        if self.keys is not None:
+            quant_cache.keys = mx.quantize(self.keys, group_size=group_size, bits=bits)
+            quant_cache.values = mx.quantize(
+                self.values, group_size=group_size, bits=bits
+            )
+        return quant_cache
 
     def make_mask(
         self, N: int, window_size: Optional[int] = None, return_array: bool = False
@@ -1482,6 +1753,472 @@ class BatchRotatingKVCache(_BaseCache):
         if self.keys is None:
             return 0
         return self.keys.nbytes + self.values.nbytes
+
+
+class BatchRotatingQuantizedKVCache(_BaseCache):
+    """Quantized counterpart of BatchRotatingKVCache — the class BatchGenerator's
+    continuous-batching path actually calls `update_and_fetch` on once per-job
+    caches are merged into a batch. `keys`/`values` are each a (packed, scales,
+    biases) triple. Never receives `keep` tokens — merge() only ever takes
+    RotatingQuantizedKVCache inputs, which themselves reject keep>0."""
+
+    step = 256
+
+    def __init__(
+        self, max_size, left_padding: List[int], group_size: int = 64, bits: int = 4
+    ):
+        self.keys = None
+        self.values = None
+
+        self.left_padding = mx.array(left_padding)
+        self.offset = mx.array([-l for l in left_padding])
+
+        self.max_size = max_size
+        self.group_size = group_size
+        self.bits = bits
+        self._idx = 0
+        self._offset = 0
+        self.rotated = False
+
+        # Lengths for right_padded inputs to make sure that padding tokens do
+        # not evict valid tokens.
+        self._lengths = None
+
+    def _quantize(self, x):
+        return mx.quantize(x, group_size=self.group_size, bits=self.bits)
+
+    def _trim(self, trim_size, v, append=None):
+        if trim_size > 0:
+            v = tree_map(lambda a: a[..., trim_size:, :], v)
+        if append is not None:
+            v = tree_map(lambda a, b: mx.concatenate([a, b], axis=2), v, append)
+        return v
+
+    def _temporal_order(self):
+        """
+        Rearrange the cache into temporal order.
+        """
+        if self.rotated:
+            self.keys = tree_map(lambda a: mx.roll(a, -self._idx, axis=2), self.keys)
+            self.values = tree_map(
+                lambda a: mx.roll(a, -self._idx, axis=2), self.values
+            )
+            self._idx = self.keys[0].shape[2]
+            self.rotated = False
+
+    def _update_concat(self, keys, values):
+        qkeys = self._quantize(keys)
+        qvalues = self._quantize(values)
+        if self.keys is None:
+            self.keys = qkeys
+            self.values = qvalues
+        else:
+            # Put the keys/values in temporal order to preserve context
+            self._temporal_order()
+
+            # Slice off the end if needed
+            if self.keys[0].shape[2] > self._idx:
+                self.keys = tree_map(lambda a: a[..., : self._idx, :], self.keys)
+                self.values = tree_map(lambda a: a[..., : self._idx, :], self.values)
+
+            # Roll right sequences that are padded to make sure that we don't
+            # trim valid cache entries
+            if self._lengths is not None:
+                roll = mx.maximum(0, self.offset - self._lengths)
+                self.keys = tree_map(
+                    lambda a: dynamic_roll(a, roll[:, None], axis=2), self.keys
+                )
+                self.values = tree_map(
+                    lambda a: dynamic_roll(a, roll[:, None], axis=2), self.values
+                )
+                self.left_padding += roll
+                self.offset -= roll
+
+            # The largest size is self.max_size + S - 1 to ensure
+            # every token gets at least self.max_size context
+            trim_size = self._idx - self.max_size + 1
+            if trim_size > 0:
+                self.left_padding -= trim_size
+            self.keys = self._trim(trim_size, self.keys, qkeys)
+            self.values = self._trim(trim_size, self.values, qvalues)
+        self.offset += keys.shape[2]
+        self._offset += keys.shape[2]
+        self._idx = self.keys[0].shape[2]
+
+        # Make sure left_padding and offset are evaluated
+        self.keys = tree_map(
+            lambda a: mx.depends(a, (self.left_padding, self.offset)), self.keys
+        )
+
+        return self.keys, self.values
+
+    def _update_in_place(self, keys, values):
+        if self._lengths is not None:
+            raise RuntimeError(
+                "finalize() should be called before decoding with "
+                "BatchRotatingQuantizedKVCache"
+            )
+
+        # May not have hit the max size yet, so potentially keep growing the cache
+        B, n_kv_heads, S, k_head_dim = keys.shape
+        v_head_dim = values.shape[3]
+        prev = self._offset
+        cur_size = self.keys[0].shape[2] if self.keys is not None else 0
+        if self.keys is None or (prev >= cur_size and cur_size < self.max_size):
+            new_size = min(self.step, self.max_size - prev)
+            new_k = _empty_quantized(
+                B,
+                n_kv_heads,
+                new_size,
+                k_head_dim,
+                self.group_size,
+                self.bits,
+                keys.dtype,
+            )
+            new_v = _empty_quantized(
+                B,
+                n_kv_heads,
+                new_size,
+                v_head_dim,
+                self.group_size,
+                self.bits,
+                values.dtype,
+            )
+            if self.keys is not None:
+                self.keys = tree_map(
+                    lambda a, b: mx.concatenate([a, b], axis=2), self.keys, new_k
+                )
+                self.values = tree_map(
+                    lambda a, b: mx.concatenate([a, b], axis=2), self.values, new_v
+                )
+            else:
+                self.keys, self.values = new_k, new_v
+            self._idx = prev
+
+        # Trim if needed
+        trim_size = self.keys[0].shape[2] - self.max_size
+        if trim_size > 0:
+            self.keys = self._trim(trim_size, self.keys)
+            self.values = self._trim(trim_size, self.values)
+            self._idx = self.max_size
+            self.left_padding -= trim_size
+
+        # Rotate
+        if self._idx == self.max_size:
+            self.rotated = True
+            self._idx = 0
+        if self.rotated:
+            self.left_padding -= S
+
+        # Assign (quantize the incoming chunk, then slice-write like QuantizedKVCache)
+        qkeys = self._quantize(keys)
+        qvalues = self._quantize(values)
+        for i in range(3):
+            self.keys[i][..., self._idx : self._idx + S, :] = qkeys[i]
+            self.values[i][..., self._idx : self._idx + S, :] = qvalues[i]
+        self._offset += S
+        self.offset += S
+        self._idx += S
+
+        # Make sure left_padding and offset are evaluated
+        self.keys = tree_map(
+            lambda a: mx.depends(a, (self.left_padding, self.offset)), self.keys
+        )
+
+        # If the buffer is not full, slice off the end
+        if self._offset < self.max_size:
+            return (
+                tree_map(lambda a: a[..., : self._offset, :], self.keys),
+                tree_map(lambda a: a[..., : self._offset, :], self.values),
+            )
+        return self.keys, self.values
+
+    def update_and_fetch(self, keys, values):
+        if keys.shape[2] == 1:
+            return self._update_in_place(keys, values)
+        return self._update_concat(keys, values)
+
+    def prepare(self, *, left_padding=None, lengths=None, right_padding=None):
+        if left_padding is not None:
+            if self.keys is not None:
+                raise ValueError(
+                    "Left padding can only be added to an empty "
+                    "BatchRotatingQuantizedKVCache"
+                )
+            left_padding = mx.array(left_padding)
+            self.left_padding += left_padding
+            self.offset -= left_padding
+
+        if right_padding is not None and max(right_padding) > 0:
+            self._lengths = mx.array(lengths) + self.offset
+
+    def finalize(self):
+        if self._lengths is not None:
+            roll = mx.maximum(0, self.offset - self._lengths)
+            self.keys = tree_map(
+                lambda a: dynamic_roll(a, roll[:, None], axis=2), self.keys
+            )
+            self.values = tree_map(
+                lambda a: dynamic_roll(a, roll[:, None], axis=2), self.values
+            )
+            self.left_padding += roll
+            self.offset -= roll
+            self._lengths = None
+
+    @property
+    def state(self):
+        k, v = self.keys, self.values
+        if self._offset < k[0].shape[2]:
+            k = tree_map(lambda a: a[..., : self._offset, :], k)
+            v = tree_map(lambda a: a[..., : self._offset, :], v)
+        return k, v, self.offset, self.left_padding
+
+    @state.setter
+    def state(self, v):
+        self.keys, self.values, self.offset, self.left_padding = v
+
+    @property
+    def meta_state(self):
+        return tuple(
+            map(
+                str,
+                (
+                    self.max_size,
+                    self._offset,
+                    self._idx,
+                    self.rotated,
+                    self.group_size,
+                    self.bits,
+                ),
+            )
+        )
+
+    @meta_state.setter
+    def meta_state(self, v):
+        self.max_size, self._offset, self._idx = map(int, v[:3])
+        self.rotated = bool(v[3])
+        self.group_size, self.bits = map(int, v[4:6])
+
+    def is_trimmable(self):
+        return self._offset < self.max_size
+
+    def trim(self, n):
+        n = min(self._offset, n)
+        self._offset -= n
+        self._idx -= n
+        self.offset -= n
+        return n
+
+    def make_mask(
+        self, N: int, window_size: Optional[int] = None, return_array: bool = False
+    ):
+        # Identical bookkeeping to BatchRotatingKVCache.make_mask — no array access.
+        left_padding = self.left_padding
+        window_size = window_size or self.max_size
+        offset = min(self.max_size - 1, self._offset)
+        rinds = mx.arange(offset + N)
+        linds = mx.arange(offset, offset + N) if offset else rinds
+        linds = linds[:, None]
+        rinds = rinds[None]
+        mask = linds >= rinds
+        mask &= linds < rinds + window_size
+        if (trim_size := self._idx - self.max_size + int(N > 1)) > 0:
+            left_padding = left_padding - trim_size
+
+        rotated = N == 1 and (self.rotated or self._idx >= self.max_size)
+        if rotated:
+            left_padding = left_padding - 1
+
+        mask = mask & (rinds >= mx.expand_dims(left_padding, (1, 2, 3)))
+
+        if rotated:
+            idx = self._idx
+            if idx >= self.max_size:
+                idx = 0
+            mask = mx.roll(mask, shift=idx + 1, axis=-1)
+
+        return mask
+
+    def filter(self, batch_indices):
+        """
+        In-place filter to keep just the given indices in the cache.
+        """
+        if self.keys is not None:
+            self.keys = tree_map(lambda a: a[batch_indices], self.keys)
+            self.values = tree_map(lambda a: a[batch_indices], self.values)
+        self.offset = self.offset[batch_indices]
+        self.left_padding = self.left_padding[batch_indices]
+
+    def extend(self, other):
+        """
+        In-place extend this cache with the other cache.
+        """
+        if self.keys is None and other.keys is None:
+            self.left_padding = mx.concatenate([self.left_padding, other.left_padding])
+            self.offset = mx.concatenate([self.offset, other.offset])
+            return
+
+        if (self.rotated != other.rotated) or self._idx != other._idx:
+            self._temporal_order()
+            other._temporal_order()
+
+        max_idx = max(self._idx, other._idx)
+        L1 = L2 = 0
+        if self.keys is not None:
+            L1 = self.keys[0].shape[2]
+        if other.keys is not None:
+            L2 = other.keys[0].shape[2]
+        max_size = max(L1, L2)
+
+        ref = self.keys if self.keys is not None else other.keys
+        ref_v = self.values if self.values is not None else other.values
+
+        def pad(c):
+            left = max_idx - c._idx
+            if c.keys is None:
+                Bc = c.offset.shape[0]
+                k = tree_map(
+                    lambda a: mx.zeros(
+                        (Bc, *a.shape[1:2], 0, a.shape[-1]), dtype=a.dtype
+                    ),
+                    ref,
+                )
+                v = tree_map(
+                    lambda a: mx.zeros(
+                        (Bc, *a.shape[1:2], 0, a.shape[-1]), dtype=a.dtype
+                    ),
+                    ref_v,
+                )
+            else:
+                k, v = c.keys, c.values
+            right = max_size - k[0].shape[2] - left
+            if right < 0:
+                k = tree_map(lambda a: a[..., :right, :], k)
+                v = tree_map(lambda a: a[..., :right, :], v)
+                right = 0
+            if left != 0 or right != 0:
+                k = tree_map(
+                    lambda a: mx.pad(a, [(0, 0), (0, 0), (left, right), (0, 0)]), k
+                )
+                v = tree_map(
+                    lambda a: mx.pad(a, [(0, 0), (0, 0), (left, right), (0, 0)]), v
+                )
+            left_padding = c.left_padding + left
+            return k, v, c.offset, left_padding
+
+        pa, pb = pad(self), pad(other)
+        self.keys = tree_map(lambda a, b: mx.concatenate([a, b], axis=0), pa[0], pb[0])
+        self.values = tree_map(
+            lambda a, b: mx.concatenate([a, b], axis=0), pa[1], pb[1]
+        )
+        self.offset = mx.concatenate([pa[2], pb[2]])
+        self.left_padding = mx.concatenate([pa[3], pb[3]])
+        self._idx = max_idx
+        self._offset = max(self._offset, other._offset)
+
+    def extract(self, idx):
+        mx.eval(self.left_padding, self.offset)
+        cache = RotatingQuantizedKVCache(
+            self.max_size, group_size=self.group_size, bits=self.bits
+        )
+        padding = max(0, self.left_padding.tolist()[idx])
+        offset = self.offset.tolist()[idx]
+        cache.keys = tree_map(lambda a: a[idx : idx + 1], self.keys)
+        cache.values = tree_map(lambda a: a[idx : idx + 1], self.values)
+        cache._idx = self._idx
+        if self.rotated:
+            cache.keys = tree_map(lambda a: mx.roll(a, -self._idx, axis=2), cache.keys)
+            cache.values = tree_map(
+                lambda a: mx.roll(a, -self._idx, axis=2), cache.values
+            )
+            cache._idx = self.max_size
+        cache.keys = tree_map(
+            lambda a: mx.contiguous(a[:, :, padding : cache._idx]), cache.keys
+        )
+        cache.values = tree_map(
+            lambda a: mx.contiguous(a[:, :, padding : cache._idx]), cache.values
+        )
+        cache.offset = offset
+        cache._idx = cache.keys[0].shape[2]
+        return cache
+
+    @classmethod
+    def merge(cls, caches):
+        if not all(c.max_size == caches[0].max_size for c in caches):
+            raise ValueError(
+                "BatchRotatingQuantizedKVCache can only merge caches with the "
+                "same maximum size"
+            )
+        if not all(
+            (c.group_size, c.bits) == (caches[0].group_size, caches[0].bits)
+            for c in caches
+        ):
+            raise ValueError(
+                "BatchRotatingQuantizedKVCache can only merge caches with the "
+                "same group_size/bits"
+            )
+
+        offsets = [c.offset for c in caches]
+        lengths = [c.size() for c in caches]
+        max_length = max(lengths)
+
+        # No cache has content so make an empty one
+        if max_length == 0:
+            return cls(
+                caches[0].max_size,
+                [0] * len(caches),
+                group_size=caches[0].group_size,
+                bits=caches[0].bits,
+            )
+
+        padding = [max_length - l for l in lengths]
+        B = len(caches)
+        ref = next(c.keys for c in caches if c.keys is not None)
+        H = ref[0].shape[1]
+        dt_p, dt_sb = ref[0].dtype, ref[1].dtype
+
+        def alloc_like(ref_tuple):
+            return tuple(
+                mx.zeros((B, H, max_length, a.shape[-1]), dtype=a.dtype)
+                for a in ref_tuple
+            )
+
+        keys = alloc_like(ref)
+        values = alloc_like(next(c.values for c in caches if c.values is not None))
+        for i, (p, l, c) in enumerate(zip(padding, lengths, caches)):
+            if c.keys is None:
+                continue
+            ok = c._temporal_order(c.keys)
+            ov = c._temporal_order(c.values)
+            for j in range(3):
+                keys[j][i : i + 1, :, p : p + l] = ok[j][..., -l:, :]
+                values[j][i : i + 1, :, p : p + l] = ov[j][..., -l:, :]
+
+        cache = cls(
+            caches[0].max_size,
+            padding,
+            group_size=caches[0].group_size,
+            bits=caches[0].bits,
+        )
+        cache.keys = keys
+        cache.values = values
+        cache.offset = mx.array(offsets)
+        cache._idx = max_length
+        cache._offset = max_length
+
+        return cache
+
+    def size(self):
+        return min(self._offset, self.max_size)
+
+    def empty(self):
+        return self.keys is None
+
+    @property
+    def nbytes(self):
+        if self.keys is None:
+            return 0
+        return tree_reduce(lambda a, x: a + x.nbytes, (self.keys, self.values), 0)
 
 
 class TokenBuffer:

--- a/tests/test_generate.py
+++ b/tests/test_generate.py
@@ -16,6 +16,8 @@ from mlx_lm.generate import (
     stream_generate,
 )
 from mlx_lm.models.cache import (
+    ArraysCache,
+    CacheList,
     KVCache,
     QuantizedKVCache,
     RotatingKVCache,
@@ -426,22 +428,21 @@ class TestGenerate(unittest.TestCase):
                 quantized_kv_start=4,
             )
 
-    def test_batch_insert_external_cache_is_quantized(self):
+    def test_batch_insert_external_rotating_cache_is_quantized(self):
         """A caller-supplied cache bypasses _make_new_cache(), which is where
         quantization is applied, so kv_bits used to be silently ignored for it:
         the caller asked for a quantized cache and got a full-precision one with
-        no error. insert() must quantize supplied caches too."""
-        prompt = self.tokenizer.encode("Hello")
-        external = make_prompt_cache(self.model)
-        self.assertTrue(
-            all(isinstance(c, KVCache) for c in external),
-            "precondition: a fresh cache for this model should be unquantized",
-        )
+        no error. insert() must quantize supplied caches too, and the rotating
+        config is the one that can actually go on to batch, so this covers the
+        conversion and generation through the merged path."""
+        prompt = self.tokenizer.encode("Hello there")
+        external = [RotatingKVCache(max_size=64) for _ in range(len(self.model.layers))]
 
         batch_gen = BatchGenerator(
             self.model,
             stop_tokens=self.tokenizer.eos_token_ids,
             max_tokens=4,
+            max_kv_size=64,
             kv_bits=8,
             kv_group_size=32,
         )
@@ -450,9 +451,14 @@ class TestGenerate(unittest.TestCase):
         # maybe_quantize_kv_cache rewrites the list in place, same as
         # generate_step, so the caller's list reflects the conversion.
         self.assertTrue(
-            all(isinstance(c, QuantizedKVCache) for c in external),
+            all(isinstance(c, RotatingQuantizedKVCache) for c in external),
             f"supplied cache not quantized: {[type(c).__name__ for c in external]}",
         )
+
+        tokens = []
+        while responses := batch_gen.next_generated():
+            tokens.extend(r.token for r in responses)
+        self.assertGreater(len(tokens), 0, "supplied-cache job produced no tokens")
 
     def test_batch_insert_external_cache_untouched_without_kv_bits(self):
         """Control for the above: with no kv_bits the supplied cache must be
@@ -470,14 +476,42 @@ class TestGenerate(unittest.TestCase):
 
         self.assertEqual(before, [type(c) for c in external])
 
-    def test_batch_insert_external_cache_already_quantized(self):
+    def test_batch_insert_external_rotating_cache_already_quantized(self):
         """An already-quantized supplied cache must not be re-quantized. The
         quantized classes define no to_quantized(), so maybe_quantize_kv_cache
-        skips them; this pins that behaviour."""
+        skips them; this pins that behaviour on the rotating config, which is
+        the one that can actually batch."""
+        prompt = self.tokenizer.encode("Hello")
+        external = [
+            RotatingKVCache(max_size=64).to_quantized(group_size=32, bits=8)
+            for _ in range(len(self.model.layers))
+        ]
+        ids_before = [id(c) for c in external]
+
+        batch_gen = BatchGenerator(
+            self.model,
+            stop_tokens=self.tokenizer.eos_token_ids,
+            max_tokens=4,
+            max_kv_size=64,
+            kv_bits=8,
+            kv_group_size=32,
+        )
+        batch_gen.insert([prompt], caches=[external])
+
+        self.assertEqual(ids_before, [id(c) for c in external])
+
+    def test_batch_insert_plain_kv_bits_without_max_kv_size_raises(self):
+        """kv_bits without max_kv_size quantizes plain KVCache to
+        QuantizedKVCache, which has no merge(), so the job can never form a
+        batch. _merge_caches would eventually reject it with a message about
+        "batching with history" even for a job that has none, so refuse it at
+        insert with a message that names the actual fix."""
         prompt = self.tokenizer.encode("Hello")
         external = make_prompt_cache(self.model)
-        external = [c.to_quantized(group_size=32, bits=8) for c in external]
-        ids_before = [id(c) for c in external]
+        self.assertTrue(
+            all(isinstance(c, KVCache) for c in external),
+            "precondition: a fresh cache for this model should be unquantized",
+        )
 
         batch_gen = BatchGenerator(
             self.model,
@@ -486,9 +520,72 @@ class TestGenerate(unittest.TestCase):
             kv_bits=8,
             kv_group_size=32,
         )
+        with self.assertRaises(ValueError) as ctx:
+            batch_gen.insert([prompt], caches=[external])
+        self.assertIn(QuantizedKVCache.__name__, str(ctx.exception))
+        self.assertIn("max_kv_size", str(ctx.exception))
+
+    def test_batch_insert_external_cachelist_nested_kv_is_quantized(self):
+        """Composite CacheList layer caches (hybrid attention+recurrent models:
+        baichuan_m1, falcon_h1, deepseek_v32, longcat_flash*) hold their KV
+        cache one level down. The wrapper has merge() but no to_quantized(), so
+        without recursing into the leaves a supplied CacheList silently stays
+        full-precision while the fresh lane quantizes, and the mixed cohort then
+        dies in CacheList.merge with AttributeError. Insert-level assertion,
+        model-independent: supplied caches only, no generation (this model's
+        attention layers don't consume CacheList). Leaf order mirrors
+        baichuan_m1's sliding-window layers: (conv ArraysCache,
+        RotatingKVCache)."""
+        prompt = self.tokenizer.encode("Hello")
+        external = [
+            CacheList(ArraysCache(size=2), RotatingKVCache(max_size=64))
+            for _ in range(len(self.model.layers))
+        ]
+
+        batch_gen = BatchGenerator(
+            self.model,
+            stop_tokens=self.tokenizer.eos_token_ids,
+            max_tokens=4,
+            max_kv_size=64,
+            kv_bits=8,
+            kv_group_size=32,
+        )
         batch_gen.insert([prompt], caches=[external])
 
-        self.assertEqual(ids_before, [id(c) for c in external])
+        for c in external:
+            self.assertIsInstance(c, CacheList)
+            self.assertIsInstance(c.caches[0], ArraysCache)
+            self.assertIsInstance(
+                c.caches[1],
+                RotatingQuantizedKVCache,
+                f"nested KV leaf not quantized: {type(c.caches[1]).__name__}",
+            )
+
+    def test_batch_insert_external_cachelist_non_mergeable_raises(self):
+        """A nested plain KVCache quantizes to QuantizedKVCache, which has no
+        merge(). _merge_caches' hasattr check only inspects the wrapper, and
+        CacheList does have merge(), so a non-mergeable nested leaf would dodge
+        the friendly ValueError and die later as an AttributeError inside
+        CacheList.merge. It must fail loudly at insert instead. baichuan_m1
+        makes the shape concrete: its non-sliding-window layers are
+        CacheList(ArraysCache, KVCache), so a blanket recursive pass leaves one
+        model mergeable on some layers and not on others."""
+        prompt = self.tokenizer.encode("Hello")
+        external = [
+            CacheList(ArraysCache(size=2), KVCache())
+            for _ in range(len(self.model.layers))
+        ]
+
+        batch_gen = BatchGenerator(
+            self.model,
+            stop_tokens=self.tokenizer.eos_token_ids,
+            max_tokens=4,
+            max_kv_size=64,
+            kv_bits=8,
+            kv_group_size=32,
+        )
+        with self.assertRaises(ValueError):
+            batch_gen.insert([prompt], caches=[external])
 
     def test_batch_continued_generation_quantized(self):
         """Round trip in the shape a real caller uses: generate, harvest the

--- a/tests/test_generate.py
+++ b/tests/test_generate.py
@@ -15,7 +15,13 @@ from mlx_lm.generate import (
     generate_step,
     stream_generate,
 )
-from mlx_lm.models.cache import KVCache, RotatingKVCache
+from mlx_lm.models.cache import (
+    KVCache,
+    QuantizedKVCache,
+    RotatingKVCache,
+    RotatingQuantizedKVCache,
+    make_prompt_cache,
+)
 from mlx_lm.sample_utils import make_logits_processors, make_sampler
 from mlx_lm.utils import load
 
@@ -419,6 +425,140 @@ class TestGenerate(unittest.TestCase):
                 kv_bits=8,
                 quantized_kv_start=4,
             )
+
+    def test_batch_insert_external_cache_is_quantized(self):
+        """A caller-supplied cache bypasses _make_new_cache(), which is where
+        quantization is applied, so kv_bits used to be silently ignored for it:
+        the caller asked for a quantized cache and got a full-precision one with
+        no error. insert() must quantize supplied caches too."""
+        prompt = self.tokenizer.encode("Hello")
+        external = make_prompt_cache(self.model)
+        self.assertTrue(
+            all(isinstance(c, KVCache) for c in external),
+            "precondition: a fresh cache for this model should be unquantized",
+        )
+
+        batch_gen = BatchGenerator(
+            self.model,
+            stop_tokens=self.tokenizer.eos_token_ids,
+            max_tokens=4,
+            kv_bits=8,
+            kv_group_size=32,
+        )
+        batch_gen.insert([prompt], caches=[external])
+
+        # maybe_quantize_kv_cache rewrites the list in place, same as
+        # generate_step, so the caller's list reflects the conversion.
+        self.assertTrue(
+            all(isinstance(c, QuantizedKVCache) for c in external),
+            f"supplied cache not quantized: {[type(c).__name__ for c in external]}",
+        )
+
+    def test_batch_insert_external_cache_untouched_without_kv_bits(self):
+        """Control for the above: with no kv_bits the supplied cache must be
+        left exactly as the caller built it."""
+        prompt = self.tokenizer.encode("Hello")
+        external = make_prompt_cache(self.model)
+        before = [type(c) for c in external]
+
+        batch_gen = BatchGenerator(
+            self.model,
+            stop_tokens=self.tokenizer.eos_token_ids,
+            max_tokens=4,
+        )
+        batch_gen.insert([prompt], caches=[external])
+
+        self.assertEqual(before, [type(c) for c in external])
+
+    def test_batch_insert_external_cache_already_quantized(self):
+        """An already-quantized supplied cache must not be re-quantized. The
+        quantized classes define no to_quantized(), so maybe_quantize_kv_cache
+        skips them; this pins that behaviour."""
+        prompt = self.tokenizer.encode("Hello")
+        external = make_prompt_cache(self.model)
+        external = [c.to_quantized(group_size=32, bits=8) for c in external]
+        ids_before = [id(c) for c in external]
+
+        batch_gen = BatchGenerator(
+            self.model,
+            stop_tokens=self.tokenizer.eos_token_ids,
+            max_tokens=4,
+            kv_bits=8,
+            kv_group_size=32,
+        )
+        batch_gen.insert([prompt], caches=[external])
+
+        self.assertEqual(ids_before, [id(c) for c in external])
+
+    def test_batch_continued_generation_quantized(self):
+        """Round trip in the shape a real caller uses: generate, harvest the
+        per-job caches off the responses, then re-insert them with kv_bits set.
+        The existing test_batch_continued_generation* tests cover this path with
+        quantization off, so this is the quantized counterpart.
+
+        max_kv_size is required here, and not incidental: continued generation
+        merges the per-job caches, and only the rotating quantized class
+        implements merge(). Plain QuantizedKVCache does not (pre-existing in
+        mlx-lm, unrelated to this PR), so kv_bits without max_kv_size cannot do
+        batching-with-history at all."""
+        prompts_a = [self.tokenizer.encode(p) for p in ("Hello", "What time is it?")]
+        prompts_b = [self.tokenizer.encode(p) for p in ("And then?", "Why?")]
+
+        batch_gen = BatchGenerator(
+            self.model,
+            stop_tokens=self.tokenizer.eos_token_ids,
+            max_tokens=4,
+            max_kv_size=32,
+            kv_bits=8,
+            kv_group_size=32,
+            prefill_batch_size=2,
+            completion_batch_size=2,
+        )
+
+        uids = batch_gen.insert(prompts_a)
+        caches = {uid: None for uid in uids}
+        while responses := batch_gen.next_generated():
+            for r in responses:
+                if r.finish_reason is not None:
+                    caches[r.uid] = r.prompt_cache
+        caches = [caches[uid] for uid in uids]
+
+        for c in caches:
+            self.assertIsNotNone(c, "no cache harvested from a finished job")
+
+        uids = batch_gen.insert(prompts_b, caches=caches)
+        batch_responses = {uid: [] for uid in uids}
+        while responses := batch_gen.next_generated():
+            for r in responses:
+                batch_responses[r.uid].append(r.token)
+
+        for uid in uids:
+            self.assertGreater(
+                len(batch_responses[uid]),
+                0,
+                "continued quantized job produced no tokens",
+            )
+            for tok in batch_responses[uid]:
+                self.assertFalse(mx.isnan(mx.array(float(tok))))
+
+    def test_batch_insert_external_rotating_cache_with_keep_raises(self):
+        """keep>0 is the one RotatingKVCache shape quantization does not
+        support. It must fail loudly at insert() rather than part-way through
+        decoding, and it must not be silently skipped."""
+        prompt = self.tokenizer.encode("Hello")
+        external = [
+            RotatingKVCache(max_size=8, keep=4) for _ in range(len(self.model.layers))
+        ]
+
+        batch_gen = BatchGenerator(
+            self.model,
+            stop_tokens=self.tokenizer.eos_token_ids,
+            max_tokens=4,
+            kv_bits=8,
+            kv_group_size=32,
+        )
+        with self.assertRaises(NotImplementedError):
+            batch_gen.insert([prompt], caches=[external])
 
     def test_batch_generate_with_logits_processors(self):
         """Test that batch_generate with logits_processors produces correct results."""

--- a/tests/test_generate.py
+++ b/tests/test_generate.py
@@ -359,6 +359,67 @@ class TestGenerate(unittest.TestCase):
 
         del self.model.make_cache
 
+    def test_batch_sliding_window_quantized(self):
+        """BatchGenerator with max_kv_size AND kv_bits set together — the exact
+        combination mira-mlx always uses (--max-kv-size is always passed), which
+        used to be blocked by BatchRotatingKVCache.to_quantized() raising
+        NotImplementedError. Forces rotation (max_tokens > max_kv_size) and
+        mid-stream job insertion (jobs finish at different times) to exercise
+        RotatingQuantizedKVCache/BatchRotatingQuantizedKVCache's merge/filter/
+        extend/extract paths under real generation, not synthetic tensors."""
+        prompts = [
+            "Write a story about Einstein",
+            "Hi",
+            "What time is it?",
+            "How tall is Mt Everest?",
+        ]
+        prompts = [
+            self.tokenizer.apply_chat_template(
+                [{"role": "user", "content": p}],
+                tokenize=True,
+                add_generation_prompt=True,
+            )
+            for p in prompts
+        ]
+
+        batch_gen = BatchGenerator(
+            self.model,
+            stop_tokens=self.tokenizer.eos_token_ids,
+            max_tokens=10,
+            max_kv_size=4,
+            kv_bits=8,
+            kv_group_size=32,
+            prefill_batch_size=1,
+            prefill_step_size=8,
+            completion_batch_size=2,
+        )
+        uids = batch_gen.insert(prompts)
+        batch_responses = {uid: [] for uid in uids}
+        while responses := batch_gen.next_generated():
+            for r in responses:
+                batch_responses[r.uid].append(r.token)
+
+        for uid in uids:
+            self.assertGreater(
+                len(batch_responses[uid]),
+                0,
+                "quantized+rotating job produced no tokens",
+            )
+            for tok in batch_responses[uid]:
+                self.assertFalse(mx.isnan(mx.array(float(tok))))
+
+    def test_batch_generator_rejects_delayed_quantized_kv_start(self):
+        """quantized_kv_start > 0 isn't supported for the batching path (per-job
+        caches are created once, empty, at insertion — there's no per-step
+        re-check that would ever trigger a delayed threshold)."""
+        with self.assertRaises(NotImplementedError):
+            BatchGenerator(
+                self.model,
+                max_kv_size=8,
+                kv_bits=8,
+                quantized_kv_start=4,
+            )
+
     def test_batch_generate_with_logits_processors(self):
         """Test that batch_generate with logits_processors produces correct results."""
         logit_bias = {0: 2000.0, 1: -2000.0}

--- a/tests/test_prompt_cache.py
+++ b/tests/test_prompt_cache.py
@@ -398,6 +398,45 @@ class TestPromptCache(unittest.TestCase):
             next_toks.append(tok)
         self.assertEqual(len(next_toks), 3)
 
+    def test_rotating_cache_to_quantized_matches_unquantized(self):
+        """The rotating-quantized path must stay numerically faithful, not just
+        non-NaN: after rotation, a quantized rotating cache should track the
+        unquantized rotating reference within the same tolerance QuantizedKVCache
+        gets in test_cache_to_quantized (rtol=4e-2). Guards against a silent
+        numerical regression in the (packed, scales, biases) bookkeeping."""
+        model, tokenizer = self.model, self.tokenizer
+        prompt = tokenizer.encode(
+            "Once upon a time in a small town", return_tensors="mlx"
+        )[0]
+
+        # Two identical warmups (argmax is deterministic, so the KV state is the
+        # same in both) run long enough to force rotation past max_size.
+        def warm():
+            c = [RotatingKVCache(max_size=8) for _ in model.layers]
+            last = None
+            for _, (tok, _) in zip(
+                range(12), generate_step(prompt, model, prompt_cache=c)
+            ):
+                last = tok
+            return c, last
+
+        ref_cache, last_ref = warm()
+        base_cache, last_base = warm()
+        self.assertEqual(last_ref, last_base)  # warmups agree
+        self.assertGreater(ref_cache[0].offset, ref_cache[0].max_size)  # rotated
+
+        # Keep one continuation unquantized (reference), quantize the other, then
+        # feed both the same next token and compare the resulting logits.
+        quant_cache = [c.to_quantized(bits=8, group_size=32) for c in base_cache]
+        for c in quant_cache:
+            self.assertIsInstance(c, RotatingQuantizedKVCache)
+
+        x = mx.array([last_ref])
+        ref_logits = next(generate_step(x, model, prompt_cache=ref_cache))[1]
+        quant_logits = next(generate_step(x, model, prompt_cache=quant_cache))[1]
+        self.assertFalse(bool(mx.any(mx.isnan(quant_logits))))
+        self.assertTrue(mx.allclose(ref_logits, quant_logits, rtol=4e-2))
+
     def test_rotating_quantized_cache_save_load(self):
         cache = [
             RotatingKVCache(max_size=4).to_quantized(bits=8, group_size=32)

--- a/tests/test_prompt_cache.py
+++ b/tests/test_prompt_cache.py
@@ -182,6 +182,28 @@ class TestPromptCache(unittest.TestCase):
         # Try to make a mask
         mask = loaded[0].make_mask(4)
 
+    def test_batch_rotating_quantized_meta_state_rotated_round_trip(self):
+        """meta_state stringifies every field, so `rotated` comes back as
+        "True"/"False". Reading it with bool() makes both truthy, which silently
+        marks an unrotated cache as rotated on reload. Same slip as
+        BatchRotatingKVCache (ml-explore/mlx-lm#1250)."""
+        for rotated in (False, True):
+            cache = BatchRotatingQuantizedKVCache(
+                max_size=8, left_padding=[0], group_size=32, bits=8
+            )
+            cache.rotated = rotated
+
+            restored = BatchRotatingQuantizedKVCache(
+                max_size=1, left_padding=[0], group_size=32, bits=8
+            )
+            restored.meta_state = cache.meta_state
+
+            self.assertEqual(restored.rotated, rotated)
+            self.assertIsInstance(restored.rotated, bool)
+            self.assertEqual(restored.max_size, cache.max_size)
+            self.assertEqual(restored.group_size, cache.group_size)
+            self.assertEqual(restored.bits, cache.bits)
+
     def test_cache_with_generate(self):
         model, tokenizer = self.model, self.tokenizer
         prompt = tokenizer.encode("this is a prompt", return_tensors="mlx")[0]

--- a/tests/test_prompt_cache.py
+++ b/tests/test_prompt_cache.py
@@ -13,11 +13,13 @@ from mlx_lm.models.cache import (
     ArraysCache,
     BatchKVCache,
     BatchRotatingKVCache,
+    BatchRotatingQuantizedKVCache,
     CacheList,
     ChunkedKVCache,
     KVCache,
     QuantizedKVCache,
     RotatingKVCache,
+    RotatingQuantizedKVCache,
     load_prompt_cache,
     make_prompt_cache,
     save_prompt_cache,
@@ -363,6 +365,96 @@ class TestPromptCache(unittest.TestCase):
             i += 1
             self.assertEqual(tok, toks[i])
             self.assertTrue(mx.allclose(logits, all_logits[i], rtol=4e-2))
+
+    def test_rotating_cache_to_quantized(self):
+        """RotatingKVCache.to_quantized() — previously NotImplementedError.
+        Build up a rotating cache past its max_size (forcing rotation) with a
+        real model, convert to quantized mid-stream, and confirm generation
+        continues producing sane (numerically close) logits."""
+        model, tokenizer = self.model, self.tokenizer
+        prompt = tokenizer.encode(
+            "Once upon a time in a small town", return_tensors="mlx"
+        )[0]
+
+        prompt_cache = [RotatingKVCache(max_size=4) for _ in model.layers]
+        toks = []
+        for _, (tok, logits) in zip(
+            range(8), generate_step(prompt, model, prompt_cache=prompt_cache)
+        ):
+            toks.append(tok)
+        self.assertIsInstance(prompt_cache[0], RotatingKVCache)
+
+        quant_cache = [c.to_quantized(bits=8, group_size=32) for c in prompt_cache]
+        for c in quant_cache:
+            self.assertEqual(c.offset, prompt_cache[0].offset)
+
+        # Generation must continue without error after the mid-stream swap.
+        next_toks = []
+        for _, (tok, logits) in zip(
+            range(3),
+            generate_step(mx.array([toks[-1]]), model, prompt_cache=quant_cache),
+        ):
+            self.assertFalse(bool(mx.any(mx.isnan(logits))))
+            next_toks.append(tok)
+        self.assertEqual(len(next_toks), 3)
+
+    def test_rotating_quantized_cache_save_load(self):
+        cache = [
+            RotatingKVCache(max_size=4).to_quantized(bits=8, group_size=32)
+            for _ in range(2)
+        ]
+        for c in cache:
+            for _ in range(10):  # forces rotation
+                x = mx.random.uniform(shape=(1, 4, 1, 32))
+                c.update_and_fetch(x, x)
+
+        cache_file = os.path.join(self.test_dir, "rotating_quant_cache.safetensors")
+        save_prompt_cache(cache_file, cache)
+        loaded_cache = load_prompt_cache(cache_file)
+        self.assertEqual(len(cache), len(loaded_cache))
+        for c, lc in zip(cache, loaded_cache):
+            self.assertIsInstance(lc, RotatingQuantizedKVCache)
+            self.assertEqual(c.offset, lc.offset)
+            self.assertEqual(c.max_size, lc.max_size)
+            self.assertEqual(c.group_size, lc.group_size)
+            self.assertEqual(c.bits, lc.bits)
+            for i in range(3):
+                self.assertTrue(mx.array_equal(c.state[0][i], lc.state[0][i]))
+                self.assertTrue(mx.array_equal(c.state[1][i], lc.state[1][i]))
+
+    def test_batch_rotating_quantized_kv_cache_merge_filter_extend_extract(self):
+        """The batching-facing surface BatchGenerator actually relies on."""
+        jobs = []
+        for j in range(3):
+            c = RotatingQuantizedKVCache(max_size=8, group_size=32, bits=8)
+            for _ in range(3 + j * 4):  # some jobs exceed max_size, forcing rotation
+                x = mx.random.uniform(shape=(1, 4, 1, 32))
+                c.update_and_fetch(x, x)
+            jobs.append(c)
+
+        batch = RotatingQuantizedKVCache.merge(jobs)
+        self.assertIsInstance(batch, BatchRotatingQuantizedKVCache)
+        self.assertEqual(batch.keys[0].shape[0], 3)
+        for j, c in enumerate(jobs):
+            self.assertEqual(int(batch.offset[j]), c.offset)
+
+        k = mx.random.uniform(shape=(3, 4, 1, 32))
+        bk, bv = batch.update_and_fetch(k, k)
+        self.assertEqual(bk[0].shape[0], 3)
+
+        batch.filter(mx.array([0, 2]))
+        self.assertEqual(batch.keys[0].shape[0], 2)
+
+        extracted = batch.extract(0)
+        self.assertIsInstance(extracted, RotatingQuantizedKVCache)
+        self.assertEqual(extracted.offset, int(batch.offset[0]))
+
+        new_job = RotatingQuantizedKVCache(max_size=8, group_size=32, bits=8)
+        for _ in range(2):
+            x = mx.random.uniform(shape=(1, 4, 1, 32))
+            new_job.update_and_fetch(x, x)
+        batch.extend(RotatingQuantizedKVCache.merge([new_job]))
+        self.assertEqual(batch.keys[0].shape[0], 3)
 
     def test_cache_list(self):
         c = CacheList(KVCache(), KVCache())


### PR DESCRIPTION
Closes #1583.

### What

`RotatingKVCache.to_quantized()` and `BatchRotatingKVCache.to_quantized()` were both stubs raising `NotImplementedError`. Since `BatchGenerator` always wraps caches in `RotatingKVCache` when `max_kv_size` is set, KV-cache quantization was unreachable end-to-end on the continuous-batching path despite the underlying `mx.quantize`/`QuantizedKVCache` primitives already being production-ready for the non-batched `generate_step`/`stream_generate` path.

Adds `RotatingQuantizedKVCache` (per-job) and `BatchRotatingQuantizedKVCache` (the batch-merged cache `BatchGenerator` actually calls `update_and_fetch()` on), implementing both `to_quantized()` methods. `BatchGenerator` gains `kv_bits`/`kv_group_size`/`quantized_kv_start` constructor params, threaded into `_make_new_cache()` — quantization happens once at cache creation (`offset=0`, no precision lost), so no per-step re-quantization is needed. `quantized_kv_start > 0` is explicitly rejected for the batching path since there's no per-step threshold check that would ever trigger it.

### Why

We use `BatchGenerator` with `max_kv_size` set (to bound per-conversation memory) in a downstream project, and wanted KV-cache quantization for the same RAM/context-window win it already gives the non-batched path. Filed as #1583 for visibility before this PR.

### Testing

- Existing test suite unaffected: the same 8 failures in `tests/test_generate.py` occur with and without this patch, verified against vanilla `upstream/main`, so they are not caused by this change. They are also not flakiness, which is what an earlier version of this description called them. The cause is TF32 in fp32 GEMM on Apple GPU gen-17 (M5): `MLX_ENABLE_TF32=0 python -m pytest tests/test_generate.py` turns 8 failed / 23 passed into 31 passed on this branch, reproducibly. Tracked upstream at ml-explore/mlx#3897.
- New tests cover: rotation+quantization accuracy against a plain `RotatingKVCache`, mid-stream `to_quantized()` conversion, save/load round-trip, and the full `merge`/`filter`/`extend`/`extract` surface `BatchGenerator` relies on for job insertion/eviction — plus an end-to-end `BatchGenerator` test with `max_kv_size`+`kv_bits` set together, forcing real rotation across real attention forward passes on `mlx-community/Qwen1.5-0.5B-Chat-4bit`.
- Also validated live against two full-size production models (Qwen3.6-35B-A3B, Ministral 3 14B) in a downstream project: no regression on a 13-question quality/agentic bench suite, ~1.88x KV-cache compression measured, and a real long-generation rotation test past `max_kv_size` with quantization on.
- Formatted with `black`/`isort` per CONTRIBUTING.md.

### Known limitations

`to_quantized()` raises on `keep > 0`, because sink tokens are not implemented in `RotatingQuantizedKVCache`. `make_prompt_cache(model, max_kv_size=N)` builds `RotatingKVCache(max_size=N, keep=4)` at `cache.py:37`, hardcoded, so for any model that does not provide its own `make_cache`, `max_kv_size` together with KV quantization stays unquantizable after this PR exactly as before it. Gemma 4 escapes only because it passes `keep=0`.

The batched path is not affected: `BatchGenerator._make_new_cache()` builds `RotatingKVCache(max_size=...)` with no `keep` argument and so gets the `keep=0` default. The limitation is a property of `make_prompt_cache`, not of the flag.

Surfaced by @soobrosa's startup probe on #1353. Sink-token support in the quantized rotating cache is the fix and is deliberately out of scope here.

### Checklist

- [x] Tests added
- [x] Formatted (`black`, `isort`)
- [ ] Review
