### PR TITLE
switch_layers: pad sorted gather rows to a multiple of 64 (silent quantized-MoE corruption, mlx#3856)

### DIFF
--- a/mlx_lm/models/switch_layers.py
+++ b/mlx_lm/models/switch_layers.py
@@ -14,7 +14,26 @@ def _gather_sort(x, indices):
     indices = indices.flatten()
     order = mx.argsort(indices)
     inv_order = mx.argsort(order)
-    return x.flatten(0, -3)[order // M], indices[order], inv_order
+    x = x.flatten(0, -3)[order // M]
+    indices = indices[order]
+    n = indices.size
+    # Metal mishandles the ragged tail tile in the sorted gather_qmm path
+    # (ml-explore/mlx#3856, still open as of mlx 0.32.x): when the flattened
+    # sorted row count exceeds 32768 and is not a multiple of 64, expert
+    # outputs come out wrong for affine-quantized experts (4/8-bit; only the
+    # mxfp4 path was fixed) — silent MoE corruption at long single-shot
+    # prefill. Pad the sorted rows up to a multiple of 64 (duplicating the
+    # last row, which keeps the indices sorted); _scatter_unsort gathers only
+    # the original rows, so the padding never reaches the output.
+    if n > 32768 and n % 64 != 0:
+        pad = 64 - n % 64
+        x = mx.concatenate(
+            [x, mx.broadcast_to(x[-1:], (pad,) + x.shape[1:])], axis=0
+        )
+        indices = mx.concatenate(
+            [indices, mx.broadcast_to(indices[-1:], (pad,))], axis=0
+        )
+    return x, indices, inv_order
 
 
 def _scatter_unsort(x, inv_order, shape=None):

--- a/tests/test_switch_layers.py
+++ b/tests/test_switch_layers.py
@@ -1,0 +1,60 @@
+import unittest
+
+import mlx.core as mx
+import mlx.nn as nn
+
+from mlx_lm.models.switch_layers import SwitchGLU
+
+
+class TestSwitchLayers(unittest.TestCase):
+    def test_quantized_switch_glu_ragged_sorted_tail(self):
+        # ml-explore/mlx#3856: the sorted gather_qmm path corrupts expert
+        # outputs for affine-quantized weights when the flattened row count
+        # exceeds 32768 and is not a multiple of 64. 16401 tokens x top-2
+        # gives n = 32802, which triggers the ragged tail; the pad guard in
+        # _gather_sort must keep the output matching a dense fp32 reference.
+        mx.random.seed(0)
+        num_tokens, top_k = 16401, 2
+        dims, hidden_dims, num_experts = 64, 64, 4
+
+        glu = SwitchGLU(dims, hidden_dims, num_experts)
+        nn.quantize(glu, group_size=64, bits=4)
+
+        x = mx.random.normal((num_tokens, dims))
+        indices = mx.random.randint(0, num_experts, (num_tokens, top_k))
+        out = glu(x, indices)
+        mx.eval(out)
+
+        def dequant(proj):
+            return mx.dequantize(
+                proj.weight,
+                proj.scales,
+                proj.biases,
+                group_size=proj.group_size,
+                bits=proj.bits,
+                mode=getattr(proj, "mode", "affine"),
+            ).astype(mx.float32)
+
+        w_gate = dequant(glu.gate_proj)
+        w_up = dequant(glu.up_proj)
+        w_down = dequant(glu.down_proj)
+
+        xf = x.astype(mx.float32)
+        per_expert = []
+        for e in range(num_experts):
+            h = nn.silu(xf @ w_gate[e].T) * (xf @ w_up[e].T)
+            per_expert.append(h @ w_down[e].T)
+        dense = mx.stack(per_expert, axis=1)
+        ref = mx.take_along_axis(
+            dense, indices[..., None], axis=1
+        )
+        mx.eval(ref)
+
+        max_err = mx.abs(out.astype(mx.float32) - ref).max().item()
+        # The gather_qmm bug produces errors ~0.5 on affected rows; a healthy
+        # run agrees with the fp32 reference to well under 1e-3.
+        self.assertLess(max_err, 1e-3)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Problem

`gather_qmm` over sorted indices silently corrupts quantized-MoE outputs when the flattened gathered row count `n = tokens × top_k` exceeds 32768 and `n % 64 != 0`. This is ml-explore/mlx#3856 (minimal pure-mlx repro posted there). It is **still present in mlx 0.32.0 (PyPI) and 0.32.1.dev** for affine-quantized experts (4-bit and 8-bit tested); only the mxfp4 manifestation was fixed in 0.32.0. mlx-lm's floor is `MIN_MLX_VERSION = "0.31.2"`, where the same trigger corrupts even more broadly — so a quantized MoE at long single-shot prefill is exposed on every supported mlx today.

Arbitrated against an fp32-dequantized dense reference through `SwitchGLU` on an M5 (mlx 0.32.0 release, 4-bit/gs32, top_k=2):

| flattened rows n | n % 64 | result |
|---|---|---|
| 8 202 / 16 402 / 32 764 / 32 768 / 40 000 | — / — / 60 / 0 / 0 | clean |
| 32 800 | 32 | **64 rows wrong, max err 0.69** |
| 32 802 | 34 | **64 rows wrong, max err 0.50** |
| 40 002 | 2 | **7 264 rows wrong, max err 0.74** |
| 49 150 | 62 | **16 384 rows wrong, max err 0.83** |

Identical map on mlx 0.31.2. mxfp4 experts: clean at all shapes on 0.32.0. With the pad below: max err vs reference 1.3e-3 (= quantization rounding) at every shape, matching a 64-aligned chunked control. The row-alignment formulation also explains why per-model reports disagree on the "token multiple" trigger: with top_k=2 it appears as tokens%32, with top_k=4 as tokens%16 — the invariant is the flattened row count.

## Fix

Pad the sorted rows up to a multiple of 64 by duplicating the last row. Correctness of the padding (beyond the reference match above): indices stay sorted and in-bounds by construction, and `inv_order` is computed before padding, so `_scatter_unsort` structurally cannot address a pad row — NaN-poisoning the pad rows leaves the output bit-identical and fully finite. Overhead is ≤63 rows on >32768 (≤0.19% extra FLOPs); measured at T=20001 the guarded forward is actually *faster* (1.29 ms vs 1.76 ms median), since the aligned row count dispatches a better kernel path.

Both `gather_qmm` and `gather_mm` call sites route through `_gather_sort`, so the guard covers all five projection uses; the unsorted path (`indices.size < 64`) cannot reach the trigger. No collision with #1319 (fused gate-up) — its fused path consumes `_gather_sort` output and inherits the guard.

The regression test arbitrates quantized `SwitchGLU` at n=32802 against the fp32-dequantized dense reference: it fails on current `main` (max err ~0.5) and passes with the pad (max err <1e-3), in ~0.02 s.

When an mlx release fixes ml-explore/mlx#3856 this can become version-gated or be dropped. A `MIN_MLX_VERSION` bump alone is *not* an alternative — 0.32.0 corrupts identically on affine quants.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
