### PR TITLE
Add opt-in disk-backed expert offloading to SwitchLinear/QuantizedSwitchLinear

### DIFF
--- a/mlx_lm/models/switch_layers.py
+++ b/mlx_lm/models/switch_layers.py
@@ -1,12 +1,64 @@
 # Copyright © 2023-2024 Apple Inc.
 
 import math
+from concurrent.futures import ThreadPoolExecutor
 from functools import partial
 
 import mlx.core as mx
 import mlx.nn as nn
 
 from .activations import swiglu
+
+# Default cap on experts materialized in one temporary stack, independent of
+# resident_expert_fraction (see _offload_enable's docstring for why this must
+# NOT scale with resident_slots). 76 (resident_expert_fraction=0.3 on
+# Qwen3.6's 256 experts) completed a ~1458-token worst-case prefill without
+# incident; 128 (fraction=0.5) hit a real Metal OOM — 64 leaves real margin
+# below the observed failure point while still bounding well below a "nearly
+# the whole table" chunk at any fraction.
+_OFFLOAD_DEFAULT_MAX_STACK = 64
+
+_OFFLOAD_EXECUTOR = None
+
+
+def _offload_executor():
+    """Lazily-created thread pool shared across every offload-enabled
+    SwitchLinear/QuantizedSwitchLinear (one per process, not one per module —
+    a model has ~120 of these, no reason to pay 120 pools' worth of thread
+    overhead). 8 workers: disk I/O bound work, not CPU bound, so this is
+    about overlapping blocking read() calls, not matching core count."""
+    global _OFFLOAD_EXECUTOR
+    if _OFFLOAD_EXECUTOR is None:
+        _OFFLOAD_EXECUTOR = ThreadPoolExecutor(max_workers=8, thread_name_prefix="mira-expert-fetch")
+    return _OFFLOAD_EXECUTOR
+
+
+def _offload_to_mx(raw):
+    """Convert one fetch_fn() result slot to an mx.array. Must run on the
+    same thread the resulting array will be used on — MLX streams are
+    thread-local, and mira-mlx's engine pins model execution to one
+    dedicated thread, so an mx.array constructed on a ThreadPoolExecutor
+    worker thread crashes the first time it's used here
+    ("RuntimeError: There is no Stream(gpu, N) in current thread", a real
+    crash hit during Phase C validation — every fetch_fn call used to build
+    its own mx.array directly, inside the worker thread). This is why
+    fetch_fn (core/inference/disk_expert_cache.py, mira-core) returns raw
+    (np.ndarray, dtype_str) instead: the parallel part (disk I/O + numpy) is
+    thread-safe, only this conversion isn't."""
+    if raw is None:
+        return None
+    np_array, dtype_str = raw
+    arr = mx.array(np_array)
+    if dtype_str == "BF16":
+        arr = arr.view(mx.bfloat16)
+    return arr
+
+
+def _offload_fetched_to_data(raw, quantized: bool):
+    if quantized:
+        w_raw, s_raw, b_raw = raw
+        return (_offload_to_mx(w_raw), _offload_to_mx(s_raw), _offload_to_mx(b_raw))
+    return _offload_to_mx(raw)
 
 
 def _gather_sort(x, indices):
@@ -22,6 +74,212 @@ def _scatter_unsort(x, inv_order, shape=None):
     if shape is not None:
         x = mx.unflatten(x, 0, shape)
     return x
+
+
+def _offload_enable(module, resident_slots: int, fetch_fn, quantized: bool, max_stack_size=None):
+    """Switch a SwitchLinear/QuantizedSwitchLinear to a disk-backed,
+    dict-keyed LRU expert cache (`expert_id -> weight data`) instead of
+    keeping every expert's weights resident, fetching cold experts via
+    `fetch_fn(expert_id)`.
+
+    No-op (module keeps its default, fully-resident behavior) if
+    `resident_slots >= num_experts` — this keeps the default/unset path
+    provably unchanged, since callers only reach this method at all when
+    offloading is explicitly requested.
+
+    The cache is keyed by expert id rather than a fixed slot array: a fixed
+    (num_experts_resident, ...) tensor with in-place row overwrites would let
+    an eviction *later in the same forward call* silently corrupt a slot an
+    *earlier* expert in that same call already resolved to (the actual
+    gather happens only after every index in the call is resolved) — with a
+    dict cache there are no shared slots to collide over, so this can't
+    happen.
+
+    `max_stack_size` (default: `min(resident_slots, _OFFLOAD_DEFAULT_MAX_STACK)`)
+    bounds how many experts' weights `_offload_chunked_gather` is allowed to
+    materialize into one temporary stacked tensor at once. Without this
+    bound, a call whose unique-expert count is large — e.g. a long prefill,
+    where tokens_in_call * top_k routinely exceeds num_experts, so nearly
+    every expert gets touched in one call regardless of how skewed
+    steady-state routing is — builds one huge temporary stack covering
+    nearly the whole expert table, which is what caused a real Metal
+    kIOGPUCommandBufferCallbackErrorOutOfMemory crash under a ~1458-token
+    prompt (specs/moe-expert-offload-02-runtime-cache.md, Phase C). Chunking
+    keeps every call's peak transient memory bounded regardless of call
+    shape, with no prefill/decode signal needed from the caller.
+
+    The default deliberately does NOT scale with resident_slots (i.e. isn't
+    just `resident_slots` itself): a first version of this fix used exactly
+    that and still crashed with the same OOM at resident_expert_fraction=0.5
+    (resident_slots=128 there → chunks of ~128, nearly half the expert
+    table again) — the whole point of a bound is that it has to hold
+    independent of how generous the residency setting is, not shrink or
+    grow with it. `_OFFLOAD_DEFAULT_MAX_STACK` is a fixed cap instead;
+    callers that know their own headroom can still override it explicitly.
+    """
+    n_experts = module.num_experts
+    if resident_slots >= n_experts:
+        return
+    module._offload_fetch = fetch_fn
+    module._offload_quantized = quantized
+    module._offload_capacity = resident_slots
+    module._offload_max_stack_size = max(
+        max_stack_size if max_stack_size is not None else min(resident_slots, _OFFLOAD_DEFAULT_MAX_STACK), 1
+    )
+    module._offload_cache = {}
+    module._offload_lru = []
+    # True expert count, stashed because the 1-row stand-in installed below
+    # can no longer carry it in weight.shape[0] (see the num_experts property).
+    module._offload_num_experts = n_experts
+
+    # Seed the resident set by FETCHING FROM DISK, not by slicing the
+    # eager-loaded tensor. `module.weight[:resident_slots]` is an mx *view*
+    # that pins the ENTIRE parent buffer for as long as it lives — verified
+    # directly: allocate (256, 1024, 1024), slice [:32], drop the parent, and 0
+    # bytes free until the slice itself is dropped too. So the previous
+    # `module.weight = module.weight[:resident_slots]` never released the other
+    # experts at all — it kept the whole table resident and offload merely
+    # piled cache + temp-stack memory on top, which is exactly why peak memory
+    # exceeded the full-resident baseline at every fraction (spec Phase C
+    # "still-open gap"). Experts fetched through the same disk path a cold miss
+    # uses are genuinely independent buffers, so once they seed the cache the
+    # full-size eager tensors have no remaining reference and are freed.
+    seed_ids = list(range(resident_slots))
+    raw_seed = list(_offload_executor().map(fetch_fn, seed_ids))
+    for e, raw in zip(seed_ids, raw_seed):
+        module._offload_cache[e] = _offload_fetched_to_data(raw, quantized)
+        module._offload_lru.append(e)
+
+    # Replace the full-size eager tensors with a 1-row stand-in (a view of a
+    # now-resident expert) so input_dims/output_dims keep resolving and the
+    # parameter tree stays intact, WITHOUT holding the other experts. Assigning
+    # here drops the last reference to the full-size tensors, which is what
+    # actually frees them. The stand-in pins exactly one expert's worth of
+    # bytes and is never read for compute — the offload __call__ path reads
+    # only the cache, never module.weight/scales/biases.
+    seed0 = module._offload_cache[0]
+    if quantized:
+        w0, s0, b0 = seed0
+        module.weight = mx.expand_dims(w0, 0)
+        module.scales = mx.expand_dims(s0, 0)
+        if b0 is not None:
+            module.biases = mx.expand_dims(b0, 0)
+        mx.eval(module.weight, module.scales)
+    else:
+        module.weight = mx.expand_dims(seed0, 0)
+        mx.eval(module.weight)
+
+    module._offload_hits = 0
+    module._offload_misses = 0
+
+
+def _offload_touch(module, expert_id):
+    if expert_id in module._offload_lru:
+        module._offload_lru.remove(expert_id)
+    module._offload_lru.append(expert_id)
+
+
+def _offload_stack_rows(rows, quantized):
+    if quantized:
+        return (
+            mx.stack([d[0] for d in rows]),
+            mx.stack([d[1] for d in rows]),
+            mx.stack([d[2] for d in rows]) if rows[0][2] is not None else None,
+        )
+    return mx.stack(rows)
+
+
+def _offload_chunked_gather(module, x, indices, gather_fn):
+    """Compute the same output as gathering against every needed expert at
+    once, but never materialize more than `module._offload_max_stack_size`
+    experts' weights in a single temporary stack.
+
+    Partitions the call's unique experts into groups of at most
+    max_stack_size, running one `gather_fn(x, stacked_data, local_indices)`
+    call per group against the *entire* index tensor (positions outside the
+    group get a dummy index and their output is discarded), then combines
+    the groups' outputs with `mx.where`. This costs more matmul work than a
+    single unchunked call when there's more than one group (every group's
+    call touches every position, not just its own) — that trade is what
+    buys a memory bound that holds for any call shape, prefill or decode,
+    without needing to know which one it is.
+
+    Fetches (and evicts) lazily, group by group, rather than resolving every
+    unique expert up front: this is what keeps the *cache dict itself*
+    bounded during a large call too, not just the final stacked tensor — the
+    original design fetched every unique expert into the cache before doing
+    any eviction, which meant the dict alone could balloon to near-full-table
+    size on a diverse call, independent of the stacking cost. Evicting after
+    each group's own gather is safe because each expert belongs to exactly
+    one group: nothing evicted here is needed again later in this same call.
+    An `mx.eval()` after each group's combine forces MLX to actually release
+    the previous group's temporary stack before the next one is built —
+    without it, laziness re-batches every group into one deferred graph
+    anyway and the memory bound is fiction.
+    """
+    flat = indices.reshape(-1).tolist()
+    unique = list(dict.fromkeys(flat))
+    max_stack = module._offload_max_stack_size
+    groups = [unique[i : i + max_stack] for i in range(0, len(unique), max_stack)]
+
+    group_of = {}
+    local_pos_of = {}
+    for gi, group in enumerate(groups):
+        for li, e in enumerate(group):
+            group_of[e] = gi
+            local_pos_of[e] = li
+
+    cache = module._offload_cache
+    result = None
+    for gi, group in enumerate(groups):
+        missing = [e for e in group if e not in cache]
+        module._offload_hits += len(group) - len(missing)
+        module._offload_misses += len(missing)
+        if missing:
+            # Concurrent, not sequential: each fetch is a blocking disk
+            # read (~0.3-0.6ms measured against the real Qwen3.6 shards),
+            # but a large/diverse call can have tens of thousands of misses
+            # in one forward pass — sequential reads there dominate wall
+            # time far more than the chunking's extra matmul work does.
+            # Each fetch opens its own file handle and only reads
+            # already-resolved (read-only after setup) shard/offset
+            # metadata, so concurrent calls need no locking. fetch_fn
+            # returns raw (numpy, dtype) data, not mx.array — the actual
+            # mx.array construction happens right after, back on THIS
+            # thread (see _offload_to_mx's docstring for why that split is
+            # required, not optional).
+            raw_fetched = list(_offload_executor().map(module._offload_fetch, missing))
+            for e, raw in zip(missing, raw_fetched):
+                cache[e] = _offload_fetched_to_data(raw, module._offload_quantized)
+        rows = []
+        for e in group:
+            rows.append(cache[e])
+            _offload_touch(module, e)
+        stacked = _offload_stack_rows(rows, module._offload_quantized)
+
+        local_flat = [local_pos_of[e] if group_of[e] == gi else 0 for e in flat]
+        local_indices = mx.array(local_flat, dtype=indices.dtype).reshape(indices.shape)
+        group_output = gather_fn(x, stacked, local_indices)
+
+        if len(groups) == 1:
+            result = group_output
+        else:
+            mask = mx.array([group_of[e] == gi for e in flat], dtype=mx.bool_).reshape(indices.shape)
+            # gather_mm/gather_qmm's output has more trailing dims than
+            # `indices` itself (e.g. indices.shape + (1, output_dims) for
+            # SwitchGLU's usual (N, top_k) indices) — pad to whatever rank
+            # this call's output actually came out at, rather than assuming
+            # a fixed offset.
+            while mask.ndim < group_output.ndim:
+                mask = mx.expand_dims(mask, -1)
+            result = group_output if result is None else mx.where(mask, group_output, result)
+        mx.eval(result)
+
+        while len(module._offload_lru) > module._offload_capacity:
+            victim = module._offload_lru.pop(0)
+            cache.pop(victim, None)
+
+    return result
 
 
 class QuantizedSwitchLinear(nn.Module):
@@ -70,21 +328,46 @@ class QuantizedSwitchLinear(nn.Module):
 
     @property
     def num_experts(self):
-        return self.weight.shape[0]
+        # After enable_offload the full weight is replaced by a 1-row stand-in,
+        # so shape[0] no longer reflects the true expert count; the real value
+        # is stashed on the module (offload path only; unset otherwise).
+        n = getattr(self, "_offload_num_experts", None)
+        return n if n is not None else self.weight.shape[0]
+
+    def enable_offload(self, resident_slots: int, fetch_fn, max_stack_size=None):
+        _offload_enable(self, resident_slots, fetch_fn, quantized=True, max_stack_size=max_stack_size)
 
     def __call__(self, x, indices, sorted_indices=False):
-        x = mx.gather_qmm(
-            x,
-            self["weight"],
-            self["scales"],
-            self.get("biases"),
-            rhs_indices=indices,
-            transpose=True,
-            group_size=self.group_size,
-            bits=self.bits,
-            mode=self.mode,
-            sorted_indices=sorted_indices,
-        )
+        if hasattr(self, "_offload_fetch"):
+            def gather_fn(x, data, local_indices):
+                weight, scales, biases = data
+                return mx.gather_qmm(
+                    x,
+                    weight,
+                    scales,
+                    biases,
+                    rhs_indices=local_indices,
+                    transpose=True,
+                    group_size=self.group_size,
+                    bits=self.bits,
+                    mode=self.mode,
+                    sorted_indices=False,
+                )
+
+            x = _offload_chunked_gather(self, x, indices, gather_fn)
+        else:
+            x = mx.gather_qmm(
+                x,
+                self["weight"],
+                self["scales"],
+                self.get("biases"),
+                rhs_indices=indices,
+                transpose=True,
+                group_size=self.group_size,
+                bits=self.bits,
+                mode=self.mode,
+                sorted_indices=sorted_indices,
+            )
         if "bias" in self:
             x = x + mx.expand_dims(self["bias"][indices], -2)
         return x
@@ -115,15 +398,32 @@ class SwitchLinear(nn.Module):
 
     @property
     def num_experts(self):
-        return self.weight.shape[0]
+        # See QuantizedSwitchLinear.num_experts: offload swaps the full weight
+        # for a 1-row stand-in, so the true count is stashed on the module.
+        n = getattr(self, "_offload_num_experts", None)
+        return n if n is not None else self.weight.shape[0]
+
+    def enable_offload(self, resident_slots: int, fetch_fn, max_stack_size=None):
+        _offload_enable(self, resident_slots, fetch_fn, quantized=False, max_stack_size=max_stack_size)
 
     def __call__(self, x, indices, sorted_indices=False):
-        x = mx.gather_mm(
-            x,
-            self["weight"].swapaxes(-1, -2),
-            rhs_indices=indices,
-            sorted_indices=sorted_indices,
-        )
+        if hasattr(self, "_offload_fetch"):
+            def gather_fn(x, weight, local_indices):
+                return mx.gather_mm(
+                    x,
+                    weight.swapaxes(-1, -2),
+                    rhs_indices=local_indices,
+                    sorted_indices=False,
+                )
+
+            x = _offload_chunked_gather(self, x, indices, gather_fn)
+        else:
+            x = mx.gather_mm(
+                x,
+                self["weight"].swapaxes(-1, -2),
+                rhs_indices=indices,
+                sorted_indices=sorted_indices,
+            )
         if "bias" in self:
             x = x + mx.expand_dims(self["bias"][indices], -2)
         return x

--- a/mlx_lm/models/switch_layers.py
+++ b/mlx_lm/models/switch_layers.py
@@ -189,7 +189,7 @@ def _offload_stack_rows(rows, quantized):
     return mx.stack(rows)
 
 
-def _offload_chunked_gather(module, x, indices, gather_fn):
+def _offload_chunked_gather(module, x, indices, gather_fn, sorted_indices=False):
     """Compute the same output as gathering against every needed expert at
     once, but never materialize more than `module._offload_max_stack_size`
     experts' weights in a single temporary stack.
@@ -230,8 +230,12 @@ def _offload_chunked_gather(module, x, indices, gather_fn):
             local_pos_of[e] = li
 
     cache = module._offload_cache
-    result = None
-    for gi, group in enumerate(groups):
+
+    def _resolve_group(group):
+        """Fetch+stack this group's experts, updating hit/miss counters and
+        LRU recency. Shared by both the mask and compact paths so the two
+        differ ONLY in how they combine group outputs, never in fetch/eviction
+        accounting (a hit is a hit regardless of which path computes it)."""
         missing = [e for e in group if e not in cache]
         module._offload_hits += len(group) - len(missing)
         module._offload_misses += len(missing)
@@ -255,7 +259,59 @@ def _offload_chunked_gather(module, x, indices, gather_fn):
         for e in group:
             rows.append(cache[e])
             _offload_touch(module, e)
-        stacked = _offload_stack_rows(rows, module._offload_quantized)
+        return _offload_stack_rows(rows, module._offload_quantized)
+
+    def _evict():
+        while len(module._offload_lru) > module._offload_capacity:
+            victim = module._offload_lru.pop(0)
+            cache.pop(victim, None)
+
+    # --- Compact path -------------------------------------------------------
+    # The mask path below runs EVERY group's gather over ALL positions and
+    # discards the out-of-group ones with mx.where: G groups x full-width
+    # matmul (the "G-fold" prefill tax). But when the caller has pre-sorted the
+    # routing (SwitchGLU/SwitchMLP call _gather_sort before dispatch whenever
+    # indices.size >= 64, i.e. exactly the multi-group prefill case), `flat` is
+    # monotonic non-decreasing, so each group's positions form ONE contiguous
+    # slice of `flat`. We can then slice x to that segment, gather once over
+    # just those positions, and concatenate the segments back — each position
+    # computed exactly once, no mx.where. Guarded by an actual monotonicity
+    # check (not just the caller's flag) so a mislabelled `sorted_indices` can
+    # never silently scatter output to the wrong positions: if the guarantee
+    # doesn't hold we fall through to the always-correct mask path.
+    use_compact = (
+        sorted_indices
+        and len(groups) > 1
+        and indices.ndim == 1
+        and all(flat[i] <= flat[i + 1] for i in range(len(flat) - 1))
+    )
+    if use_compact:
+        # Contiguous per-group position counts (monotonic flat => group ids
+        # appear in non-decreasing order, so cumulative counts are the segment
+        # boundaries).
+        counts = [0] * len(groups)
+        for e in flat:
+            counts[group_of[e]] += 1
+        outputs = []
+        pos = 0
+        for gi, group in enumerate(groups):
+            cnt = counts[gi]
+            stacked = _resolve_group(group)
+            seg = flat[pos : pos + cnt]
+            local_indices = mx.array(
+                [local_pos_of[e] for e in seg], dtype=indices.dtype
+            ).reshape((cnt,) + tuple(indices.shape[1:]))
+            seg_output = gather_fn(x[pos : pos + cnt], stacked, local_indices)
+            outputs.append(seg_output)
+            mx.eval(seg_output)
+            _evict()
+            pos += cnt
+        return mx.concatenate(outputs, axis=0)
+
+    # --- Mask path (always correct, any call shape) -------------------------
+    result = None
+    for gi, group in enumerate(groups):
+        stacked = _resolve_group(group)
 
         local_flat = [local_pos_of[e] if group_of[e] == gi else 0 for e in flat]
         local_indices = mx.array(local_flat, dtype=indices.dtype).reshape(indices.shape)
@@ -274,10 +330,7 @@ def _offload_chunked_gather(module, x, indices, gather_fn):
                 mask = mx.expand_dims(mask, -1)
             result = group_output if result is None else mx.where(mask, group_output, result)
         mx.eval(result)
-
-        while len(module._offload_lru) > module._offload_capacity:
-            victim = module._offload_lru.pop(0)
-            cache.pop(victim, None)
+        _evict()
 
     return result
 
@@ -354,7 +407,7 @@ class QuantizedSwitchLinear(nn.Module):
                     sorted_indices=False,
                 )
 
-            x = _offload_chunked_gather(self, x, indices, gather_fn)
+            x = _offload_chunked_gather(self, x, indices, gather_fn, sorted_indices=sorted_indices)
         else:
             x = mx.gather_qmm(
                 x,
@@ -416,7 +469,7 @@ class SwitchLinear(nn.Module):
                     sorted_indices=False,
                 )
 
-            x = _offload_chunked_gather(self, x, indices, gather_fn)
+            x = _offload_chunked_gather(self, x, indices, gather_fn, sorted_indices=sorted_indices)
         else:
             x = mx.gather_mm(
                 x,

--- a/mlx_lm/models/switch_layers.py
+++ b/mlx_lm/models/switch_layers.py
@@ -171,6 +171,13 @@ def _offload_enable(module, resident_slots: int, fetch_fn, quantized: bool, max_
 
     module._offload_hits = 0
     module._offload_misses = 0
+    # Decode-only split of the same counters. The blended hit-rate is dragged
+    # down by the diverse cold prefill (routes to ~all experts, no cache fits
+    # it); decode steady-state is the number a residency/policy change actually
+    # moves, so expose it separately. Phase is inferred per call from indices
+    # size (see _offload_chunked_gather).
+    module._offload_hits_decode = 0
+    module._offload_misses_decode = 0
 
 
 def _offload_touch(module, expert_id):
@@ -220,6 +227,11 @@ def _offload_chunked_gather(module, x, indices, gather_fn, sorted_indices=False)
     there is no next group to bound against — see the guard at the eval below.
     """
     flat = indices.reshape(-1).tolist()
+    # Phase heuristic for the split decode-only hit-rate stat: decode drives one
+    # token (top_k experts, size well under 64) while a diverse prefill drives
+    # many. This is the same size threshold SwitchGLU/SwitchMLP use to decide
+    # sorting, so it stays consistent with the dispatch path.
+    is_decode = indices.size < 64
     unique = list(dict.fromkeys(flat))
     max_stack = module._offload_max_stack_size
     groups = [unique[i : i + max_stack] for i in range(0, len(unique), max_stack)]
@@ -239,8 +251,12 @@ def _offload_chunked_gather(module, x, indices, gather_fn, sorted_indices=False)
         differ ONLY in how they combine group outputs, never in fetch/eviction
         accounting (a hit is a hit regardless of which path computes it)."""
         missing = [e for e in group if e not in cache]
-        module._offload_hits += len(group) - len(missing)
+        n_hit = len(group) - len(missing)
+        module._offload_hits += n_hit
         module._offload_misses += len(missing)
+        if is_decode:
+            module._offload_hits_decode += n_hit
+            module._offload_misses_decode += len(missing)
         if missing:
             # Concurrent, not sequential: each fetch is a blocking disk
             # read (~0.3-0.6ms measured against the real Qwen3.6 shards),

--- a/mlx_lm/models/switch_layers.py
+++ b/mlx_lm/models/switch_layers.py
@@ -215,7 +215,9 @@ def _offload_chunked_gather(module, x, indices, gather_fn, sorted_indices=False)
     An `mx.eval()` after each group's combine forces MLX to actually release
     the previous group's temporary stack before the next one is built —
     without it, laziness re-batches every group into one deferred graph
-    anyway and the memory bound is fiction.
+    anyway and the memory bound is fiction. That eval is skipped when there is
+    only ONE group (the decode case: top_k experts fit a single stack), where
+    there is no next group to bound against — see the guard at the eval below.
     """
     flat = indices.reshape(-1).tolist()
     unique = list(dict.fromkeys(flat))
@@ -329,7 +331,17 @@ def _offload_chunked_gather(module, x, indices, gather_fn, sorted_indices=False)
             while mask.ndim < group_output.ndim:
                 mask = mx.expand_dims(mask, -1)
             result = group_output if result is None else mx.where(mask, group_output, result)
-        mx.eval(result)
+        # The per-group eval bounds transient memory by materializing this
+        # group's contribution before the next group's gather allocates. With a
+        # single group (always the case at decode: top_k experts < max_stack, so
+        # every selection fits one group) there is no next group to bound
+        # against, and the eval only forces a per-layer GPU sync with no memory
+        # benefit — it defers the token's gather graph to the caller's next eval
+        # boundary (the sampler evals each token anyway). Bit-identical either
+        # way; measured +13% decode (7.15->8.09 t/s) at identical 12.73GB peak on
+        # Qwen3.6-35B-A3B-8bit over-DRAM offload.
+        if len(groups) > 1:
+            mx.eval(result)
         _evict()
 
     return result

--- a/mlx_lm/models/switch_layers.py
+++ b/mlx_lm/models/switch_layers.py
@@ -61,6 +61,15 @@ def _offload_fetched_to_data(raw, quantized: bool):
     return _offload_to_mx(raw)
 
 
+def _offload_data_nbytes(data):
+    """Resident byte size of one cache entry, for byte-budgeted residency. A
+    quantized entry is a (weight, scales, biases) tuple whose biases may be
+    None; a dense entry is a single array."""
+    if isinstance(data, tuple):
+        return sum(a.nbytes for a in data if a is not None)
+    return data.nbytes
+
+
 def _gather_sort(x, indices):
     *_, M = indices.shape
     indices = indices.flatten()
@@ -76,7 +85,7 @@ def _scatter_unsort(x, inv_order, shape=None):
     return x
 
 
-def _offload_enable(module, resident_slots: int, fetch_fn, quantized: bool, max_stack_size=None):
+def _offload_enable(module, resident_slots, fetch_fn, quantized: bool, max_stack_size=None, resident_bytes=None):
     """Switch a SwitchLinear/QuantizedSwitchLinear to a disk-backed,
     dict-keyed LRU expert cache (`expert_id -> weight data`) instead of
     keeping every expert's weights resident, fetching cold experts via
@@ -116,8 +125,32 @@ def _offload_enable(module, resident_slots: int, fetch_fn, quantized: bool, max_
     independent of how generous the residency setting is, not shrink or
     grow with it. `_OFFLOAD_DEFAULT_MAX_STACK` is a fixed cap instead;
     callers that know their own headroom can still override it explicitly.
+
+    `resident_bytes` is an optional byte budget offered as an alternative to
+    the `resident_slots` count. `resident_slots` is the wrong unit when experts
+    are not all the same size — heterogeneous or mixed-precision tables — where
+    bytes, not a slot count, are the real memory budget. When given, the slot
+    count is derived from it by measuring one expert through the same fetch
+    path a cold miss uses and floor-dividing; passing both keeps the tighter of
+    the two, so a byte budget can only ever lower a slot count, never raise it.
     """
     n_experts = module.num_experts
+    if fetch_fn is None:
+        raise ValueError("enable_offload requires a fetch_fn")
+
+    # Derive the slot count from a byte budget when the caller gives one. Probe
+    # a single expert through the real fetch path so the per-expert figure is
+    # the true resident footprint of a cache entry (quantized: weight + scales
+    # + biases), not an estimate off the on-disk layout. The probe expert seeds
+    # slot 0 in the loop below regardless, so this is one extra fetch total, not
+    # one per slot.
+    if resident_bytes is not None:
+        per_expert = _offload_data_nbytes(_offload_fetched_to_data(fetch_fn(0), quantized))
+        derived = max(1, int(resident_bytes // per_expert))
+        resident_slots = derived if resident_slots is None else min(resident_slots, derived)
+    if resident_slots is None:
+        raise ValueError("enable_offload requires resident_slots or resident_bytes")
+
     if resident_slots >= n_experts:
         return
     module._offload_fetch = fetch_fn
@@ -415,8 +448,15 @@ class QuantizedSwitchLinear(nn.Module):
         n = getattr(self, "_offload_num_experts", None)
         return n if n is not None else self.weight.shape[0]
 
-    def enable_offload(self, resident_slots: int, fetch_fn, max_stack_size=None):
-        _offload_enable(self, resident_slots, fetch_fn, quantized=True, max_stack_size=max_stack_size)
+    def enable_offload(self, resident_slots=None, fetch_fn=None, max_stack_size=None, resident_bytes=None):
+        _offload_enable(
+            self,
+            resident_slots,
+            fetch_fn,
+            quantized=True,
+            max_stack_size=max_stack_size,
+            resident_bytes=resident_bytes,
+        )
 
     def __call__(self, x, indices, sorted_indices=False):
         if hasattr(self, "_offload_fetch"):
@@ -484,8 +524,15 @@ class SwitchLinear(nn.Module):
         n = getattr(self, "_offload_num_experts", None)
         return n if n is not None else self.weight.shape[0]
 
-    def enable_offload(self, resident_slots: int, fetch_fn, max_stack_size=None):
-        _offload_enable(self, resident_slots, fetch_fn, quantized=False, max_stack_size=max_stack_size)
+    def enable_offload(self, resident_slots=None, fetch_fn=None, max_stack_size=None, resident_bytes=None):
+        _offload_enable(
+            self,
+            resident_slots,
+            fetch_fn,
+            quantized=False,
+            max_stack_size=max_stack_size,
+            resident_bytes=resident_bytes,
+        )
 
     def __call__(self, x, indices, sorted_indices=False):
         if hasattr(self, "_offload_fetch"):

--- a/mlx_lm/models/switch_layers.py
+++ b/mlx_lm/models/switch_layers.py
@@ -449,6 +449,21 @@ class QuantizedSwitchLinear(nn.Module):
         return n if n is not None else self.weight.shape[0]
 
     def enable_offload(self, resident_slots=None, fetch_fn=None, max_stack_size=None, resident_bytes=None):
+        """Page experts from disk instead of keeping the whole table resident.
+
+        Keeps a bounded working set resident and fetches cold experts via
+        ``fetch_fn`` on a router miss, so a model whose expert table exceeds
+        unified memory can run with just the resident set plus activations live.
+        Size the resident set with either ``resident_slots`` (a count) or
+        ``resident_bytes`` (a byte budget, preferred when experts differ in size,
+        e.g. a mixed-precision table); the byte budget is turned into a slot
+        count by measuring one expert through ``fetch_fn``, and giving both keeps
+        the tighter. Off unless enabled -- offload trades throughput for memory,
+        so only reach for it when the table does not fit. When budgeting bytes,
+        leave page-cache headroom rather than sizing the resident set up to free
+        RAM: the buffered reads a miss issues go through the page cache, and
+        squeezing it slows every miss.
+        """
         _offload_enable(
             self,
             resident_slots,
@@ -525,6 +540,21 @@ class SwitchLinear(nn.Module):
         return n if n is not None else self.weight.shape[0]
 
     def enable_offload(self, resident_slots=None, fetch_fn=None, max_stack_size=None, resident_bytes=None):
+        """Page experts from disk instead of keeping the whole table resident.
+
+        Keeps a bounded working set resident and fetches cold experts via
+        ``fetch_fn`` on a router miss, so a model whose expert table exceeds
+        unified memory can run with just the resident set plus activations live.
+        Size the resident set with either ``resident_slots`` (a count) or
+        ``resident_bytes`` (a byte budget, preferred when experts differ in size,
+        e.g. a mixed-precision table); the byte budget is turned into a slot
+        count by measuring one expert through ``fetch_fn``, and giving both keeps
+        the tighter. Off unless enabled -- offload trades throughput for memory,
+        so only reach for it when the table does not fit. When budgeting bytes,
+        leave page-cache headroom rather than sizing the resident set up to free
+        RAM: the buffered reads a miss issues go through the page cache, and
+        squeezing it slows every miss.
+        """
         _offload_enable(
             self,
             resident_slots,

--- a/tests/test_switch_offload.py
+++ b/tests/test_switch_offload.py
@@ -1,0 +1,261 @@
+# Copyright © 2024 Apple Inc.
+
+"""Tests for opt-in disk-backed expert offloading on SwitchLinear /
+QuantizedSwitchLinear (enable_offload).
+
+Self-contained: the "disk" is an in-memory numpy fetch_fn returning the same
+raw (np.ndarray, dtype_str) shape a real storage-backed fetch_fn returns, so no
+model download or on-disk shard is needed. The core guarantee under test is
+that an offloaded module produces output bit-identical to the unmodified
+fully-resident path, on both a cold cache (every call misses) and a warm one
+(repeated calls hit the LRU), across enough evictions that the dict cache and
+the chunked gather are actually exercised.
+"""
+import unittest
+from unittest import mock
+
+import mlx.core as mx
+import numpy as np
+
+import mlx_lm.models.switch_layers as sl
+from mlx_lm.models.switch_layers import (
+    SwitchGLU,
+    SwitchLinear,
+    _offload_data_nbytes,
+    _offload_fetched_to_data,
+)
+
+INPUT_DIMS = 32
+OUTPUT_DIMS = 48
+NUM_EXPERTS = 16
+RESIDENT_SLOTS = 3  # << NUM_EXPERTS, so most calls miss and force eviction
+
+
+def _dense_fetch(weight):
+    """fetch_fn(e) -> (np.ndarray, dtype_str) for one expert row of a dense
+    (num_experts, out, in) weight. Built before enable_offload replaces the
+    module's weight with a 1-row stand-in."""
+    w = np.array(weight)
+
+    def fetch(e):
+        return (w[e], "F32")
+
+    return fetch
+
+
+def _quant_fetch(module):
+    """fetch_fn(e) -> ((w,dt), (s,dt), (b,dt)|None) for one expert of a
+    QuantizedSwitchLinear, mirroring the 3-part quantized fetch shape."""
+    w = np.array(module.weight)
+    s = np.array(module.scales)
+    b = np.array(module.biases) if module.biases is not None else None
+
+    def fetch(e):
+        return (
+            (w[e], "U32"),
+            (s[e], "F32"),
+            (b[e], "F32") if b is not None else None,
+        )
+
+    return fetch
+
+
+def _random_indices(n_calls=6, tokens=5, top_k=1, seed=0):
+    key = mx.random.key(seed)
+    out = []
+    for _ in range(n_calls):
+        key, sub = mx.random.split(key)
+        out.append(mx.random.randint(0, NUM_EXPERTS, (tokens, top_k), key=sub))
+    return out
+
+
+def _copy_params(dst, src, attrs):
+    for a in attrs:
+        if src.get(a) is not None:
+            dst[a] = src[a]
+    mx.eval(dst.parameters())
+
+
+def _per_expert_bytes(fetch, quantized):
+    return _offload_data_nbytes(_offload_fetched_to_data(fetch(0), quantized))
+
+
+class TestSwitchOffload(unittest.TestCase):
+    # --- Core bit-identity guarantee -------------------------------------
+
+    def test_dense_offload_matches_baseline(self):
+        baseline = SwitchLinear(INPUT_DIMS, OUTPUT_DIMS, NUM_EXPERTS, bias=False)
+        mx.eval(baseline.parameters())
+
+        offloaded = SwitchLinear(INPUT_DIMS, OUTPUT_DIMS, NUM_EXPERTS, bias=False)
+        _copy_params(offloaded, baseline, ["weight"])
+        offloaded.enable_offload(RESIDENT_SLOTS, _dense_fetch(baseline.weight))
+
+        x = mx.random.normal((5, 1, 1, INPUT_DIMS))
+        calls = _random_indices()
+
+        for indices in calls:  # cold: first sighting of each expert misses
+            self.assertTrue(mx.array_equal(baseline(x, indices), offloaded(x, indices)))
+        for indices in calls:  # warm: replay hits the LRU and re-misses evicted ids
+            self.assertTrue(mx.array_equal(baseline(x, indices), offloaded(x, indices)))
+
+    def test_quantized_offload_matches_baseline(self):
+        baseline = SwitchLinear(INPUT_DIMS, OUTPUT_DIMS, NUM_EXPERTS, bias=False).to_quantized(
+            group_size=32, bits=4
+        )
+        mx.eval(baseline.parameters())
+
+        offloaded = SwitchLinear(INPUT_DIMS, OUTPUT_DIMS, NUM_EXPERTS, bias=False).to_quantized(
+            group_size=32, bits=4
+        )
+        _copy_params(offloaded, baseline, ["weight", "scales", "biases"])
+        offloaded.enable_offload(RESIDENT_SLOTS, _quant_fetch(baseline))
+
+        x = mx.random.normal((5, 1, 1, INPUT_DIMS))
+        calls = _random_indices()
+
+        for indices in calls:
+            self.assertTrue(mx.array_equal(baseline(x, indices), offloaded(x, indices)))
+        for indices in calls:
+            self.assertTrue(mx.array_equal(baseline(x, indices), offloaded(x, indices)))
+
+    def _offloaded_glu(self, baseline, hidden, max_stack_size=4):
+        offloaded = SwitchGLU(INPUT_DIMS, hidden, NUM_EXPERTS)
+        for name in ("gate_proj", "up_proj", "down_proj"):
+            _copy_params(getattr(offloaded, name), getattr(baseline, name), ["weight"])
+            getattr(offloaded, name).enable_offload(
+                RESIDENT_SLOTS,
+                _dense_fetch(getattr(baseline, name).weight),
+                max_stack_size=max_stack_size,
+            )
+        return offloaded
+
+    def test_switch_glu_decode_matches_baseline(self):
+        """A decode-shaped SwitchGLU call routes to a single gather group and is
+        bit-identical to the full-resident baseline (no sort, so no
+        sorted_indices kernel-hint mismatch)."""
+        hidden = 40
+        baseline = SwitchGLU(INPUT_DIMS, hidden, NUM_EXPERTS)
+        mx.eval(baseline.parameters())
+        offloaded = self._offloaded_glu(baseline, hidden)
+
+        x = mx.random.normal((1, INPUT_DIMS))
+        indices = mx.random.randint(0, NUM_EXPERTS, (1, 2))  # size 2 < 64, no sort
+        self.assertTrue(mx.array_equal(baseline(x, indices), offloaded(x, indices)))
+
+    def test_switch_glu_compact_matches_mask(self):
+        """Prefill across all three projections: SwitchGLU's own _gather_sort
+        feeds sorted indices to the sublayers, so the compact gather path runs
+        with a small max_stack_size forcing multiple groups. Compact must be
+        bit-identical to the always-correct mask path. (Not compared to the
+        full-resident SwitchGLU: it dispatches gather with sorted_indices=True,
+        whose kernel hint is not bit-identical to the offload path's False.)"""
+        hidden = 40
+        baseline = SwitchGLU(INPUT_DIMS, hidden, NUM_EXPERTS)
+        mx.eval(baseline.parameters())
+        offloaded = self._offloaded_glu(baseline, hidden)
+
+        x = mx.random.normal((16, INPUT_DIMS))
+        indices = mx.random.randint(0, NUM_EXPERTS, (16, 8))  # 128 >= 64 -> sorted dispatch
+        self.assertGreaterEqual(indices.size, 64)
+
+        compact = offloaded(x, indices)  # compact path in all three sublayers
+
+        orig = sl._offload_chunked_gather
+        with mock.patch.object(
+            sl,
+            "_offload_chunked_gather",
+            lambda m, xx, ii, g, sorted_indices=False: orig(m, xx, ii, g, sorted_indices=False),
+        ):
+            mask = offloaded(x, indices)  # same module forced onto the mask path
+
+        self.assertEqual(compact.shape, mask.shape)
+        self.assertTrue(mx.array_equal(compact, mask))
+
+    # --- resident_bytes byte-budgeted residency --------------------------
+
+    def test_resident_bytes_derives_slot_count_dense(self):
+        module = SwitchLinear(INPUT_DIMS, OUTPUT_DIMS, NUM_EXPERTS, bias=False)
+        mx.eval(module.parameters())
+        fetch = _dense_fetch(module.weight)
+        per_expert = _per_expert_bytes(fetch, quantized=False)
+
+        module.enable_offload(resident_bytes=5 * per_expert, fetch_fn=fetch)
+        self.assertEqual(module._offload_capacity, 5)
+
+    def test_resident_bytes_derives_slot_count_quantized(self):
+        """Per-expert footprint of a quantized entry is weight + scales +
+        biases, so the byte budget must account for all three, not just the
+        weight."""
+        module = SwitchLinear(INPUT_DIMS, OUTPUT_DIMS, NUM_EXPERTS, bias=False).to_quantized(
+            group_size=32, bits=4
+        )
+        mx.eval(module.parameters())
+        fetch = _quant_fetch(module)
+        per_expert = _per_expert_bytes(fetch, quantized=True)
+
+        module.enable_offload(resident_bytes=4 * per_expert, fetch_fn=fetch)
+        self.assertEqual(module._offload_capacity, 4)
+
+    def test_resident_bytes_and_slots_takes_tighter(self):
+        m0 = SwitchLinear(INPUT_DIMS, OUTPUT_DIMS, NUM_EXPERTS, bias=False)
+        per_expert = _per_expert_bytes(_dense_fetch(m0.weight), quantized=False)
+
+        # bytes budget (3) tighter than the slot count (8) -> 3 wins
+        m1 = SwitchLinear(INPUT_DIMS, OUTPUT_DIMS, NUM_EXPERTS, bias=False)
+        m1.enable_offload(
+            resident_slots=8, fetch_fn=_dense_fetch(m1.weight), resident_bytes=3 * per_expert
+        )
+        self.assertEqual(m1._offload_capacity, 3)
+
+        # slot count (2) tighter than the bytes budget (9) -> 2 wins
+        m2 = SwitchLinear(INPUT_DIMS, OUTPUT_DIMS, NUM_EXPERTS, bias=False)
+        m2.enable_offload(
+            resident_slots=2, fetch_fn=_dense_fetch(m2.weight), resident_bytes=9 * per_expert
+        )
+        self.assertEqual(m2._offload_capacity, 2)
+
+    def test_resident_bytes_result_still_bit_identical(self):
+        """A byte-derived slot count runs the same offload path as an equivalent
+        slot count -- derivation only picks the number."""
+        baseline = SwitchLinear(INPUT_DIMS, OUTPUT_DIMS, NUM_EXPERTS, bias=False)
+        mx.eval(baseline.parameters())
+
+        offloaded = SwitchLinear(INPUT_DIMS, OUTPUT_DIMS, NUM_EXPERTS, bias=False)
+        _copy_params(offloaded, baseline, ["weight"])
+        fetch = _dense_fetch(baseline.weight)
+        per_expert = _per_expert_bytes(fetch, quantized=False)
+        offloaded.enable_offload(resident_bytes=RESIDENT_SLOTS * per_expert, fetch_fn=fetch)
+        self.assertEqual(offloaded._offload_capacity, RESIDENT_SLOTS)
+
+        x = mx.random.normal((5, 1, 1, INPUT_DIMS))
+        for indices in _random_indices():
+            self.assertTrue(mx.array_equal(baseline(x, indices), offloaded(x, indices)))
+
+    # --- Guards and the unchanged default path ---------------------------
+
+    def test_missing_fetch_fn_raises(self):
+        module = SwitchLinear(INPUT_DIMS, OUTPUT_DIMS, NUM_EXPERTS, bias=False)
+        with self.assertRaises(ValueError):
+            module.enable_offload(resident_slots=RESIDENT_SLOTS)
+
+    def test_no_budget_raises(self):
+        module = SwitchLinear(INPUT_DIMS, OUTPUT_DIMS, NUM_EXPERTS, bias=False)
+        with self.assertRaises(ValueError):
+            module.enable_offload(fetch_fn=_dense_fetch(module.weight))
+
+    def test_noop_when_resident_slots_covers_all_experts(self):
+        module = SwitchLinear(INPUT_DIMS, OUTPUT_DIMS, NUM_EXPERTS, bias=False)
+
+        def _unused_fetch(e):  # must never be called on the no-op path
+            raise AssertionError("fetch_fn called on a no-op enable_offload")
+
+        module.enable_offload(NUM_EXPERTS, _unused_fetch)
+        self.assertFalse(hasattr(module, "_offload_fetch"))
+        # Still the plain resident path: full weight, no stand-in, no offload attrs.
+        self.assertEqual(module.num_experts, NUM_EXPERTS)
+        self.assertEqual(module.weight.shape[0], NUM_EXPERTS)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## What this adds

An opt-in `enable_offload(resident_slots, fetch_fn)` on `SwitchLinear` and `QuantizedSwitchLinear`. When enabled, only `resident_slots` experts stay resident in a dict-keyed LRU cache; the rest are fetched on a router miss via a caller-supplied `fetch_fn` and evicted to capacity. The forward path reads only the cache, never the full stacked weight, so a MoE model whose expert table exceeds unified memory can run with just the resident set plus activations live.

This addresses #1438 (running MoE models larger than unified memory on Apple Silicon). It is a single-file change and off by default; nothing changes unless a caller opts in.

## How it is meant to be used

The primitive is deliberately storage-agnostic: `fetch_fn(expert_id)` returns the raw host data for one expert, and the caller decides where it comes from. In my app I read expert bytes by explicit byte-range from the model's own safetensors shards (0.3 to 0.6ms per expert on an Apple SSD, no repacking, no separate cache format). Two design points I learned the hard way:

- The cache is dict-keyed rather than a fixed slot array. With a fixed array, an eviction later in the same forward call can overwrite a slot an earlier expert already resolved to, because the gather runs only after every index in the call resolves. A dict has no shared slots to collide over.
- The `mx.array` for a fetched expert must be constructed on the thread that runs the model. MLX arrays are thread-affine, so building one on a worker thread crashes the first time the engine thread touches it. Split the disk I/O (parallel, thread-safe) from the array construction (on the calling thread).

There is also a subtle memory point baked into the seeding: seed the resident set from `fetch_fn`, not by slicing the loaded weight, and replace the weight with a 1-row stand-in. A prefix slice of an `mx.array` is a view that pins the whole parent buffer, so slicing does not actually free the rest of the table.

## Demonstrated

Running Qwen3.6-35B-A3B-8bit (35GB on disk, ~33.8GB stacked expert table) on a 32GB Mac, where eager load cannot complete: with `load(lazy=True)` plus offload at fraction 0.3 it loads and generates coherent text at a peak of 12.7GB resident.

## Honest tradeoff

Offload trades throughput for memory and should be used only when a model would not otherwise fit. On a model that does fit (Qwen3.6-35B-A3B-4bit), enabling offload at fraction 0.3 measured about 5x slower decode and 8 to 12x slower prefill, because a diverse prefill routes to nearly all experts while the cache holds only a fraction, so it re-fetches most of the table every prefill.

Those two figures predate the two commits below and now understate the current state. Both commits cut part of that tax without moving hit_rate, and both are bit-identical to the path they replace: the compact chunked-gather drops the G-fold matmul on sorted prefill, and the lone-group guard skips a memory barrier that does nothing at decode. Their measurements are in the comments below, and I will update this section with a fresh end-to-end measurement on the current build.

Co-activation-aware on-disk expert ordering is the remaining natural follow-up and is out of scope here. Cross-layer prefetch is not a follow-up: it measures as a null on this architecture, see #1438.

## Notes

- No change to the default path; existing models load and run identically.
- The disk-backed `fetch_fn` and the lazy-load wiring live in my application, not in this PR, since they are storage- and app-specific. Happy to add a small reference `fetch_fn` or a short doc example if that would help.

