### PR TITLE
Never lower RLIMIT_NOFILE when importing mlx_lm

### DIFF
--- a/mlx_lm/utils.py
+++ b/mlx_lm/utils.py
@@ -32,8 +32,14 @@ if os.getenv("MLXLM_USE_MODELSCOPE", "False").lower() == "true":
 else:
     from huggingface_hub import snapshot_download
 
-# For large models with lots of files
-resource.setrlimit(resource.RLIMIT_NOFILE, (2048, 4096))
+# For large models with lots of files, ensure the soft limit on open file
+# descriptors is at least 2048. Only ever raise it: lowering the hard limit is
+# irreversible for an unprivileged process, and would permanently cap a host
+# application that had deliberately raised its own limit.
+_soft, _hard = resource.getrlimit(resource.RLIMIT_NOFILE)
+if _soft != resource.RLIM_INFINITY and _soft < 2048:
+    _soft = 2048 if _hard == resource.RLIM_INFINITY else min(2048, _hard)
+    resource.setrlimit(resource.RLIMIT_NOFILE, (_soft, _hard))
 
 from mlx.utils import tree_flatten, tree_map, tree_reduce, tree_unflatten
 

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -2,6 +2,8 @@
 
 import json
 import os
+import subprocess
+import sys
 import tempfile
 import unittest
 from pathlib import Path
@@ -263,6 +265,45 @@ class TestTrustRemoteCode(unittest.TestCase):
         model, loaded_config = utils.load_model(self.model_path, strict=False)
         self.assertIsInstance(model, nn.Module)
         self.assertEqual(loaded_config["model_type"], "llama")
+
+
+class TestOpenFileLimit(unittest.TestCase):
+    def test_import_does_not_lower_nofile_limit(self):
+        """Importing mlx_lm must never reduce the process descriptor limits."""
+        # Raise to a finite value first: an infinite soft limit would exercise
+        # only the early-out branch, and degenerates any code that iterates
+        # over range(soft).
+        script = (
+            "import resource\n"
+            "soft, hard = resource.getrlimit(resource.RLIMIT_NOFILE)\n"
+            "raised = 8192 if hard == resource.RLIM_INFINITY else min(hard, 8192)\n"
+            "resource.setrlimit(resource.RLIMIT_NOFILE, (raised, hard))\n"
+            "before = resource.getrlimit(resource.RLIMIT_NOFILE)\n"
+            "import mlx_lm.utils\n"
+            "after = resource.getrlimit(resource.RLIMIT_NOFILE)\n"
+            "print(before[0], before[1], after[0], after[1])\n"
+        )
+        out = subprocess.run(
+            [sys.executable, "-c", script], capture_output=True, text=True, check=True
+        )
+        before_soft, before_hard, after_soft, after_hard = map(int, out.stdout.split())
+        self.assertGreaterEqual(after_soft, before_soft)
+        self.assertEqual(after_hard, before_hard)
+
+    def test_import_survives_low_hard_limit(self):
+        """A hard limit below 4096 must not make the import fail."""
+        script = (
+            "import resource\n"
+            "resource.setrlimit(resource.RLIMIT_NOFILE, (1024, 1024))\n"
+            "import mlx_lm.utils\n"
+            "print(*resource.getrlimit(resource.RLIMIT_NOFILE))\n"
+        )
+        out = subprocess.run(
+            [sys.executable, "-c", script], capture_output=True, text=True, check=True
+        )
+        soft, hard = map(int, out.stdout.split())
+        self.assertLessEqual(soft, hard)
+        self.assertEqual(hard, 1024)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

Fixes #1589.

`mlx_lm/utils.py` overwrites `RLIMIT_NOFILE` with a fixed `(2048, 4096)` at module scope, without reading the current limits.

Raising the *soft* limit toward 2048 is reasonable and works as intended on a default macOS box, where the limit starts at `(256, RLIM_INFINITY)`. The problem is the second value:

- **Lowering the hard limit is irreversible.** An unprivileged process can only ever lower a hard limit, so `RLIM_INFINITY -> 4096` permanently caps the process at 4096 descriptors as an import side effect. A `ulimit -n` raised beforehand is silently clamped, and a host application that raises its own limit at startup cannot restore it afterwards. I hit this running mlx-lm under vLLM's Metal backend.
- **The import hard-fails when the existing hard limit is below 4096.** The call then tries to *raise* the hard limit, which is not permitted, so `import mlx_lm` dies with `ValueError` — e.g. in a container started with `--ulimit nofile=1024:1024`.

This reads the current limits and only raises the soft limit toward the 2048 floor, never touching the hard limit. The original motivation is preserved for the common macOS case, and the call becomes a no-op when the limit is already sufficient.

`RLIM_INFINITY` is handled explicitly rather than via `min()`, since it is represented as `-1` on Linux.

## Verification

macOS 15.7.4, Apple M4, Python 3.12.12.

| Starting limit | Before | After |
| --- | --- | --- |
| macOS default (launchd) | `(256, ∞)` → `(2048, 4096)` | `(256, ∞)` → `(2048, ∞)` — soft still raised, hard preserved |
| Operator raised it | `(65536, ∞)` → `(2048, 4096)` | `(65536, ∞)` unchanged |
| Hard limit below 4096 | `(1024, 1024)` → `ValueError`, import fails | `(1024, 1024)` unchanged, import succeeds |

The first row is the case the original code was written for, and it still works — the difference is that the hard limit survives. Rows two and three are the bugs.

Before this change, row two could not be undone:

```console
restore hard->65536: FAILED (not allowed to raise maximum limit)
```

## Tests

Adds `TestOpenFileLimit` with two cases:

- `test_import_does_not_lower_nofile_limit` — raises the soft limit in a subprocess, imports `mlx_lm.utils`, asserts the soft limit did not decrease and the hard limit is unchanged.
- `test_import_survives_low_hard_limit` — imports under `(1024, 1024)` and asserts the import succeeds with the hard limit intact.

```console
$ python -m unittest tests.test_utils.TestOpenFileLimit
Ran 2 tests in 3.24s

OK
```

Formatted with `black`.

## Note

Arguably this adjustment should move out of module scope into the loader path that actually opens many files, so that importing the module has no global side effect at all. I kept this PR to the minimal correctness fix — happy to follow up if you'd prefer that shape.
