### PR TITLE
Fix speculative_generate_step with max_tokens=-1

### DIFF
--- a/mlx_lm/generate.py
+++ b/mlx_lm/generate.py
@@ -601,7 +601,10 @@ def speculative_generate_step(
     n = 0
     try:
         while True:
-            num_draft = min(max_tokens - ntoks, num_draft_tokens)
+            if max_tokens < 0:
+                num_draft = num_draft_tokens
+            else:
+                num_draft = min(max_tokens - ntoks, num_draft_tokens)
             draft_tokens = _draft_generate(draft_y, num_draft)
             if prev_tokens is not None:
                 prev_tokens = prev_tokens[: prev_tokens.size - y.size - num_draft + 1]
@@ -620,7 +623,7 @@ def speculative_generate_step(
                 yield tn, lpn, True
                 if ntoks == max_tokens:
                     break
-            if ntoks < max_tokens:
+            if ntoks != max_tokens:
                 ntoks += 1
                 yield tokens[n], logprobs[n], False
 


### PR DESCRIPTION
## Summary

`max_tokens=-1` is documented in `speculative_generate_step` as the sentinel for infinite generation, but passing it raises immediately:

```
ValueError: [concatenate] No arrays provided for concatenation
```

Two separate places assume a non-negative `max_tokens`:

1. `num_draft = min(max_tokens - ntoks, num_draft_tokens)` goes negative. `_draft_generate` only guards `num_draft == 0`, so `range(num_draft)` yields nothing and `mx.concatenate(ys)` is called with an empty list on the first draft step. This is the crash.

2. The bonus (non draft) token is emitted under `if ntoks < max_tokens:`, which is never true for a negative `max_tokens`. Fixing only the first issue would stop the crash but silently drop that token from the output while still feeding it forward as the next input, so generation would be quietly wrong rather than broken.

This change treats a negative `max_tokens` as unbounded in the draft count, and switches the bonus token check to `ntoks != max_tokens`. The `!=` form matches the two existing `ntoks == max_tokens` checks in the same loop, and is equivalent to `<` for non-negative `max_tokens` since `ntoks` never exceeds it.

## Testing

Verified with a small fake model, since the bug is pure loop arithmetic and does not depend on real weights:

- `max_tokens=-1`: raised `ValueError` before, now yields tokens indefinitely (pulled 5).
- `max_tokens=4`: yields exactly 4 tokens before and after.
- `max_tokens=1`: yields exactly 1 token before and after.

This is the same class of boundary bug as #1379.