### PR TITLE
Drop import-level sampler compilation

### DIFF
--- a/mlx_lm/sample_utils.py
+++ b/mlx_lm/sample_utils.py
@@ -1,7 +1,6 @@
 # Copyright © 2023-2024 Apple Inc.
 
 import math
-from functools import partial
 from typing import Callable, Dict, List, Optional
 
 import mlx.core as mx
@@ -66,7 +65,10 @@ def make_sampler(
         # Return the sampled token
         return categorical_sampling(logprobs, temp)
 
-    return sampler
+    # ``mx.random.state`` is thread-local, so a sampler compiled
+    # on the main thread (at import time) would ignore reseeding
+    # on another thread
+    return mx.compile(sampler, inputs=mx.random.state, outputs=mx.random.state)
 
 
 def make_logits_processors(
@@ -126,7 +128,6 @@ def make_logits_processors(
     return logits_processors
 
 
-@partial(mx.compile, inputs=mx.random.state, outputs=mx.random.state)
 def apply_top_k(
     logprobs: mx.array,
     top_k: int,
@@ -151,7 +152,6 @@ def apply_top_k(
     return masked_logprobs
 
 
-@partial(mx.compile, inputs=mx.random.state, outputs=mx.random.state)
 def apply_min_p(
     logprobs: mx.array,
     min_p: float,
@@ -201,7 +201,6 @@ def apply_min_p(
     return mx.where(tokens_to_remove, -float("inf"), logprobs)
 
 
-@partial(mx.compile, inputs=mx.random.state, outputs=mx.random.state)
 def apply_top_p(logprobs: mx.array, top_p: float) -> mx.array:
     """
     Apply top-p (nucleus) sampling to logits.
@@ -237,7 +236,6 @@ def apply_top_p(logprobs: mx.array, top_p: float) -> mx.array:
     )
 
 
-@partial(mx.compile, inputs=mx.random.state, outputs=mx.random.state)
 def apply_xtc(
     logits: mx.array,
     xtc_probability: float,
@@ -274,7 +272,6 @@ def apply_xtc(
     )
 
 
-@partial(mx.compile, inputs=mx.random.state, outputs=mx.random.state)
 def categorical_sampling(logits, temp):
     return mx.random.categorical(logits * (1 / temp))
 

--- a/tests/test_sample_utils.py
+++ b/tests/test_sample_utils.py
@@ -203,7 +203,6 @@ class TestSampleUtils(unittest.TestCase):
 
         tokens = run_threaded()
 
-        # seeds are [1, 2, 1, 2, 3]
         self.assertEqual(tokens[0], tokens[2])
         self.assertEqual(tokens[1], tokens[3])
         self.assertEqual(tokens[4], tokens[5])

--- a/tests/test_sample_utils.py
+++ b/tests/test_sample_utils.py
@@ -1,8 +1,15 @@
+import threading
 import unittest
 
 import mlx.core as mx
 
-from mlx_lm.sample_utils import apply_min_p, apply_top_k, apply_top_p, apply_xtc
+from mlx_lm.sample_utils import (
+    apply_min_p,
+    apply_top_k,
+    apply_top_p,
+    apply_xtc,
+    make_sampler,
+)
 
 
 class TestSampleUtils(unittest.TestCase):
@@ -173,6 +180,38 @@ class TestSampleUtils(unittest.TestCase):
         self.assertAlmostEqual(logits[0, 1].item(), -0.6667, places=4)
         self.assertAlmostEqual(logits[0, 2].item(), 0.0, places=4)
         self.assertAlmostEqual(logits[0, 3].item(), -0.5, places=4)
+
+    def test_sampler_seed(self):
+        def sample_with_seeds(out: list[list[int]]) -> None:
+            sampler = make_sampler(temp=1.0)
+            logits = mx.zeros((1024,))  # uniform, so the seed drives the pick
+            tokens = []
+            for seed in [1, 2, 1, 2, 3, 3]:
+                mx.random.seed(seed)
+                token = sampler(logits)
+                mx.eval(token)
+                tokens.append(token.item())
+            out.append(tokens)
+
+        def run_threaded() -> list[int]:
+            out = []
+            t = threading.Thread(target=sample_with_seeds, args=(out,))
+            t.start()
+            t.join()
+            assert len(out) == 1, out
+            return out[0]
+
+        tokens = run_threaded()
+
+        # seeds are [1, 2, 1, 2, 3]
+        self.assertEqual(tokens[0], tokens[2])
+        self.assertEqual(tokens[1], tokens[3])
+        self.assertEqual(tokens[4], tokens[5])
+        self.assertNotEqual(tokens[1], tokens[2])
+        self.assertNotEqual(tokens[1], tokens[5])
+        self.assertNotEqual(tokens[2], tokens[5])
+        # reproducibility
+        self.assertEqual(tokens, run_threaded())
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Drop module-level `mx.compile` in `sampling_utils.py`. This fixes `server.py`'s sampling seed.

Fixes #1245
Closes #1331