### PR TITLE
tests: pin MLX_ENABLE_TF32=0 so kernel-vs-reference checks stay fp32-exact on M5

### DIFF
--- a/tests/test_generate.py
+++ b/tests/test_generate.py
@@ -1,8 +1,15 @@
 # Copyright © 2024 Apple Inc.
 
+import os
 import random
 import unittest
 from typing import List
+
+# mlx >= 0.32 runs float32 GEMMs at TF32-class precision on M5 neural
+# accelerators unless MLX_ENABLE_TF32=0. The batch-vs-single equivalence checks
+# in this file compare against fp32-exact references and fail otherwise.
+# Pin it off; the flag latches process-wide on first matmul.
+os.environ.setdefault("MLX_ENABLE_TF32", "0")
 
 import mlx.core as mx
 

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -1,7 +1,16 @@
 # Copyright © 2024 Apple Inc.
 import copy
 import importlib
+import os
 import unittest
+
+# mlx >= 0.32 runs float32 GEMMs at TF32-class precision on M5 neural
+# accelerators unless MLX_ENABLE_TF32=0. Kernel-vs-reference checks in this
+# file that build the reference via matmul (e.g. test_ssm's SSD outer-product
+# state path) then fail their 1e-4 allclose against fp32-exact elementwise
+# kernels (TF32 is ~2e-3 relative). Pin it off; the flag latches process-wide
+# on first matmul.
+os.environ.setdefault("MLX_ENABLE_TF32", "0")
 
 import mlx.core as mx
 import mlx.nn as nn


### PR DESCRIPTION
On M5-class GPUs with mlx >= 0.32, `tests.test_models.TestModels.test_ssm` fails deterministically on current `main`:

```
FAIL: test_ssm (tests.test_models.TestModels.test_ssm)
AssertionError: array(False, dtype=bool) is not true   # out_state allclose, atol=rtol=1e-4
```

There is nothing wrong with the ssm kernels — the failure is a precision-regime mismatch introduced by the environment.

## Root cause

mlx defaults `MLX_ENABLE_TF32=1`, so float32 GEMMs run on the M5 neural accelerator at TF32-class precision (confirmed as expected behavior in ml-explore/mlx#3534). `test_ssm` compares the SSD reference path (`ssm_attn`) against the elementwise single-step Metal kernel (`ssm_update`) at `atol=rtol=1e-4`:

- The reference computes `next_state` via the outer product `dtxdecay @ B` — a GEMM shape, so it picks up ~2e-3 relative TF32 error.
- The step kernel does the same math elementwise in fp32 and stays exact. A float64 cross-check confirms the **kernel is the correct side** (max abs err 3.3e-6; the GPU reference is off by ~1.5e-3 relative).
- The `out` comparison keeps passing because at `seq_len=1` its contractions are gemv-shaped (M=1 or N=1), which don't take the NAX GEMM route.

Measured on an M5 Max (macOS 26.5, mlx 0.32.0 wheel), fp32 vs float64 reference:

| shape | default | `MLX_ENABLE_TF32=0` |
|---|---|---|
| `(64,1)@(1,128)` outer product, max rel err | 1.9e-3 | 6.0e-8 |
| `(48,64,128)@(48,128,32)`, max abs err | 4.3e-2 | 2.8e-5 |

## Fix

Pin `MLX_ENABLE_TF32=0` at test-module import via `os.environ.setdefault`. The flag latches process-wide on the first matmul, so import time is early enough, and `setdefault` keeps an explicit `MLX_ENABLE_TF32=1` run possible. The kernel-vs-reference tolerances stay at 1e-4, where they can still catch real kernel bugs.

## Verification

M5 Max, macOS 26.5, mlx 0.32.0:

- `main` without this patch: `test_ssm` fails deterministically.
- With this patch: full `test_models` suite passes (80 tests, 1 skipped).

M1–M4 machines are unaffected either way (no NAX, fp32 GEMM already exact).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
