### PR TITLE
Prompt cache trimming for recurrent/hybrid and sliding-window models via prefill-boundary state checkpoints

### DIFF
--- a/mlx_lm/generate.py
+++ b/mlx_lm/generate.py
@@ -28,6 +28,7 @@ from .models.cache import (
     RotatingKVCache,
     TokenBuffer,
     load_prompt_cache,
+    record_state_checkpoints,
 )
 from .sample_utils import make_sampler
 from .tokenizer_utils import TokenizerWrapper
@@ -417,6 +418,9 @@ def generate_step(
             len(input_embeddings) if input_embeddings is not None else len(prompt)
         )
         prompt_processed_tokens = 0
+        checkpoint_base = max(
+            (c.size() for c in prompt_cache if hasattr(c, "size")), default=0
+        )
         prompt_progress_callback(prompt_processed_tokens, total_prompt_tokens)
         while total_prompt_tokens - prompt_processed_tokens > 1:
             remaining = (total_prompt_tokens - prompt_processed_tokens) - 1
@@ -432,6 +436,9 @@ def generate_step(
             quantize_cache_fn(prompt_cache)
             mx.eval([c.state for c in prompt_cache])
             prompt_processed_tokens += n_to_process
+            record_state_checkpoints(
+                prompt_cache, [checkpoint_base + prompt_processed_tokens]
+            )
             prompt_progress_callback(prompt_processed_tokens, total_prompt_tokens)
             prompt = prompt[n_to_process:]
             input_embeddings = (
@@ -440,6 +447,15 @@ def generate_step(
                 else input_embeddings
             )
             mx.clear_cache()
+
+        # The end-of-prefill boundary is the position a regenerate-style
+        # prompt-cache trim lands on, so always record it.
+        if prompt_processed_tokens > 0:
+            record_state_checkpoints(
+                prompt_cache,
+                [checkpoint_base + prompt_processed_tokens],
+                force=True,
+            )
 
         y, logprobs = _step(input_tokens=prompt, input_embeddings=input_embeddings)
 
@@ -568,13 +584,19 @@ def speculative_generate_step(
                 return _process_and_sample(None, logits.squeeze(0))
 
     def _prefill(model, cache, y):
+        base = max((c.size() for c in cache if hasattr(c, "size")), default=0)
+        processed = 0
         while y.size > 1:
             n_to_process = min(prefill_step_size, y.size - 1)
             model(y[:n_to_process][None], cache=cache)
             quantize_cache_fn(cache)
             mx.eval([c.state for c in cache])
+            processed += n_to_process
+            record_state_checkpoints(cache, [base + processed])
             y = y[n_to_process:]
             mx.clear_cache()
+        if processed > 0:
+            record_state_checkpoints(cache, [base + processed], force=True)
         return y
 
     def _rewind_cache(num_draft, num_accept):
@@ -1229,6 +1251,12 @@ class PromptProcessingBatch:
         padding = [max_length - l for l in lengths]
         max_padding = max(padding)
 
+        # Absolute per-lane positions for recurrent-state checkpoints. A lane
+        # that exhausts its (right-padded) prompt mid-chunk holds a frozen,
+        # exact state at its own total, so clamp per lane.
+        totals = [len(st) for st in self.tokens]
+        bases = [t - l for t, l in zip(totals, lengths)]
+
         # Prepare the caches and inputs. Right pad if needed otherwise just
         # cast to array.
         if max_padding > 0:
@@ -1239,10 +1267,16 @@ class PromptProcessingBatch:
             tokens = mx.array(tokens)
 
         # Actual prompt processing loop
+        processed = 0
         while tokens.shape[1] > 0:
             n_to_process = min(self.prefill_step_size, tokens.shape[1])
             self.model(tokens[:, :n_to_process], cache=self.prompt_cache)
             mx.eval([c.state for c in self.prompt_cache])
+            processed += n_to_process
+            record_state_checkpoints(
+                self.prompt_cache,
+                [b + min(processed, l) for b, l in zip(bases, lengths)],
+            )
             mx.clear_cache()
             tokens = tokens[:, n_to_process:]
 
@@ -1252,6 +1286,10 @@ class PromptProcessingBatch:
                 c.finalize()
             mx.eval([c.state for c in self.prompt_cache])
             mx.clear_cache()
+
+        # The end of each prompt segment is exactly the position the server
+        # keys prompt-cache entries on; always record it.
+        record_state_checkpoints(self.prompt_cache, totals, force=True)
 
     def generate(self, tokens: List[List[int]]):
         """

--- a/mlx_lm/models/cache.py
+++ b/mlx_lm/models/cache.py
@@ -1,6 +1,7 @@
 # Copyright © 2023-2024 Apple Inc.
 
 import copy
+import os
 from collections import deque
 from dataclasses import dataclass
 from typing import Any, Dict, List, Optional
@@ -92,7 +93,73 @@ def can_trim_prompt_cache(cache: List[Any]) -> bool:
     return all(c.is_trimmable() for c in cache)
 
 
-def trim_prompt_cache(cache: List[Any], num_tokens: int) -> List[Any]:
+def _snap_trim_position(cache: List[Any], position: int) -> Optional[int]:
+    """Largest position <= ``position`` that every cache in the list can be
+    restored to, or ``None`` if some cache cannot restore any position.
+
+    Iterates to a fixpoint: lowering the position for one cache (to its
+    nearest state checkpoint) may lower it again for another.
+    """
+    while True:
+        start = position
+        for c in cache:
+            position = c.snap_trim_position(position)
+            if position is None or position < 0:
+                return None
+        if position == start:
+            return position
+
+
+def _absolute_position(c) -> int:
+    """Absolute token position of a cache. ``RotatingKVCache.size()``
+    saturates at ``max_size``; its ``offset`` is the true count."""
+    position = getattr(c, "offset", None)
+    if isinstance(position, int):
+        return position
+    return c.size() if hasattr(c, "size") else 0
+
+
+def _thin_checkpoints(checkpoints: List, max_checkpoints: int):
+    """Drop the checkpoint with the smallest gap to its predecessor
+    (implicit predecessor at 0), never the newest: this roughly doubles the
+    effective stride over the older history while keeping the
+    end-of-prefill checkpoint exact. Entries are tuples whose first element
+    is the position."""
+    while len(checkpoints) > max_checkpoints:
+        prev = 0
+        gaps = []
+        for j, entry in enumerate(checkpoints[:-1]):
+            gaps.append((entry[0] - prev, j))
+            prev = entry[0]
+        _, drop = min(gaps)
+        del checkpoints[drop]
+
+
+def achievable_trim(cache: List[Any], num_tokens: int):
+    """Dry-run of ``trim_prompt_cache(cache, num_tokens, allow_partial=True)``.
+
+    Returns ``(position, actual_num_tokens)`` — the absolute position the
+    cache would land on and the number of tokens that would actually be
+    trimmed (``>= num_tokens`` when the landing snaps to an earlier state
+    checkpoint) — or ``None`` if the cache cannot be trimmed at all.
+    """
+    if len(cache) == 0:
+        return None
+    size = max((_absolute_position(c) for c in cache), default=0)
+    if size <= 0:
+        return None
+    target = max(0, size - num_tokens)
+    if can_trim_prompt_cache(cache):
+        return target, size - target
+    position = _snap_trim_position(cache, target)
+    if position is None:
+        return None
+    return position, size - position
+
+
+def trim_prompt_cache(
+    cache: List[Any], num_tokens: int, allow_partial: bool = False
+) -> int:
     """
     Trim the model's cache by the given number of tokens.
 
@@ -102,13 +169,60 @@ def trim_prompt_cache(cache: List[Any], num_tokens: int) -> List[Any]:
     Args:
         cache (List[Any]): The model's cache.
         num_tokens (int): The number of tokens to trim.
+        allow_partial (bool): If the cache is not exactly trimmable (e.g. it
+            mixes recurrent-state ``ArraysCache`` layers with KV layers),
+            allow trimming *more* than ``num_tokens`` by restoring the
+            recurrent layers to their nearest recorded state checkpoint at or
+            before the requested position. The caller must use the returned
+            count (which may exceed ``num_tokens``) to decide how many tokens
+            to re-process. Default: ``False``.
 
     Returns:
         (int): The number of tokens that were trimmed.
     """
-    if not can_trim_prompt_cache(cache) or len(cache) == 0:
+    if len(cache) == 0:
         return 0
-    return [c.trim(num_tokens) for c in cache][0]
+    if can_trim_prompt_cache(cache):
+        return [c.trim(num_tokens) for c in cache][0]
+    if not allow_partial:
+        return 0
+    landing = achievable_trim(cache, num_tokens)
+    if landing is None:
+        return 0
+    position, actual = landing
+    for c in cache:
+        c.trim_to_position(position, actual)
+    return actual
+
+
+def record_state_checkpoints(cache: List[Any], positions: List[int], force=False):
+    """Record a recurrent-state checkpoint on every cache that supports one.
+
+    Called by the prefill loops at chunk boundaries. ``positions`` gives the
+    absolute number of tokens processed per batch lane at this boundary
+    (length-1 list for unbatched caches). No-op for pure KV caches and for
+    duck-typed caches that predate this hook.
+    """
+    for c in cache:
+        record = getattr(c, "state_checkpoint", None)
+        if record is not None:
+            record(positions, force=force)
+
+
+def _state_checkpoint_max() -> int:
+    """Max recorded state checkpoints per ArraysCache lane (0 disables)."""
+    try:
+        return int(os.environ.get("MLX_LM_STATE_CHECKPOINT_MAX", "4"))
+    except ValueError:
+        return 4
+
+
+def _state_checkpoint_stride() -> int:
+    """Minimum token gap between recorded (non-forced) state checkpoints."""
+    try:
+        return max(1, int(os.environ.get("MLX_LM_STATE_CHECKPOINT_STRIDE", "2048")))
+    except ValueError:
+        return 2048
 
 
 def create_attention_mask(
@@ -145,6 +259,30 @@ class _BaseCache:
 
     def is_trimmable(self):
         return False
+
+    def state_checkpoint(self, positions: List[int], force: bool = False):
+        """Record a restorable snapshot of this cache's state at the given
+        absolute per-lane positions. No-op by default: KV caches can trim to
+        any position already, so only caches with irreversible state (e.g.
+        ``ArraysCache``) record checkpoints.
+        """
+        pass
+
+    def snap_trim_position(self, position: int) -> Optional[int]:
+        """Largest absolute position <= ``position`` this cache can be
+        restored to. Exactly-trimmable caches can restore any position;
+        caches with irreversible state snap to a recorded checkpoint.
+        Returns ``None`` if no position is restorable.
+        """
+        return position if self.is_trimmable() else None
+
+    def trim_to_position(self, position: int, num_tokens: int) -> int:
+        """Restore the cache to absolute position ``position`` by trimming
+        ``num_tokens`` tokens from its end. Exactly-trimmable caches just
+        trim; checkpointed caches restore the snapshot recorded at
+        ``position`` (which ``snap_trim_position`` guaranteed exists).
+        """
+        return self.trim(num_tokens)
 
     def size(self):
         """
@@ -410,6 +548,19 @@ class KVCache(_BaseCache):
 class RotatingKVCache(_BaseCache):
     step = 256
 
+    def __new__(cls, *args, **kwargs):
+        # Set on __new__ (not __init__) so caches reconstructed by
+        # load_prompt_cache (which bypasses __init__) still have it.
+        instance = super().__new__(cls)
+        # Prefill-time window checkpoints: (position, keys, values) with the
+        # arrays in temporal order. Once the ring wraps, evicted rows are
+        # gone and the cache cannot be trimmed backward; these are the only
+        # positions (plus the implicit empty state at 0) a trim can land on.
+        # Bounded by the window size (not the context length), unlike a full
+        # cache snapshot.
+        instance._checkpoints = []
+        return instance
+
     def __init__(self, max_size, keep=0):
         self.keep = keep
         self.keys = None
@@ -417,6 +568,62 @@ class RotatingKVCache(_BaseCache):
         self.offset = 0
         self.max_size = max_size
         self._idx = 0
+
+    def state_checkpoint(self, positions: List[int], force: bool = False):
+        max_checkpoints = _state_checkpoint_max()
+        if max_checkpoints <= 0 or self.keys is None or len(positions) != 1:
+            return
+        position = positions[0]
+        last = self._checkpoints[-1][0] if self._checkpoints else 0
+        if position <= last:
+            return
+        if not force and position - last < _state_checkpoint_stride():
+            return
+        # Temporal-order copies: the single-token update path mutates the
+        # ring buffers in place, so views would be corrupted later.
+        keys = self._temporal_order(self.keys)
+        values = self._temporal_order(self.values)
+        self._checkpoints.append((position, mx.array(keys), mx.array(values)))
+        _thin_checkpoints(self._checkpoints, max_checkpoints)
+
+    def snap_trim_position(self, position: int) -> Optional[int]:
+        if self.is_trimmable():
+            # Not wrapped yet: every position is natively reachable.
+            return position
+        best = 0  # the empty state at position 0 is always restorable
+        for p, _, _ in self._checkpoints:
+            if p <= position:
+                best = max(best, p)
+        return best
+
+    def trim_to_position(self, position: int, num_tokens: int) -> int:
+        if self.is_trimmable():
+            return self.trim(num_tokens)
+        if position > 0:
+            found = None
+            for p, keys, values in reversed(self._checkpoints):
+                if p == position:
+                    found = (keys, values)
+                    break
+            if found is None:
+                raise RuntimeError(
+                    f"RotatingKVCache has no window checkpoint at position "
+                    f"{position}"
+                )
+            # Copy on restore too, so the retained checkpoint stays pristine
+            # when the in-place update path later mutates the live buffers.
+            self.keys = mx.array(found[0])
+            self.values = mx.array(found[1])
+            self.offset = position
+            self._idx = self.keys.shape[2]
+        else:
+            self.keys = None
+            self.values = None
+            self.offset = 0
+            self._idx = 0
+        while self._checkpoints and self._checkpoints[-1][0] > position:
+            self._checkpoints.pop()
+        return num_tokens
 
     def _trim(self, trim_size, v, append=None):
         to_cat = []
@@ -588,7 +795,10 @@ class RotatingKVCache(_BaseCache):
     def nbytes(self):
         if self.keys is None:
             return 0
-        return self.keys.nbytes + self.values.nbytes
+        total = self.keys.nbytes + self.values.nbytes
+        for _, keys, values in self._checkpoints:
+            total += keys.nbytes + values.nbytes
+        return total
 
 
 class ArraysCache(_BaseCache):
@@ -596,12 +806,80 @@ class ArraysCache(_BaseCache):
         instance = super().__new__(cls)
         instance.left_padding = None
         instance.lengths = None
+        # Prefill-time state checkpoints, stored per batch lane: one list per
+        # lane of (position, snapshot) pairs, where ``position`` is the lane's
+        # absolute token position and ``snapshot`` holds batch-size-1 copies
+        # of ``self.cache`` at that position. Recurrent state cannot be
+        # trimmed backward, so these are the only positions (plus the
+        # implicit empty state at 0) a trim can land on. Per-lane storage
+        # lets extend/filter/merge/extract carry histories across batch
+        # membership changes with plain list operations.
+        instance._checkpoints = []
         return instance
 
     def __init__(self, size, left_padding: Optional[List[int]] = None):
         self.cache = [None] * size
         if left_padding:
             self.left_padding = mx.array(left_padding)
+
+    def state_checkpoint(self, positions: List[int], force: bool = False):
+        max_checkpoints = _state_checkpoint_max()
+        if max_checkpoints <= 0 or self.empty():
+            return
+        if len(self._checkpoints) != len(positions):
+            # First record, or the lane set changed without going through
+            # extend/filter/merge: (re)start the histories.
+            self._checkpoints = [[] for _ in positions]
+        stride = _state_checkpoint_stride()
+        for i, position in enumerate(positions):
+            lane = self._checkpoints[i]
+            last = lane[-1][0] if lane else 0
+            # A lane that exhausted its prompt is frozen at ``last``; only
+            # record monotone advances.
+            if lane and position <= last:
+                continue
+            if not force and position - last < stride:
+                continue
+            # mx.array of a slice is a true copy: the snapshot neither pins
+            # the full batch buffer nor can be corrupted by later updates.
+            snapshot = [
+                None if c is None else mx.array(c[i : i + 1]) for c in self.cache
+            ]
+            lane.append((position, snapshot))
+            _thin_checkpoints(lane, max_checkpoints)
+
+    def snap_trim_position(self, position: int) -> Optional[int]:
+        # Restores are only defined for single-lane caches (batch entries are
+        # sliced apart by ``extract`` before they reach a trim).
+        if self.batch_size > 1 or len(self._checkpoints) > 1:
+            return None
+        best = 0  # the empty state at position 0 is always restorable
+        if self._checkpoints:
+            for p, _ in self._checkpoints[0]:
+                if p <= position:
+                    best = max(best, p)
+        return best
+
+    def trim_to_position(self, position: int, num_tokens: int) -> int:
+        lane = self._checkpoints[0] if self._checkpoints else []
+        if position > 0:
+            found = None
+            for p, snapshot in reversed(lane):
+                if p == position:
+                    found = snapshot
+                    break
+            if found is None:
+                raise RuntimeError(
+                    f"ArraysCache has no state checkpoint at position {position}"
+                )
+            # Copy on restore too, so the retained checkpoint stays pristine
+            # if a layer mutates its live state entries in place.
+            self.cache = [None if a is None else mx.array(a) for a in found]
+        else:
+            self.cache = [None] * len(self.cache)
+        while lane and lane[-1][0] > position:
+            lane.pop()
+        return num_tokens
 
     @property
     def batch_size(self):
@@ -638,6 +916,8 @@ class ArraysCache(_BaseCache):
             self.left_padding = self.left_padding[batch_indices]
         if self.lengths is not None:
             self.lengths = self.lengths[batch_indices]
+        if self._checkpoints:
+            self._checkpoints = [self._checkpoints[i] for i in batch_indices]
 
     def extend(self, other):
         """
@@ -669,10 +949,15 @@ class ArraysCache(_BaseCache):
         self.cache = [cat(c, o) for c, o in zip(self.cache, other.cache)]
         self.left_padding = cat(self.left_padding, other.left_padding)
         self.lengths = cat(self.lengths, other.lengths)
+        a_lanes = self._checkpoints or [[] for _ in range(a_batch)]
+        b_lanes = other._checkpoints or [[] for _ in range(b_batch)]
+        self._checkpoints = [list(l) for l in a_lanes] + [list(l) for l in b_lanes]
 
     def extract(self, idx):
         cache = ArraysCache(len(self.cache))
         cache.cache = [c[idx : idx + 1] for c in self.cache]
+        if idx < len(self._checkpoints):
+            cache._checkpoints = [list(self._checkpoints[idx])]
         return cache
 
     def prepare(self, lengths=None, **kwargs):
@@ -718,6 +1003,10 @@ class ArraysCache(_BaseCache):
                 if caches[i][e] is None:
                     continue
                 cache[e][i : i + 1] = caches[i][e]
+        cache._checkpoints = [
+            list(c._checkpoints[0]) if len(c._checkpoints) == 1 else []
+            for c in caches
+        ]
         return cache
 
     def empty(self):
@@ -725,7 +1014,11 @@ class ArraysCache(_BaseCache):
 
     @property
     def nbytes(self):
-        return sum(c.nbytes for c in self.cache if c is not None)
+        total = sum(c.nbytes for c in self.cache if c is not None)
+        for lane in self._checkpoints:
+            for _, snapshot in lane:
+                total += sum(a.nbytes for a in snapshot if a is not None)
+        return total
 
 
 class ChunkedKVCache(_BaseCache):
@@ -820,6 +1113,25 @@ class CacheList(_BaseCache):
 
     def is_trimmable(self):
         return all(c.is_trimmable() for c in self.caches)
+
+    def state_checkpoint(self, positions: List[int], force: bool = False):
+        for c in self.caches:
+            c.state_checkpoint(positions, force=force)
+
+    def snap_trim_position(self, position: int) -> Optional[int]:
+        while True:
+            start = position
+            for c in self.caches:
+                position = c.snap_trim_position(position)
+                if position is None:
+                    return None
+            if position == start:
+                return position
+
+    def trim_to_position(self, position: int, num_tokens: int) -> int:
+        for c in self.caches:
+            m = c.trim_to_position(position, num_tokens)
+        return m
 
     def trim(self, n):
         for c in self.caches:
@@ -1680,12 +1992,26 @@ class LRUPromptCache:
         short_length = len(result.shorter) if result.shorter is not None else 0
         if result.longer is not None and result.common_prefix > short_length:
             cache_entry = self._trie.get(result.model, result.longer)
+            prefix = min(len(tokens) - 1, result.common_prefix)
+            num_to_trim = len(result.longer) - prefix
             if can_trim_prompt_cache(cache_entry.prompt_cache):
                 cache = copy.deepcopy(cache_entry.prompt_cache)
-                prefix = min(len(tokens) - 1, result.common_prefix)
-                num_to_trim = len(result.longer) - prefix
                 trim_prompt_cache(cache, num_to_trim)
                 return cache, tokens[prefix:]
+            # A hybrid (recurrent + KV) cache can only land on a recorded
+            # state checkpoint at or before the requested position, so dry-run
+            # the trim first and only prefer this entry over an exact-prefix
+            # entry when it actually lands deeper.
+            landing = achievable_trim(cache_entry.prompt_cache, num_to_trim)
+            if landing is not None:
+                landed = len(result.longer) - landing[1]
+                if 0 < landed <= len(tokens) - 1 and landed > short_length:
+                    cache = copy.deepcopy(cache_entry.prompt_cache)
+                    trimmed = trim_prompt_cache(
+                        cache, num_to_trim, allow_partial=True
+                    )
+                    landed = len(result.longer) - trimmed
+                    return cache, tokens[landed:]
 
         if short_length > 0:
             cache_entry = self._trie.get(result.model, result.shorter)

--- a/mlx_lm/models/cache.py
+++ b/mlx_lm/models/cache.py
@@ -727,20 +727,53 @@ class RotatingKVCache(_BaseCache):
     @property
     def state(self):
         if self.offset < self.keys.shape[2]:
-            return self.keys[..., : self.offset, :], self.values[..., : self.offset, :]
+            live = [self.keys[..., : self.offset, :], self.values[..., : self.offset, :]]
         else:
-            return self.keys, self.values
+            live = [self.keys, self.values]
+        if self._checkpoints:
+            snaps = []
+            for _, k, v in self._checkpoints:
+                snaps.extend([k, v])
+            return [live, snaps]
+        return live[0], live[1]
 
     @state.setter
     def state(self, v):
-        self.keys, self.values = v
+        # New-format state is [[keys, values], [ck_k, ck_v, ...]] (nested
+        # lists); legacy state is the flat (keys, values) pair. Checkpoint
+        # positions arrive in meta_state, whose setter runs after this one.
+        if len(v) == 2 and isinstance(v[0], list) and isinstance(v[1], list):
+            self.keys, self.values = v[0]
+            self._pending_checkpoint_snapshots = list(v[1])
+        else:
+            self.keys, self.values = v
 
     @property
     def meta_state(self):
-        return tuple(map(str, (self.keep, self.max_size, self.offset, self._idx)))
+        base = tuple(map(str, (self.keep, self.max_size, self.offset, self._idx)))
+        if self._checkpoints:
+            return base + tuple(
+                ["ckptv1"] + [str(p) for p, _, _ in self._checkpoints]
+            )
+        return base
 
     @meta_state.setter
     def meta_state(self, v):
+        pending = getattr(self, "_pending_checkpoint_snapshots", None)
+        self._pending_checkpoint_snapshots = None
+        v = list(v)
+        if "ckptv1" in v:
+            i = v.index("ckptv1")
+            positions = [int(p) for p in v[i + 1 :]]
+            v = v[:i]
+            if pending is None or len(pending) != 2 * len(positions):
+                raise ValueError(
+                    "RotatingKVCache checkpoint state/metadata mismatch"
+                )
+            self._checkpoints = [
+                (p, pending[2 * j], pending[2 * j + 1])
+                for j, p in enumerate(positions)
+            ]
         self.keep, self.max_size, self.offset, self._idx = map(
             int,
             v,
@@ -899,13 +932,59 @@ class ArraysCache(_BaseCache):
     def __getitem__(self, idx):
         return self.cache[idx]
 
+    def _persistable_checkpoints(self):
+        """Single-lane checkpoints whose snapshots are fully materialized.
+
+        Snapshots containing ``None`` entries cannot round-trip through
+        ``save_prompt_cache`` (safetensors holds arrays only), so they are
+        skipped. Batched histories are never persisted (snapshot files hold
+        per-request caches).
+        """
+        if len(self._checkpoints) != 1:
+            return []
+        return [
+            (p, snapshot)
+            for p, snapshot in self._checkpoints[0]
+            if all(a is not None for a in snapshot)
+        ]
+
     @property
     def state(self):
+        checkpoints = self._persistable_checkpoints()
+        if checkpoints:
+            return [list(self.cache), [list(s) for _, s in checkpoints]]
         return self.cache
 
     @state.setter
     def state(self, v):
-        self.cache = v
+        # New-format state is [live_entries, [snapshot, ...]] (nested lists);
+        # legacy state is a flat list of arrays. The positions arrive in
+        # meta_state, whose setter runs after this one.
+        if len(v) == 2 and isinstance(v[0], list) and isinstance(v[1], list):
+            self.cache = list(v[0])
+            self._pending_checkpoint_snapshots = [list(s) for s in v[1]]
+        else:
+            self.cache = v
+
+    @property
+    def meta_state(self):
+        checkpoints = self._persistable_checkpoints()
+        if checkpoints:
+            return tuple(["ckptv1"] + [str(p) for p, _ in checkpoints])
+        return ""
+
+    @meta_state.setter
+    def meta_state(self, v):
+        pending = getattr(self, "_pending_checkpoint_snapshots", None)
+        self._pending_checkpoint_snapshots = None
+        if not v:
+            return
+        if v[0] != "ckptv1":
+            raise ValueError(f"Unknown ArraysCache metadata version: {v[0]}")
+        positions = [int(p) for p in v[1:]]
+        if pending is None or len(pending) != len(positions):
+            raise ValueError("ArraysCache checkpoint state/metadata mismatch")
+        self._checkpoints = [list(zip(positions, pending))]
 
     def filter(self, batch_indices):
         """

--- a/mlx_lm/models/cache.py
+++ b/mlx_lm/models/cache.py
@@ -2064,9 +2064,30 @@ class LRUPromptCache:
 
     def fetch_nearest_cache(self, model: Any, tokens: List[int]):
         result = self._trie.search(model, tokens)
-        if result.exact is not None:
+        if result.exact is not None and len(tokens) == 0:
             cache_entry = self._trie.get(result.model, result.exact)
             return copy.deepcopy(cache_entry.prompt_cache), []
+        if result.exact is not None:
+            cache_entry = self._trie.get(result.model, result.exact)
+            # Never hand back an empty remainder: the caller re-processes
+            # ``rest`` to obtain last-token logits, so an exact hit (e.g. a
+            # client retrying an identical prompt) must land at or before
+            # len(tokens) - 1. Trimmable caches give back the last token;
+            # hybrids land on their deepest interior checkpoint.
+            if can_trim_prompt_cache(cache_entry.prompt_cache):
+                cache = copy.deepcopy(cache_entry.prompt_cache)
+                trim_prompt_cache(cache, 1)
+                return cache, tokens[-1:]
+            landing = achievable_trim(cache_entry.prompt_cache, 1)
+            if landing is not None and landing[1] < len(tokens):
+                cache = copy.deepcopy(cache_entry.prompt_cache)
+                trimmed = trim_prompt_cache(cache, 1, allow_partial=True)
+                landed = len(tokens) - trimmed
+                if 0 < landed <= len(tokens) - 1:
+                    return cache, tokens[landed:]
+            # No usable landing (e.g. checkpointing disabled): fall through
+            # to the shorter/longer candidates rather than return an
+            # unusable full cache.
 
         short_length = len(result.shorter) if result.shorter is not None else 0
         if result.longer is not None and result.common_prefix > short_length:

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -624,7 +624,7 @@ class TestLRUPromptCache(unittest.TestCase):
 
         c, t = cache.fetch_nearest_cache(model, [1, 2])
         self.assertEqual(c, [MockCache("test1")])
-        self.assertEqual(t, [])
+        self.assertEqual(t, [2])  # exact hit re-processes the last token
         c, t = cache.fetch_nearest_cache(model, [1])
         self.assertEqual(c, [MockCache("test1")])
         self.assertEqual(t, [1])
@@ -647,10 +647,10 @@ class TestLRUPromptCache(unittest.TestCase):
         self.assertEqual(t, [1, 2])
         c, t = cache.fetch_nearest_cache(model, [2, 3])
         self.assertEqual(c, [MockCache("test2")])
-        self.assertEqual(t, [])
+        self.assertEqual(t, [3])
         c, t = cache.fetch_nearest_cache(model, [3, 4])
         self.assertEqual(c, [MockCache("test3")])
-        self.assertEqual(t, [])
+        self.assertEqual(t, [4])
 
         cache.insert_cache(model, [4, 5], [MockCache("test4")], cache_type="user")
         c, t = cache.fetch_nearest_cache(model, [2, 3])
@@ -658,10 +658,10 @@ class TestLRUPromptCache(unittest.TestCase):
         self.assertEqual(t, [2, 3])
         c, t = cache.fetch_nearest_cache(model, [3, 4])
         self.assertEqual(c, [MockCache("test3")])
-        self.assertEqual(t, [])
+        self.assertEqual(t, [4])
         c, t = cache.fetch_nearest_cache(model, [4, 5])
         self.assertEqual(c, [MockCache("test4")])
-        self.assertEqual(t, [])
+        self.assertEqual(t, [5])
 
         cache.insert_cache(model, [5, 6], [MockCache("test5")])
         cache.insert_cache(model, [6, 7], [MockCache("test6")])
@@ -670,10 +670,10 @@ class TestLRUPromptCache(unittest.TestCase):
         self.assertEqual(t, [5, 6])
         c, t = cache.fetch_nearest_cache(model, [6, 7])
         self.assertEqual(c, [MockCache("test6")])
-        self.assertEqual(t, [])
+        self.assertEqual(t, [7])
         c, t = cache.fetch_nearest_cache(model, [4, 5])
         self.assertEqual(c, [MockCache("test4")])
-        self.assertEqual(t, [])
+        self.assertEqual(t, [5])
 
     def test_insert_trimmable_cache_removes_immediate_prefix(self):
         cache = LRUPromptCache(max_size=10)

--- a/tests/test_state_checkpoint_trim.py
+++ b/tests/test_state_checkpoint_trim.py
@@ -1,0 +1,426 @@
+# Copyright © 2026 Apple Inc.
+"""Prefix-cache trim for linear-attention hybrid caches.
+
+Hybrid models (Qwen3-Next / Kimi-Linear class) mix ArraysCache (recurrent
+state, not trimmable backward) with KVCache. These tests cover the
+prefill-time state checkpoints recorded on ArraysCache and the coordinated
+partial trim that lands on a checkpoint boundary, including the
+LRUPromptCache reuse path the server drives.
+"""
+
+import copy
+import importlib
+import os
+import unittest
+
+# Keep fp32 GEMMs off the TF32 path so the checkpoint-restore
+# equivalence checks stay fp32-exact on M5-class devices.
+os.environ.setdefault("MLX_ENABLE_TF32", "0")
+
+import mlx.core as mx
+
+from mlx_lm.models.cache import (
+    ArraysCache,
+    KVCache,
+    LRUPromptCache,
+    RotatingKVCache,
+    achievable_trim,
+    can_trim_prompt_cache,
+    make_prompt_cache,
+    record_state_checkpoints,
+    trim_prompt_cache,
+)
+
+QWEN3_NEXT_CONFIG = {
+    "model_type": "qwen3_next",
+    "hidden_size": 128,
+    "num_hidden_layers": 4,
+    "intermediate_size": 128,
+    "num_attention_heads": 8,
+    "num_key_value_heads": 4,
+    "vocab_size": 1000,
+    "linear_num_value_heads": 4,
+    "linear_num_key_heads": 4,
+    "linear_key_head_dim": 32,
+    "linear_value_head_dim": 32,
+    "linear_conv_kernel_dim": 3,
+    "num_experts": 4,
+    "num_experts_per_tok": 2,
+    "decoder_sparse_step": 1,
+    "shared_expert_intermediate_size": 128,
+    "mlp_only_layers": [0],
+    "moe_intermediate_size": 128,
+    "rms_norm_eps": 1e-5,
+    "head_dim": 64,
+    "rope_theta": 1000.0,
+    "partial_rotary_factor": 0.5,
+    "max_position_embeddings": 1000,
+}
+
+KIMI_LINEAR_CONFIG = {
+    "model_type": "kimi_linear",
+    "vocab_size": 1000,
+    "hidden_size": 128,
+    "num_hidden_layers": 4,
+    "num_attention_heads": 8,
+    "num_key_value_heads": 4,
+    "intermediate_size": 128,
+    "head_dim": 32,
+    "rope_theta": 100.0,
+    "rms_norm_eps": 1e-6,
+    "linear_attn_config": {
+        "num_heads": 8,
+        "head_dim": 32,
+        "kda_layers": [1],
+    },
+    "model_max_length": 1000,
+    "num_experts": 2,
+    "moe_intermediate_size": 128,
+    "kv_lora_rank": 8,
+    "qk_nope_head_dim": 16,
+    "qk_rope_head_dim": 16,
+    "v_head_dim": 16,
+}
+
+
+def make_model(config):
+    arch = importlib.import_module(f"mlx_lm.models.{config['model_type']}")
+    model = arch.Model(arch.ModelArgs.from_dict(config))
+    model.eval()
+    return model
+
+
+def prefill(model, cache, tokens, chunk):
+    """Chunked prefill mirroring generate_step: record a checkpoint at every
+    chunk boundary and force one at the end. Returns the last chunk logits."""
+    base = max((c.size() for c in cache), default=0)
+    logits = None
+    processed = 0
+    for i in range(0, len(tokens), chunk):
+        seg = mx.array(tokens[i : i + chunk])[None]
+        logits = model(seg, cache=cache)
+        mx.eval(logits, [c.state for c in cache])
+        processed += seg.shape[1]
+        record_state_checkpoints(cache, [base + processed])
+    if processed > 0:
+        record_state_checkpoints(cache, [base + processed], force=True)
+    return logits
+
+
+def greedy(model, cache, last_logits, n):
+    ids = []
+    y = mx.argmax(last_logits[:, -1, :], axis=-1)
+    for _ in range(n):
+        ids.append(int(y.item()))
+        logits = model(y[None], cache=cache)
+        y = mx.argmax(logits[:, -1, :], axis=-1)
+    return ids
+
+
+class TestStateCheckpointTrim(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls._env = {
+            k: os.environ.get(k)
+            for k in ("MLX_LM_STATE_CHECKPOINT_STRIDE", "MLX_LM_STATE_CHECKPOINT_MAX")
+        }
+        os.environ["MLX_LM_STATE_CHECKPOINT_STRIDE"] = "32"
+        os.environ["MLX_LM_STATE_CHECKPOINT_MAX"] = "8"
+
+    @classmethod
+    def tearDownClass(cls):
+        for k, v in cls._env.items():
+            if v is None:
+                os.environ.pop(k, None)
+            else:
+                os.environ[k] = v
+
+    # ---------------- synthetic caches ----------------
+
+    def _synthetic_hybrid(self, boundaries):
+        """KVCache + ArraysCache advanced through the given chunk boundaries."""
+        kv = KVCache()
+        ar = ArraysCache(size=2)
+        cache = [kv, ar]
+        states = {}
+        pos = 0
+        for b in boundaries:
+            n = b - pos
+            k = mx.random.normal((1, 2, n, 4))
+            kv.update_and_fetch(k, k)
+            ar[0] = mx.random.normal((1, 3))
+            ar[1] = mx.random.normal((1, 5))
+            pos = b
+            record_state_checkpoints(cache, [pos])
+            states[pos] = [mx.array(ar[0]), mx.array(ar[1])]
+        record_state_checkpoints(cache, [pos], force=True)
+        return cache, states
+
+    def test_partial_trim_lands_on_checkpoint(self):
+        cache, states = self._synthetic_hybrid([32, 64, 96, 113])
+        kv, ar = cache
+        self.assertFalse(can_trim_prompt_cache(cache))
+
+        # Requested landing 95 is between checkpoints; snaps back to 64.
+        self.assertEqual(achievable_trim(cache, 18), (64, 49))
+        # Exact-checkpoint landing stays exact.
+        self.assertEqual(achievable_trim(cache, 17), (96, 17))
+
+        n = trim_prompt_cache(cache, 18, allow_partial=True)
+        self.assertEqual(n, 49)
+        self.assertEqual(kv.offset, 64)
+        for got, want in zip([ar[0], ar[1]], states[64]):
+            self.assertTrue(mx.allclose(got, want).item())
+        # Checkpoints past the landing were dropped.
+        self.assertEqual(ar.snap_trim_position(1000), 64)
+
+    def test_partial_trim_is_opt_in(self):
+        cache, _ = self._synthetic_hybrid([32, 64])
+        kv, ar = cache
+        state_before = [mx.array(ar[0]), mx.array(ar[1])]
+        self.assertEqual(trim_prompt_cache(cache, 10), 0)
+        self.assertEqual(kv.offset, 64)
+        for got, want in zip([ar[0], ar[1]], state_before):
+            self.assertTrue(mx.allclose(got, want).item())
+
+    def test_trim_below_oldest_checkpoint_resets(self):
+        cache, _ = self._synthetic_hybrid([32, 64])
+        kv, ar = cache
+        # target 54 -> lands on the checkpoint at 32
+        n = trim_prompt_cache(cache, 10, allow_partial=True)
+        self.assertEqual(n, 32)
+        self.assertEqual(kv.offset, 32)
+        # target 12 is below every checkpoint -> full reset
+        n = trim_prompt_cache(cache, 20, allow_partial=True)
+        self.assertEqual(n, 32)
+        self.assertEqual(kv.offset, 0)
+        self.assertTrue(ar.empty())
+
+    def test_checkpoint_cap_and_thinning(self):
+        os.environ["MLX_LM_STATE_CHECKPOINT_MAX"] = "3"
+        try:
+            cache, _ = self._synthetic_hybrid([32, 64, 96, 128, 160, 192])
+            ar = cache[1]
+            lane = ar._checkpoints[0]
+            self.assertLessEqual(len(lane), 3)
+            # The newest (end-of-prefill) checkpoint always survives.
+            self.assertEqual(lane[-1][0], 192)
+        finally:
+            os.environ["MLX_LM_STATE_CHECKPOINT_MAX"] = "8"
+
+    def test_disabled_via_env(self):
+        os.environ["MLX_LM_STATE_CHECKPOINT_MAX"] = "0"
+        try:
+            cache, _ = self._synthetic_hybrid([32, 64])
+            ar = cache[1]
+            self.assertEqual(ar._checkpoints, [])
+            # Only the implicit empty state remains reachable.
+            self.assertEqual(achievable_trim(cache, 10), (0, 64))
+        finally:
+            os.environ["MLX_LM_STATE_CHECKPOINT_MAX"] = "8"
+
+    def test_deepcopy_preserves_checkpoints(self):
+        cache, states = self._synthetic_hybrid([32, 64, 96])
+        clone = copy.deepcopy(cache)
+        # target 56 -> lands on the checkpoint at 32
+        n = trim_prompt_cache(clone, 40, allow_partial=True)
+        self.assertEqual(n, 64)
+        for got, want in zip([clone[1][0], clone[1][1]], states[32]):
+            self.assertTrue(mx.allclose(got, want).item())
+        # The original is untouched.
+        self.assertEqual(cache[0].offset, 96)
+        self.assertEqual(cache[1].snap_trim_position(1000), 96)
+
+    # ---------------- rotating (sliding-window) caches ----------------
+
+    def _rotating_hybrid(self, window, boundaries):
+        """KVCache + RotatingKVCache advanced through the given boundaries,
+        recording checkpoints. Returns the caches plus reference window
+        copies (temporal order) captured at every boundary."""
+        kv = KVCache()
+        rot = RotatingKVCache(max_size=window)
+        cache = [kv, rot]
+        refs = {}
+        pos = 0
+        for b in boundaries:
+            n = b - pos
+            k = mx.random.normal((1, 2, n, 4))
+            kv.update_and_fetch(k, k)
+            rot.update_and_fetch(k, k)
+            pos = b
+            record_state_checkpoints(cache, [pos])
+            refs[pos] = (
+                mx.array(rot._temporal_order(rot.keys)),
+                mx.array(rot._temporal_order(rot.values)),
+            )
+        record_state_checkpoints(cache, [pos], force=True)
+        return cache, refs
+
+    def test_rotating_hybrid_partial_trim(self):
+        cache, refs = self._rotating_hybrid(32, [32, 64, 96, 113])
+        kv, rot = cache
+        # The ring has wrapped: not trimmable, so the strict path is closed.
+        self.assertFalse(can_trim_prompt_cache(cache))
+        # size() saturates at the window; the coordinator must use the
+        # absolute position (113), not min(offset, max_size).
+        self.assertEqual(achievable_trim(cache, 18), (64, 49))
+
+        n = trim_prompt_cache(cache, 18, allow_partial=True)
+        self.assertEqual(n, 49)
+        self.assertEqual(kv.offset, 64)
+        self.assertEqual(rot.offset, 64)
+        self.assertTrue(mx.array_equal(rot.keys, refs[64][0]).item())
+        self.assertTrue(mx.array_equal(rot.values, refs[64][1]).item())
+
+        # The restored cache keeps working: advance again and re-trim.
+        k = mx.random.normal((1, 2, 10, 4))
+        kv.update_and_fetch(k, k)
+        rot.update_and_fetch(k, k)
+        n = trim_prompt_cache(cache, 42, allow_partial=True)
+        self.assertEqual(n, 42)  # target 32 is an exact checkpoint
+        self.assertEqual(rot.offset, 32)
+        self.assertTrue(mx.array_equal(rot.keys, refs[32][0]).item())
+
+    def test_rotating_wrapped_without_checkpoints_lands_at_zero(self):
+        os.environ["MLX_LM_STATE_CHECKPOINT_MAX"] = "0"
+        try:
+            cache, _ = self._rotating_hybrid(32, [64])
+        finally:
+            os.environ["MLX_LM_STATE_CHECKPOINT_MAX"] = "8"
+        kv, rot = cache
+        # Only the empty state is reachable; the whole cache is trimmed.
+        self.assertEqual(achievable_trim(cache, 10), (0, 64))
+        n = trim_prompt_cache(cache, 10, allow_partial=True)
+        self.assertEqual(n, 64)
+        self.assertEqual(kv.offset, 0)
+        self.assertIsNone(rot.keys)
+        self.assertEqual(rot.offset, 0)
+
+    def test_rotating_unwrapped_stays_natively_trimmable(self):
+        cache, _ = self._rotating_hybrid(256, [32, 64])
+        kv, rot = cache
+        self.assertTrue(can_trim_prompt_cache(cache))
+        self.assertEqual(trim_prompt_cache(cache, 10), 10)
+        self.assertEqual(rot.offset, 54)
+
+    # ---------------- batch lanes ----------------
+
+    def test_batch_lanes_record_extract_extend(self):
+        ar = ArraysCache(size=1)
+        ar[0] = mx.random.normal((2, 3))
+        record_state_checkpoints([ar], [40, 32], force=True)
+        state0 = mx.array(ar[0])
+        ar[0] = mx.random.normal((2, 3))
+        record_state_checkpoints([ar], [80, 32], force=True)
+
+        # Lane 1 was frozen at 32: only one (monotone) record kept.
+        self.assertEqual([p for p, _ in ar._checkpoints[1]], [32])
+        self.assertEqual([p for p, _ in ar._checkpoints[0]], [40, 80])
+
+        # Batched caches never snap (extract slices them apart first).
+        self.assertIsNone(ar.snap_trim_position(100))
+
+        lane0 = ar.extract(0)
+        self.assertEqual(lane0.snap_trim_position(50), 40)
+        lane0.trim_to_position(40, 40)
+        self.assertTrue(mx.allclose(lane0[0], state0[0:1]).item())
+
+        # extend preserves both sides' histories.
+        other = ArraysCache(size=1)
+        other[0] = mx.random.normal((1, 3))
+        record_state_checkpoints([other], [16], force=True)
+        base = ar.extract(1)
+        base.extend(other)
+        self.assertEqual([p for p, _ in base._checkpoints[0]], [32])
+        self.assertEqual([p for p, _ in base._checkpoints[1]], [16])
+
+        # merge carries per-lane histories back into a batch cache.
+        merged = ArraysCache.merge([lane0, other])
+        self.assertEqual([p for p, _ in merged._checkpoints[0]], [40])
+        self.assertEqual([p for p, _ in merged._checkpoints[1]], [16])
+
+        # filter keeps the selected lanes' histories.
+        merged.filter([1])
+        self.assertEqual([p for p, _ in merged._checkpoints[0]], [16])
+
+    # ---------------- LRU prompt cache path ----------------
+
+    def _lru_roundtrip(self, config):
+        """Serving scenario: stored entry = prompt + generated tail; new
+        request repeats the prompt (regenerate). The fetch must land on a
+        checkpoint and hand back the exact suffix to re-process."""
+        mx.random.seed(0)
+        model = make_model(config)
+        chunk = 32
+        prompt = mx.random.randint(0, config["vocab_size"], (96,)).tolist()
+        tail = mx.random.randint(0, config["vocab_size"], (17,)).tolist()
+        stored_key = prompt + tail
+
+        stored_cache = make_prompt_cache(model)
+        prefill(model, stored_cache, stored_key, chunk)
+        self.assertFalse(can_trim_prompt_cache(stored_cache))
+
+        lru = LRUPromptCache()
+        lru.insert_cache("model-key", stored_key, stored_cache)
+
+        cache, rest = lru.fetch_nearest_cache("model-key", prompt)
+        self.assertIsNotNone(cache)
+        # Landing must be a checkpoint at or before len(prompt) - 1 = 95,
+        # and rest must be exactly the un-cached suffix of the prompt.
+        landed = len(prompt) - len(rest)
+        self.assertEqual(landed, 64)
+        self.assertEqual(rest, prompt[64:])
+
+        # Decode consistency: chunk-aligned landing makes the reused arm
+        # bit-comparable with a fresh prefill of the same prompt.
+        logits_reused = prefill(model, cache, rest, chunk)
+        ids_reused = greedy(model, cache, logits_reused, 5)
+
+        fresh_cache = make_prompt_cache(model)
+        logits_fresh = prefill(model, fresh_cache, prompt, chunk)
+        ids_fresh = greedy(model, fresh_cache, logits_fresh, 5)
+
+        self.assertTrue(
+            mx.allclose(
+                logits_reused[:, -1, :], logits_fresh[:, -1, :], atol=1e-5
+            ).item()
+        )
+        self.assertEqual(ids_reused, ids_fresh)
+
+    def test_lru_fetch_qwen3_next(self):
+        self._lru_roundtrip(QWEN3_NEXT_CONFIG)
+
+    def test_lru_fetch_kimi_linear(self):
+        self._lru_roundtrip(KIMI_LINEAR_CONFIG)
+
+    def test_lru_fetch_prefers_deeper_exact_prefix(self):
+        """If the longer entry's landing is shallower than an exact-prefix
+        entry, the exact-prefix entry wins."""
+        mx.random.seed(1)
+        model = make_model(QWEN3_NEXT_CONFIG)
+        chunk = 32
+        prompt = mx.random.randint(0, 1000, (96,)).tolist()
+        tail = mx.random.randint(0, 1000, (17,)).tolist()
+
+        # Longer entry recorded WITHOUT checkpoints: it can only land at 0.
+        os.environ["MLX_LM_STATE_CHECKPOINT_MAX"] = "0"
+        try:
+            longer_cache = make_prompt_cache(model)
+            prefill(model, longer_cache, prompt + tail, chunk)
+        finally:
+            os.environ["MLX_LM_STATE_CHECKPOINT_MAX"] = "8"
+
+        shorter_cache = make_prompt_cache(model)
+        prefill(model, shorter_cache, prompt[:80], chunk)
+
+        lru = LRUPromptCache()
+        lru.insert_cache("model-key", prompt + tail, longer_cache)
+        lru.insert_cache("model-key", prompt[:80], shorter_cache)
+
+        cache, rest = lru.fetch_nearest_cache("model-key", prompt)
+        self.assertIsNotNone(cache)
+        self.assertEqual(rest, prompt[80:])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_state_checkpoint_trim.py
+++ b/tests/test_state_checkpoint_trim.py
@@ -117,6 +117,15 @@ def greedy(model, cache, last_logits, n):
     return ids
 
 
+def replay(model, cache, ids):
+    """Feed known token ids one step at a time (decode path)."""
+    logits = None
+    for t in ids:
+        logits = model(mx.array([[t]]), cache=cache)
+    mx.eval(logits, [c.state for c in cache])
+    return logits
+
+
 class TestStateCheckpointTrim(unittest.TestCase):
     @classmethod
     def setUpClass(cls):
@@ -420,6 +429,115 @@ class TestStateCheckpointTrim(unittest.TestCase):
         cache, rest = lru.fetch_nearest_cache("model-key", prompt)
         self.assertIsNotNone(cache)
         self.assertEqual(rest, prompt[80:])
+
+
+    # ------- state-level audit + through-decode round trip -------
+
+    def _assert_state_trees_equal(self, a, b):
+        if isinstance(a, mx.array):
+            self.assertTrue(mx.array_equal(a, b).item())
+        elif isinstance(a, (list, tuple)):
+            self.assertEqual(len(a), len(b))
+            for x, y in zip(a, b):
+                self._assert_state_trees_equal(x, y)
+        else:
+            self.assertEqual(a, b)
+
+    def _checkpoint_state_audit(self, config):
+        """Every recorded checkpoint must restore to a state bit-identical
+        to a fresh prefill of the same prefix. Output-level checks alone
+        can hide a wrong-state restore (downstream generations may look
+        plausible and even benchmark-clean), so compare the cache state
+        itself at every landing."""
+        mx.random.seed(3)
+        model = make_model(config)
+        chunk = 32
+        tokens = mx.random.randint(0, config["vocab_size"], (113,)).tolist()
+        cache = make_prompt_cache(model)
+        prefill(model, cache, tokens, chunk)
+        size = max(c.size() for c in cache)
+        self.assertEqual(size, 113)
+
+        for p in (32, 64, 96):
+            landing = achievable_trim(cache, size - p)
+            self.assertIsNotNone(landing)
+            self.assertEqual(landing[0], p)
+
+            trimmed = copy.deepcopy(cache)
+            actual = trim_prompt_cache(trimmed, size - p, allow_partial=True)
+            self.assertEqual(actual, size - p)
+
+            fresh = make_prompt_cache(model)
+            prefill(model, fresh, tokens[:p], chunk)
+            for ct, cf in zip(trimmed, fresh):
+                self.assertEqual(ct.size(), cf.size())
+                self._assert_state_trees_equal(ct.state, cf.state)
+
+    def test_checkpoint_state_audit_qwen3_next(self):
+        self._checkpoint_state_audit(QWEN3_NEXT_CONFIG)
+
+    def test_checkpoint_state_audit_kimi_linear(self):
+        self._checkpoint_state_audit(KIMI_LINEAR_CONFIG)
+
+    def _generation_roundtrip(self, config):
+        """Serving round trip THROUGH decode: prefill -> greedy decode ->
+        store (forced end checkpoint) -> follow-up request reuses the
+        generated prefix -> re-extend -> continue. Guards the
+        wrong-position class of bugs where state committed during decode
+        displaces or contaminates the checkpoint a later request restores.
+        The reference arm replicates the identical computation path
+        (chunked prefill + per-token replay) with no store/fetch/trim, so
+        the reuse machinery must be numerically a no-op: the continuation
+        is required to be token-exact."""
+        mx.random.seed(2)
+        model = make_model(config)
+        chunk = 32
+        vocab = config["vocab_size"]
+        prompt = mx.random.randint(0, vocab, (96,)).tolist()
+        extra = mx.random.randint(0, vocab, (7,)).tolist()
+
+        # Serving pass: prefill, decode 24 tokens, store prompt+generated.
+        cache = make_prompt_cache(model)
+        logits = prefill(model, cache, prompt, chunk)
+        generated = greedy(model, cache, logits, 24)
+        record_state_checkpoints(
+            cache, [max(c.size() for c in cache)], force=True
+        )
+        stored_key = prompt + generated
+        lru = LRUPromptCache()
+        lru.insert_cache("model-key", stored_key, cache)
+
+        # Follow-up: the conversation continues past the generated tail.
+        # The landing must be the forced end-of-generation checkpoint at
+        # 120 — i.e. the decode-produced state is what gets reused.
+        request = stored_key + extra
+        reused, rest = lru.fetch_nearest_cache("model-key", request)
+        self.assertIsNotNone(reused)
+        self.assertEqual(len(request) - len(rest), 120)
+        self.assertEqual(rest, extra)
+
+        logits_reused = prefill(model, reused, rest, chunk)
+        cont_reused = greedy(model, reused, logits_reused, 32)
+
+        # Reference arm: identical computation, no reuse machinery.
+        fresh = make_prompt_cache(model)
+        prefill(model, fresh, prompt, chunk)
+        replay(model, fresh, generated)
+        logits_fresh = prefill(model, fresh, extra, chunk)
+        cont_fresh = greedy(model, fresh, logits_fresh, 32)
+
+        self.assertTrue(
+            mx.allclose(
+                logits_reused[:, -1, :], logits_fresh[:, -1, :], atol=1e-5
+            ).item()
+        )
+        self.assertEqual(cont_reused, cont_fresh)
+
+    def test_generation_roundtrip_token_exact_qwen3_next(self):
+        self._generation_roundtrip(QWEN3_NEXT_CONFIG)
+
+    def test_generation_roundtrip_token_exact_kimi_linear(self):
+        self._generation_roundtrip(KIMI_LINEAR_CONFIG)
 
 
 if __name__ == "__main__":

--- a/tests/test_state_checkpoint_trim.py
+++ b/tests/test_state_checkpoint_trim.py
@@ -542,6 +542,33 @@ class TestStateCheckpointTrim(unittest.TestCase):
     def test_generation_roundtrip_token_exact_kimi_linear(self):
         self._generation_roundtrip(KIMI_LINEAR_CONFIG)
 
+    def test_exact_hit_never_returns_empty_remainder(self):
+        """An exact-key fetch (client retrying an identical prompt) must
+        leave at least one token to re-process — the caller needs
+        last-token logits. Trimmable caches give back the last token
+        (matching the contract of the server-side guard proposed in
+        #1581); hybrids land on their deepest interior checkpoint instead
+        of forcing a recompute from scratch."""
+        cache, _ = self._synthetic_hybrid([32, 64, 96])
+        key = list(range(96))
+        lru = LRUPromptCache()
+        lru.insert_cache("m", key, cache)
+        got, rest = lru.fetch_nearest_cache("m", key)
+        self.assertIsNotNone(got)
+        self.assertGreaterEqual(len(rest), 1)
+        self.assertEqual(len(key) - len(rest), 64)  # deepest ckpt <= 95
+        self.assertEqual(rest, key[64:])
+
+        kv = KVCache()
+        k = mx.random.normal((1, 2, 96, 4))
+        kv.update_and_fetch(k, k)
+        lru2 = LRUPromptCache()
+        lru2.insert_cache("m", key, [kv])
+        got2, rest2 = lru2.fetch_nearest_cache("m", key)
+        self.assertIsNotNone(got2)
+        self.assertEqual(rest2, key[-1:])
+        self.assertEqual(got2[0].offset, 95)
+
     # ------- persistence: checkpoints must survive save/load -------
 
     def _full_hybrid(self, boundaries, window=64):

--- a/tests/test_state_checkpoint_trim.py
+++ b/tests/test_state_checkpoint_trim.py
@@ -11,6 +11,7 @@ LRUPromptCache reuse path the server drives.
 import copy
 import importlib
 import os
+import tempfile
 import unittest
 
 # Keep fp32 GEMMs off the TF32 path so the checkpoint-restore
@@ -26,8 +27,10 @@ from mlx_lm.models.cache import (
     RotatingKVCache,
     achievable_trim,
     can_trim_prompt_cache,
+    load_prompt_cache,
     make_prompt_cache,
     record_state_checkpoints,
+    save_prompt_cache,
     trim_prompt_cache,
 )
 
@@ -538,6 +541,91 @@ class TestStateCheckpointTrim(unittest.TestCase):
 
     def test_generation_roundtrip_token_exact_kimi_linear(self):
         self._generation_roundtrip(KIMI_LINEAR_CONFIG)
+
+    # ------- persistence: checkpoints must survive save/load -------
+
+    def _full_hybrid(self, boundaries, window=64):
+        """KVCache + ArraysCache + wrapped RotatingKVCache advanced through
+        the given chunk boundaries, checkpoints recorded at each."""
+        kv, ar = KVCache(), ArraysCache(size=2)
+        rot = RotatingKVCache(max_size=window, keep=4)
+        cache = [kv, ar, rot]
+        snaps = {}
+        pos = 0
+        for b in boundaries:
+            n = b - pos
+            k = mx.random.normal((1, 2, n, 4))
+            kv.update_and_fetch(k, k)
+            rot.update_and_fetch(k, k)
+            ar[0] = mx.random.normal((1, 3))
+            ar[1] = mx.random.normal((1, 5))
+            pos = b
+            record_state_checkpoints(cache, [pos])
+            snaps[pos] = [mx.array(ar[0]), mx.array(ar[1])]
+        record_state_checkpoints(cache, [pos], force=True)
+        return cache, snaps
+
+    def test_persistence_roundtrip_preserves_checkpoints(self):
+        """A restored cache must land where the in-memory cache lands.
+        Losing checkpoints on save/load makes every restore silently
+        reprocess from zero (a wrapped rotating cache alone drags the
+        whole hybrid's landing to 0)."""
+        mx.random.seed(4)
+        cache, snaps = self._full_hybrid([32, 64, 96, 113])
+        size = max(c.size() for c in cache)
+        self.assertEqual(achievable_trim(cache, size - 96), (96, 17))
+
+        with tempfile.TemporaryDirectory() as d:
+            path = os.path.join(d, "hybrid.safetensors")
+            save_prompt_cache(path, cache)
+            loaded = load_prompt_cache(path)
+
+        self.assertEqual(
+            [type(c).__name__ for c in loaded],
+            ["KVCache", "ArraysCache", "RotatingKVCache"],
+        )
+        lsize = max(c.size() for c in loaded)
+        self.assertEqual(lsize, size)
+        self.assertEqual(achievable_trim(loaded, lsize - 96), (96, 17))
+
+        actual = trim_prompt_cache(loaded, lsize - 96, allow_partial=True)
+        self.assertEqual(actual, 17)
+        for a, b in zip(loaded[1].cache, snaps[96]):
+            self.assertTrue(mx.array_equal(a, b).item())
+
+        # Parity contract: restore-from-disk then trim must equal the pure
+        # in-memory trim of the original cache — every cache, full state
+        # tree, including the rotating window contents.
+        actual_mem = trim_prompt_cache(cache, size - 96, allow_partial=True)
+        self.assertEqual(actual_mem, 17)
+        for cl, cm in zip(loaded, cache):
+            self.assertEqual(cl.size(), cm.size())
+            self._assert_state_trees_equal(cl.state, cm.state)
+
+    def test_persistence_without_checkpoints_stays_legacy(self):
+        """No checkpoints -> the on-disk format is unchanged (legacy state
+        and meta_state shapes), and old files keep loading."""
+        os.environ["MLX_LM_STATE_CHECKPOINT_MAX"] = "0"
+        try:
+            mx.random.seed(5)
+            cache, _ = self._full_hybrid([32, 64])
+        finally:
+            os.environ["MLX_LM_STATE_CHECKPOINT_MAX"] = "8"
+        ar, rot = cache[1], cache[2]
+        self.assertEqual(ar.meta_state, "")
+        self.assertEqual(len(rot.meta_state), 4)
+        self.assertIsInstance(ar.state, list)
+        self.assertTrue(all(isinstance(a, mx.array) for a in ar.state))
+        k, v = rot.state
+        self.assertIsInstance(k, mx.array)
+
+        with tempfile.TemporaryDirectory() as d:
+            path = os.path.join(d, "legacy.safetensors")
+            save_prompt_cache(path, cache)
+            loaded = load_prompt_cache(path)
+        self.assertEqual(max(c.size() for c in loaded), 64)
+        for a, b in zip(loaded[1].cache, cache[1].cache):
+            self.assertTrue(mx.array_equal(a, b).item())
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
### Problem

`can_trim_prompt_cache()` returns `False` for every model whose `make_cache` mixes `ArraysCache` (recurrent state) with KV caches, because recurrent state cannot be trimmed backward — and likewise for a `RotatingKVCache` once the ring has wrapped. As a result the server prompt cache (`LRUPromptCache.fetch_nearest_cache`) can never reuse a longer stored entry for these models: the common "regenerate" and "edited message" request shapes re-prefill the entire shared prefix.

That covers a large and growing class: `qwen3_next`, `kimi_linear`, `falcon_h1`, `jamba`, `lfm2`/`lfm2_moe`, `nemotron_h`, `mamba`/`mamba2`, `plamo2`, `rwkv7`, `granitemoehybrid`, `bailing_moe_linear`, `baichuan_m1`, `qwen3_5`/`qwen3_5_moe`, plus sliding-window/SWA models past their window.

SGLang recently merged the analogous capability for KDA/mamba prefix caching (sgl-project/sglang#31474) using chunk-boundary state snapshots; this PR brings the same capability to mlx-lm's prompt cache, so prefix caching works for this class — including day-0 support for upcoming hybrid releases.

### Approach

- **`ArraysCache` records bounded state checkpoints at prefill chunk boundaries.** The prefill loops (`generate_step`, speculative `_prefill`, `PromptBatch.prompt`) call `record_state_checkpoints(cache, positions)` after each chunk's `mx.eval`, and force-record the end-of-prefill boundary — which is exactly `len(prompt) - 1`, the landing position of a regenerate-style trim, so the most common trim is exact.
- **`RotatingKVCache` records temporal-order window copies at the same boundaries** — bounded by the window size, not the context length — so a wrapped ring can land a trim on a recorded boundary instead of being excluded from reuse. Unwrapped rings keep their native exact trim. (The trim coordinator anchors on absolute positions, since `RotatingKVCache.size()` saturates at `max_size`.)
- **`trim_prompt_cache(cache, n, allow_partial=True)`** finds the newest position `<= size - n` that every cache in the list can restore (`snap_trim_position` fixpoint), restores checkpointed layers, trims exactly-trimmable layers by the same amount, and returns the **actual** trimmed count (`>= n`). Position 0 (empty state) is always restorable, so the worst case degrades to a full re-prefill — never a wrong answer. `allow_partial` defaults to `False`: speculative-decoding rewinds and every existing caller are unchanged.
- **`fetch_nearest_cache`** dry-runs the landing (`achievable_trim`), prefers a longer entry only when it lands deeper than the best exact-prefix entry, and computes the un-cached suffix from the actual landing.
- **Per-lane checkpoint storage.** `ArraysCache` checkpoints are `(position, batch-size-1 array copies)` per lane, so batch `extend`/`filter`/`merge`/`extract` carry histories across lane membership changes in the batch server with plain list operations (`mx.array` of a slice is a true copy — snapshots don't pin batch buffers).
- **Bounded memory, accounted.** `MLX_LM_STATE_CHECKPOINT_STRIDE` (default 2048 tokens) and `MLX_LM_STATE_CHECKPOINT_MAX` (default 4 per lane; `0` disables). Thinning drops the checkpoint with the smallest predecessor gap (never the newest). Checkpoint bytes count toward `nbytes`, so `--prompt-cache-bytes` limits include them. For scale: a Qwen3-Next-80B state checkpoint is ~77 MB (context-independent), so the default cap adds at most ~310 MB per cached entry on the largest models, proportionally less on smaller ones; rotating-window copies are bounded by the window plus at most one prefill chunk.

### Correctness

- `tests/test_state_checkpoint_trim.py` (13 tests): coordinated-trim landings, opt-in gating, cap/thinning, env disable, deepcopy, batch-lane carry through `extend`/`filter`/`merge`/`extract`, sliding-window restore (exact window equality after a wrapped-ring landing, reset semantics, unwrapped native trim preserved), and end-to-end `LRUPromptCache` reuse with decode-consistency (greedy token match + logits allclose) on tiny random-weight `qwen3_next` and `kimi_linear`.
- Validated on real models (M-series, 4-bit `Kimi-Linear-48B-A3B-Instruct` and `Qwen3-Next-80B-A3B-Instruct`): trimmed-and-reprocessed decode is **bit-exact** vs a fresh prefill with shared chunk boundaries (max |Δlogits| = 0.0, greedy-32 identical) for both the regenerate and edited-turn scenarios. Regenerating a 3k-token conversation drops from 2.0–2.5s (fresh prefill) to 0.3–0.6s (reuse).
- `tests/test_prompt_cache.py`, `tests/test_server.py`, `tests/test_generate.py` pass unchanged.

### Supersedes #1515, #1516, #1517

The anchor-stride series (#1515–#1517) targets the same problem by deep-copying the entire prompt cache at stride positions and storing the copies as extra shorter-prefix LRU entries. This PR reaches the same landings at strictly lower cost, so I'd like to close that series in favor of this one:

- **Memory per landing point**: anchors copy the whole cache (all KV + state, growing with context) and multiply LRU entries; checkpoints copy only what cannot be re-derived — recurrent state (context-independent) and the bounded rotating window — inside the existing entry. Exactly-trimmable KV layers need no copies at all.
- **Batch path**: native here (per-lane histories survive lane churn), vs the separate capture machinery in #1517.
- **Coverage**: identical, including wrapped sliding-window caches.

### Related open PRs

- #1502 adds reuse-correctness guards in the same region (`trim_prompt_cache` return accounting, `fetch_nearest_cache` refusing inexact trims). The landing-aware fetch here enforces the same invariant — never serve KV inconsistent with the keyed prefix — while additionally allowing checkpoint landings with the suffix recomputed from the actual trim. Happy to rebase whichever lands second.
- #1486 (rollback cache API) touches `ArraysCache.__new__` — textual-only overlap, the features are complementary and coexist cleanly; same offer.

### Not included (possible follow-up)

Checkpoints are in-memory only: `save_prompt_cache`/`load_prompt_cache` drop them, so trims on caches loaded from disk land at 0. Persisting them (a versioned state layout) works — we run it in our fork — but it changes the saved-cache format, so it's split out.
