### PR TITLE
Detect and recover from livelocked batch generation (#1493)

### DIFF
--- a/mlx_lm/generate.py
+++ b/mlx_lm/generate.py
@@ -1147,12 +1147,12 @@ class PromptProcessingBatch:
         if not any(self.samplers):
             self.samplers = [None] * len(self.uids)
         if not any(self.logits_processors):
-            self.logits_processors = [None] * len(self.uids)
+            self.logits_processors = [[]] * len(self.uids)
         samplers = batch.samplers if any(batch.samplers) else [None] * len(batch.uids)
         logits_processors = (
             batch.logits_processors
             if any(batch.logits_processors)
-            else [None] * len(batch.uids)
+            else [[]] * len(batch.uids)
         )
 
         self.uids.extend(batch.uids)

--- a/mlx_lm/server.py
+++ b/mlx_lm/server.py
@@ -674,50 +674,51 @@ class ResponseGenerator:
                         prompt, segments, segment_types, initial_state = self._tokenize(
                             current_tokenizer, request, args
                         )
+
+                        stop_matcher, text_sm = self._make_state_machine(
+                            self.model_provider.model_key,
+                            tokenizer,
+                            args.stop_words,
+                        )
+
+                        self._log_cache_stats()
+                        cache, rest = self.prompt_cache.fetch_nearest_cache(
+                            current_model_key, prompt
+                        )
+                        prompt_cache_count = len(prompt) - len(rest)
+                        N = prompt_cache_count
+                        while N > 0:
+                            if N >= len(segments[0]):
+                                N -= len(segments.pop(0))
+                                segment_types.pop(0)
+                            else:
+                                segments[0] = segments[0][N:]
+                                break
+
+                        ctx = GenerationContext(
+                            has_tool_calling=tokenizer.has_tool_calling,
+                            has_thinking=tokenizer.has_thinking,
+                            tool_parser=tokenizer.tool_parser,
+                            text_sm=text_sm,
+                            initial_state=initial_state,
+                            prompt=prompt,
+                            prompt_cache_count=prompt_cache_count,
+                        )
+
+                        (uid,) = batch_generator.insert_segments(
+                            segments=[segments],
+                            max_tokens=[args.max_tokens],
+                            caches=[cache],
+                            all_tokens=[prompt[:prompt_cache_count]],
+                            samplers=[_make_sampler(args, tokenizer)],
+                            logits_processors=[_make_logits_processors(args)],
+                            stop_matchers=[stop_matcher],
+                        )
                     except Exception as e:
                         rqueue.put(e)
                         continue
 
-                    stop_matcher, text_sm = self._make_state_machine(
-                        self.model_provider.model_key,
-                        tokenizer,
-                        args.stop_words,
-                    )
-
-                    self._log_cache_stats()
-                    cache, rest = self.prompt_cache.fetch_nearest_cache(
-                        current_model_key, prompt
-                    )
-                    prompt_cache_count = len(prompt) - len(rest)
-                    N = prompt_cache_count
-                    while N > 0:
-                        if N >= len(segments[0]):
-                            N -= len(segments.pop(0))
-                            segment_types.pop(0)
-                        else:
-                            segments[0] = segments[0][N:]
-                            break
-
-                    ctx = GenerationContext(
-                        has_tool_calling=tokenizer.has_tool_calling,
-                        has_thinking=tokenizer.has_thinking,
-                        tool_parser=tokenizer.tool_parser,
-                        text_sm=text_sm,
-                        initial_state=initial_state,
-                        prompt=prompt,
-                        prompt_cache_count=prompt_cache_count,
-                    )
                     rqueue.put(ctx)
-
-                    (uid,) = batch_generator.insert_segments(
-                        segments=[segments],
-                        max_tokens=[args.max_tokens],
-                        caches=[cache],
-                        all_tokens=[prompt[:prompt_cache_count]],
-                        samplers=[_make_sampler(args, tokenizer)],
-                        logits_processors=[_make_logits_processors(args)],
-                        stop_matchers=[stop_matcher],
-                    )
                     batch_results[uid] = {
                         "ctx": ctx,
                         "rqueue": rqueue,
@@ -773,97 +774,121 @@ class ResponseGenerator:
 
             # No request so serve from the current batch
             elif batch_generator is not None:
-                if len(batch_results) == 0:
-                    if drain_batch:
-                        current_model = None
-                        current_sampling = None
-                        current_tokenizer = None
-                        current_model_key = None
-                        batch_generator.close()
-                        batch_generator = None
-                        drain_batch = False
-                    continue
+                try:
+                    if len(batch_results) == 0:
+                        if drain_batch:
+                            current_model = None
+                            current_sampling = None
+                            current_tokenizer = None
+                            current_model_key = None
+                            batch_generator.close()
+                            batch_generator = None
+                            drain_batch = False
+                        continue
 
-                uids_to_remove = []
-                for _ in self._time_budget:
-                    prompt_responses, gen_responses = batch_generator.next()
-                    if not prompt_responses and not gen_responses:
-                        break
+                    uids_to_remove = []
+                    for _ in self._time_budget:
+                        prompt_responses, gen_responses = batch_generator.next()
+                        if not prompt_responses and not gen_responses:
+                            break
 
-                    # Progress report for prompt processing
-                    for r in prompt_responses:
-                        result = batch_results[r.uid]
-                        result["rqueue"].put(r.progress)
-                        if result["ctx"]._should_stop:
-                            uids_to_remove.append(r.uid)
+                        # Progress report for prompt processing
+                        for r in prompt_responses:
+                            result = batch_results[r.uid]
+                            result["rqueue"].put(r.progress)
+                            if result["ctx"]._should_stop:
+                                uids_to_remove.append(r.uid)
 
-                    # Save the caches at end of segments
-                    eos_ids = [
-                        r.uid
-                        for r in prompt_responses
-                        if r.end_of_segment
-                        and not r.end_of_prompt
-                        and batch_results[r.uid]["segment_types"]
-                    ]
-                    caches = batch_generator.extract_cache(eos_ids)
-                    for uid, (cache, cache_key) in caches.items():
-                        self.prompt_cache.insert_cache(
-                            self.model_provider.model_key,
-                            cache_key[:],
-                            cache,
-                            cache_type=batch_results[uid]["segment_types"].pop(),
-                        )
-                    del caches
-
-                    for r in gen_responses:
-                        result = batch_results[r.uid]
-
-                        # Don't decode the final stop token
-                        if r.finish_reason == "stop":
-                            result["detokenizer"].finalize()
-                            text = result["detokenizer"].last_segment
-                        elif r.finish_reason == "length":
-                            result["detokenizer"].add_token(r.token)
-                            result["detokenizer"].finalize()
-                            text = result["detokenizer"].last_segment
-                        else:
-                            result["detokenizer"].add_token(r.token)
-                            text = result["detokenizer"].last_segment
-
-                        result["rqueue"].put(
-                            Response(
-                                text,
-                                r.token,
-                                r.logprobs[r.token].item(),
-                                r.finish_reason,
-                                _format_top_logprobs(
-                                    r.logprobs,
-                                    result["top_logprobs"],
-                                    current_tokenizer,
-                                ),
-                            )
-                        )
-
-                        if r.finish_reason is not None:
-                            result["rqueue"].put(None)
+                        # Save the caches at end of segments
+                        eos_ids = [
+                            r.uid
+                            for r in prompt_responses
+                            if r.end_of_segment
+                            and not r.end_of_prompt
+                            and batch_results[r.uid]["segment_types"]
+                        ]
+                        caches = batch_generator.extract_cache(eos_ids)
+                        for uid, (cache, cache_key) in caches.items():
                             self.prompt_cache.insert_cache(
-                                current_model_key,
-                                r.all_tokens[:],
-                                r.prompt_cache,
-                                cache_type="assistant",
+                                self.model_provider.model_key,
+                                cache_key[:],
+                                cache,
+                                cache_type=batch_results[uid]["segment_types"].pop(),
                             )
-                            del batch_results[r.uid]
+                        del caches
 
-                        if result["ctx"]._should_stop:
-                            uids_to_remove.append(r.uid)
+                        for r in gen_responses:
+                            result = batch_results[r.uid]
 
-                uids_to_remove = self._share_object(uids_to_remove)
-                if uids_to_remove:
-                    batch_generator.remove(uids_to_remove)
-                    for uid in uids_to_remove:
-                        # It may have already been removed during
-                        # generation
-                        batch_results.pop(uid, None)
+                            # Don't decode the final stop token
+                            if r.finish_reason == "stop":
+                                result["detokenizer"].finalize()
+                                text = result["detokenizer"].last_segment
+                            elif r.finish_reason == "length":
+                                result["detokenizer"].add_token(r.token)
+                                result["detokenizer"].finalize()
+                                text = result["detokenizer"].last_segment
+                            else:
+                                result["detokenizer"].add_token(r.token)
+                                text = result["detokenizer"].last_segment
+
+                            result["rqueue"].put(
+                                Response(
+                                    text,
+                                    r.token,
+                                    r.logprobs[r.token].item(),
+                                    r.finish_reason,
+                                    _format_top_logprobs(
+                                        r.logprobs,
+                                        result["top_logprobs"],
+                                        current_tokenizer,
+                                    ),
+                                )
+                            )
+
+                            if r.finish_reason is not None:
+                                result["rqueue"].put(None)
+                                self.prompt_cache.insert_cache(
+                                    current_model_key,
+                                    r.all_tokens[:],
+                                    r.prompt_cache,
+                                    cache_type="assistant",
+                                )
+                                del batch_results[r.uid]
+
+                            if result["ctx"]._should_stop:
+                                uids_to_remove.append(r.uid)
+
+                    uids_to_remove = self._share_object(uids_to_remove)
+                    if uids_to_remove:
+                        batch_generator.remove(uids_to_remove)
+                        for uid in uids_to_remove:
+                            # It may have already been removed during
+                            # generation
+                            batch_results.pop(uid, None)
+                except Exception as e:
+                    # An uncaught exception here used to kill the generation
+                    # thread while the HTTP threads kept accepting requests
+                    # that could never be answered. Fail the in-flight
+                    # requests and keep serving; queued requests are retried
+                    # with a fresh batch generator.
+                    logging.exception(
+                        "Generation batch failed. Failing the in-flight "
+                        "requests and continuing to serve."
+                    )
+                    for result in batch_results.values():
+                        result["rqueue"].put(e)
+                    batch_results = {}
+                    try:
+                        batch_generator.close()
+                    except Exception:
+                        logging.exception("Failed to close the batch generator.")
+                    batch_generator = None
+                    current_model = None
+                    current_sampling = None
+                    current_tokenizer = None
+                    current_model_key = None
+                    drain_batch = False
 
     def _serve_single(self, request):
         rqueue, request, args = request
@@ -978,6 +1003,11 @@ class ResponseGenerator:
         generation_args: GenerationArguments,
         progress_callback: Optional[Callable[[int, int], None]] = None,
     ):
+        if not self._generation_thread.is_alive():
+            raise RuntimeError(
+                "The generation thread is not running. The server needs to "
+                "be restarted."
+            )
         response_queue = Queue()
         self.requests.put((response_queue, request, generation_args))
 

--- a/mlx_lm/server.py
+++ b/mlx_lm/server.py
@@ -644,6 +644,26 @@ class ResponseGenerator:
         # anything to any request -- a livelock. Thread liveness and a
         # naive per-iteration heartbeat both miss this; only delivery
         # staleness catches it.
+        #
+        # Two deliberate scoping choices, worth calling out explicitly:
+        #
+        # 1. This is one timestamp for the whole generator, not one per
+        #    request. It is refreshed by delivery to *any* uid, so ongoing
+        #    admissions or progress on other requests postpone recovery for
+        #    a single wedged request in the same batch. That is intentional:
+        #    the goal is to bound an engine-wide livelock (the batch loop
+        #    itself makes no forward progress for anyone -- the #1493
+        #    failure mode), not to guarantee a per-request delivery SLA. A
+        #    per-request stall inside an otherwise-healthy batch is a
+        #    different problem and is out of scope here.
+        #
+        # 2. "Delivered" means put onto this process's internal per-request
+        #    queue, i.e. handed off to the HTTP handler thread that owns
+        #    that request. It does not mean the bytes reached the client
+        #    (SSE flush, socket write, etc.); that layer is downstream of
+        #    this thread and isn't observable from here. This is the
+        #    correct boundary for detecting a stalled *generation engine*,
+        #    but it does not, by itself, prove client-visible progress.
         last_delivery = time.monotonic()
 
         unprocessed_requests = []
@@ -663,10 +683,26 @@ class ResponseGenerator:
             nonlocal batch_results, batch_generator, current_model
             nonlocal current_sampling, current_tokenizer, current_model_key
             nonlocal drain_batch, last_delivery
+            # Fail every in-flight request's queue first, before touching
+            # the batch generator at all: if close() below ends up blocking
+            # (see note there), the requests we already know about are
+            # still unblocked on their own error rather than waiting on a
+            # recovery step that may itself be stuck.
             for result in batch_results.values():
                 result["rqueue"].put(exc)
             batch_results = {}
             try:
+                # BatchGenerator.close() calls mx.synchronize(self._stream)
+                # when a wired memory limit was set (the Metal path). If
+                # the generation stream itself is what's wedged, that
+                # synchronize could block here too, on this same thread,
+                # with no timeout -- which would turn "detected and reset
+                # the batch" into "the generation thread is now stuck in
+                # recovery instead." This has not been observed in
+                # practice (the reproduced #1493 failure is an *iterating*
+                # livelock, where the stream keeps completing steps, just
+                # without delivering output); it is a documented risk for
+                # a stream-level hang specifically, not a confirmed one.
                 batch_generator.close()
             except Exception:
                 logging.exception("Failed to close the batch generator.")
@@ -826,6 +862,20 @@ class ResponseGenerator:
                     # a real-world failure mode in #1493. is_alive() and a
                     # per-iteration heartbeat both stay green through this;
                     # only "nothing delivered in N seconds" catches it.
+                    #
+                    # This check runs on the generation thread itself,
+                    # between calls to batch_generator.next(), not
+                    # concurrently with them: it is checked here, before
+                    # entering the inner loop below, and again on the next
+                    # trip through this outer while loop once next()
+                    # returns. There is no separate supervisor thread that
+                    # could interrupt a next() call from the outside. That
+                    # means this bounds an *iterating* livelock (next()
+                    # keeps returning, just without ever delivering
+                    # anything) but cannot recover from a single next()
+                    # call that blocks and never returns at all -- the
+                    # generation thread is inside that call and can't run
+                    # this check again until it comes back.
                     stall_timeout = self.cli_args.generation_stall_timeout
                     if (
                         stall_timeout > 0

--- a/mlx_lm/server.py
+++ b/mlx_lm/server.py
@@ -638,6 +638,14 @@ class ResponseGenerator:
         drain_batch = False
         batch_results = {}
 
+        # Wall-clock time a token, prompt-progress update, or admission ack
+        # was last actually handed to a consumer queue. A batch loop can
+        # keep iterating (and burning real CPU/GPU) while never delivering
+        # anything to any request -- a livelock. Thread liveness and a
+        # naive per-iteration heartbeat both miss this; only delivery
+        # staleness catches it.
+        last_delivery = time.monotonic()
+
         unprocessed_requests = []
 
         def get_next_request(timeout=None):
@@ -645,6 +653,30 @@ class ResponseGenerator:
                 return unprocessed_requests.pop()
             else:
                 return self._next_request(timeout)
+
+        def _reset_batch(exc):
+            # Shared recovery for both an outright exception in the batch
+            # loop and a detected delivery stall: fail every in-flight
+            # request with an explicit error, drop the batch generator, and
+            # let the loop start fresh. Queued-but-not-yet-admitted
+            # requests are retried against a new batch generator.
+            nonlocal batch_results, batch_generator, current_model
+            nonlocal current_sampling, current_tokenizer, current_model_key
+            nonlocal drain_batch, last_delivery
+            for result in batch_results.values():
+                result["rqueue"].put(exc)
+            batch_results = {}
+            try:
+                batch_generator.close()
+            except Exception:
+                logging.exception("Failed to close the batch generator.")
+            batch_generator = None
+            current_model = None
+            current_sampling = None
+            current_tokenizer = None
+            current_model_key = None
+            drain_batch = False
+            last_delivery = time.monotonic()
 
         if self._is_distributed:
             seed = mx.distributed.all_sum(mx.random.state[0]).view(mx.uint64).item()
@@ -719,6 +751,7 @@ class ResponseGenerator:
                         continue
 
                     rqueue.put(ctx)
+                    last_delivery = time.monotonic()
                     batch_results[uid] = {
                         "ctx": ctx,
                         "rqueue": rqueue,
@@ -786,6 +819,27 @@ class ResponseGenerator:
                             drain_batch = False
                         continue
 
+                    # Detect a livelocked batch: the loop below can keep
+                    # calling batch_generator.next() and doing real work
+                    # (forward pass, eval sync) indefinitely without ever
+                    # putting anything on a request's queue -- reported as
+                    # a real-world failure mode in #1493. is_alive() and a
+                    # per-iteration heartbeat both stay green through this;
+                    # only "nothing delivered in N seconds" catches it.
+                    stall_timeout = self.cli_args.generation_stall_timeout
+                    if (
+                        stall_timeout > 0
+                        and time.monotonic() - last_delivery > stall_timeout
+                    ):
+                        stall_exc = RuntimeError(
+                            "generation stalled: no output delivered for "
+                            f"{stall_timeout:.0f}s; failing in-flight "
+                            "requests and resetting the batch"
+                        )
+                        logging.warning(str(stall_exc))
+                        _reset_batch(stall_exc)
+                        continue
+
                     uids_to_remove = []
                     for _ in self._time_budget:
                         prompt_responses, gen_responses = batch_generator.next()
@@ -796,6 +850,7 @@ class ResponseGenerator:
                         for r in prompt_responses:
                             result = batch_results[r.uid]
                             result["rqueue"].put(r.progress)
+                            last_delivery = time.monotonic()
                             if result["ctx"]._should_stop:
                                 uids_to_remove.append(r.uid)
 
@@ -845,9 +900,11 @@ class ResponseGenerator:
                                     ),
                                 )
                             )
+                            last_delivery = time.monotonic()
 
                             if r.finish_reason is not None:
                                 result["rqueue"].put(None)
+                                last_delivery = time.monotonic()
                                 self.prompt_cache.insert_cache(
                                     current_model_key,
                                     r.all_tokens[:],
@@ -876,19 +933,7 @@ class ResponseGenerator:
                         "Generation batch failed. Failing the in-flight "
                         "requests and continuing to serve."
                     )
-                    for result in batch_results.values():
-                        result["rqueue"].put(e)
-                    batch_results = {}
-                    try:
-                        batch_generator.close()
-                    except Exception:
-                        logging.exception("Failed to close the batch generator.")
-                    batch_generator = None
-                    current_model = None
-                    current_sampling = None
-                    current_tokenizer = None
-                    current_model_key = None
-                    drain_batch = False
+                    _reset_batch(e)
 
     def _serve_single(self, request):
         rqueue, request, args = request
@@ -1863,6 +1908,18 @@ def main():
         type=int,
         default=2048,
         help="Step size for prefill processing (default: 2048)",
+    )
+    parser.add_argument(
+        "--generation-stall-timeout",
+        type=float,
+        default=60.0,
+        help=(
+            "Seconds without any output delivered to a request before the "
+            "batch generation loop is treated as stalled (livelocked) and "
+            "reset: in-flight requests fail with an explicit error and the "
+            "server keeps serving without a restart. Set to 0 to disable. "
+            "(default: 60.0)"
+        ),
     )
     parser.add_argument(
         "--prompt-cache-size",

--- a/mlx_lm/server.py
+++ b/mlx_lm/server.py
@@ -640,10 +640,10 @@ class ResponseGenerator:
 
         # Wall-clock time a token, prompt-progress update, or admission ack
         # was last actually handed to a consumer queue. A batch loop can
-        # keep iterating (and burning real CPU/GPU) while never delivering
-        # anything to any request -- a livelock. Thread liveness and a
-        # naive per-iteration heartbeat both miss this; only delivery
-        # staleness catches it.
+        # keep iterating (and burning real CPU/GPU) while delivering
+        # nothing to *any* in-flight request -- a generator-wide delivery
+        # drought. Thread liveness and a naive per-iteration heartbeat both
+        # miss this; only delivery staleness catches it.
         #
         # Two deliberate scoping choices, worth calling out explicitly:
         #
@@ -651,11 +651,29 @@ class ResponseGenerator:
         #    request. It is refreshed by delivery to *any* uid, so ongoing
         #    admissions or progress on other requests postpone recovery for
         #    a single wedged request in the same batch. That is intentional:
-        #    the goal is to bound an engine-wide livelock (the batch loop
-        #    itself makes no forward progress for anyone -- the #1493
-        #    failure mode), not to guarantee a per-request delivery SLA. A
-        #    per-request stall inside an otherwise-healthy batch is a
-        #    different problem and is out of scope here.
+        #    the goal is to bound a generator-wide delivery drought (every
+        #    in-flight request goes silent for `stall_timeout` seconds), not
+        #    to guarantee a per-request delivery SLA. A per-request stall
+        #    inside an otherwise-healthy batch is a different problem and is
+        #    out of scope here.
+        #
+        #    This is narrower than the archived #1493 incident itself, not
+        #    an exact match for it. The July 17 capture (server log,
+        #    06:55:15-06:57:47) shows one decode request wedged while
+        #    prompt-progress for other, unrelated uids kept being delivered
+        #    throughout the hang -- and that unrelated progress refreshes
+        #    this same timestamp. On that captured incident, a 60s
+        #    `stall_timeout` would not have fired until roughly 3.5 minutes
+        #    after the wedge started, and there is no fixed upper bound on
+        #    the delay under regular long-prompt traffic. So: this watchdog
+        #    is a generator-wide-drought detector, and it is a real safety
+        #    net for the case where the whole batch genuinely stops
+        #    delivering; it is not a bounded-time detector for a single
+        #    wedged decode masked by unrelated admission/prefill progress,
+        #    which is the shape #1493 actually captured. See
+        #    `test_stall_watchdog_is_generator_wide_not_per_request` and
+        #    `test_stall_watchdog_prompt_progress_from_other_uid_can_mask_a_wedged_decode`,
+        #    which exercise this masking directly (PR #1598 review).
         #
         # 2. "Delivered" means put onto this process's internal per-request
         #    queue, i.e. handed off to the HTTP handler thread that owns
@@ -699,10 +717,13 @@ class ResponseGenerator:
                 # with no timeout -- which would turn "detected and reset
                 # the batch" into "the generation thread is now stuck in
                 # recovery instead." This has not been observed in
-                # practice (the reproduced #1493 failure is an *iterating*
-                # livelock, where the stream keeps completing steps, just
-                # without delivering output); it is a documented risk for
-                # a stream-level hang specifically, not a confirmed one.
+                # practice: the reproduced #1493 failure is an *iterating*
+                # livelock -- the stream keeps completing steps, and per
+                # the archived capture, other in-flight requests kept
+                # receiving prompt-progress throughout; only the one
+                # wedged decode request's queue went silent. It is a
+                # documented risk for a stream-level hang specifically,
+                # not a confirmed one.
                 batch_generator.close()
             except Exception:
                 logging.exception("Failed to close the batch generator.")
@@ -858,10 +879,13 @@ class ResponseGenerator:
                     # Detect a livelocked batch: the loop below can keep
                     # calling batch_generator.next() and doing real work
                     # (forward pass, eval sync) indefinitely without ever
-                    # putting anything on a request's queue -- reported as
-                    # a real-world failure mode in #1493. is_alive() and a
-                    # per-iteration heartbeat both stay green through this;
-                    # only "nothing delivered in N seconds" catches it.
+                    # putting anything on any request's queue -- a
+                    # generator-wide delivery drought (see the scope note
+                    # at `last_delivery`'s declaration above for how this
+                    # relates to, and differs from, the #1493 incident
+                    # itself). is_alive() and a per-iteration heartbeat
+                    # both stay green through this; only "nothing delivered
+                    # in N seconds" catches it.
                     #
                     # This check runs on the generation thread itself,
                     # between calls to batch_generator.next(), not

--- a/tests/test_generate.py
+++ b/tests/test_generate.py
@@ -213,6 +213,36 @@ class TestGenerate(unittest.TestCase):
                 self.assertTrue(mx.allclose(blp, lp))
                 break
 
+    def test_batch_extend_mixed_logits_processors(self):
+        # Regression test for a sequence without logits processors entering
+        # the prompt batch alone, which left a None placeholder behind. A
+        # sequence with processors joining a step later produced a mixed
+        # [None, [...]] list, and when both moved to generation in the same
+        # step, GenerationBatch._step raised
+        # "TypeError: 'NoneType' object is not iterable".
+        filler = self.tokenizer.encode("hello " * 40)
+        gen = BatchGenerator(
+            self.model,
+            max_tokens=4,
+            prefill_batch_size=2,
+            prefill_step_size=8,
+        )
+        procs = make_logits_processors(repetition_penalty=1.5)
+
+        # 20 tokens prefill as 8 + 8 + 3; the 15-token sequence inserted one
+        # step later prefills as 8 + 6 so both finish on the same step.
+        (uid_a,) = gen.insert([filler[:20]], logits_processors=[[]])
+        gen.next()
+        (uid_b,) = gen.insert([filler[:15]], logits_processors=[procs])
+
+        finished = set()
+        for _ in range(100):
+            _, gen_responses = gen.next()
+            finished.update(r.uid for r in gen_responses if r.finish_reason is not None)
+            if {uid_a, uid_b} <= finished:
+                break
+        self.assertEqual(finished, {uid_a, uid_b})
+
     def test_many_batches(self):
 
         prompts = [

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -5,15 +5,20 @@ import io
 import json
 import threading
 import unittest
+from unittest import mock
 
 import mlx.core as mx
 import requests
 
-from mlx_lm.generate import TextStateMachine
+from mlx_lm.generate import BatchGenerator, TextStateMachine
 from mlx_lm.models.cache import KVCache
 from mlx_lm.server import (
     APIHandler,
+    CompletionRequest,
+    GenerationArguments,
+    LogitsProcessorArguments,
     LRUPromptCache,
+    ModelDescription,
     Response,
     ResponseGenerator,
     SamplingArguments,
@@ -563,6 +568,74 @@ class TestKeepalive(unittest.TestCase):
             keepalive_callback(3072, 4096)
         except Exception as e:
             self.fail(f"Callback should handle BrokenPipeError: {e}")
+
+
+class TestResponseGeneratorResilience(unittest.TestCase):
+
+    @staticmethod
+    def _make_request():
+        request = CompletionRequest(
+            request_type="chat",
+            prompt="",
+            messages=[{"role": "user", "content": "Hi"}],
+            tools=None,
+            role_mapping=None,
+        )
+        args = GenerationArguments(
+            model=ModelDescription(model="default_model", draft=None, adapter=None),
+            sampling=SamplingArguments(
+                temperature=0.0,
+                top_p=1.0,
+                top_k=0,
+                min_p=0.0,
+                xtc_probability=0.0,
+                xtc_threshold=0.0,
+            ),
+            logits=LogitsProcessorArguments(
+                logit_bias=None,
+                repetition_penalty=None,
+                repetition_context_size=20,
+                presence_penalty=None,
+                presence_context_size=20,
+                frequency_penalty=None,
+                frequency_context_size=20,
+            ),
+            stop_words=[],
+            max_tokens=4,
+            num_draft_tokens=0,
+            logprobs=False,
+            top_logprobs=0,
+            seed=None,
+            chat_template_kwargs=None,
+        )
+        return request, args
+
+    def test_generation_thread_survives_batch_exception(self):
+        # Regression test: an uncaught exception in the generation loop used
+        # to kill the generation thread while the HTTP server kept accepting
+        # requests that could never be answered.
+        response_generator = ResponseGenerator(DummyModelProvider(), LRUPromptCache())
+        try:
+            request, args = self._make_request()
+
+            with mock.patch.object(
+                BatchGenerator, "next", side_effect=RuntimeError("boom")
+            ):
+                _, responses = response_generator.generate(request, args)
+                with self.assertRaises(RuntimeError):
+                    for _ in responses:
+                        pass
+
+            # The generation thread must survive and keep serving
+            self.assertTrue(response_generator._generation_thread.is_alive())
+
+            request, args = self._make_request()
+            _, responses = response_generator.generate(request, args)
+            responses = list(responses)
+            self.assertTrue(len(responses) > 0)
+            self.assertEqual(responses[-1].finish_reason, "length")
+        finally:
+            response_generator.stop_and_join()
 
 
 class TestLRUPromptCache(unittest.TestCase):

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -4,13 +4,15 @@ import http
 import io
 import json
 import threading
+import time
 import unittest
+from queue import Empty, Queue
 from unittest import mock
 
 import mlx.core as mx
 import requests
 
-from mlx_lm.generate import BatchGenerator, TextStateMachine
+from mlx_lm.generate import BatchGenerator, GenerationBatch, TextStateMachine
 from mlx_lm.models.cache import KVCache
 from mlx_lm.server import (
     APIHandler,
@@ -665,6 +667,164 @@ class TestResponseGeneratorResilience(unittest.TestCase):
             # freshly (re)created real BatchGenerator's first prefill/decode
             # step can legitimately take longer than the tiny timeout used
             # above to force a stall quickly.
+            response_generator.model_provider.cli_args.generation_stall_timeout = 0
+            request, args = self._make_request()
+            _, responses = response_generator.generate(request, args)
+            responses = list(responses)
+            self.assertTrue(len(responses) > 0)
+            self.assertEqual(responses[-1].finish_reason, "length")
+        finally:
+            response_generator.stop_and_join()
+
+    def test_stall_watchdog_is_generator_wide_not_per_request(self):
+        # Documents/locks in the scope of `last_delivery`: it is a single
+        # timestamp for the whole generator, refreshed by delivery to *any*
+        # uid. Continued delivery on request A must therefore postpone
+        # recovery for a different, wedged request B in the same batch --
+        # this is the intentional bound (an engine-wide livelock detector),
+        # not a per-request delivery guarantee.
+        response_generator = ResponseGenerator(DummyModelProvider(), LRUPromptCache())
+        # Wide enough that ordinary thread-scheduling jitter around request
+        # admission (observed up to ~0.1s between an admission and the next
+        # loop iteration under test load) can't itself read as a stall --
+        # the assertions below rely on distinguishing "before" and "after"
+        # states in time, unlike the tighter 0.05s used where every path
+        # is expected to stall regardless of exact timing.
+        stall_timeout = 0.5
+        response_generator.model_provider.cli_args.generation_stall_timeout = (
+            stall_timeout
+        )
+        keep_delivering_to_a = threading.Event()
+        keep_delivering_to_a.set()
+
+        def fake_next(self):
+            time.sleep(0.02)
+            if keep_delivering_to_a.is_set():
+                # uid 0 is request A (admitted first below); it never
+                # finishes, so it stays in batch_results and keeps
+                # refreshing last_delivery every call.
+                return [], [
+                    GenerationBatch.Response(
+                        uid=0,
+                        token=0,
+                        logprobs=mx.array([0.0]),
+                        finish_reason=None,
+                        prompt_cache=None,
+                        all_tokens=None,
+                    )
+                ]
+            return [], []
+
+        try:
+            request_a, args_a = self._make_request()
+            request_b, args_b = self._make_request()
+
+            with mock.patch.object(BatchGenerator, "next", fake_next):
+                queue_a = Queue()
+                response_generator.requests.put((queue_a, request_a, args_a))
+                ctx_a = queue_a.get(timeout=30)
+                self.assertNotIsInstance(ctx_a, Exception)
+
+                queue_b = Queue()
+                response_generator.requests.put((queue_b, request_b, args_b))
+                ctx_b = queue_b.get(timeout=30)
+                self.assertNotIsInstance(ctx_b, Exception)
+
+                # Let A keep "generating" for several multiples of the
+                # stall timeout. If the watchdog were per-request, B would
+                # already have been failed by now.
+                time.sleep(stall_timeout * 3)
+
+                self.assertTrue(response_generator._generation_thread.is_alive())
+                # A is receiving real deliveries.
+                self.assertGreater(queue_a.qsize(), 0)
+                # B has received nothing at all since admission -- no
+                # token, no error, no reset.
+                with self.assertRaises(Empty):
+                    queue_b.get_nowait()
+
+                # Now stop delivering to A too: with no uid delivering
+                # anything, the shared timestamp finally goes stale and
+                # the watchdog must fire for both in-flight requests.
+                keep_delivering_to_a.clear()
+
+                def drain_for_stall_error(q):
+                    deadline = time.monotonic() + 5
+                    while time.monotonic() < deadline:
+                        try:
+                            item = q.get(timeout=0.5)
+                        except Empty:
+                            continue
+                        if isinstance(item, Exception):
+                            return item
+                    return None
+
+                exc_b = drain_for_stall_error(queue_b)
+                self.assertIsInstance(exc_b, RuntimeError)
+                self.assertIn("generation stalled", str(exc_b))
+
+                exc_a = drain_for_stall_error(queue_a)
+                self.assertIsInstance(exc_a, RuntimeError)
+                self.assertIn("generation stalled", str(exc_a))
+
+            self.assertTrue(response_generator._generation_thread.is_alive())
+        finally:
+            response_generator.stop_and_join()
+
+    def test_stall_watchdog_cannot_interrupt_a_blocking_next_call(self):
+        # Documents/locks in a boundary of the watchdog: the stall_timeout
+        # check runs on the generation thread itself, between calls to
+        # BatchGenerator.next(), not concurrently with them. A next() call
+        # that blocks (rather than returning quickly with nothing) cannot
+        # be interrupted -- a consumer waiting on that request's queue
+        # stays blocked for the full duration of the call, and recovery
+        # only happens once next() actually returns.
+        response_generator = ResponseGenerator(DummyModelProvider(), LRUPromptCache())
+        # See the wide-margin note in
+        # test_stall_watchdog_is_generator_wide_not_per_request: ordinary
+        # scheduling jitter around admission (observed up to ~0.1s) can
+        # itself exceed a too-tight timeout before the mocked next() is
+        # even called once, so this needs real headroom, not the 0.05s
+        # used where every path is expected to stall regardless of timing.
+        stall_timeout = 0.3
+        response_generator.model_provider.cli_args.generation_stall_timeout = (
+            stall_timeout
+        )
+        # Comfortably longer than the timeout so the ordering below has
+        # slack even under CI scheduling noise.
+        hold_seconds = stall_timeout * 5
+        call_started = threading.Event()
+
+        def fake_next(self):
+            call_started.set()
+            time.sleep(hold_seconds)
+            return [], []
+
+        try:
+            request, args = self._make_request()
+            with mock.patch.object(BatchGenerator, "next", fake_next):
+                response_queue = Queue()
+                response_generator.requests.put((response_queue, request, args))
+                ctx = response_queue.get(timeout=30)
+                self.assertNotIsInstance(ctx, Exception)
+
+                self.assertTrue(call_started.wait(timeout=30))
+                # We're now partway through the single blocking next()
+                # call (well past the stall timeout, well before the call
+                # releases). The watchdog cannot have run yet.
+                time.sleep(stall_timeout * 2)
+                with self.assertRaises(Empty):
+                    response_queue.get_nowait()
+
+                # Once the blocking call finally releases, the very next
+                # trip through the outer loop sees a stale last_delivery
+                # and resets immediately.
+                item = response_queue.get(timeout=hold_seconds + 10)
+                self.assertIsInstance(item, RuntimeError)
+                self.assertIn("generation stalled", str(item))
+
+            self.assertTrue(response_generator._generation_thread.is_alive())
+
             response_generator.model_provider.cli_args.generation_stall_timeout = 0
             request, args = self._make_request()
             _, responses = response_generator.generate(request, args)

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -57,6 +57,7 @@ class DummyModelProvider:
                 "decode_concurrency": 32,
                 "prompt_concurrency": 8,
                 "prefill_step_size": 2048,
+                "generation_stall_timeout": 0,
                 "prompt_cache_size": 10,
                 "prompt_cache_bytes": 1 << 63,
                 "prompt_cache_total_bytes": None,
@@ -629,6 +630,42 @@ class TestResponseGeneratorResilience(unittest.TestCase):
             # The generation thread must survive and keep serving
             self.assertTrue(response_generator._generation_thread.is_alive())
 
+            request, args = self._make_request()
+            _, responses = response_generator.generate(request, args)
+            responses = list(responses)
+            self.assertTrue(len(responses) > 0)
+            self.assertEqual(responses[-1].finish_reason, "length")
+        finally:
+            response_generator.stop_and_join()
+
+    def test_generation_thread_survives_delivery_stall(self):
+        # Regression test for the livelock failure mode reported in
+        # mlx-lm#1493: the batch loop keeps calling BatchGenerator.next()
+        # (real iterations, thread stays alive) but never delivers a
+        # token, prompt-progress update, or anything else to any request's
+        # queue. Neither _generation_thread.is_alive() nor a naive
+        # per-iteration heartbeat would catch this; only "nothing
+        # delivered in N seconds" does.
+        response_generator = ResponseGenerator(DummyModelProvider(), LRUPromptCache())
+        response_generator.model_provider.cli_args.generation_stall_timeout = 0.05
+        try:
+            request, args = self._make_request()
+
+            with mock.patch.object(BatchGenerator, "next", return_value=([], [])):
+                _, responses = response_generator.generate(request, args)
+                with self.assertRaisesRegex(RuntimeError, "generation stalled"):
+                    for _ in responses:
+                        pass
+
+            # The generation thread must survive and keep serving, with no
+            # process restart required.
+            self.assertTrue(response_generator._generation_thread.is_alive())
+
+            # Disable the stall watchdog for the recovery check itself: a
+            # freshly (re)created real BatchGenerator's first prefill/decode
+            # step can legitimately take longer than the tiny timeout used
+            # above to force a stall quickly.
+            response_generator.model_provider.cli_args.generation_stall_timeout = 0
             request, args = self._make_request()
             _, responses = response_generator.generate(request, args)
             responses = list(responses)

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -12,7 +12,12 @@ from unittest import mock
 import mlx.core as mx
 import requests
 
-from mlx_lm.generate import BatchGenerator, GenerationBatch, TextStateMachine
+from mlx_lm.generate import (
+    BatchGenerator,
+    GenerationBatch,
+    PromptProcessingBatch,
+    TextStateMachine,
+)
 from mlx_lm.models.cache import KVCache
 from mlx_lm.server import (
     APIHandler,
@@ -747,6 +752,113 @@ class TestResponseGeneratorResilience(unittest.TestCase):
                 # anything, the shared timestamp finally goes stale and
                 # the watchdog must fire for both in-flight requests.
                 keep_delivering_to_a.clear()
+
+                def drain_for_stall_error(q):
+                    deadline = time.monotonic() + 5
+                    while time.monotonic() < deadline:
+                        try:
+                            item = q.get(timeout=0.5)
+                        except Empty:
+                            continue
+                        if isinstance(item, Exception):
+                            return item
+                    return None
+
+                exc_b = drain_for_stall_error(queue_b)
+                self.assertIsInstance(exc_b, RuntimeError)
+                self.assertIn("generation stalled", str(exc_b))
+
+                exc_a = drain_for_stall_error(queue_a)
+                self.assertIsInstance(exc_a, RuntimeError)
+                self.assertIn("generation stalled", str(exc_a))
+
+            self.assertTrue(response_generator._generation_thread.is_alive())
+        finally:
+            response_generator.stop_and_join()
+
+    def test_stall_watchdog_prompt_progress_from_other_uid_can_mask_a_wedged_decode(
+        self,
+    ):
+        # Documents/locks in the exact masking shape from the archived
+        # #1493 incident (PR #1598 review, 2026-07-29): the July 17 server
+        # log shows one decode request (uid) wedged while *prompt-progress*
+        # for other, unrelated uids kept being delivered throughout the
+        # hang (06:55:15-06:57:47). Because last_delivery is refreshed by
+        # prompt-progress delivery too -- not just tokens -- that unrelated
+        # progress postpones detection of the wedged decode request.
+        #
+        # test_stall_watchdog_is_generator_wide_not_per_request already
+        # covers the shared-timestamp mechanism generically (token delivery
+        # to uid A masks a stalled uid B). This test drives the same
+        # mechanism with the specific signal from the archived incident --
+        # prompt-progress, not tokens -- for the request that keeps
+        # "generating," to lock in that the masking is not limited to the
+        # decode phase.
+        response_generator = ResponseGenerator(DummyModelProvider(), LRUPromptCache())
+        stall_timeout = 0.5
+        response_generator.model_provider.cli_args.generation_stall_timeout = (
+            stall_timeout
+        )
+        keep_progress_for_a = threading.Event()
+        keep_progress_for_a.set()
+
+        def fake_next(self):
+            time.sleep(0.02)
+            if keep_progress_for_a.is_set():
+                # uid 0 is request A (admitted first below); it is still
+                # in prefill and never finishes, so it keeps refreshing
+                # last_delivery every call via prompt-progress alone --
+                # request B never receives a token, an error, or a
+                # progress update of its own.
+                return (
+                    [
+                        PromptProcessingBatch.Response(
+                            uid=0,
+                            progress=(1, 2),
+                            end_of_segment=False,
+                            end_of_prompt=False,
+                        )
+                    ],
+                    [],
+                )
+            return [], []
+
+        try:
+            request_a, args_a = self._make_request()
+            request_b, args_b = self._make_request()
+
+            with mock.patch.object(BatchGenerator, "next", fake_next):
+                queue_a = Queue()
+                response_generator.requests.put((queue_a, request_a, args_a))
+                ctx_a = queue_a.get(timeout=30)
+                self.assertNotIsInstance(ctx_a, Exception)
+
+                queue_b = Queue()
+                response_generator.requests.put((queue_b, request_b, args_b))
+                ctx_b = queue_b.get(timeout=30)
+                self.assertNotIsInstance(ctx_b, Exception)
+
+                # Let A keep receiving prompt-progress for several
+                # multiples of the stall timeout. If the watchdog detected
+                # a per-request decode stall, B would already have been
+                # failed by now -- it never receives anything at all.
+                time.sleep(stall_timeout * 3)
+
+                self.assertTrue(response_generator._generation_thread.is_alive())
+                # A is receiving real prompt-progress deliveries.
+                self.assertGreater(queue_a.qsize(), 0)
+                # B has received nothing at all since admission -- no
+                # progress, no token, no error, no reset. This is the
+                # archived #1493 shape: a wedged request masked by
+                # unrelated prompt-progress, not detected within
+                # stall_timeout.
+                with self.assertRaises(Empty):
+                    queue_b.get_nowait()
+
+                # Now stop delivering progress for A too: with no uid
+                # delivering anything, the shared timestamp finally goes
+                # stale and the watchdog fires for both in-flight requests.
+                keep_progress_for_a.clear()
 
                 def drain_for_stall_error(q):
                     deadline = time.monotonic() + 5


### PR DESCRIPTION
Fixes the livelock failure mode reported in #1493, as a stacked draft on top of #1513 per @TadeuszWolfGang's [suggestion](https://github.com/ml-explore/mlx-lm/issues/1493#issuecomment-5039365743) — keeps #1513 focused on exceptions/dead-worker recovery while this handles delivery-stall detection independently. Happy to fold into #1513 instead if maintainers prefer.

**Note on the diff:** `fix-server-generation-thread` (#1513) only exists on my fork, not upstream, so GitHub won't let me set it as this PR's base — this PR is opened against `main` instead, and the diff below includes #1513's changes until #1513 merges (the `_reset_batch()` refactor here only makes sense on top of it). Once #1513 lands, this diff will shrink to just the new commit — [rajanshxrma/mlx-lm@6e3f367](https://github.com/rajanshxrma/mlx-lm/commit/6e3f367c4b4b6693ef1006d2b9fc23dc4695842b) — which is this PR's actual content.

## The problem

#1513 fixes the case where the generation thread dies (uncaught exception) and the server zombies. But @TadeuszWolfGang [caught a third failure mode live](https://github.com/ml-explore/mlx-lm/issues/1493#issuecomment-4999212001) with py-spy stack captures: a **livelock**. The batch loop keeps calling `BatchGenerator.next()` and doing real work (forward pass, `mx.async_eval` sync) — thread `is_alive()` stays `True`, real CPU/GPU burn — but nothing is ever delivered to any request's response queue. Requests in flight (and new ones) hang indefinitely; only a process restart recovers.

This defeats both `_generation_thread.is_alive()` (#1513 as written) and a naive per-iteration heartbeat, since the loop genuinely keeps iterating the whole time.

*(Scope note added 2026-07-29, after @TadeuszWolfGang's review of the archived incident log: the fix below detects a generator-wide delivery drought, meaning nothing delivered to any in-flight request for `--generation-stall-timeout` seconds. The archived #1493 capture itself is narrower than that. One decode request stayed wedged while prompt-progress for other, unrelated requests kept being delivered throughout the hang. Because that unrelated progress also counts as delivery, a watchdog reset on that exact captured incident would not have fired until roughly 3.5 minutes after the wedge started, with no fixed upper bound under regular long-prompt traffic. See the PR discussion and the scope comment on `last_delivery` in `server.py` for the full detail.)*

## The fix

Track wall-clock time since a token, prompt-progress update, or admission ack was last actually put on a consumer's queue. If requests are in flight and nothing has been delivered for `--generation-stall-timeout` seconds (default 60.0, `0` disables), treat the batch as stalled: fail the in-flight requests with an explicit `RuntimeError`, close and drop the batch generator, and let the loop start fresh — the exact recovery shape #1513 already uses for an uncaught exception, just gated on a delivery-staleness timer instead of (or in addition to) an exception. Refactored the shared reset logic into `_reset_batch()` so both paths use it.

Default of 60s is chosen to be well clear of legitimate long first-decode-step latency on large models, while staying far under the 5-minute external-probe workaround @IzD680 deployed as a production stopgap.

## Test

`test_generation_thread_survives_delivery_stall` in `tests/test_server.py`, mirroring #1513's `test_generation_thread_survives_batch_exception`: mocks `BatchGenerator.next` to return `([], [])` forever (simulating the livelock) with a tiny stall timeout, asserts the in-flight request raises to the client, the generation thread survives, and a subsequent request completes normally with no process restart.

## Known limitation (out of scope here)

This is a safety net, not a root-cause fix. @TadeuszWolfGang's hypothesis for *why* the livelock happens — a poisoned prompt-cache/position entry from a >22k cache-primed prompt interacting with gemma4's sliding-window layers, likely #1494 territory — is unresolved. The watchdog stops the hang and keeps the server alive, but if the same poisoned cache entry gets reused, the livelock could recur. Worth a follow-up once #1494 is better understood.

**Scope limitation surfaced 2026-07-29:** the shared `last_delivery` timestamp is refreshed by admission acks, prompt-progress, and tokens from any uid in the batch (intentional — see the `server.py` scope comment and `test_stall_watchdog_is_generator_wide_not_per_request`). @TadeuszWolfGang's re-examination of the archived #1493 log shows this isn't just a theoretical corner case: in the captured incident, unrelated prompt-progress delivery continued while one decode request was wedged, which would have delayed this watchdog's detection of that exact incident by roughly 3.5 minutes past the configured 60s timeout, with no fixed bound under regular traffic. Two directions have been proposed to close this: tracking decode-delivery staleness separately from admission/prompt-progress signals, or keeping per-uid timestamps/phase state once a request finishes prefill. Neither is implemented yet. @TadeuszWolfGang is running a long soak test of this exact head with a periodic liveness probe, which will produce empirical evidence on whether this gap matters in practice; a redesign before that data lands would be premature. Docs now state the actual scope precisely; implementation is follow-up work pending the soak results.

@TadeuszWolfGang — this is armed and ready for you to validate against your Gemma reproducer whenever you get a chance.
