### PR TITLE
Fix TypeError in apply_min_p when min_tokens_to_keep > 1

### DIFF
--- a/mlx_lm/sample_utils.py
+++ b/mlx_lm/sample_utils.py
@@ -194,7 +194,7 @@ def apply_min_p(
         tokens_to_remove = mx.put_along_axis(
             tokens_to_remove,
             top_indices,
-            False,
+            mx.array(False),
             axis=-1,
         )
 

--- a/tests/test_sample_utils.py
+++ b/tests/test_sample_utils.py
@@ -68,6 +68,23 @@ class TestSampleUtils(unittest.TestCase):
             actual_probs.tolist(), [[1.0, 0.0, 0.0, 0.0], [0.0, 1.0, 0.0, 0.0]]
         )
 
+    def test_apply_min_p_min_tokens_to_keep(self):
+        # min_tokens_to_keep > 1 must execute (regression: bare Python
+        # False passed to mx.put_along_axis raised TypeError) and must
+        # keep exactly that many candidates under an aggressive filter.
+        probs = mx.array([0.7, 0.2, 0.05, 0.05])[None]
+        logits = mx.log(probs)
+        new_logits = apply_min_p(logits, 0.9, min_tokens_to_keep=2)
+        kept = (new_logits > -float("inf")).sum().item()
+        self.assertEqual(kept, 2)
+
+        # Batch mode
+        probs = mx.array([[0.9, 0.05, 0.03, 0.02], [0.4, 0.3, 0.2, 0.1]])
+        logits = mx.log(probs)
+        new_logits = apply_min_p(logits, 0.99, min_tokens_to_keep=3)
+        kept_per_row = (new_logits > -float("inf")).sum(axis=-1).tolist()
+        self.assertEqual(kept_per_row, [3, 3])
+
     def test_apply_top_k(self):
         probs = mx.array([0.9, 0.0, 0.0, 0.1])[None]
         logits = mx.log(probs)

--- a/tests/test_sample_utils.py
+++ b/tests/test_sample_utils.py
@@ -78,6 +78,23 @@ class TestSampleUtils(unittest.TestCase):
             actual_probs.tolist(), [[1.0, 0.0, 0.0, 0.0], [0.0, 1.0, 0.0, 0.0]]
         )
 
+    def test_apply_min_p_min_tokens_to_keep(self):
+        # min_tokens_to_keep > 1 must execute (regression: bare Python
+        # False passed to mx.put_along_axis raised TypeError) and must
+        # keep exactly that many candidates under an aggressive filter.
+        probs = mx.array([0.7, 0.2, 0.05, 0.05])[None]
+        logits = mx.log(probs)
+        new_logits = apply_min_p(logits, 0.9, min_tokens_to_keep=2)
+        kept = (new_logits > -float("inf")).sum().item()
+        self.assertEqual(kept, 2)
+
+        # Batch mode
+        probs = mx.array([[0.9, 0.05, 0.03, 0.02], [0.4, 0.3, 0.2, 0.1]])
+        logits = mx.log(probs)
+        new_logits = apply_min_p(logits, 0.99, min_tokens_to_keep=3)
+        kept_per_row = (new_logits > -float("inf")).sum(axis=-1).tolist()
+        self.assertEqual(kept_per_row, [3, 3])
+
     def test_apply_top_k(self):
         probs = mx.array([0.9, 0.0, 0.0, 0.1])[None]
         logits = mx.log(probs)


### PR DESCRIPTION
`apply_min_p`'s `min_tokens_to_keep > 1` branch passes bare Python `False` as the `values` argument of `mx.put_along_axis`, whose binding requires an `mx.array`. The branch raises `TypeError` on every invocation:

```python
>>> from mlx_lm.sample_utils import apply_min_p
>>> import mlx.core as mx
>>> logprobs = mx.log(mx.softmax(mx.random.normal((1, 100)), axis=-1))
>>> apply_min_p(logprobs, 0.05, 3)
TypeError: put_along_axis(): incompatible function arguments. ...
Invoked with types: mlx.core.array, mlx.core.array, bool, kwargs = { axis: int }
```

Verified the rejection is not mlx-version-dependent (probed mlx 0.31.2 and 0.32.0 — bare bool rejected on both). The scalar was introduced in #1083's refactor (the pre-refactor code passed proper arrays); it has stayed latent because `tests/test_sample_utils.py` has no `min_tokens_to_keep` coverage and `mlx_lm.server` doesn't expose the parameter — only direct library consumers of `make_sampler(min_tokens_to_keep=...)` can reach the branch. We hit it in a production server built on `BatchGenerator` the first time a client set the knob.

One-line fix: `False` → `mx.array(False)`. Adds a regression test that fails with the `TypeError` pre-fix and pins the keep-floor semantics (exactly `min_tokens_to_keep` survivors under an aggressive `min_p`), single-row and batched.