### PR TITLE
Add Laguna (Poolside) architecture support

### DIFF
--- a/mlx_lm/models/laguna.py
+++ b/mlx_lm/models/laguna.py
@@ -305,10 +305,22 @@ class Model(nn.Module):
         fused ``mlp.switch_mlp.*`` layout ``SwitchGLU`` expects. Verified
         against the real ``poolside/Laguna-S-2.1`` safetensors index — this
         checkpoint ships experts unfused, one tensor per expert per
-        projection (unlike gpt_oss's fused-then-interleaved layout)."""
+        projection (unlike gpt_oss's fused-then-interleaved layout).
+
+        Also remaps the aux-loss-free routing correction bias. vLLM-trained
+        Laguna checkpoints (including ``poolside/Laguna-S-2.1``) store it at
+        ``mlp.experts.e_score_correction_bias``, but our ``Router`` module
+        holds the parameter at ``mlp.gate.e_score_correction_bias`` (mirrors
+        the reference HF implementation's own
+        ``_checkpoint_conversion_mapping``). Guarded with a presence check
+        since not every checkpoint variant ships the bias — matching the
+        reference's zero-init no-op behavior for those."""
         num_experts = self.args.num_experts
         for l in range(self.args.num_hidden_layers):
             prefix = f"model.layers.{l}.mlp"
+            bias_key = f"{prefix}.experts.e_score_correction_bias"
+            if bias_key in weights:
+                weights[f"{prefix}.gate.e_score_correction_bias"] = weights.pop(bias_key)
             if f"{prefix}.experts.0.gate_proj.weight" not in weights:
                 continue  # dense (mlp_only) layer — nothing to stack
             for name in ("gate_proj", "up_proj", "down_proj"):

--- a/mlx_lm/models/laguna.py
+++ b/mlx_lm/models/laguna.py
@@ -60,7 +60,9 @@ class ModelArgs(BaseModelArgs):
             )
 
 
-def _resolve_rope_config(rope_parameters: Dict[str, Any], attention_type: str) -> Dict[str, Any]:
+def _resolve_rope_config(
+    rope_parameters: Dict[str, Any], attention_type: str
+) -> Dict[str, Any]:
     """Laguna nests RoPE config by layer type when the model mixes full and
     sliding attention: ``{"full_attention": {...}, "sliding_attention": {...}}``.
     A flat (non-nested) config applies to every layer as-is."""
@@ -169,7 +171,9 @@ class Attention(nn.Module):
 class MLP(nn.Module):
     def __init__(self, args: ModelArgs, intermediate_size: Optional[int] = None):
         super().__init__()
-        inter = args.intermediate_size if intermediate_size is None else intermediate_size
+        inter = (
+            args.intermediate_size if intermediate_size is None else intermediate_size
+        )
         self.gate_proj = nn.Linear(args.hidden_size, inter, bias=False)
         self.up_proj = nn.Linear(args.hidden_size, inter, bias=False)
         self.down_proj = nn.Linear(inter, args.hidden_size, bias=False)
@@ -215,7 +219,9 @@ class MoEBlock(nn.Module):
         self.switch_mlp = SwitchGLU(
             args.hidden_size, args.moe_intermediate_size, args.num_experts
         )
-        self.shared_expert = MLP(args, intermediate_size=args.shared_expert_intermediate_size)
+        self.shared_expert = MLP(
+            args, intermediate_size=args.shared_expert_intermediate_size
+        )
         self.routed_scaling_factor = args.moe_routed_scaling_factor
 
     def __call__(self, x: mx.array) -> mx.array:
@@ -241,7 +247,9 @@ class DecoderLayer(nn.Module):
         self.mlp = MoEBlock(args) if is_moe_layer else MLP(args)
 
         self.input_layernorm = nn.RMSNorm(args.hidden_size, eps=args.rms_norm_eps)
-        self.post_attention_layernorm = nn.RMSNorm(args.hidden_size, eps=args.rms_norm_eps)
+        self.post_attention_layernorm = nn.RMSNorm(
+            args.hidden_size, eps=args.rms_norm_eps
+        )
 
     def __call__(self, x: mx.array, mask=None, cache=None) -> mx.array:
         h = x + self.self_attn(self.input_layernorm(x), mask, cache)
@@ -274,9 +282,13 @@ class LanguageModel(nn.Module):
             else None
         )
 
-        full_mask = create_attention_mask(h, cache[full_idx]) if full_idx is not None else None
+        full_mask = (
+            create_attention_mask(h, cache[full_idx]) if full_idx is not None else None
+        )
         sliding_mask = (
-            create_attention_mask(h, cache[sliding_idx], window_size=self.sliding_window)
+            create_attention_mask(
+                h, cache[sliding_idx], window_size=self.sliding_window
+            )
             if sliding_idx is not None
             else None
         )
@@ -320,7 +332,9 @@ class Model(nn.Module):
             prefix = f"model.layers.{l}.mlp"
             bias_key = f"{prefix}.experts.e_score_correction_bias"
             if bias_key in weights:
-                weights[f"{prefix}.gate.e_score_correction_bias"] = weights.pop(bias_key)
+                weights[f"{prefix}.gate.e_score_correction_bias"] = weights.pop(
+                    bias_key
+                )
             if f"{prefix}.experts.0.gate_proj.weight" not in weights:
                 continue  # dense (mlp_only) layer — nothing to stack
             for name in ("gate_proj", "up_proj", "down_proj"):

--- a/mlx_lm/models/laguna.py
+++ b/mlx_lm/models/laguna.py
@@ -225,3 +225,24 @@ class MoEBlock(nn.Module):
         if self.routed_scaling_factor != 1.0:
             y = y * self.routed_scaling_factor
         return y + self.shared_expert(x)
+
+
+class DecoderLayer(nn.Module):
+    def __init__(self, args: ModelArgs, layer_idx: int):
+        super().__init__()
+        self.attention_type = args.layer_types[layer_idx]
+        self.self_attn = Attention(args, layer_idx)
+
+        is_moe_layer = (
+            layer_idx not in args.mlp_only_layers
+            and args.num_experts > 0
+            and (layer_idx + 1) % args.decoder_sparse_step == 0
+        )
+        self.mlp = MoEBlock(args) if is_moe_layer else MLP(args)
+
+        self.input_layernorm = nn.RMSNorm(args.hidden_size, eps=args.rms_norm_eps)
+        self.post_attention_layernorm = nn.RMSNorm(args.hidden_size, eps=args.rms_norm_eps)
+
+    def __call__(self, x: mx.array, mask=None, cache=None) -> mx.array:
+        h = x + self.self_attn(self.input_layernorm(x), mask, cache)
+        return h + self.mlp(self.post_attention_layernorm(h))

--- a/mlx_lm/models/laguna.py
+++ b/mlx_lm/models/laguna.py
@@ -68,3 +68,99 @@ def _resolve_rope_config(rope_parameters: Dict[str, Any], attention_type: str) -
     if isinstance(sub, dict):
         return sub
     return rope_parameters
+
+
+class Attention(nn.Module):
+    def __init__(self, args: ModelArgs, layer_idx: int):
+        super().__init__()
+        head_dim = args.head_dim
+        self.head_dim = head_dim
+
+        per_layer_heads = args.num_attention_heads_per_layer
+        self.n_heads = (
+            per_layer_heads[layer_idx]
+            if per_layer_heads is not None
+            else args.num_attention_heads
+        )
+        self.n_kv_heads = args.num_key_value_heads
+        self.scale = head_dim**-0.5
+
+        attention_type = args.layer_types[layer_idx]
+        self.is_sliding = attention_type == "sliding_attention"
+        self.sliding_window = args.sliding_window if self.is_sliding else None
+
+        self.q_proj = nn.Linear(
+            args.hidden_size, self.n_heads * head_dim, bias=args.attention_bias
+        )
+        self.k_proj = nn.Linear(
+            args.hidden_size, self.n_kv_heads * head_dim, bias=args.attention_bias
+        )
+        self.v_proj = nn.Linear(
+            args.hidden_size, self.n_kv_heads * head_dim, bias=args.attention_bias
+        )
+        self.o_proj = nn.Linear(self.n_heads * head_dim, args.hidden_size, bias=False)
+
+        self.q_norm = nn.RMSNorm(head_dim, eps=args.rms_norm_eps)
+        self.k_norm = nn.RMSNorm(head_dim, eps=args.rms_norm_eps)
+
+        gating = args.gating
+        self.gating = bool(gating)
+        self.gate_per_head = gating == "per-head"
+        if self.gating:
+            g_out = self.n_heads if self.gate_per_head else self.n_heads * head_dim
+            self.g_proj = nn.Linear(args.hidden_size, g_out, bias=False)
+
+        self.sinks = (
+            mx.zeros((self.n_heads,))
+            if (self.is_sliding and args.swa_attention_sink_enabled)
+            else None
+        )
+
+        rope_cfg = _resolve_rope_config(args.rope_parameters, attention_type)
+        rope_type = rope_cfg.get("rope_type", "default")
+        partial = rope_cfg.get("partial_rotary_factor", 1.0)
+        self.rope = initialize_rope(
+            dims=int(head_dim * partial),
+            base=rope_cfg.get("rope_theta", 10000.0),
+            traditional=False,
+            scaling_config=rope_cfg if rope_type != "default" else None,
+            max_position_embeddings=args.max_position_embeddings,
+        )
+
+    def __call__(self, x: mx.array, mask=None, cache=None) -> mx.array:
+        B, L, _ = x.shape
+
+        q = self.q_proj(x).reshape(B, L, self.n_heads, self.head_dim)
+        k = self.k_proj(x).reshape(B, L, self.n_kv_heads, self.head_dim)
+        v = self.v_proj(x).reshape(B, L, self.n_kv_heads, self.head_dim)
+
+        # RMSNorm always normalizes the last axis (head_dim), so applying it
+        # here (before the head/seq transpose) or after is numerically
+        # identical — this order matches the reference's own comments.
+        q = self.q_norm(q).transpose(0, 2, 1, 3)
+        k = self.k_norm(k).transpose(0, 2, 1, 3)
+        v = v.transpose(0, 2, 1, 3)
+
+        if cache is not None:
+            q = self.rope(q, offset=cache.offset)
+            k = self.rope(k, offset=cache.offset)
+            k, v = cache.update_and_fetch(k, v)
+        else:
+            q = self.rope(q)
+            k = self.rope(k)
+
+        out = scaled_dot_product_attention(
+            q, k, v, cache=cache, scale=self.scale, mask=mask, sinks=self.sinks
+        )
+        out = out.transpose(0, 2, 1, 3).reshape(B, L, self.n_heads * self.head_dim)
+
+        if self.gating:
+            gate = nn.softplus(self.g_proj(x))
+            if self.gate_per_head:
+                out = (
+                    out.reshape(B, L, self.n_heads, self.head_dim) * gate[..., None]
+                ).reshape(B, L, -1)
+            else:
+                out = out * gate
+
+        return self.o_proj(out)

--- a/mlx_lm/models/laguna.py
+++ b/mlx_lm/models/laguna.py
@@ -1,0 +1,70 @@
+# Copyright © 2025 Apple Inc.
+
+from dataclasses import dataclass, field
+from typing import Any, Dict, List, Optional
+
+import mlx.core as mx
+import mlx.nn as nn
+
+from .base import BaseModelArgs, create_attention_mask, scaled_dot_product_attention
+from .cache import KVCache, RotatingKVCache
+from .rope_utils import initialize_rope
+from .switch_layers import SwitchGLU
+
+
+@dataclass
+class ModelArgs(BaseModelArgs):
+    model_type: str = "laguna"
+    vocab_size: int = 100352
+    hidden_size: int = 3072
+    intermediate_size: int = 12288
+    num_hidden_layers: int = 48
+    num_attention_heads: int = 48
+    num_key_value_heads: int = 8
+    head_dim: int = 128
+    attention_bias: bool = False
+    gating: Any = True
+    rms_norm_eps: float = 1e-6
+    max_position_embeddings: int = 1048576
+    rope_parameters: Dict[str, Any] = field(
+        default_factory=lambda: {"rope_type": "default", "rope_theta": 500000.0}
+    )
+    sliding_window: Optional[int] = None
+    layer_types: Optional[List[str]] = None
+    num_attention_heads_per_layer: Optional[List[int]] = None
+    swa_attention_sink_enabled: bool = False
+    num_experts: int = 256
+    num_experts_per_tok: int = 10
+    moe_intermediate_size: int = 1024
+    shared_expert_intermediate_size: int = 1024
+    norm_topk_prob: bool = True
+    decoder_sparse_step: int = 1
+    mlp_only_layers: Optional[List[int]] = None
+    moe_routed_scaling_factor: float = 1.0
+    moe_apply_router_weight_on_input: bool = False
+    moe_router_logit_softcapping: float = 0.0
+    tie_word_embeddings: bool = False
+
+    def __post_init__(self):
+        if self.mlp_only_layers is None:
+            self.mlp_only_layers = [0]
+        if self.layer_types is None:
+            self.layer_types = ["full_attention"] * self.num_hidden_layers
+        if self.moe_apply_router_weight_on_input:
+            # Matches the transformers reference, which also raises for this
+            # flag: routing the weight into the expert *input* (rather than
+            # scaling the output) needs different math in SwitchGLU than what
+            # this port implements. No known Laguna checkpoint sets this.
+            raise NotImplementedError(
+                "moe_apply_router_weight_on_input=True is not supported."
+            )
+
+
+def _resolve_rope_config(rope_parameters: Dict[str, Any], attention_type: str) -> Dict[str, Any]:
+    """Laguna nests RoPE config by layer type when the model mixes full and
+    sliding attention: ``{"full_attention": {...}, "sliding_attention": {...}}``.
+    A flat (non-nested) config applies to every layer as-is."""
+    sub = rope_parameters.get(attention_type)
+    if isinstance(sub, dict):
+        return sub
+    return rope_parameters

--- a/mlx_lm/models/laguna.py
+++ b/mlx_lm/models/laguna.py
@@ -164,3 +164,64 @@ class Attention(nn.Module):
                 out = out * gate
 
         return self.o_proj(out)
+
+
+class MLP(nn.Module):
+    def __init__(self, args: ModelArgs, intermediate_size: Optional[int] = None):
+        super().__init__()
+        inter = args.intermediate_size if intermediate_size is None else intermediate_size
+        self.gate_proj = nn.Linear(args.hidden_size, inter, bias=False)
+        self.up_proj = nn.Linear(args.hidden_size, inter, bias=False)
+        self.down_proj = nn.Linear(inter, args.hidden_size, bias=False)
+
+    def __call__(self, x: mx.array) -> mx.array:
+        return self.down_proj(nn.silu(self.gate_proj(x)) * self.up_proj(x))
+
+
+class Router(nn.Module):
+    """Sigmoid-scored router (not softmax) with an auxiliary-loss-free
+    correction bias (arXiv:2408.15664): the bias shifts which experts are
+    *selected* but the returned routing weights stay unbiased (gathered from
+    the un-shifted sigmoid scores, matching the reference)."""
+
+    def __init__(self, args: ModelArgs):
+        super().__init__()
+        self.top_k = args.num_experts_per_tok
+        self.num_experts = args.num_experts
+        self.norm_topk_prob = args.norm_topk_prob
+        self.softcapping = args.moe_router_logit_softcapping
+        self.weight = mx.zeros((self.num_experts, args.hidden_size))
+        self.e_score_correction_bias = mx.zeros((self.num_experts,))
+
+    def __call__(self, x: mx.array):
+        logits = (x @ self.weight.T).astype(mx.float32)
+        if self.softcapping > 0.0:
+            logits = mx.tanh(logits / self.softcapping) * self.softcapping
+        scores = mx.sigmoid(logits)
+        scores_for_selection = scores + self.e_score_correction_bias
+
+        k = self.top_k
+        inds = mx.argpartition(-scores_for_selection, kth=k - 1, axis=-1)[..., :k]
+        weights = mx.take_along_axis(scores, inds, axis=-1)
+        if self.norm_topk_prob:
+            weights = weights / weights.sum(axis=-1, keepdims=True)
+        return inds, weights.astype(x.dtype)
+
+
+class MoEBlock(nn.Module):
+    def __init__(self, args: ModelArgs):
+        super().__init__()
+        self.gate = Router(args)
+        self.switch_mlp = SwitchGLU(
+            args.hidden_size, args.moe_intermediate_size, args.num_experts
+        )
+        self.shared_expert = MLP(args, intermediate_size=args.shared_expert_intermediate_size)
+        self.routed_scaling_factor = args.moe_routed_scaling_factor
+
+    def __call__(self, x: mx.array) -> mx.array:
+        inds, weights = self.gate(x)
+        y = self.switch_mlp(x, inds)
+        y = (y * weights[..., None]).sum(axis=-2).astype(y.dtype)
+        if self.routed_scaling_factor != 1.0:
+            y = y * self.routed_scaling_factor
+        return y + self.shared_expert(x)

--- a/mlx_lm/models/laguna.py
+++ b/mlx_lm/models/laguna.py
@@ -246,3 +246,100 @@ class DecoderLayer(nn.Module):
     def __call__(self, x: mx.array, mask=None, cache=None) -> mx.array:
         h = x + self.self_attn(self.input_layernorm(x), mask, cache)
         return h + self.mlp(self.post_attention_layernorm(h))
+
+
+class LanguageModel(nn.Module):
+    def __init__(self, args: ModelArgs):
+        super().__init__()
+        self.embed_tokens = nn.Embedding(args.vocab_size, args.hidden_size)
+        self.layers = [DecoderLayer(args, i) for i in range(args.num_hidden_layers)]
+        self.norm = nn.RMSNorm(args.hidden_size, eps=args.rms_norm_eps)
+        self.layer_types = args.layer_types
+        self.sliding_window = args.sliding_window
+
+    def __call__(self, inputs: mx.array, cache=None) -> mx.array:
+        h = self.embed_tokens(inputs)
+
+        if cache is None:
+            cache = [None] * len(self.layers)
+
+        full_idx = (
+            self.layer_types.index("full_attention")
+            if "full_attention" in self.layer_types
+            else None
+        )
+        sliding_idx = (
+            self.layer_types.index("sliding_attention")
+            if "sliding_attention" in self.layer_types
+            else None
+        )
+
+        full_mask = create_attention_mask(h, cache[full_idx]) if full_idx is not None else None
+        sliding_mask = (
+            create_attention_mask(h, cache[sliding_idx], window_size=self.sliding_window)
+            if sliding_idx is not None
+            else None
+        )
+
+        for layer, c, lt in zip(self.layers, cache, self.layer_types):
+            mask = full_mask if lt == "full_attention" else sliding_mask
+            h = layer(h, mask, c)
+
+        return self.norm(h)
+
+
+class Model(nn.Module):
+    def __init__(self, args: ModelArgs):
+        super().__init__()
+        self.args = args
+        self.model_type = args.model_type
+        self.model = LanguageModel(args)
+        self.lm_head = nn.Linear(args.hidden_size, args.vocab_size, bias=False)
+
+    def __call__(self, inputs: mx.array, cache=None) -> mx.array:
+        return self.lm_head(self.model(inputs, cache))
+
+    def sanitize(self, weights: dict) -> dict:
+        """Stack the checkpoint's per-expert tensors
+        (``mlp.experts.{i}.{gate_proj,up_proj,down_proj}.weight``) into the
+        fused ``mlp.switch_mlp.*`` layout ``SwitchGLU`` expects. Verified
+        against the real ``poolside/Laguna-S-2.1`` safetensors index — this
+        checkpoint ships experts unfused, one tensor per expert per
+        projection (unlike gpt_oss's fused-then-interleaved layout)."""
+        num_experts = self.args.num_experts
+        for l in range(self.args.num_hidden_layers):
+            prefix = f"model.layers.{l}.mlp"
+            if f"{prefix}.experts.0.gate_proj.weight" not in weights:
+                continue  # dense (mlp_only) layer — nothing to stack
+            for name in ("gate_proj", "up_proj", "down_proj"):
+                stacked = mx.stack(
+                    [
+                        weights.pop(f"{prefix}.experts.{e}.{name}.weight")
+                        for e in range(num_experts)
+                    ]
+                )
+                weights[f"{prefix}.switch_mlp.{name}.weight"] = stacked
+        return weights
+
+    def make_cache(self):
+        caches = []
+        for lt in self.args.layer_types:
+            if lt == "full_attention":
+                caches.append(KVCache())
+            else:
+                caches.append(RotatingKVCache(max_size=self.args.sliding_window))
+        return caches
+
+    @property
+    def layers(self):
+        return self.model.layers
+
+    @property
+    def cast_predicate(self):
+        def predicate(k):
+            # Router correction bias must stay in its native precision when
+            # the rest of the model is cast (matches glm4_moe's convention) —
+            # it is a small additive term, not a matmul weight.
+            return "e_score_correction_bias" not in k
+
+        return predicate

--- a/scripts/laguna_quant_predicate.py
+++ b/scripts/laguna_quant_predicate.py
@@ -1,8 +1,21 @@
 """Custom per-module quantization predicate for Laguna's requested mixed
-variants: attention/router/embeddings/output at one bit width, with routed
-experts at a lower one (2, 4, or 6). The three uniform variants
+variants: attention/embeddings/output at one bit width, with routed experts
+at a lower one (2, 4, or 6). The three uniform variants
 (4bit/6bit/8bit-everything) need no custom predicate — use
 `mlx_lm.convert(..., quantize=True, q_bits=4|6|8)` directly.
+
+Note on the router: `Router.weight` (`mlx_lm/models/laguna.py`) is a raw
+array, not an `nn.Linear`, so it has no `to_quantized`.
+`mlx_lm.utils.quantize_model`'s wrapper checks `hasattr(module,
+"to_quantized")` before ever calling a custom `quant_predicate`, so the
+router (and the model's RMSNorm layers) are always left at full precision
+regardless of what a predicate here returns for their paths -- there is no
+way to quantize the router via this mechanism today, and no need to
+special-case it above. Concretely, this means a "protect the router, shrink
+everything else" recipe needs no custom predicate at all: plain
+`mlx_lm.convert(..., quantize=True, q_bits=6)` already leaves the router at
+full precision (stricter than 8-bit) while quantizing attention and routed
+experts uniformly to 6-bit.
 
 Usage:
     from mlx_lm.convert import convert
@@ -49,11 +62,9 @@ def build_laguna_quant_predicate(
     def predicate(path: str, module: nn.Module) -> Union[bool, dict]:
         # Routed experts (SwitchGLU's three projections) get the lower bit
         # width poolside requested; everything else quantizable (attention
-        # projections, the router's `weight` matmul, embeddings, lm_head,
-        # the shared expert) stays at attention_bits. The router's
-        # `e_score_correction_bias` is excluded from casting entirely via
-        # `Model.cast_predicate`, and `mx.quantize` only touches weight
-        # matrices, not that bias vector, so it needs no special-casing here.
+        # projections, embeddings, lm_head, the shared expert) stays at
+        # attention_bits. The router never reaches this predicate at all --
+        # see the module docstring -- so it needs no special-casing here.
         if "switch_mlp" in path:
             return {"group_size": group_size, "bits": expert_bits, "mode": "affine"}
         return {"group_size": group_size, "bits": attention_bits, "mode": "affine"}

--- a/scripts/laguna_quant_predicate.py
+++ b/scripts/laguna_quant_predicate.py
@@ -1,13 +1,14 @@
 """Custom per-module quantization predicate for Laguna's requested mixed
-variants (see DOCS compatibility report): 8-bit attention/router/embeddings/
-output, with routed experts at a lower bit width (4 or 6). The three uniform
-variants (4bit/6bit/8bit-everything) need no custom predicate — use
+variants: attention/router/embeddings/output at one bit width, with routed
+experts at a lower one (2, 4, or 6). The three uniform variants
+(4bit/6bit/8bit-everything) need no custom predicate — use
 `mlx_lm.convert(..., quantize=True, q_bits=4|6|8)` directly.
 
 Usage:
     from mlx_lm.convert import convert
     from laguna_quant_predicate import build_laguna_quant_predicate
 
+    # 8-bit attention, 4-bit experts
     convert(
         hf_path="poolside/Laguna-S-2.1",
         mlx_path="Laguna-S-2.1-8bit-Att-4bit-Ex",
@@ -15,6 +16,20 @@ Usage:
         q_group_size=64,
         quant_predicate=build_laguna_quant_predicate(expert_bits=4),
         upload_repo="poolside/Laguna-S-2.1-8bit-Att-4bit-Ex-mlx",
+    )
+
+    # 4-bit attention, 2-bit experts (routed experts hold ~116B of Laguna
+    # S-2.1's ~117.6B stored parameters, so this is the variant that
+    # actually shrinks a 118B checkpoint to fit a 64 GB Mac)
+    convert(
+        hf_path="poolside/Laguna-S-2.1",
+        mlx_path="Laguna-S-2.1-4bit-Att-2bit-Ex",
+        quantize=True,
+        q_group_size=64,
+        quant_predicate=build_laguna_quant_predicate(
+            expert_bits=2, attention_bits=4
+        ),
+        upload_repo="poolside/Laguna-S-2.1-4bit-Att-2bit-Ex-mlx",
     )
 """
 
@@ -26,9 +41,9 @@ import mlx.nn as nn
 def build_laguna_quant_predicate(
     expert_bits: int, group_size: int = 64, attention_bits: int = 8
 ) -> Callable[[str, nn.Module], Union[bool, dict]]:
-    if expert_bits not in (4, 6):
+    if expert_bits not in (2, 4, 6):
         raise ValueError(
-            f"Laguna's requested variants use 4 or 6-bit experts, got {expert_bits}"
+            f"Laguna's requested variants use 2, 4, or 6-bit experts, got {expert_bits}"
         )
 
     def predicate(path: str, module: nn.Module) -> Union[bool, dict]:

--- a/scripts/laguna_quant_predicate.py
+++ b/scripts/laguna_quant_predicate.py
@@ -1,0 +1,46 @@
+"""Custom per-module quantization predicate for Laguna's requested mixed
+variants (see DOCS compatibility report): 8-bit attention/router/embeddings/
+output, with routed experts at a lower bit width (4 or 6). The three uniform
+variants (4bit/6bit/8bit-everything) need no custom predicate — use
+`mlx_lm.convert(..., quantize=True, q_bits=4|6|8)` directly.
+
+Usage:
+    from mlx_lm.convert import convert
+    from laguna_quant_predicate import build_laguna_quant_predicate
+
+    convert(
+        hf_path="poolside/Laguna-S-2.1",
+        mlx_path="Laguna-S-2.1-8bit-Att-4bit-Ex",
+        quantize=True,
+        q_group_size=64,
+        quant_predicate=build_laguna_quant_predicate(expert_bits=4),
+        upload_repo="poolside/Laguna-S-2.1-8bit-Att-4bit-Ex-mlx",
+    )
+"""
+
+from typing import Callable, Union
+
+import mlx.nn as nn
+
+
+def build_laguna_quant_predicate(
+    expert_bits: int, group_size: int = 64, attention_bits: int = 8
+) -> Callable[[str, nn.Module], Union[bool, dict]]:
+    if expert_bits not in (4, 6):
+        raise ValueError(
+            f"Laguna's requested variants use 4 or 6-bit experts, got {expert_bits}"
+        )
+
+    def predicate(path: str, module: nn.Module) -> Union[bool, dict]:
+        # Routed experts (SwitchGLU's three projections) get the lower bit
+        # width poolside requested; everything else quantizable (attention
+        # projections, the router's `weight` matmul, embeddings, lm_head,
+        # the shared expert) stays at attention_bits. The router's
+        # `e_score_correction_bias` is excluded from casting entirely via
+        # `Model.cast_predicate`, and `mx.quantize` only touches weight
+        # matrices, not that bias vector, so it needs no special-casing here.
+        if "switch_mlp" in path:
+            return {"group_size": group_size, "bits": expert_bits, "mode": "affine"}
+        return {"group_size": group_size, "bits": attention_bits, "mode": "affine"}
+
+    return predicate

--- a/tests/test_laguna_quant.py
+++ b/tests/test_laguna_quant.py
@@ -70,5 +70,79 @@ class TestLagunaQuantPredicate(unittest.TestCase):
             build_laguna_quant_predicate(expert_bits=5)
 
 
+class TestLagunaQuantPredicateAgainstRealModel(unittest.TestCase):
+    """`build_laguna_quant_predicate`'s own unit tests above call the
+    returned predicate directly, in isolation, which only proves what the
+    predicate *would* return for a path -- not what `mlx_lm.convert`
+    actually does with that return value. `mlx_lm.utils.quantize_model`
+    wraps any custom predicate with its own `hasattr(module,
+    "to_quantized")` check, so paths for modules that can't be quantized
+    (like Laguna's `Router`, which stores `weight` as a raw array, and
+    every `RMSNorm`) never reach our predicate at all, regardless of what
+    it would have returned for them. This test exercises the real
+    `quantize_model` entry point against an actual (tiny) `Model` instance
+    to confirm that end-to-end behavior, not just the predicate's isolated
+    return values.
+    """
+
+    def test_router_and_norms_stay_full_precision_through_quantize_model(self):
+        import mlx.core as mx
+        import mlx.nn as nn
+
+        from mlx_lm.models import laguna
+        from mlx_lm.models.switch_layers import QuantizedSwitchLinear
+        from mlx_lm.utils import quantize_model
+
+        args = laguna.ModelArgs(
+            model_type="laguna",
+            vocab_size=1000,
+            hidden_size=128,
+            intermediate_size=256,
+            num_hidden_layers=2,
+            num_attention_heads=8,
+            num_key_value_heads=2,
+            head_dim=16,
+            rope_parameters={
+                "full_attention": {"rope_type": "default", "rope_theta": 10000.0},
+                "sliding_attention": {"rope_type": "default", "rope_theta": 10000.0},
+            },
+            sliding_window=8,
+            layer_types=["full_attention", "sliding_attention"],
+            num_attention_heads_per_layer=[8, 8],
+            gating="per-head",
+            num_experts=4,
+            num_experts_per_tok=2,
+            moe_intermediate_size=64,
+            shared_expert_intermediate_size=64,
+            mlp_only_layers=[],
+            decoder_sparse_step=1,
+            moe_routed_scaling_factor=2.5,
+        )
+        model = laguna.Model(args)
+        mx.eval(model.parameters())
+
+        predicate = build_laguna_quant_predicate(expert_bits=4, attention_bits=8)
+        quantized_model, _ = quantize_model(
+            model,
+            config={"model_type": "laguna"},
+            group_size=64,
+            bits=8,
+            quant_predicate=predicate,
+        )
+
+        router = quantized_model.model.layers[0].mlp.gate
+        self.assertIsInstance(router, laguna.Router)
+        self.assertEqual(router.weight.dtype, mx.float32)
+
+        norm = quantized_model.model.layers[0].input_layernorm
+        self.assertIsInstance(norm, nn.RMSNorm)
+
+        expert_proj = quantized_model.model.layers[0].mlp.switch_mlp.gate_proj
+        self.assertIsInstance(expert_proj, QuantizedSwitchLinear)
+
+        attn_proj = quantized_model.model.layers[0].self_attn.q_proj
+        self.assertIsInstance(attn_proj, nn.QuantizedLinear)
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_laguna_quant.py
+++ b/tests/test_laguna_quant.py
@@ -1,0 +1,65 @@
+"""Regression coverage for scripts/laguna_quant_predicate.py.
+
+`scripts/` is not a package (no __init__.py) and the module's own usage
+example (see its docstring) assumes it is imported with `scripts/` on
+sys.path, so we add it explicitly here rather than relying on package
+machinery.
+"""
+
+import sys
+import unittest
+from pathlib import Path
+
+SCRIPTS_DIR = Path(__file__).resolve().parent.parent / "scripts"
+if str(SCRIPTS_DIR) not in sys.path:
+    sys.path.insert(0, str(SCRIPTS_DIR))
+
+from laguna_quant_predicate import build_laguna_quant_predicate  # noqa: E402
+
+
+class DummyModule:
+    """Stand-in for mlx.nn.Module: build_laguna_quant_predicate's predicate
+    never inspects the module argument, only the path string."""
+
+
+class TestLagunaQuantPredicate(unittest.TestCase):
+    def _check_paths(self, expert_bits: int):
+        predicate = build_laguna_quant_predicate(expert_bits=expert_bits)
+        module = DummyModule()
+
+        switch_mlp_paths = [
+            "model.layers.1.mlp.switch_mlp",
+            "model.layers.3.mlp.switch_mlp.gate_proj",
+        ]
+        for path in switch_mlp_paths:
+            with self.subTest(path=path):
+                self.assertEqual(
+                    predicate(path, module),
+                    {"group_size": 64, "bits": expert_bits, "mode": "affine"},
+                )
+
+        non_switch_mlp_paths = [
+            "model.layers.1.self_attn.q_proj",
+            "model.layers.1.mlp.gate",
+            "model.layers.1.mlp.shared_expert.gate_proj",
+        ]
+        for path in non_switch_mlp_paths:
+            with self.subTest(path=path):
+                self.assertEqual(
+                    predicate(path, module),
+                    {"group_size": 64, "bits": 8, "mode": "affine"},
+                )
+
+    def test_expert_bits_4(self):
+        self._check_paths(expert_bits=4)
+
+    def test_expert_bits_6(self):
+        self._check_paths(expert_bits=6)
+
+    def test_invalid_expert_bits_raises(self):
+        with self.assertRaises(ValueError):
+            build_laguna_quant_predicate(expert_bits=5)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_laguna_quant.py
+++ b/tests/test_laguna_quant.py
@@ -23,8 +23,10 @@ class DummyModule:
 
 
 class TestLagunaQuantPredicate(unittest.TestCase):
-    def _check_paths(self, expert_bits: int):
-        predicate = build_laguna_quant_predicate(expert_bits=expert_bits)
+    def _check_paths(self, expert_bits: int, attention_bits: int = 8):
+        predicate = build_laguna_quant_predicate(
+            expert_bits=expert_bits, attention_bits=attention_bits
+        )
         module = DummyModule()
 
         switch_mlp_paths = [
@@ -47,7 +49,7 @@ class TestLagunaQuantPredicate(unittest.TestCase):
             with self.subTest(path=path):
                 self.assertEqual(
                     predicate(path, module),
-                    {"group_size": 64, "bits": 8, "mode": "affine"},
+                    {"group_size": 64, "bits": attention_bits, "mode": "affine"},
                 )
 
     def test_expert_bits_4(self):
@@ -55,6 +57,13 @@ class TestLagunaQuantPredicate(unittest.TestCase):
 
     def test_expert_bits_6(self):
         self._check_paths(expert_bits=6)
+
+    def test_expert_bits_2_with_4bit_attention(self):
+        # The compatibility report's `4bit-Att-2bit-Ex` recipe: routed
+        # experts dominate Laguna's footprint (~116B of ~117.6B stored
+        # parameters), so this is the variant that actually shrinks a
+        # 118B model down to a 64 GB-Mac-friendly size.
+        self._check_paths(expert_bits=2, attention_bits=4)
 
     def test_invalid_expert_bits_raises(self):
         with self.assertRaises(ValueError):

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -1997,6 +1997,58 @@ class TestModels(unittest.TestCase):
             model, args.model_type, args.vocab_size, args.num_hidden_layers
         )
 
+    def test_laguna(self):
+        from mlx_lm.models import laguna
+
+        args = laguna.ModelArgs(
+            model_type="laguna",
+            vocab_size=10_000,
+            hidden_size=128,
+            intermediate_size=256,
+            num_hidden_layers=4,
+            num_attention_heads=8,
+            num_key_value_heads=2,
+            head_dim=16,
+            rms_norm_eps=1e-5,
+            max_position_embeddings=4096,
+            rope_parameters={
+                "full_attention": {
+                    "rope_type": "yarn",
+                    "rope_theta": 500000.0,
+                    "factor": 8.0,
+                    "original_max_position_embeddings": 512,
+                    "beta_fast": 32.0,
+                    "beta_slow": 1.0,
+                    "partial_rotary_factor": 0.5,
+                },
+                "sliding_attention": {
+                    "rope_type": "default",
+                    "rope_theta": 10000.0,
+                    "partial_rotary_factor": 1.0,
+                },
+            },
+            sliding_window=8,
+            layer_types=[
+                "full_attention",
+                "sliding_attention",
+                "sliding_attention",
+                "full_attention",
+            ],
+            num_attention_heads_per_layer=[8, 12, 12, 8],
+            gating="per-head",
+            num_experts=4,
+            num_experts_per_tok=2,
+            moe_intermediate_size=64,
+            shared_expert_intermediate_size=64,
+            mlp_only_layers=[0],
+            decoder_sparse_step=1,
+            moe_routed_scaling_factor=2.5,
+        )
+        model = laguna.Model(args)
+        self.model_test_runner(
+            model, args.model_type, args.vocab_size, args.num_hidden_layers
+        )
+
     def test_all_models(self):
         test_configs = [
             {


### PR DESCRIPTION
## Why

`poolside/Laguna-S-2.1` (118B total / ~8B active MoE, 256 experts top-10 routed
plus one shared expert, OpenMDW-1.1) — and its siblings `Laguna-XS-2.1`
(33B-A3B) and `Laguna-M.1` (225B-A23B) — have no `mlx-lm` architecture module
today. `model_type: "laguna"` in their `config.json` maps only to remote
`custom_code` classes (`configuration_laguna.LagunaConfig` /
`modeling_laguna.LagunaForCausalLM`) hosted in the HF repo, which `mlx-lm`
cannot run natively. This PR adds `mlx_lm/models/laguna.py`, so Laguna
checkpoints load and convert through the same path as every other
architecture — **no `trust_remote_code` required**, which matters more than
usual now that `transformers` gates `custom_code` execution behind
`trust_remote_code=True` (CVE-2026-5843, merged 2026-06-11).

Evidence of real demand: poolside has already uploaded an mlx-quantized
checkpoint (`poolside/Laguna-S-2.1-NVFP4-mlx`) whose weight-key layout
(`mlp.switch_mlp.*`, `mlp.gate.*`) already matches this port's target
naming — i.e. this is the naming convention the checkpoint publisher expects
mlx-lm support to use.

## What

Laguna combines several features `mlx-lm` already supports individually,
just not previously combined in one model:

- Sigmoid-scored MoE router with an auxiliary-loss-free correction bias
  (same pattern as `glm4_moe.py`'s `MoEGate`), 256 routed experts (top-10)
  plus one shared expert, via `SwitchGLU`.
- Alternating full/sliding-window attention with **separate RoPE per layer
  type** (YaRN for full-attention layers, default for sliding — same
  `make_cache`/alternating-mask pattern as `gpt_oss.py`).
- Per-layer attention head-count override (`num_attention_heads_per_layer`).
- Optional softplus output gating on attention (`attn_out *= softplus(g_proj(x))`,
  per-head or per-element) and optional learnable attention sinks on
  sliding layers (`gpt_oss.py` precedent for the sinks mechanism).
- QK-RMSNorm.

Also included: `tests/test_models.py::test_laguna` (exercises every
non-standard feature above through the existing shape/dtype/cache/batch>1
harness), and `scripts/laguna_quant_predicate.py` — a custom per-module
quantization predicate demonstrating how to produce the mixed-precision
variants some Laguna publishers may want (attention/router/embeddings at
one bit width, routed experts at a lower one — 8-bit/{4,6}-bit-experts, or
4-bit/2-bit-experts for a footprint that actually fits a 64 GB Mac, since
routed experts hold ~116B of Laguna S-2.1's ~117.6B stored parameters),
for recipes the standard `mlx_lm.convert -q --q-bits N` flag can't express
directly. The three uniform variants (4-bit/6-bit/8-bit everywhere) need no
custom predicate.

## How tested

- `tests/test_models.py::test_laguna` (new, in this PR): a tiny random-init
  config that forces every layer through a genuinely distinct code path —
  dense MLP vs. MoE, full vs. sliding attention, YaRN vs. default RoPE,
  different per-layer head counts (8 vs. 12) — verified through the existing
  `model_test_runner` shape/dtype/cache/batch>1/deepcopy checks.
- **Numerical parity against the reference `transformers` implementation.**
  A local harness (not included in this PR — it depends on `torch`/
  `transformers`, which `mlx-lm` does not otherwise require) built a matched
  3-layer config in both the reference and this port from an identical
  random seed, ran this port's real `Model.sanitize()` on the reference's
  actual per-expert weight layout (not a hand-constructed shortcut around
  it), loaded with `strict=True`, and compared logits:
  **max abs diff 5.1e-4, mean abs diff 1.3e-4** (float32, tolerance 1e-3).
  The router's auxiliary-loss-free correction bias was set to a nonzero
  random tensor before comparison — with it left at its zero default the
  first pass, an earlier review round found `sanitize()` was silently
  dropping this bias's real on-disk key (`mlp.experts.e_score_correction_bias`
  → `mlp.gate.e_score_correction_bias`) rather than remapping it, which a
  zero-valued bias could not have exposed; that gap is now closed and
  covered by a dedicated unit test, and the harness's discriminating power
  was confirmed by deliberately breaking the bias-add sign and observing the
  diff jump to 0.025 (fails, as it should).
- Structural shapes were additionally cross-checked against the **real**
  `poolside/Laguna-S-2.1` checkpoint's safetensors headers (HTTP range
  request — no 219 GiB download), confirming the per-layer head-count
  override (48 vs. 72 heads) and per-expert unfused weight layout this port
  assumes are correct.

## Known limitations / explicitly out of scope

- **DFlash speculative-decoding draft checkpoints are not supported by this
  module**, even though they share the same `config.json` `model_type:
  "laguna"` string. `poolside/Laguna-S-2.1-DFlash` (and its siblings) use a
  structurally different architecture (`architectures: ["DFlashLagunaForCausalLM"]`
  — dense, no MoE, all-sliding-window, with EAGLE-style auxiliary hidden
  states and block-causal masking for multi-token draft generation), and
  `mlx-lm` dispatches purely on `model_type` (`mlx_lm/utils.py`), not
  `architectures`. Converting a DFlash checkpoint with this module would not
  produce a working draft model. A separate architecture module would be
  needed for DFlash support; out of scope here (a dedicated
  `dflash_laguna` speculator is already proposed separately in #1531).
- Attention sinks: the reference stores a per-layer sink parameter as
  `self.sink` (singular) when `swa_attention_sink_enabled=True`; this port
  uses `self.sinks` and `sanitize()` does not remap the name. None of the
  three published Laguna checkpoints (S-2.1, XS-2.1, M.1) set this flag, so
  it's inert today; a checkpoint that does would need the name reconciled
  first.
- `attention_bias` is read from config by this port, but the reference
  hardcodes no bias on Q/K/V/O regardless of config — inert for all three
  published checkpoints (all set it `false`), but worth aligning if a future
  variant sets it `true`.
- The parity harness compares a single full-prompt forward pass; it doesn't
  exercise incremental/cached decode (`RotatingKVCache` stepping) or router
  logit soft-capping (no published checkpoint sets a nonzero value there
  either).
- Loading a real Laguna checkpoint's tokenizer logs a `transformers`
  warning about an "incorrect regex pattern" and suggests
  `fix_mistral_regex=True`. This is a false positive of `transformers`'s own
  detection heuristic (it fires for any `config.json` missing
  `transformers_version`, which Laguna's does, regardless of `model_type`)
  and not a real tokenization bug: round-tripping code samples with
  contractions, mixed case, and multi-newline runs through Laguna's real
  tokenizer produces byte-identical output with and without the flag, and
  the flag's own fix targets a different pipeline stage than the one
  Laguna's pre-tokenizer actually differs on. Safe to ignore.
