### PR TITLE
Add native Nanbeige model support

### DIFF
--- a/mlx_lm/generate.py
+++ b/mlx_lm/generate.py
@@ -510,18 +510,31 @@ def speculative_generate_step(
     prev_tokens = None
 
     # Create the KV cache for generation
-    if prompt_cache is None:
-        model_cache = cache.make_prompt_cache(model)
-        draft_cache = cache.make_prompt_cache(draft_model)
-    else:
-        model_cache = prompt_cache[: len(model.layers)]
-        draft_cache = prompt_cache[len(model.layers) :]
+    model_cache = cache.make_prompt_cache(model)
+    draft_cache = cache.make_prompt_cache(draft_model)
+    if prompt_cache is not None:
+        model_cache_size = len(model_cache)
+        expected_cache_size = model_cache_size + len(draft_cache)
+        if len(prompt_cache) != expected_cache_size:
+            raise ValueError(
+                "Speculative decoding requires "
+                f"{expected_cache_size} prompt cache entries, got {len(prompt_cache)}."
+            )
+        model_cache = prompt_cache[:model_cache_size]
+        draft_cache = prompt_cache[model_cache_size:]
 
-    if not cache.can_trim_prompt_cache(model_cache):
-        types = {type(c).__name__ for c in model_cache if not c.is_trimmable()}
-        raise ValueError(
-            f"Speculative decoding requires a trimmable prompt cache " f"(got {types})."
-        )
+    for cache_name, prompt_model_cache in (
+        ("target", model_cache),
+        ("draft", draft_cache),
+    ):
+        if not cache.can_trim_prompt_cache(prompt_model_cache):
+            types = {
+                type(c).__name__ for c in prompt_model_cache if not c.is_trimmable()
+            }
+            raise ValueError(
+                "Speculative decoding requires a trimmable "
+                f"{cache_name} prompt cache (got {types})."
+            )
 
     sampler = sampler or (lambda x: mx.argmax(x, axis=-1))
 
@@ -2063,6 +2076,12 @@ def batch_generate(
 def main():
     parser = setup_arg_parser()
     args = parser.parse_args()
+
+    if args.prompt_cache_file is not None and args.draft_model is not None:
+        raise ValueError(
+            "--prompt-cache-file cannot be combined with --draft-model because "
+            "saved prompt caches contain only the target model cache."
+        )
 
     if args.seed is not None:
         mx.random.seed(args.seed)

--- a/mlx_lm/models/nanbeige.py
+++ b/mlx_lm/models/nanbeige.py
@@ -1,0 +1,88 @@
+# Copyright © 2026 Apple Inc.
+
+from dataclasses import dataclass
+from typing import Any, List, Optional
+
+import mlx.core as mx
+import mlx.nn as nn
+
+from . import llama
+from .cache import KVCache
+
+
+@dataclass
+class ModelArgs(llama.ModelArgs):
+    num_loops: int = 1
+    loop_loss_weights: Optional[List[float]] = None
+    skip_loop_final_norm: bool = False
+
+    @classmethod
+    def from_dict(cls, params):
+        unsupported = {
+            "qk_layernorm": params.get("qk_layernorm"),
+            "emb_neighbor_num": params.get("emb_neighbor_num") is not None,
+            "insert_ngram_layer_idx": bool(params.get("insert_ngram_layer_idx")),
+            "ngram_insert_all_layers": params.get("ngram_insert_all_layers"),
+            "enable_double_loop_split": params.get("enable_double_loop_split"),
+            "loop_middle_layers": bool(params.get("loop_middle_layers")),
+            "loop_share_kv": params.get("loop_share_kv"),
+            "enable_hyper_connection": params.get("enable_hyper_connection"),
+            "enable_mhc": params.get("enable_mhc"),
+            "enable_h_res_identity": params.get("enable_h_res_identity"),
+            "enable_depth_attention": params.get("enable_depth_attention"),
+        }
+        enabled = [name for name, value in unsupported.items() if value]
+        if enabled:
+            raise ValueError(
+                "Unsupported Nanbeige architecture options: " + ", ".join(enabled)
+            )
+        return super().from_dict(params)
+
+    def __post_init__(self):
+        super().__post_init__()
+        if self.num_loops != 2:
+            raise ValueError(f"Only num_loops=2 is supported, got {self.num_loops}.")
+        if self.skip_loop_final_norm:
+            raise ValueError("skip_loop_final_norm=True is not supported.")
+        if self.loop_loss_weights:
+            raise ValueError("loop_loss_weights is only supported when empty.")
+        if any(layer_type != "full_attention" for layer_type in self.layer_types):
+            raise ValueError("Only full-attention Nanbeige layers are supported.")
+
+
+class NanbeigeModel(llama.LlamaModel):
+    def __call__(
+        self,
+        inputs: mx.array,
+        cache: Optional[List[Any]] = None,
+        input_embeddings: Optional[mx.array] = None,
+    ):
+        h = input_embeddings
+        num_layers = len(self.layers)
+        expected_caches = self.args.num_loops * num_layers
+
+        if cache is None:
+            cache = [None] * expected_caches
+        elif len(cache) != expected_caches:
+            raise ValueError(
+                f"Nanbeige requires {expected_caches} cache entries, got {len(cache)}."
+            )
+
+        for loop_idx in range(self.args.num_loops):
+            loop_cache = cache[loop_idx * num_layers : (loop_idx + 1) * num_layers]
+            h = super().__call__(inputs, cache=loop_cache, input_embeddings=h)
+
+        return h
+
+
+class Model(llama.Model):
+    def __init__(self, args: ModelArgs):
+        nn.Module.__init__(self)
+        self.args = args
+        self.model_type = args.model_type
+        self.model = NanbeigeModel(args)
+        if not args.tie_word_embeddings:
+            self.lm_head = nn.Linear(args.hidden_size, args.vocab_size, bias=False)
+
+    def make_cache(self):
+        return [KVCache() for _ in range(self.args.num_loops * len(self.layers))]

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -1953,6 +1953,28 @@ class TestModels(unittest.TestCase):
             model, args.model_type, args.vocab_size, args.num_hidden_layers
         )
 
+    def test_nanbeige(self):
+        from mlx_lm.models import nanbeige
+
+        args = nanbeige.ModelArgs(
+            model_type="nanbeige",
+            hidden_size=64,
+            num_hidden_layers=2,
+            intermediate_size=128,
+            num_attention_heads=2,
+            num_key_value_heads=1,
+            head_dim=32,
+            rms_norm_eps=1e-5,
+            vocab_size=64,
+            num_loops=2,
+            skip_loop_final_norm=False,
+            tie_word_embeddings=False,
+        )
+        model = nanbeige.Model(args)
+        self.model_test_runner(
+            model, args.model_type, args.vocab_size, args.num_hidden_layers
+        )
+
     def test_smollm3(self):
         from mlx_lm.models import smollm3
 

--- a/tests/test_nanbeige.py
+++ b/tests/test_nanbeige.py
@@ -1,0 +1,272 @@
+# Copyright © 2026 Apple Inc.
+
+import functools
+import os
+import sys
+import tempfile
+import unittest
+from unittest.mock import patch
+
+import mlx.core as mx
+import mlx.nn as nn
+from mlx.utils import tree_flatten
+
+from mlx_lm.generate import BatchGenerator, generate_step
+from mlx_lm.generate import main as generate_main
+from mlx_lm.generate import speculative_generate_step
+from mlx_lm.models import llama, nanbeige
+from mlx_lm.models.cache import KVCache, load_prompt_cache, save_prompt_cache
+from mlx_lm.utils import quantize_model
+
+
+def make_nanbeige(num_hidden_layers=2):
+    model = nanbeige.Model(
+        nanbeige.ModelArgs(
+            model_type="nanbeige",
+            hidden_size=64,
+            num_hidden_layers=num_hidden_layers,
+            intermediate_size=128,
+            num_attention_heads=2,
+            num_key_value_heads=1,
+            head_dim=32,
+            rms_norm_eps=1e-5,
+            vocab_size=64,
+            num_loops=2,
+            skip_loop_final_norm=False,
+            tie_word_embeddings=False,
+        )
+    )
+    model.set_dtype(mx.float32)
+    return model
+
+
+class TestNanbeige(unittest.TestCase):
+    def test_recurrent_forward_and_cache(self):
+        model = make_nanbeige()
+        inputs = mx.array([[0, 1, 2]])
+
+        self.assertEqual(len(model.layers), 2)
+        self.assertEqual(len(model.make_cache()), 4)
+        self.assertEqual(len({id(layer) for layer in model.layers}), 2)
+        parameter_names = dict(tree_flatten(model.parameters())).keys()
+        self.assertEqual(
+            sum(name.endswith("self_attn.q_proj.weight") for name in parameter_names),
+            2,
+        )
+
+        full_logits = model(inputs)
+        cache = model.make_cache()
+        cached_logits = mx.concatenate(
+            [model(inputs[:, i : i + 1], cache=cache) for i in range(inputs.shape[1])],
+            axis=1,
+        )
+        self.assertTrue(mx.allclose(full_logits, cached_logits, rtol=1e-4, atol=1e-4))
+
+        with self.assertRaisesRegex(ValueError, "requires 4 cache entries"):
+            model(inputs, cache=model.make_cache()[:-1])
+        with self.assertRaisesRegex(ValueError, "requires 4 cache entries"):
+            model(inputs, cache=model.make_cache() + model.make_cache()[:1])
+
+    def test_variable_length_batch_generation(self):
+        model = make_nanbeige()
+        prompts = [[0, 1, 2], [3, 4], [5]]
+        generator = BatchGenerator(
+            model,
+            max_tokens=1,
+            prefill_batch_size=3,
+            completion_batch_size=3,
+        )
+        uids = generator.insert(prompts)
+        responses = {}
+        while batch := generator.next_generated():
+            responses.update((response.uid, response) for response in batch)
+
+        self.assertEqual(set(responses), set(uids))
+        for uid, prompt in zip(uids, prompts):
+            _, expected = next(generate_step(mx.array(prompt), model, max_tokens=1))
+            self.assertTrue(mx.allclose(responses[uid].logprobs, expected))
+
+    def test_quantized_kv_cache(self):
+        model = make_nanbeige()
+        inputs = mx.array([[0, 1, 2]])
+        cache = model.make_cache()
+        model(inputs[:, :2], cache=cache)
+        quantized_cache = [entry.to_quantized(group_size=32, bits=4) for entry in cache]
+        quantized_kv_logits = model(inputs[:, 2:], cache=quantized_cache)
+        self.assertTrue(mx.all(mx.isfinite(quantized_kv_logits)).item())
+
+    def _assert_quantized_weights(self, bits):
+        model = make_nanbeige()
+        quantized, _ = quantize_model(model, {"model_type": "nanbeige"}, 64, bits)
+        logits = quantized(mx.array([[0, 1, 2]]))
+        mx.eval(logits)
+        self.assertIsInstance(
+            quantized.model.layers[0].self_attn.q_proj, nn.QuantizedLinear
+        )
+        self.assertTrue(mx.all(mx.isfinite(logits)).item())
+
+    def test_4_bit_weights(self):
+        self._assert_quantized_weights(4)
+
+    def test_8_bit_weights(self):
+        self._assert_quantized_weights(8)
+
+    def test_norm_runs_after_each_physical_pass(self):
+        events = []
+
+        class Layer(nn.Module):
+            def __init__(self, index):
+                super().__init__()
+                self.index = index
+                self.use_sliding = False
+
+            def __call__(self, x, mask=None, cache=None):
+                events.append(f"layer-{self.index}")
+                return x
+
+        class Norm(nn.Module):
+            def __call__(self, x):
+                events.append("norm")
+                return x
+
+        model = make_nanbeige().model
+        model.layers = [Layer(0), Layer(1)]
+        model.norm = Norm()
+        model(None, input_embeddings=mx.zeros((1, 1, 64)))
+
+        self.assertEqual(
+            events,
+            ["layer-0", "layer-1", "norm", "layer-0", "layer-1", "norm"],
+        )
+
+    def test_prompt_cache_round_trip_continues(self):
+        model = make_nanbeige(num_hidden_layers=22)
+        inputs = mx.array([[0, 1, 2]])
+        cache = model.make_cache()
+        model(inputs[:, :2], cache=cache)
+
+        with tempfile.TemporaryDirectory() as directory:
+            path = os.path.join(directory, "prompt.safetensors")
+            save_prompt_cache(path, cache)
+            loaded_cache = load_prompt_cache(path)
+
+        expected = model(inputs[:, 2:], cache=cache)
+        actual = model(inputs[:, 2:], cache=loaded_cache)
+        self.assertEqual(len(loaded_cache), 44)
+        self.assertTrue(mx.allclose(expected, actual, rtol=1e-5, atol=1e-5))
+
+    def test_config_validation(self):
+        config = {
+            "model_type": "nanbeige",
+            "hidden_size": 64,
+            "num_hidden_layers": 2,
+            "intermediate_size": 128,
+            "num_attention_heads": 2,
+            "num_key_value_heads": 1,
+            "head_dim": 32,
+            "rms_norm_eps": 1e-5,
+            "vocab_size": 64,
+            "num_loops": 2,
+            "loop_loss_weights": [],
+            "skip_loop_final_norm": False,
+        }
+        self.assertEqual(nanbeige.ModelArgs.from_dict(config).num_loops, 2)
+
+        for num_loops in (None, 0, 1, 3):
+            invalid = dict(config)
+            if num_loops is None:
+                invalid.pop("num_loops")
+            else:
+                invalid["num_loops"] = num_loops
+            with self.subTest(num_loops=num_loops), self.assertRaisesRegex(
+                ValueError, "Only num_loops=2"
+            ):
+                nanbeige.ModelArgs.from_dict(invalid)
+
+        with self.assertRaisesRegex(ValueError, "skip_loop_final_norm"):
+            nanbeige.ModelArgs.from_dict({**config, "skip_loop_final_norm": True})
+        with self.assertRaisesRegex(ValueError, "loop_loss_weights"):
+            nanbeige.ModelArgs.from_dict({**config, "loop_loss_weights": [1.0]})
+
+        for option, value in (
+            ("qk_layernorm", True),
+            ("emb_neighbor_num", 2),
+            ("insert_ngram_layer_idx", [0]),
+            ("ngram_insert_all_layers", True),
+            ("enable_double_loop_split", True),
+            ("loop_middle_layers", 1),
+            ("loop_share_kv", True),
+            ("enable_hyper_connection", True),
+            ("enable_mhc", True),
+            ("enable_h_res_identity", True),
+            ("enable_depth_attention", True),
+        ):
+            with self.subTest(option=option), self.assertRaisesRegex(
+                ValueError, rf"Unsupported Nanbeige architecture options:.*{option}"
+            ):
+                nanbeige.ModelArgs.from_dict({**config, option: value})
+
+    def test_speculative_cache_uses_logical_cache_count(self):
+        target = make_nanbeige()
+        draft = llama.Model(
+            llama.ModelArgs(
+                model_type="llama",
+                hidden_size=64,
+                num_hidden_layers=1,
+                intermediate_size=128,
+                num_attention_heads=4,
+                num_key_value_heads=2,
+                head_dim=16,
+                rms_norm_eps=1e-5,
+                vocab_size=64,
+            )
+        )
+        combined_cache = target.make_cache() + draft.make_cache()
+        speculate = functools.partial(
+            speculative_generate_step,
+            mx.array([0, 1]),
+            target,
+            draft,
+            max_tokens=1,
+        )
+
+        self.assertEqual(len(list(speculate(prompt_cache=combined_cache))), 1)
+
+        wrong_sizes = (
+            ("target", target.make_cache()[:-1] + draft.make_cache()),
+            ("draft", target.make_cache() + draft.make_cache()[:-1]),
+        )
+        for cache_name, invalid_cache in wrong_sizes:
+            with self.subTest(cache=cache_name), self.assertRaisesRegex(
+                ValueError, "requires 5 prompt cache entries"
+            ):
+                next(speculate(prompt_cache=invalid_cache))
+
+        class NonTrimmableKVCache(KVCache):
+            def is_trimmable(self):
+                return False
+
+        for index, cache_name in ((0, "target"), (-1, "draft")):
+            invalid_cache = list(combined_cache)
+            invalid_cache[index] = NonTrimmableKVCache()
+            with self.subTest(cache=cache_name), self.assertRaisesRegex(
+                ValueError, rf"trimmable {cache_name} prompt cache"
+            ):
+                next(speculate(prompt_cache=invalid_cache))
+
+    def test_cli_rejects_saved_cache_with_draft_model(self):
+        argv = [
+            "mlx_lm.generate",
+            "--prompt-cache-file",
+            "cache.safetensors",
+            "--draft-model",
+            "draft",
+        ]
+        with patch.object(sys, "argv", argv), self.assertRaisesRegex(
+            ValueError, "cannot be combined"
+        ):
+            generate_main()
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- Add native `model_type="nanbeige"` support for the released Nanbeige4.2-3B checkpoint.
- Reuse the existing Llama stack for two recurrent passes while keeping 22 physical layers and 44 independent KV-cache entries.
- Split speculative target and draft caches using each model's declared cache layout instead of `len(model.layers)`.
- Reject unsupported vendor architecture modes explicitly rather than loading them with different semantics.

## Why a separate implementation

PRs #1597 and #1599 both implement the core loop and correctly recognize that each pass needs its own cache state. This version differs in a few runtime-level details:

1. It subclasses the existing Llama implementation instead of copying attention, MLP, masking, RoPE, model output, and sharding logic. Nanbeige therefore inherits fixes to those shared paths.
2. It fixes speculative prompt-cache partitioning. Nanbeige exposes 22 physical layers but creates 44 target-cache entries, so splitting at `len(model.layers)` assigns half of the target cache to the draft model.
3. It validates the exact combined cache size and the trimmability of both target and draft caches.
4. It adds the standard model-discovery test plus focused coverage for variable-length batch generation, serialized 44-entry prompt caches, 4-bit and 8-bit weights, 4-bit KV caches, and invalid target/draft cache layouts.
5. It deliberately supports the released two-loop, full-attention checkpoint configuration and names unsupported vendor fields in the load error.

## Validation

The official checkpoint was pinned to revision `5ff54fb7ed86ce8e216d78bff5417ab9981de3d4` and loaded strictly without checkpoint Python.

Float32 vendor parity, evaluated over the full vocabulary at all positions of the fixed prompt:

| Comparison | Max absolute error | Mean absolute error |
| --- | ---: | ---: |
| Vendor vs MLX, full prompt | 0.000141144 | 0.0000143511 |
| Vendor vs MLX, cached | 0.0000257492 | 0.00000285435 |
| Vendor full vs cached | 0.000110626 | 0.0000132345 |
| MLX full vs cached | 0.0000782013 | 0.00000763334 |

All comparisons pass with `rtol=1e-4`, `atol=1e-4`, and vendor and MLX produce the same 32-token greedy continuation.

Fresh BF16, 8-bit group-64, 4-bit group-64, and 4-bit weight plus KV4 generation checks pass. Both weight-only quantized models contain the expected 155 quantized linear modules.

Local focused checks:

```text
69 tests passed:
  tests.test_models.TestModels.test_nanbeige
  tests.test_nanbeige
  tests.test_generate
  tests.test_prompt_cache
  tests.test_utils
  tests.test_evaluate

pre-commit on all changed Python files:
  black 25.1.0: pass
  isort 6.0.0: pass
```

Full `python -m unittest discover tests/`: 219 passed, 1 skipped, and 1 error in `test_datsets.TestDatasets.test_hf`. The same Hugging Face `billsum` URI error reproduces on a clean `origin/main` checkout in this environment.

BF16 does not reproduce the vendor continuation bit for bit. Both PyTorch and MLX show full-versus-cached BF16 drift, while the float32 architecture gate passes. The first BF16 token difference occurs at an exact vendor logit tie; this is recorded as backend numerical behavior rather than hidden by a wider tolerance.
