### PR TITLE
fix(granitemoehybrid): accept nested rope_parameters and tied lm_head weight

### DIFF
--- a/mlx_lm/models/granitemoehybrid.py
+++ b/mlx_lm/models/granitemoehybrid.py
@@ -37,7 +37,6 @@ class ModelArgs(BaseModelArgs):
     residual_multiplier: float
     layer_types: List[str]
     rms_norm_eps: float
-    rope_theta: float
 
     # Optional fields (with defaults)
     # MoE parameters (optional for dense mode)
@@ -61,6 +60,16 @@ class ModelArgs(BaseModelArgs):
     position_embedding_type: str = "rope"
     tie_word_embeddings: bool = True
     time_step_limit: Tuple[float, float] = (0.001, 100.0)
+
+    # rope_theta may arrive as a flat field (older configs) or nested under
+    # rope_parameters (newer transformers releases, e.g. Granite 4.0 Hybrid
+    # checkpoints). Accept both and normalize to a flat rope_theta.
+    rope_theta: float = 10000.0
+    rope_parameters: Optional[dict] = None
+
+    def __post_init__(self):
+        if self.rope_parameters is not None and "rope_theta" in self.rope_parameters:
+            self.rope_theta = self.rope_parameters["rope_theta"]
 
     # Mode flags - inferred from num_local_experts
     @property
@@ -546,6 +555,11 @@ class Model(nn.Module):
                 weights[f"model.layers.{l}.mlp.down_proj.weight"] = weights.pop(
                     f"{prefix}.output_linear.weight"
                 )
+
+        # Some checkpoints ship a redundant lm_head.weight even though
+        # embeddings are tied and this model never instantiates lm_head.
+        if self.args.tie_word_embeddings:
+            weights.pop("lm_head.weight", None)
 
         return weights
 

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -1997,6 +1997,54 @@ class TestModels(unittest.TestCase):
             model, args.model_type, args.vocab_size, args.num_hidden_layers
         )
 
+    def test_granitemoehybrid_rope_parameters(self):
+        # Regression test: some checkpoints (e.g. Granite 4.0 Hybrid) only
+        # provide rope_theta nested under rope_parameters, with no flat
+        # rope_theta field, and ship a redundant lm_head.weight even though
+        # tie_word_embeddings is True.
+        from mlx_lm.models import granitemoehybrid
+
+        config = {
+            "model_type": "granitemoehybrid",
+            "vocab_size": 1000,
+            "hidden_size": 128,
+            "intermediate_size": 128,
+            "num_hidden_layers": 4,
+            "max_position_embeddings": 1000,
+            "num_attention_heads": 8,
+            "num_key_value_heads": 4,
+            "attention_bias": False,
+            "embedding_multiplier": 1.0,
+            "attention_multiplier": 1.0,
+            "logits_scaling": 1.0,
+            "residual_multiplier": 1.0,
+            "mamba_n_heads": 8,
+            "mamba_d_head": 16,
+            "mamba_proj_bias": False,
+            "mamba_d_state": 128,
+            "mamba_d_conv": 4,
+            "mamba_n_groups": 1,
+            "mamba_conv_bias": False,
+            "layer_types": ["mamba", "attention", "mamba", "attention"],
+            "rms_norm_eps": 1e-5,
+            "tie_word_embeddings": True,
+            "rope_parameters": {"rope_theta": 1000.0, "rope_type": "default"},
+        }
+        args = granitemoehybrid.ModelArgs.from_dict(config)
+        self.assertEqual(args.rope_theta, 1000.0)
+
+        model = granitemoehybrid.Model(args)
+        self.model_test_runner(
+            model, args.model_type, config["vocab_size"], config["num_hidden_layers"]
+        )
+
+        weights = dict(tree_flatten(model.parameters()))
+        weights["lm_head.weight"] = mx.zeros(
+            (config["vocab_size"], config["hidden_size"])
+        )
+        sanitized = model.sanitize(weights)
+        self.assertNotIn("lm_head.weight", sanitized)
+
     def test_all_models(self):
         test_configs = [
             {


### PR DESCRIPTION
## Summary

Granite 4.0 Hybrid checkpoints produced by newer `transformers` releases (e.g. [`fdtn-ai/antares-1b`](https://huggingface.co/fdtn-ai/antares-1b), based on `ibm-granite/granite-4.0-1b`) fail to load in `mlx_lm.models.granitemoehybrid` for two independent reasons:

1. **`rope_theta` is nested, not flat.** The checkpoint's `config.json` provides:
   ```json
   "rope_parameters": {"rope_theta": 10000000, "rope_type": "default"}
   ```
   with no top-level `rope_theta` field. `ModelArgs.rope_theta` is a required positional field with no default, so loading fails with:
   ```
   TypeError: ModelArgs.__init__() missing 1 required positional argument: 'rope_theta'
   ```
   `lfm2`, `lfm2_moe`, and `exaone_moe` already handle this by accepting an optional `rope_parameters` dict and unpacking it in `__post_init__`. `granitemoehybrid` never got the same treatment.

2. **Redundant `lm_head.weight` when embeddings are tied.** The same checkpoint ships an `lm_head.weight` tensor even though `tie_word_embeddings: true`, and `Model.__init__` only creates `self.lm_head` when embeddings are *not* tied. Strict weight loading then rejects the extra key:
   ```
   ValueError: Received 1 parameters not in model: lm_head.weight
   ```
   `apertus.py` already handles this pattern via `weights.pop("lm_head.weight", None)` in `sanitize()`.

## Fix

- `ModelArgs`: move `rope_theta` to an optional field with a default, add an optional `rope_parameters: Optional[dict]`, and unpack it in `__post_init__` — same pattern as `lfm2.py`.
- `Model.sanitize()`: drop `lm_head.weight` when `tie_word_embeddings` is `True` — same pattern as `apertus.py`.

Both changes are backward compatible: the existing `test_all_models` config for `granitemoehybrid` (flat `rope_theta`, no `rope_parameters`) still passes unchanged.

## Testing

- Added `test_granitemoehybrid_rope_parameters`, which builds a `ModelArgs` from a config using only nested `rope_parameters` (no flat `rope_theta`), runs it through `model_test_runner`, and confirms `sanitize()` drops a synthetic `lm_head.weight` when `tie_word_embeddings=True`.
- Confirmed the new test fails with the exact `TypeError` above against unpatched `main`, and passes after the fix.
- Full `tests/test_models.py` suite passes locally (78 tests, 1 skipped — pre-existing/unrelated).
- `black --check` clean on both changed files.
- Verified against the real checkpoint end to end: `fdtn-ai/antares-1b` now loads and serves correctly through `vllm-metal` (0.25.1) on Apple Silicon, producing coherent completions via `/v1/completions`.

## Context

Found while trying to run Cisco Foundation AI's [Antares](https://huggingface.co/fdtn-ai/antares-1b) vulnerability-localization models locally via `vllm-metal`, which routes `granitemoehybrid` through this file's `mlx_lm.load`/`load_model` path.
