### PR TITLE
Fix InternLM2/InterLN3 DynamicNTKScalingRoPE

### DIFF
--- a/mlx_lm/models/internlm2.py
+++ b/mlx_lm/models/internlm2.py
@@ -8,6 +8,7 @@ import mlx.nn as nn
 
 from .activations import swiglu
 from .base import BaseModelArgs, create_attention_mask, scaled_dot_product_attention
+from .rope_utils import initialize_rope
 
 
 @dataclass
@@ -42,46 +43,6 @@ class ModelArgs(BaseModelArgs):
                 )
 
 
-class DynamicNTKScalingRoPE(nn.Module):
-    """Implements the rotary positional encoding with Dynamic NTK scaling."""
-
-    def __init__(
-        self,
-        dims: int,
-        max_position_embeddings: int = 2048,
-        traditional: bool = False,
-        base: float = 10000,
-        scale: float = 1.0,
-    ):
-        super().__init__()
-        self.max_position_embeddings = max_position_embeddings
-        self.original_base = base
-        self.dims = dims
-        self.traditional = traditional
-        self.scale = scale
-
-    def extra_repr(self):
-        return f"{self.dims}, traditional={self.traditional}, max_position_embeddings={self.max_position_embeddings}, scaling_factor={self.scaling_factor}"
-
-    def __call__(self, x, offset: int = 0):
-        seq_len = x.shape[1] + offset
-        if seq_len > self.max_position_embeddings:
-            base = self.original_base * (
-                (self.scale * seq_len / self.max_position_embeddings) - (self.scale - 1)
-            ) ** (self.dims / (self.dims - 2))
-        else:
-            base = self.original_base
-
-        return mx.fast.rope(
-            x,
-            self.dims,
-            traditional=self.traditional,
-            base=base,
-            scale=self.scale,
-            offset=offset,
-        )
-
-
 class Attention(nn.Module):
     def __init__(self, args: ModelArgs):
         super().__init__()
@@ -99,18 +60,12 @@ class Attention(nn.Module):
         )
         self.wo = nn.Linear(n_heads * head_dim, dim, bias=args.bias)
 
-        rope_scale = (
-            1 / args.rope_scaling["factor"]
-            if args.rope_scaling is not None and args.rope_scaling["type"] == "linear"
-            else 2.0
-        )
-
-        self.rope = DynamicNTKScalingRoPE(
+        self.rope = initialize_rope(
             head_dim,
-            max_position_embeddings=args.max_position_embeddings,
-            traditional=args.rope_traditional,
             base=args.rope_theta,
-            scale=rope_scale,
+            traditional=args.rope_traditional,
+            scaling_config=args.rope_scaling,
+            max_position_embeddings=args.max_position_embeddings,
         )
 
     def __call__(

--- a/mlx_lm/models/internlm3.py
+++ b/mlx_lm/models/internlm3.py
@@ -175,7 +175,7 @@ class TransformerBlock(nn.Module):
         return out
 
 
-class InternLM2Model(nn.Module):
+class InternLM3Model(nn.Module):
     def __init__(self, args: ModelArgs):
         super().__init__()
         assert args.vocab_size > 0
@@ -207,7 +207,7 @@ class Model(nn.Module):
         super().__init__()
         self.args = args
         self.model_type = args.model_type
-        self.model = InternLM2Model(args)
+        self.model = InternLM3Model(args)
         if not args.tie_word_embeddings:
             self.lm_head = nn.Linear(args.hidden_size, args.vocab_size, bias=False)
 

--- a/mlx_lm/models/internlm3.py
+++ b/mlx_lm/models/internlm3.py
@@ -8,6 +8,7 @@ import mlx.nn as nn
 
 from .activations import swiglu
 from .base import BaseModelArgs, create_attention_mask, scaled_dot_product_attention
+from .rope_utils import initialize_rope
 
 
 @dataclass
@@ -101,19 +102,12 @@ class Attention(nn.Module):
         self.v_proj = nn.Linear(dim, n_kv_heads * head_dim, bias=qkv_bias)
         self.o_proj = nn.Linear(n_heads * head_dim, dim, bias=qkv_bias)
 
-        rope_scale = (
-            1 / args.rope_scaling["factor"]
-            if args.rope_scaling is not None
-            and args.rope_scaling["rope_type"] == "linear"
-            else 2.0
-        )
-
-        self.rope = DynamicNTKScalingRoPE(
+        self.rope = initialize_rope(
             head_dim,
-            max_position_embeddings=args.max_position_embeddings,
-            traditional=args.rope_traditional,
             base=args.rope_theta,
-            scale=rope_scale,
+            traditional=args.rope_traditional,
+            scaling_config=args.rope_scaling,
+            max_position_embeddings=args.max_position_embeddings,
         )
 
     def __call__(

--- a/mlx_lm/models/rope_utils.py
+++ b/mlx_lm/models/rope_utils.py
@@ -232,6 +232,46 @@ class ProportionalRoPE(nn.Module):
         )
 
 
+class DynamicNTKScalingRoPE(nn.Module):
+
+    def __init__(
+        self,
+        dims: int,
+        max_position_embeddings: int,
+        traditional: bool,
+        base: float,
+        factor: float,
+    ):
+        super().__init__()
+        self.dims = dims
+        self.max_position_embeddings = max_position_embeddings
+        self.traditional = traditional
+        self.base = base
+        self.factor = factor
+
+    def extra_repr(self) -> str:
+        return (
+            f"{self.dims}, traditional={self.traditional}, "
+            f"max_position_embeddings={self.max_position_embeddings}, "
+            f"factor={self.factor}"
+        )
+
+    def __call__(self, x: mx.array, offset: int = 0) -> mx.array:
+        # x.shape: [batch, num_heads, seq_len, head_dim]
+        seq_len = max(x.shape[-2] + offset, self.max_position_embeddings)
+        base = self.base * (
+            (self.factor * seq_len / self.max_position_embeddings) - (self.factor - 1)
+        ) ** (self.dims / (self.dims - 2))
+        return mx.fast.rope(
+            x,
+            self.dims,
+            traditional=self.traditional,
+            base=base,
+            scale=1.0,
+            offset=offset,
+        )
+
+
 def initialize_rope(
     dims,
     base,
@@ -249,6 +289,15 @@ def initialize_rope(
     if rope_type in ["default", "linear"]:
         scale = 1 / scaling_config["factor"] if rope_type == "linear" else 1.0
         return nn.RoPE(dims, traditional=traditional, base=base, scale=scale)
+
+    elif rope_type == "dynamic":
+        return DynamicNTKScalingRoPE(
+            dims=dims,
+            max_position_embeddings=max_position_embeddings,
+            traditional=traditional,
+            base=base,
+            factor=scaling_config["factor"],
+        )
 
     elif rope_type == "llama3":
         return Llama3RoPE(


### PR DESCRIPTION
Fix `DynamicNTKScalingRoPE`; I've done parity checks for both InternLM2/InternLM3 in bf16/fp32

Also fixes typo for `InternLM2Model` -> `InternLM3Model`.

Per-layer diffs for InternLM3Model (fp32):

<details>

```commandline
stage              max abs    mean abs  Δmax vs prev
embeddings      0.0000e+00  0.0000e+00   +0.0000e+00
layer  0        2.1935e-05  2.1588e-08   +2.1935e-05
layer  1        2.3842e-05  3.7467e-08   +1.9073e-06
layer  2        2.4796e-05  5.3179e-08   +9.5367e-07
layer  3        5.4932e-04  1.3868e-07   +5.2452e-04
layer  4        5.4932e-04  1.6798e-07   +0.0000e+00
layer  5        5.4932e-04  2.0177e-07   +0.0000e+00
layer  6        5.4932e-04  2.3335e-07   +0.0000e+00
layer  7        5.4932e-04  2.6904e-07   +0.0000e+00
layer  8        5.4932e-04  3.1151e-07   +0.0000e+00
layer  9        5.4932e-04  3.5688e-07   +0.0000e+00
layer 10        5.4932e-04  4.1828e-07   +0.0000e+00
layer 11        5.4932e-04  4.6634e-07   +0.0000e+00
layer 12        5.4932e-04  5.4093e-07   +0.0000e+00
layer 13        5.4932e-04  6.1406e-07   +0.0000e+00
layer 14        5.4932e-04  6.8721e-07   +0.0000e+00
layer 15        5.4932e-04  7.8666e-07   +0.0000e+00
layer 16        5.4932e-04  8.5657e-07   +0.0000e+00
layer 17        5.4932e-04  9.2318e-07   +0.0000e+00
layer 18        5.4932e-04  9.9479e-07   +0.0000e+00
layer 19        4.8828e-04  1.1296e-06   -6.1035e-05
layer 20        4.8828e-04  1.2521e-06   +0.0000e+00
layer 21        4.8828e-04  1.3359e-06   +0.0000e+00
layer 22        4.8828e-04  1.4446e-06   +0.0000e+00
layer 23        4.8828e-04  1.5285e-06   +0.0000e+00
layer 24        4.8828e-04  1.6002e-06   +0.0000e+00
layer 25        4.8828e-04  1.6893e-06   +0.0000e+00
layer 26        4.2725e-04  1.7170e-06   -6.1035e-05
layer 27        3.6621e-04  1.7650e-06   -6.1035e-05
layer 28        3.6621e-04  1.7803e-06   +0.0000e+00
layer 29        3.6621e-04  1.8475e-06   +0.0000e+00
layer 30        3.6621e-04  1.9195e-06   +0.0000e+00
layer 31        3.6621e-04  2.0273e-06   +0.0000e+00
layer 32        3.6621e-04  2.1177e-06   +0.0000e+00
layer 33        3.6621e-04  2.3002e-06   +0.0000e+00
layer 34        3.6621e-04  2.4995e-06   +0.0000e+00
layer 35        4.2725e-04  2.7606e-06   +6.1035e-05
layer 36        4.2725e-04  3.0551e-06   +0.0000e+00
layer 37        4.8828e-04  3.4085e-06   +6.1035e-05
layer 38        4.8828e-04  3.7889e-06   +0.0000e+00
layer 39        4.8828e-04  4.1197e-06   +0.0000e+00
layer 40        4.8828e-04  4.4659e-06   +0.0000e+00
layer 41        4.8828e-04  4.8655e-06   +0.0000e+00
layer 42        4.8828e-04  5.2824e-06   +0.0000e+00
layer 43        4.8828e-04  5.8591e-06   +0.0000e+00
layer 44        4.8828e-04  6.4599e-06   +0.0000e+00
layer 45        5.4932e-04  7.1053e-06   +6.1035e-05
layer 46        5.4932e-04  8.0155e-06   +0.0000e+00
final (norm)    3.9101e-05  1.6672e-06   -5.1022e-04
```

</details>

closes #1545 #1553 #1562