### PR TITLE
Avoid quadratic path copying in prompt trie search

### DIFF
--- a/mlx_lm/models/cache.py
+++ b/mlx_lm/models/cache.py
@@ -1607,15 +1607,28 @@ class PromptTrie:
         common_prefix = index
         if index > 0:
             best = None
-            stack = [(current, [])]
+            # Reuse one path while traversing instead of copying the growing
+            # path for every node. Markers restore it after each child.
+            path = []
+            pop_path = object()
+            stack = [(current, None, False)]
             while stack:
-                current, extra = stack.pop()
+                item = stack.pop()
+                if item is pop_path:
+                    path.pop()
+                    continue
+
+                current, tok, append_token = item
+                if append_token:
+                    path.append(tok)
+
                 if "__value__" in current:
-                    if best is None or len(extra) < len(best):
-                        best = extra
-                elif best is None or len(extra) < len(best):
+                    if best is None or len(path) < len(best):
+                        best = list(path)
+                elif best is None or len(path) < len(best):
                     for tok in current:
-                        stack.append((current[tok], extra + [tok]))
+                        stack.append(pop_path)
+                        stack.append((current[tok], tok, True))
             longer = tokens[:index] + best
         return PromptTrieResult(model, None, shorter, longer, common_prefix)
 

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -10,7 +10,7 @@ import mlx.core as mx
 import requests
 
 from mlx_lm.generate import TextStateMachine
-from mlx_lm.models.cache import KVCache
+from mlx_lm.models.cache import KVCache, PromptTrie
 from mlx_lm.server import (
     APIHandler,
     LRUPromptCache,
@@ -563,6 +563,29 @@ class TestKeepalive(unittest.TestCase):
             keepalive_callback(3072, 4096)
         except Exception as e:
             self.fail(f"Callback should handle BrokenPipeError: {e}")
+
+
+class TestPromptTrie(unittest.TestCase):
+    def test_search_finds_shortest_longer_sequence(self):
+        trie = PromptTrie()
+        model = object()
+        trie.add(model, [1, 2, 3, 4], "long")
+        trie.add(model, [1, 5, 6], "short")
+
+        result = trie.search(model, [1])
+
+        self.assertEqual(result.longer, [1, 5, 6])
+        self.assertEqual(result.common_prefix, 1)
+
+    def test_search_longer_sequence_tie_breaking(self):
+        trie = PromptTrie()
+        model = object()
+        trie.add(model, [1, 2, 3], "first")
+        trie.add(model, [1, 4, 5], "second")
+
+        result = trie.search(model, [1])
+
+        self.assertEqual(result.longer, [1, 4, 5])
 
 
 class TestLRUPromptCache(unittest.TestCase):


### PR DESCRIPTION
## Summary

- reuse one backtracked path while searching `PromptTrie` instead of copying the growing path at every visited edge
- preserve the existing LIFO traversal and equal-length tie-breaking behavior
- add regression coverage for shortest-match selection and tie-breaking

## Motivation

`PromptTrie.search()` looks for the shortest cached sequence extending a shared prompt prefix. Its DFS currently builds every child path with `extra + [tok]`, so a long branch repeatedly copies its full prefix. This makes the server's prompt-cache lookup quadratic in the length of a long divergent suffix before generation begins.

The new traversal keeps a single mutable path and uses stack markers to backtrack. It only copies the path when recording a better match; cache contents and selection semantics are unchanged.

## Performance

Measured on an Apple M5 Max through the actual `LRUPromptCache.fetch_nearest_cache()` path with four cached branches:

| Divergent suffix | Before | After | Speedup |
| ---: | ---: | ---: | ---: |
| 8,192 tokens | 156.5 ms | 3.43 ms | 45.7x |
| 32,768 tokens | 2.822 s | 13.57 ms | 208.4x |

The 8K result is the median of seven runs; the 32K result is the median of three runs.

## Validation

- 200,000 randomized searches matched the previous traversal exactly
- 30 prompt-trie and prompt-cache tests pass under Python 3.10
- all 27 server tests pass under Python 3.10, including HTTP request paths
- Black, isort, and `git diff --check` pass
