### PR TITLE
Add granitemoe_swa (GraniteMoE + sliding-window attention)

### DIFF
--- a/mlx_lm/models/granitemoe_swa.py
+++ b/mlx_lm/models/granitemoe_swa.py
@@ -1,0 +1,247 @@
+# Copyright © 2025 Apple Inc.
+
+from dataclasses import dataclass
+from typing import Any, List, Optional
+
+import mlx.core as mx
+import mlx.nn as nn
+
+from .activations import swiglu
+from .base import BaseModelArgs, create_attention_mask, scaled_dot_product_attention
+from .cache import KVCache, RotatingKVCache
+from .rope_utils import initialize_rope
+from .switch_layers import SwitchGLU
+
+
+@dataclass
+class ModelArgs(BaseModelArgs):
+    model_type: str
+    vocab_size: int
+    hidden_size: int
+    intermediate_size: int
+    num_hidden_layers: int
+    num_attention_heads: int
+    num_key_value_heads: int
+    num_local_experts: int
+    num_experts_per_tok: int
+    shared_intermediate_size: int
+    max_position_embeddings: int
+    rms_norm_eps: float
+    embedding_multiplier: float
+    attention_multiplier: float
+    residual_multiplier: float
+    logits_scaling: float
+    sliding_window: int
+    layer_types: List[str]
+    attention_bias: bool = False
+    tie_word_embeddings: bool = True
+    rope_theta: float = 10000.0
+    rope_parameters: Optional[dict] = None
+
+    def __post_init__(self):
+        # transformers 5.x nests rope config under `rope_parameters`
+        if self.rope_parameters:
+            self.rope_theta = float(
+                self.rope_parameters.get("rope_theta", self.rope_theta)
+            )
+
+
+class Attention(nn.Module):
+    def __init__(self, args: ModelArgs):
+        super().__init__()
+        dim = args.hidden_size
+        self.n_heads = args.num_attention_heads
+        self.n_kv_heads = args.num_key_value_heads
+        self.head_dim = head_dim = dim // self.n_heads
+        self.scale = args.attention_multiplier
+        bias = args.attention_bias
+
+        self.q_proj = nn.Linear(dim, self.n_heads * head_dim, bias=bias)
+        self.k_proj = nn.Linear(dim, self.n_kv_heads * head_dim, bias=bias)
+        self.v_proj = nn.Linear(dim, self.n_kv_heads * head_dim, bias=bias)
+        self.o_proj = nn.Linear(self.n_heads * head_dim, dim, bias=bias)
+
+        # gpt-oss-style attention sinks (one learned logit per head)
+        self.sinks = mx.zeros((self.n_heads,))
+
+        self.rope = initialize_rope(
+            head_dim, args.rope_theta, False, None, args.max_position_embeddings
+        )
+
+    def __call__(self, x: mx.array, mask=None, cache=None) -> mx.array:
+        B, L, _ = x.shape
+
+        q = self.q_proj(x).reshape(B, L, self.n_heads, -1).transpose(0, 2, 1, 3)
+        k = self.k_proj(x).reshape(B, L, self.n_kv_heads, -1).transpose(0, 2, 1, 3)
+        v = self.v_proj(x).reshape(B, L, self.n_kv_heads, -1).transpose(0, 2, 1, 3)
+
+        if cache is not None:
+            q = self.rope(q, offset=cache.offset)
+            k = self.rope(k, offset=cache.offset)
+            k, v = cache.update_and_fetch(k, v)
+        else:
+            q = self.rope(q)
+            k = self.rope(k)
+
+        out = scaled_dot_product_attention(
+            q, k, v, cache=cache, scale=self.scale, mask=mask, sinks=self.sinks
+        )
+        return self.o_proj(out.transpose(0, 2, 1, 3).reshape(B, L, -1))
+
+
+class MoE(nn.Module):
+    def __init__(self, args: ModelArgs):
+        super().__init__()
+        self.top_k = args.num_experts_per_tok
+        self.router = nn.Linear(args.hidden_size, args.num_local_experts, bias=False)
+        self.experts = SwitchGLU(
+            args.hidden_size, args.intermediate_size, args.num_local_experts
+        )
+
+    def __call__(self, x: mx.array) -> mx.array:
+        logits = self.router(x).astype(
+            mx.float32
+        )  # route in fp32 (HF/granitemoe parity)
+        idx = mx.argpartition(logits, kth=-self.top_k, axis=-1)[..., -self.top_k :]
+        gates = mx.softmax(
+            mx.take_along_axis(logits, idx, axis=-1), precise=True, axis=-1
+        )
+        y = self.experts(x, idx)
+        return (y * gates[..., None]).sum(axis=-2).astype(y.dtype)
+
+
+class SharedMLP(nn.Module):
+    def __init__(self, args: ModelArgs):
+        super().__init__()
+        self.input_linear = nn.Linear(
+            args.hidden_size, args.shared_intermediate_size * 2, bias=False
+        )
+        self.output_linear = nn.Linear(
+            args.shared_intermediate_size, args.hidden_size, bias=False
+        )
+
+    def __call__(self, x: mx.array) -> mx.array:
+        gate, up = mx.split(self.input_linear(x), 2, axis=-1)
+        return self.output_linear(swiglu(gate, up))
+
+
+class DecoderLayer(nn.Module):
+    def __init__(self, args: ModelArgs, layer_type: str):
+        super().__init__()
+        self.layer_type = layer_type
+        self.residual_multiplier = args.residual_multiplier
+        self.self_attn = Attention(args)
+        self.block_sparse_moe = MoE(args)
+        self.shared_mlp = SharedMLP(args)
+        self.input_layernorm = nn.RMSNorm(args.hidden_size, eps=args.rms_norm_eps)
+        self.post_attention_layernorm = nn.RMSNorm(
+            args.hidden_size, eps=args.rms_norm_eps
+        )
+
+    def __call__(self, x: mx.array, mask=None, cache=None) -> mx.array:
+        h = x + self.self_attn(self.input_layernorm(x), mask, cache) * (
+            self.residual_multiplier
+        )
+        normed = self.post_attention_layernorm(h)
+        mlp_out = self.block_sparse_moe(normed) + self.shared_mlp(normed)
+        return h + mlp_out * self.residual_multiplier
+
+
+class GraniteMoeSwaModel(nn.Module):
+    def __init__(self, args: ModelArgs):
+        super().__init__()
+        self.embed_tokens = nn.Embedding(args.vocab_size, args.hidden_size)
+        self.layers = [DecoderLayer(args, lt) for lt in args.layer_types]
+        self.norm = nn.RMSNorm(args.hidden_size, eps=args.rms_norm_eps)
+        self.embedding_multiplier = args.embedding_multiplier
+        self.layer_types = args.layer_types
+        self.window_size = args.sliding_window
+        self.ga_idx = args.layer_types.index("full_attention")
+        self.swa_idx = (
+            args.layer_types.index("sliding_attention")
+            if "sliding_attention" in args.layer_types
+            else self.ga_idx
+        )
+
+    def __call__(self, inputs: mx.array, cache=None) -> mx.array:
+        h = self.embed_tokens(inputs) * self.embedding_multiplier
+        if cache is None:
+            cache = [None] * len(self.layers)
+
+        full_mask = create_attention_mask(h, cache[self.ga_idx])
+        swa_mask = create_attention_mask(
+            h, cache[self.swa_idx], window_size=self.window_size
+        )
+
+        for layer, c in zip(self.layers, cache):
+            mask = full_mask if layer.layer_type == "full_attention" else swa_mask
+            h = layer(h, mask, c)
+        return self.norm(h)
+
+
+class Model(nn.Module):
+    # Sliding-window layers use RotatingKVCache, which records an exact rollback
+    # within the verify window — enables --draft-model speculative decoding.
+    supports_speculative_rollback = True
+
+    def __init__(self, args: ModelArgs):
+        super().__init__()
+        self.args = args
+        self.model_type = args.model_type
+        self.model = GraniteMoeSwaModel(args)
+        if not args.tie_word_embeddings:
+            self.lm_head = nn.Linear(args.hidden_size, args.vocab_size, bias=False)
+        self.logits_scaling = args.logits_scaling
+
+    def __call__(self, inputs: mx.array, cache=None) -> mx.array:
+        out = self.model(inputs, cache)
+        if self.args.tie_word_embeddings:
+            out = self.model.embed_tokens.as_linear(out)
+        else:
+            out = self.lm_head(out)
+        return out / self.logits_scaling
+
+    def sanitize(self, weights):
+        if any("experts.gate_proj" in k for k in weights):
+            return weights  # already sanitized
+        new = {}
+        for k, v in weights.items():
+            if k.endswith("block_sparse_moe.experts.gate_up_proj"):
+                out = v.shape[1]
+                new[k.replace("gate_up_proj", "gate_proj") + ".weight"] = v[
+                    :, : out // 2, :
+                ]
+                new[k.replace("gate_up_proj", "up_proj") + ".weight"] = v[
+                    :, out // 2 :, :
+                ]
+            elif k.endswith("block_sparse_moe.experts.down_proj"):
+                new[k + ".weight"] = v
+            elif k == "lm_head.weight" and self.args.tie_word_embeddings:
+                continue
+            else:
+                new[k] = v
+        return new
+
+    def make_cache(self, max_kv_size=None):
+        caches = []
+        for lt in self.model.layer_types:
+            if lt == "full_attention":
+                caches.append(
+                    RotatingKVCache(max_size=max_kv_size) if max_kv_size else KVCache()
+                )
+            else:
+                caches.append(RotatingKVCache(max_size=self.args.sliding_window))
+        return caches
+
+    @property
+    def layers(self):
+        return self.model.layers
+
+    @property
+    def quant_predicate(self):
+        def predicate(path, _):
+            if path.endswith("block_sparse_moe.router"):
+                return {"group_size": 64, "bits": 8}
+            return True
+
+        return predicate

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -472,6 +472,40 @@ class TestModels(unittest.TestCase):
             model, args.model_type, args.vocab_size, args.num_hidden_layers
         )
 
+    def test_granitemoe_swa(self):
+        from mlx_lm.models import granitemoe_swa
+
+        args = granitemoe_swa.ModelArgs(
+            model_type="granitemoe_swa",
+            vocab_size=10_000,
+            hidden_size=512,
+            intermediate_size=256,
+            num_hidden_layers=4,
+            num_attention_heads=4,
+            num_key_value_heads=2,
+            num_local_experts=4,
+            num_experts_per_tok=2,
+            shared_intermediate_size=512,
+            max_position_embeddings=1000,
+            rms_norm_eps=1e-5,
+            embedding_multiplier=12.0,
+            attention_multiplier=0.5,
+            residual_multiplier=0.26,
+            logits_scaling=5.0,
+            sliding_window=8,
+            layer_types=[
+                "full_attention",
+                "sliding_attention",
+                "sliding_attention",
+                "full_attention",
+            ],
+            rope_theta=10000,
+        )
+        model = granitemoe_swa.Model(args)
+        self.model_test_runner(
+            model, args.model_type, args.vocab_size, args.num_hidden_layers
+        )
+
     def test_bitnet(self):
         from mlx_lm.models import bitnet
 


### PR DESCRIPTION
# Add granitemoe_swa (GraniteMoE + sliding-window attention)

Adds `mlx_lm/models/granitemoe_swa.py` for `model_type: "granitemoe_swa"` /
`GraniteMoeSWAForCausalLM`, so mlx-lm can load the new IBM Granite MoE+SWA
checkpoints (e.g. `ibm-granite/granite-swash-3b-a600m`). No existing module or
remapping handles this arch today — loading it currently raises
`Model type granitemoe_swa not supported.`

## Architecture

GraniteMoE with sliding-window attention. Reuses existing mlx-lm infrastructure
throughout (mirrors `granitemoehybrid.py` for the Granite MoE/shared-expert side
and `gpt_oss.py` for the sinks/SWA side):

- **MoE**: `nn.Linear` router + `SwitchGLU` experts, top-k routing computed in
  **fp32** (matches HF Granite and `granitemoe.py`), result cast back to the
  activation dtype.
- **Shared expert**: always-on `shared_mlp` (fused `input_linear` gate/up +
  `output_linear`), added to the routed MoE output.
- **Attention sinks**: one learned logit per head, passed through
  `base.scaled_dot_product_attention(..., sinks=...)`.
- **Sliding-window attention** driven by `layer_types`: full-attention layers use
  `KVCache`, sliding layers use `RotatingKVCache(max_size=sliding_window)`, with
  the correct full/SWA mask selected per layer via
  `create_attention_mask(..., window_size=...)`.
- **Granite scalars**: `embedding_multiplier`, `attention_multiplier` (attention
  scale), `residual_multiplier`, `logits_scaling`; tied embeddings; nested
  `rope_parameters` unwrapped to `rope_theta`.
- `sanitize()` splits the fused `block_sparse_moe.experts.gate_up_proj`
  `[E, 2*inter, hidden]` into `SwitchGLU` gate/up **by halves** (gate = first
  half, up = second half — matching HF `GraniteMoeParallelExperts`, *not*
  gpt-oss interleaving).
- `supports_speculative_rollback = True` (the SWA `RotatingKVCache` records an
  exact in-window rollback, enabling `--draft-model`); `make_cache(max_kv_size=…)`
  caps the full-attention layers for long serving.

## Testing

- `tests/test_models.py::test_granitemoe_swa` (tiny 4-layer full/sliding config)
  passes on a pristine `main` checkout — exercises fp32/fp16 forward, cached
  decode, batch > 1, and deepcopy via `model_test_runner`.
- `black`/`isort` clean.

## Validation on the real checkpoint (`granite-swash-3b-a600m`)

- Loads and generates coherently in **bf16** and after MLX **4-bit** conversion.
- **SWA cache is numerically identical to one-shot prefill** past the 128 window:
  cached vs no-cache next-token logits `max|Δ| = 0.00000`; two-chunk prefill vs
  one-shot `0.00001`; full-attention cache grows with the sequence while sliding
  layers cap at `sliding_window`.
- The fused `gate_up_proj` halves-vs-interleaved split was verified empirically
  (per-token NLL **2.09 halves** vs **10.13 interleaved**) and cross-checked
  against the HF `GraniteMoeParallelExperts` source.

## Performance

Apple M5 Max, mlx `0.32.0-dev`, greedy, 64 generated tokens. `prefill` = prompt
tokens/s, `decode` = generation tokens/s, `peak` = MLX peak memory. Rows above
8192 exceed `max_position_embeddings` (the trained window) — perf-only.

4-bit (`granite-swash-3b-a600m-mlx-4bit`, 1.6 GB weights):

|   ctx | prefill tok/s | decode tok/s | peak GB |
|------:|--------------:|-------------:|--------:|
|   128 |         3,791 |          287 |    1.90 |
|   256 |         7,993 |          299 |    2.05 |
|   512 |        12,664 |          289 |    2.37 |
|  1024 |        16,636 |          282 |    2.63 |
|  2048 |        23,163 |          285 |    2.75 |
|  3072 |        22,959 |          282 |    2.75 |
|  4096 |        24,485 |          281 |    2.83 |
|  6144 |        24,663 |          272 |    2.89 |
|  8192 |        24,502 |          277 |    2.95 |
| 12288 |        23,937 |          282 |    3.04 |
| 16384 |        23,337 |          279 |    3.06 |

bf16:

|   ctx | prefill tok/s | decode tok/s | peak GB |
|------:|--------------:|-------------:|--------:|
|   128 |         4,101 |          242 |    6.12 |
|   256 |         7,590 |          246 |    6.20 |
|   512 |        12,229 |          245 |    6.26 |
|  1024 |        18,771 |          239 |    6.47 |
|  2048 |        23,714 |          241 |    6.70 |
|  3072 |        24,202 |          241 |    6.70 |
|  4096 |        25,158 |          229 |    6.77 |
|  6144 |        25,714 |          238 |    6.83 |
|  8192 |        25,053 |          229 |    6.90 |
| 12288 |        24,857 |          220 |    6.98 |
| 16384 |        24,250 |          176 |    7.02 |

Sliding-window attention keeps decode throughput and memory nearly flat across a
**128× context range** (128 → 16384): 20 of 28 layers cap their KV at
`sliding_window=128`, so only the 8 full-attention layers grow. 4-bit decode
holds ~280 tok/s throughout with peak rising just **1.16 GB** (1.90 → 3.06);
bf16 holds ~230 tok/s to 12k (dipping to 176 at 16k as the 8 global layers' KV
begins to dominate) with peak +0.9 GB. Prefill scales to ~25k tok/s.

Notes: the upstream base checkpoint ships no chat template (it is a base model);
a standard Granite template can be added downstream. Weights are bf16
safetensors; `sanitize()` targets that layout (not pre-quantized `_blocks`/
`_scales` variants).
