### PR TITLE
Faster loglikelihood scoring in mlx_lm.evaluate

### DIFF
--- a/mlx_lm/evaluate.py
+++ b/mlx_lm/evaluate.py
@@ -23,7 +23,7 @@ from lm_eval.api.registry import register_model
 from tqdm import tqdm
 
 from .generate import batch_generate
-from .models.cache import make_prompt_cache
+from .models.cache import can_trim_prompt_cache, make_prompt_cache, trim_prompt_cache
 from .sample_utils import make_sampler
 from .utils import load
 
@@ -96,13 +96,25 @@ class MLXLM(LM):
             self.use_chat_template = self.tokenizer.chat_template is not None
         self._sampler = sampler
 
-    def _process_prompt(self, prompt, step_size: int = 2048):
+    def _process_prompt(self, prompt, step_size: int = 2048, min_split: int = 512):
         prompt = mx.array(prompt)[None]
         cache = make_prompt_cache(self._model)
-        for i in range(0, prompt.shape[1], step_size):
-            logits = self._model(prompt[:, i : i + step_size], cache=cache)
+        length = prompt.shape[1]
+        # When the prompt's final chunk is long, process the final token by
+        # itself. The preceding tokens then only evaluate the cache state so
+        # their logits are never computed, and the vocabulary projection only
+        # runs for the one position whose log probabilities are needed. When
+        # the final chunk is shorter than ``min_split``, the projection costs
+        # less than the extra model call, so the chunk is processed whole.
+        last_len = (
+            1 if (length - 1) % step_size >= min_split else (length - 1) % step_size + 1
+        )
+        rest = prompt[:, : length - last_len]
+        for i in range(0, rest.shape[1], step_size):
+            self._model(rest[:, i : i + step_size], cache=cache)
             mx.eval([c.state for c in cache])
             mx.clear_cache()
+        logits = self._model(prompt[:, length - last_len :], cache=cache)
         logprobs = nn.log_softmax(logits[:, -1, :].astype(mx.float32))
         return logprobs, cache
 
@@ -208,14 +220,18 @@ class MLXLM(LM):
             # If the entire prompt got truncated ignore the question
             if prefix_l == 0:
                 long_completions += 1
-                all_scores.extend([-float("inf")] * len(rs))
-                all_is_greedy.extend([False] * len(rs))
+                scores.extend([-float("inf")] * len(rs))
+                is_greedy.extend([False] * len(rs))
                 continue
 
             # model scoring, returns num_requests x (logp, is_greedy, length).
             logprobs, cache = self._process_prompt(prefix)
             max_idx = mx.argmax(logprobs).item()
 
+            # When the cache is trimmable, score every continuation with the
+            # same cache and rewind it in-between instead of copying it for
+            # each continuation.
+            reuse_cache = can_trim_prompt_cache(cache)
             for s in full_sequences:
                 inputs = s[len(prefix) :]
                 # The logprobs from the last token of the prompt are
@@ -226,8 +242,11 @@ class MLXLM(LM):
                 if len(inputs) == 1:
                     continue
                 score, _, ig = self._score_fn(
-                    mx.array(inputs)[None, :], cache=copy.deepcopy(cache)
+                    mx.array(inputs)[None, :],
+                    cache=cache if reuse_cache else copy.deepcopy(cache),
                 )
+                if reuse_cache:
+                    trim_prompt_cache(cache, len(inputs) - 1)
                 scores[-1] += mx.sum(score).item()
                 is_greedy[-1] &= mx.all(ig).item()
 

--- a/tests/test_evaluate.py
+++ b/tests/test_evaluate.py
@@ -4,6 +4,7 @@ import unittest
 from unittest.mock import MagicMock, patch
 
 import mlx.core as mx
+import mlx.nn as nn
 
 from mlx_lm.evaluate import MLXLM
 
@@ -53,6 +54,72 @@ class TestMLXLM(unittest.TestCase):
         self.assertEqual(len(call_args_list[0][0][0]), 2)  # First batch: 2 items
         self.assertEqual(len(call_args_list[1][0][0]), 2)  # Second batch: 2 items
         self.assertEqual(len(call_args_list[2][0][0]), 1)  # Third batch: 1 item
+
+
+class TestMLXLMLoglikelihood(unittest.TestCase):
+    """End-to-end tests for loglikelihood scoring with a real model."""
+
+    @classmethod
+    def setUpClass(cls):
+        cls.lm = MLXLM("mlx-community/Qwen1.5-0.5B-Chat-4bit")
+        base = (
+            "The city council met on Tuesday to discuss the new transit "
+            "plan, which includes additional bus routes and longer service "
+            "hours for the northern districts. "
+        )
+        ids = cls.lm.tokenizer.encode(base * 60, add_special_tokens=False)[:700]
+        cls.long_context = cls.lm.tokenizer.decode(ids)
+
+    def _reference(self, context, continuation):
+        """Score a continuation with a single forward pass over the full
+        sequence."""
+        prefix = self.lm._tokenize([context])[0]
+        full = self.lm._tokenize([context + continuation])[0]
+        logits = self.lm._model(mx.array(full[:-1])[None])
+        logprobs = nn.log_softmax(logits[0].astype(mx.float32), axis=-1)
+        score = 0.0
+        greedy = True
+        for pos in range(len(prefix) - 1, len(full) - 1):
+            target = full[pos + 1]
+            score += logprobs[pos, target].item()
+            greedy &= mx.argmax(logprobs[pos]).item() == target
+        return score, greedy
+
+    def test_loglikelihood_matches_full_forward(self):
+        cases = [
+            ("The capital of France is", " Paris"),
+            ("The capital of France is", " the city of Paris, which is known"),
+            ("The capital of France is", " Berlin"),
+            # A long context exercises the split prefill path
+            (self.long_context, " The council approved the plan."),
+        ]
+        requests = [MagicMock(args=case) for case in cases]
+        results = self.lm.loglikelihood(requests)
+        self.assertEqual(len(results), len(cases))
+        for (score, greedy), case in zip(results, cases):
+            ref_score, ref_greedy = self._reference(*case)
+            self.assertLess(abs(score - ref_score), 2e-1)
+            self.assertEqual(greedy, ref_greedy)
+
+    def test_loglikelihood_continuation_order_invariance(self):
+        # Continuations of different lengths after a common long prefix.
+        # Scoring them in either order must give the same results, which
+        # checks that scoring one continuation does not contaminate the
+        # cached prefix state used by the others.
+        context = self.long_context
+        continuations = [
+            " the lazy dog. " * 20,
+            " The fence.",
+            " A log lies on the other side of the river.",
+        ]
+        requests = [MagicMock(args=(context, c)) for c in continuations]
+        forward = self.lm.loglikelihood(requests)
+        backward = self.lm.loglikelihood(list(reversed(requests)))
+        for (score_f, greedy_f), (score_b, greedy_b) in zip(
+            forward, reversed(backward)
+        ):
+            self.assertAlmostEqual(score_f, score_b, places=3)
+            self.assertEqual(greedy_f, greedy_b)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Two changes to the `loglikelihood` path in `mlx_lm.evaluate`, plus a bug fix found along the way:

1. **Skip the vocabulary projection for the final prompt chunk in `_process_prompt`.** The last prefill chunk previously materialized logits for up to `step_size` positions (a `[1, 2048, vocab]` tensor) when only the final position's log probabilities are used. When the final chunk is long, the prompt is now processed the way `generate_step` handles it: everything before the last token is prefilled evaluating only the cache state (the logits are never computed, thanks to lazy evaluation), then the last token is processed by itself so the vocabulary projection runs for one position instead of up to 2048. For prompts whose final chunk is shorter than 512 tokens, the extra model call costs more than the projection it avoids (measured crossover is ~150–250 tokens on M-series), so those keep the previous single-call behavior and are bit-identical to main.

2. **Rewind the prompt cache between continuations instead of deep-copying it.** When the cache is trimmable, all continuations of a question are scored with the same cache, using `trim_prompt_cache` to rewind in between. This is bit-exact — scoring reads identical cache contents either way — and saves a cache copy plus a buffer-growth reallocation per continuation. Models with non-trimmable caches (SSM states, sliding-window caches past the window) keep the `copy.deepcopy` behavior.

3. **Fix a latent `NameError` in the truncated-prompt branch** (`all_scores` / `all_is_greedy` → `scores` / `is_greedy`), which crashed evaluation whenever a completion was longer than the context limit. Same shape as the `loglikelihood_rolling` fix in #339.

### Benchmarks

M5 Max (40-core GPU, 128 GB), mlx 0.32.0, macOS 15. Paired A/B — the two implementations alternate per round in fresh processes, N questions × 4 continuations, median over rounds:

| model | context tokens | speedup vs main |
|---|---|---|
| Llama-3.2-1B-Instruct-4bit | 1500 | **1.27×** (faster in 4/4 rounds) |
| Llama-3.2-1B-Instruct-4bit | 8192 | 1.07× (4/4) |
| Qwen3-4B-4bit | 1500 | 1.10× (4/4) |
| Qwen3-4B-4bit | 120 (below split threshold) | 1.02× (4/4) |

The gain comes from dropping the `[chunk, vocab]` projection, so it is largest when the vocabulary is a big share of the model (small models, large vocabs) and for prompts just under a chunk boundary. Peak memory is unchanged (the prefill working set dominates it).

End-to-end `mlx_lm evaluate --tasks arc_challenge --num-shots 10 --limit 150` (prompts long enough to take the new path): accuracy and normalized accuracy are unchanged for both models, wall time 13.1s → 12.6s (1B) and 27.0s → 26.6s (4B), which includes model load and harness overhead.

### Correctness

- Prompts below the split threshold (all the 0-shot configs I ran) take an unchanged code path; verified identical metrics on arc_challenge + hellaswag.
- For long prompts, the last prompt token is now computed exactly the way generation computes it, so scores shift within half-precision chunk-boundary noise: on 10-shot arc_challenge (150 questions × 4 choices), max per-continuation |Δlogprob| was 0.07 for the fp16 1B model and 0.84 for the bf16 Qwen3-4B (multi-token continuations). All aggregate metrics were unchanged in every CLI configuration tested. The only per-question flips I could find (under a different fewshot formatting) were questions whose top-2 choice margins were already below that noise floor (0.04 and 0.19 respectively).
- The cache rewind is bit-exact: scoring the same continuations in forward and reversed order gives identical results (delta exactly 0.0), which also rules out cross-continuation cache contamination.
- Verified both cache strategies on gemma-3-1b-it-4bit: contexts below the sliding window use the rewind path, contexts past the window correctly fall back to deep copies; both agree with a full-sequence forward pass reference.
- Edge cases: length-1 and length-2 prefixes, chunk-boundary prompt lengths, and the previously crashing fully-truncated-prompt branch.
- New end-to-end tests in `tests/test_evaluate.py`: score agreement with a full-sequence forward pass, and continuation order invariance, over both short and long contexts. Both tests also pass on `main`.
