### PR TITLE
Fix glm47 tool parser: strip whitespace from the parsed function name

### DIFF
--- a/mlx_lm/tool_parsers/glm47.py
+++ b/mlx_lm/tool_parsers/glm47.py
@@ -218,7 +218,7 @@ def parse_tool_call(text: str, tools: list[Any] | None = None):
             return fallback
         return dict(name="unknown", arguments={"raw": text.strip()})
 
-    func_name = match.group(1)
+    func_name = match.group(1).strip()
     string_args = _get_string_arg_names(func_name, tools)
     arg_dct = {}
     for match in _func_arg_regex.finditer(text):

--- a/tests/test_tool_parsing.py
+++ b/tests/test_tool_parsing.py
@@ -29,6 +29,12 @@ class TestToolParsing(unittest.TestCase):
                 "multiply<arg_key>a</arg_key><arg_value>12234585</arg_value><arg_key>b</arg_key><arg_value>48838483920</arg_value>",
                 glm47,
             ),
+            # GLM-4.5/4.6 chat templates emit a newline between the function
+            # name and the first <arg_key>; the name must come back clean.
+            (
+                "multiply\n<arg_key>a</arg_key><arg_value>12234585</arg_value><arg_key>b</arg_key><arg_value>48838483920</arg_value>",
+                glm47,
+            ),
             (
                 '{"name": "multiply", "arguments": {"a": 12234585, "b": 48838483920}}',
                 json_tools,


### PR DESCRIPTION
### What

`glm47.parse_tool_call` returns the function name with surrounding whitespace still attached when the model emits a separator between the name and the first `<arg_key>` tag. GLM-4.5/4.6 chat templates place the argument tags on the line after the function name, so in practice every tool call parsed by this code path carries a trailing `"\n"` in `function.name`.

Minimal reproduction (mlx-lm 0.31.2):

```python
>>> from mlx_lm.tool_parsers import glm47
>>> glm47.parse_tool_call("multiply\n<arg_key>a</arg_key><arg_value>3</arg_value>")
{'name': 'multiply\n', 'arguments': {'a': 3}}
```

### Why it matters

OpenAI-compatible clients match tool names exactly. With `mlx-community/GLM-4.6-4bit` served by `mlx_lm.server`, a LangChain/LangGraph agent rejects every tool call with `"multiply\n" is not a valid tool`, the model retries (its retry inherits the mangled name from the echoed history, so the whitespace even accumulates: `\n` → `\n\n` → `\n\n\n`), and the agent loops until its recursion limit. Tool calling is effectively unusable for GLM-family models through the server, despite the model producing perfectly correct calls.

### Fix

`func_name = match.group(1).strip()` — mirroring what the same file already does for `arg_key`/`arg_val` (both `.strip()`ed a few lines below) and what `longcat.py` does for its function name. Function names cannot legitimately contain leading/trailing whitespace, so this is safe for all inputs.

The existing glm47 test only covers the no-separator form (`"multiply<arg_key>…"`), which is why this was missed; the added case covers the newline-separated form the GLM chat templates actually produce. Verified: the new case fails without the fix and `tests/test_tool_parsing.py` passes with it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)