### PR TITLE
Fix Qwen3 Coder parser fallback for malformed arguments

### DIFF
--- a/mlx_lm/tool_parsers/qwen3_coder.py
+++ b/mlx_lm/tool_parsers/qwen3_coder.py
@@ -19,6 +19,14 @@ _bool_types = {"boolean", "bool", "binary"}
 _obj_types = {"object", "array", "arr"}
 
 
+def _literal_eval_or_raw(param_value: str) -> Any:
+    """Parse a Python literal, falling back to the model's raw output."""
+    try:
+        return ast.literal_eval(param_value)
+    except (SyntaxError, ValueError):
+        return param_value
+
+
 def _get_arguments_config(func_name: str, tools: Optional[Any]) -> dict:
     """Extract argument configuration for a function."""
     if tools is None:
@@ -74,9 +82,9 @@ def _convert_param_value(param_value: str, param_name: str, param_config: dict) 
             try:
                 return json.loads(param_value)
             except json.JSONDecodeError:
-                return ast.literal_eval(param_value)
+                return _literal_eval_or_raw(param_value)
 
-        return ast.literal_eval(param_value)
+        return _literal_eval_or_raw(param_value)
 
 
 def _parse_xml_function_call(function_call_str: str, tools: Optional[Any]):

--- a/tests/test_tool_parsing.py
+++ b/tests/test_tool_parsing.py
@@ -197,6 +197,36 @@ class TestToolParsing(unittest.TestCase):
         self.assertEqual(tool_call["arguments"]["filters"], {"category": "books"})
         self.assertEqual(tool_call["arguments"]["tags"], ["fiction", "new"])
 
+    def test_qwen3_coder_unparseable_params_fall_back_to_strings(self):
+        tools = [
+            {
+                "type": "function",
+                "function": {
+                    "name": "search",
+                    "parameters": {
+                        "type": "object",
+                        "properties": {
+                            "filters": {"type": "object"},
+                            "mode": {"type": "custom"},
+                        },
+                    },
+                },
+            }
+        ]
+        test_case = (
+            "<function=search>"
+            "<parameter=filters>{invalid: true</parameter>"
+            "<parameter=mode>not a literal</parameter>"
+            "</function>"
+        )
+
+        tool_call = qwen3_coder.parse_tool_call(test_case, tools)
+
+        self.assertEqual(
+            tool_call["arguments"],
+            {"filters": "{invalid: true", "mode": "not a literal"},
+        )
+
     def test_gemma4(self):
         # Nested object
         test_case = 'call:configure{settings:{enabled:true,name:<|"|>test<|"|>}}'


### PR DESCRIPTION
## Summary

- preserve the existing JSON and Python-literal conversions for Qwen3 Coder tool arguments
- fall back to the raw model output when a schema-directed literal conversion fails
- cover malformed object and custom-typed arguments with a regression test

This keeps malformed model output from crashing the parser while retaining the original value for downstream handling.

## Testing

- `python -m unittest tests.test_tool_parsing`
- `black --check mlx_lm/tool_parsers/qwen3_coder.py tests/test_tool_parsing.py`
- `isort --check-only --profile=black mlx_lm/tool_parsers/qwen3_coder.py tests/test_tool_parsing.py`

Fixes #1604