### PR TITLE
server: make qwen3_coder tool-call parsing robust (parse unwrapped calls + do not crash on non-literal object/array params)

### DIFF
--- a/mlx_lm/generate.py
+++ b/mlx_lm/generate.py
@@ -1077,6 +1077,21 @@ def make_text_state_machine(tokenizer, stop_words=None):
             [(tokenizer.tool_call_end, "normal")] if tokenizer.tool_call_end else []
         )
 
+        # Optional: recognize a bare "<function=...>...</function>" block emitted
+        # WITHOUT the <tool_call> wrapper (a common failure mode for some models
+        # under a heavy system prompt). Handled as a separate "tool_unwrapped"
+        # state so the well-formed <tool_call> path above is unchanged. The
+        # server reconstructs the wrapped form before parsing.
+        tool_call_start_alt = getattr(tokenizer, "tool_call_start_alt", None)
+        if tool_call_start_alt:
+            transitions["normal"].append((tool_call_start_alt, "tool_unwrapped"))
+            if tokenizer.has_thinking:
+                transitions["reasoning"].append((tool_call_start_alt, "tool_unwrapped"))
+            tool_call_end_alt = getattr(tokenizer, "tool_call_end_alt", None)
+            transitions["tool_unwrapped"] = (
+                [(tool_call_end_alt, "normal")] if tool_call_end_alt else []
+            )
+
     if stop_words:
         for state_name in set(transitions) | {"normal"}:
             for w in stop_words:

--- a/mlx_lm/server.py
+++ b/mlx_lm/server.py
@@ -1425,11 +1425,18 @@ class APIHandler(BaseHTTPRequestHandler):
                 # Collect the clean text by state: reasoning, tool, or normal
                 if current_state == "reasoning":
                     reasoning_text += clean_text
-                elif current_state == "tool":
+                elif current_state in ("tool", "tool_unwrapped"):
                     tool_text += clean_text
                 elif current_state == "normal":
                     if prev_state == "tool":
                         tool_calls.append(tool_text)
+                        tool_text = ""
+                        made_tool_call = True
+                    elif prev_state == "tool_unwrapped":
+                        # Reconstruct the wrapped form the parser expects, since
+                        # the "<function=" / "</function>" delimiters were
+                        # stripped on the state transitions.
+                        tool_calls.append("<function=" + tool_text + "</function>")
                         tool_text = ""
                         made_tool_call = True
                     text += clean_text
@@ -1443,7 +1450,7 @@ class APIHandler(BaseHTTPRequestHandler):
 
                 if (
                     self.stream
-                    and current_state != "tool"
+                    and current_state not in ("tool", "tool_unwrapped")
                     and (text or tool_calls or reasoning_text)
                 ):
                     resp = self.generate_response(
@@ -1465,6 +1472,11 @@ class APIHandler(BaseHTTPRequestHandler):
 
             if prev_state == "tool" and tool_text:
                 tool_calls.append(tool_text)
+                made_tool_call = True
+            elif prev_state == "tool_unwrapped" and tool_text:
+                # An EOS ended generation mid-call (no closing "</function>");
+                # flush the reconstructed wrapped form.
+                tool_calls.append("<function=" + tool_text + "</function>")
                 made_tool_call = True
 
             if finish_reason == "stop" and made_tool_call:

--- a/mlx_lm/tokenizer_utils.py
+++ b/mlx_lm/tokenizer_utils.py
@@ -297,6 +297,8 @@ class TokenizerWrapper:
         tool_call_start=None,
         tool_call_end=None,
         tool_parser=None,
+        tool_call_start_alt=None,
+        tool_call_end_alt=None,
     ):
         self._tokenizer = tokenizer
         self._detokenizer_class = detokenizer_class
@@ -328,6 +330,12 @@ class TokenizerWrapper:
             self._tool_call_end_tokens = tuple(
                 tokenizer.encode(tool_call_end, add_special_tokens=False)
             )
+        # Optional alternate (unwrapped) tool-call delimiters, e.g. a bare
+        # "<function=...>...</function>" block emitted without <tool_call>
+        # tags. Matched on decoded text by the state machine, so no encoded
+        # token tuples are needed.
+        self._tool_call_start_alt = tool_call_start_alt
+        self._tool_call_end_alt = tool_call_end_alt
 
     def apply_chat_template(self, *args, tokenize=True, **kwargs):
         if "enable_thinking" not in kwargs:
@@ -440,6 +448,14 @@ class TokenizerWrapper:
     @property
     def tool_call_end_tokens(self):
         return self._tool_call_end_tokens
+
+    @property
+    def tool_call_start_alt(self):
+        return self._tool_call_start_alt
+
+    @property
+    def tool_call_end_alt(self):
+        return self._tool_call_end_alt
 
     @property
     def tool_parser(self):
@@ -624,11 +640,16 @@ def load(
         "tool_parser_type", _infer_tool_parser(tokenizer.chat_template)
     )
 
+    tool_call_start_alt = None
+    tool_call_end_alt = None
     if tool_parser_type is not None:
         tool_module = importlib.import_module(f"mlx_lm.tool_parsers.{tool_parser_type}")
         tool_parser = tool_module.parse_tool_call
         tool_call_start = tool_module.tool_call_start
         tool_call_end = tool_module.tool_call_end
+        # Optional: a parser may advertise alternate (unwrapped) delimiters.
+        tool_call_start_alt = getattr(tool_module, "tool_call_start_alt", None)
+        tool_call_end_alt = getattr(tool_module, "tool_call_end_alt", None)
         tokenizer_config["tool_parser_type"] = tool_parser_type
     else:
         tool_parser = None
@@ -643,6 +664,8 @@ def load(
         tool_parser=tool_parser,
         tool_call_start=tool_call_start,
         tool_call_end=tool_call_end,
+        tool_call_start_alt=tool_call_start_alt,
+        tool_call_end_alt=tool_call_end_alt,
     )
 
 

--- a/mlx_lm/tool_parsers/qwen3_coder.py
+++ b/mlx_lm/tool_parsers/qwen3_coder.py
@@ -73,10 +73,16 @@ def _convert_param_value(param_value: str, param_name: str, param_config: dict) 
         ):
             try:
                 return json.loads(param_value)
-            except json.JSONDecodeError:
-                return ast.literal_eval(param_value)
-
-        return ast.literal_eval(param_value)
+            except (json.JSONDecodeError, ValueError):
+                pass
+        # Fall back to the raw string rather than crashing the whole request:
+        # models often emit multi-line code (unbalanced quotes/brackets) inside
+        # an object/array parameter that is neither valid JSON nor a valid
+        # Python literal. A best-effort string is far better than a 500.
+        try:
+            return ast.literal_eval(param_value)
+        except (ValueError, SyntaxError):
+            return param_value
 
 
 def _parse_xml_function_call(function_call_str: str, tools: Optional[Any]):

--- a/mlx_lm/tool_parsers/qwen3_coder.py
+++ b/mlx_lm/tool_parsers/qwen3_coder.py
@@ -104,6 +104,16 @@ tool_call_start = "<tool_call>"
 
 tool_call_end = "</tool_call>"
 
+# Some models (especially under a heavy system prompt) emit the inner
+# <function=...> block WITHOUT the enclosing <tool_call></tool_call> wrapper.
+# These optional "alt" delimiters let the server recognize a bare function
+# block as a tool call. The server reconstructs "<function=" + captured +
+# "</function>" before calling parse_tool_call, so no change to the parser
+# logic below is needed.
+tool_call_start_alt = "<function="
+
+tool_call_end_alt = "</function>"
+
 
 def parse_tool_call(
     model_output: str,

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -355,6 +355,122 @@ class TestServer(unittest.TestCase):
         stop_state, matched = stop_matcher.match(stop_state, stop_matcher._trie, 2)
         self.assertTrue(matched)
 
+    def test_make_state_machine_unwrapped_tool_call(self):
+        # Qwen3-Coder (esp. under a heavy system prompt) sometimes emits a bare
+        # "<function=...>...</function>" block WITHOUT the "<tool_call>" wrapper.
+        # The state machine must recognize it via a separate "tool_unwrapped"
+        # state so the server can reconstruct the wrapped form and still produce
+        # a structured tool call.
+        from mlx_lm.tool_parsers import qwen3_coder
+
+        class FakeTokenizer:
+            has_thinking = False
+            has_tool_calling = True
+            tool_call_start = "<tool_call>"
+            tool_call_end = "</tool_call>"
+            tool_call_start_alt = "<function="
+            tool_call_end_alt = "</function>"
+            tool_call_start_tokens = (100,)
+            tool_call_end_tokens = (101,)
+            eos_token_ids = [2]
+
+            def convert_ids_to_tokens(self, t):
+                return f"<eos{t}>"
+
+            def encode(self, text, add_special_tokens=False):
+                return []
+
+        _, text_sm = self.response_generator._make_state_machine(
+            ("fake-unwrapped", None, None),
+            FakeTokenizer(),
+            stop_words=[],
+        )
+
+        tools = [
+            {
+                "type": "function",
+                "function": {
+                    "name": "multiply",
+                    "parameters": {
+                        "type": "object",
+                        "properties": {
+                            "a": {"type": "number"},
+                            "b": {"type": "number"},
+                        },
+                    },
+                },
+            }
+        ]
+
+        def collect(model_output):
+            # Drive the state machine one character at a time (mimicking
+            # token-by-token streaming) and collect text by state exactly the
+            # way the server response loop does, reconstructing the wrapped
+            # form on the "tool_unwrapped" -> "normal" transition.
+            state = text_sm.make_state()
+            prev = "normal"
+            normal_text = ""
+            tool_text = ""
+            tool_calls = []
+            for ch in model_output:
+                state, clean, cur = text_sm.step(state, ch)
+                if cur in ("tool", "tool_unwrapped"):
+                    tool_text += clean
+                elif cur == "normal":
+                    if prev == "tool":
+                        tool_calls.append(tool_text)
+                        tool_text = ""
+                    elif prev == "tool_unwrapped":
+                        tool_calls.append("<function=" + tool_text + "</function>")
+                        tool_text = ""
+                    normal_text += clean
+                prev = cur
+            # A trailing EOS ends generation via discard (mid-call flush).
+            _, prev_after = text_sm.discard(state)
+            if prev == "tool_unwrapped" and tool_text:
+                tool_calls.append("<function=" + tool_text + "</function>")
+            return normal_text, tool_calls
+
+        inner = (
+            "<function=multiply>\n"
+            "<parameter=a>\n12234585\n</parameter>\n"
+            "<parameter=b>\n48838483920\n</parameter>\n"
+            "</function>"
+        )
+        expected = {
+            "name": "multiply",
+            "arguments": {"a": 12234585, "b": 48838483920},
+        }
+
+        # 1. Bare function block, nothing around it.
+        _, tool_calls = collect(inner)
+        self.assertEqual(len(tool_calls), 1)
+        self.assertEqual(qwen3_coder.parse_tool_call(tool_calls[0], tools), expected)
+
+        # 2. Leading prose sentence before the bare block.
+        normal_text, tool_calls = collect("Sure, let me do that.\n" + inner)
+        self.assertEqual(len(tool_calls), 1)
+        self.assertEqual(qwen3_coder.parse_tool_call(tool_calls[0], tools), expected)
+        self.assertIn("Sure, let me do that.", normal_text)
+
+        # 3. Trailing stray "</tool_call>" after the bare block.
+        _, tool_calls = collect(inner + "</tool_call>")
+        self.assertEqual(len(tool_calls), 1)
+        self.assertEqual(qwen3_coder.parse_tool_call(tool_calls[0], tools), expected)
+
+        # 4. EOS ends generation before the closing "</function>": the partial
+        #    call must still be flushed and parse correctly.
+        truncated = inner[: -len("</function>")]
+        _, tool_calls = collect(truncated)
+        self.assertEqual(len(tool_calls), 1)
+        self.assertEqual(qwen3_coder.parse_tool_call(tool_calls[0], tools), expected)
+
+        # Regression: a well-formed "<tool_call>...</tool_call>" block still
+        # takes the unchanged "tool" path and yields exactly one tool call.
+        _, tool_calls = collect("<tool_call>" + inner + "</tool_call>")
+        self.assertEqual(len(tool_calls), 1)
+        self.assertEqual(qwen3_coder.parse_tool_call(tool_calls[0], tools), expected)
+
     def test_handle_models(self):
         url = f"http://localhost:{self.port}/v1/models"
         response = requests.get(url)

--- a/tests/test_tool_parsing.py
+++ b/tests/test_tool_parsing.py
@@ -197,6 +197,49 @@ class TestToolParsing(unittest.TestCase):
         self.assertEqual(tool_call["arguments"]["filters"], {"category": "books"})
         self.assertEqual(tool_call["arguments"]["tags"], ["fiction", "new"])
 
+    def test_qwen3_coder_non_literal_object_array_params(self):
+        # An object/array parameter whose value is multi-line code (unbalanced
+        # quotes / brackets) is neither valid JSON nor a valid Python literal.
+        # ast.literal_eval would raise SyntaxError; the parser must fall back to
+        # the raw string rather than crashing the whole request.
+        tools = [
+            {
+                "type": "function",
+                "function": {
+                    "name": "edit",
+                    "parameters": {
+                        "type": "object",
+                        "properties": {
+                            "edits": {"type": "array"},
+                            "config": {"type": "object"},
+                        },
+                    },
+                },
+            }
+        ]
+
+        # e.g. an editor tool asked to write flask config.py: unterminated
+        # string literal + unbalanced bracket.
+        code = 'SECRET_KEY = os.environ.get("SECRET_KEY", "dev\nDEBUG = [True'
+        test_case = (
+            "<function=edit>" f"<parameter=edits>{code}</parameter>" "</function>"
+        )
+        tool_call = qwen3_coder.parse_tool_call(test_case, tools)
+        self.assertEqual(tool_call["name"], "edit")
+        # Best-effort raw string, no exception raised.
+        self.assertEqual(tool_call["arguments"]["edits"], code)
+
+        # Valid JSON for an object/array param must still be parsed as-is.
+        test_case = (
+            "<function=edit>"
+            '<parameter=edits>["a", "b"]</parameter>'
+            '<parameter=config>{"x": 1}</parameter>'
+            "</function>"
+        )
+        tool_call = qwen3_coder.parse_tool_call(test_case, tools)
+        self.assertEqual(tool_call["arguments"]["edits"], ["a", "b"])
+        self.assertEqual(tool_call["arguments"]["config"], {"x": 1})
+
     def test_gemma4(self):
         # Nested object
         test_case = 'call:configure{settings:{enabled:true,name:<|"|>test<|"|>}}'


### PR DESCRIPTION
Two closely-related fixes that make `qwen3_coder` tool-call parsing robust in `mlx_lm.server`: **(1)** parse tool calls the model emits without the `<tool_call>` wrapper, and **(2)** don't 500 the whole request when an object/array parameter value isn't a valid literal. Bug 2 is only reliably reachable once Bug 1 is fixed (before the fix, unwrapped calls rarely reached the parser), so they belong together.

## Environment where these reproduce

- **mlx-lm 0.31.3** (Homebrew `0.31.3_2`), **mlx 0.32.0**
- macOS arm64 (Apple M4 Max), Python 3.14
- Model: **`mlx-community/Qwen3-Coder-30B-A3B-Instruct-8bit`** (Qwen3-Coder 30B A3B Instruct, 8-bit MLX quant)
- Originally surfaced by the Pi coding agent (`@earendil-works/pi-coding-agent`) driving the local server via the OpenAI-compatible `/v1/chat/completions` endpoint with `tools`, but both reproduce without Pi (see below).

---

## Bug 1 — unwrapped tool calls leak out as content

`mlx_lm.server`'s tool-call text state machine only leaves the `normal` state when it sees the literal `<tool_call>` start marker. Under a non-trivial system prompt, **Qwen3-Coder** frequently emits the inner tool-call block

```
<function=NAME>...<parameter=...>...</parameter>...</function>
```

**WITHOUT** the enclosing `<tool_call>...</tool_call>` wrapper (and sometimes with a stray trailing `</tool_call>`). Because the state machine never leaves `normal`, the entire call leaks out as assistant `content` with `finish_reason: "stop"` and **no `tool_calls`**. The client sees text, not a tool call, and nothing executes. The model's own `qwen3_coder` parser (`parse_tool_call`) parses the inner block fine — the server just never hands it the text.

### Root cause

`make_text_state_machine` (in `mlx_lm/generate.py`) registers only `tokenizer.tool_call_start` (`<tool_call>`) as the `normal -> tool` transition. When the model omits that opener, the machine stays in `normal` and the emitted `<function=...></function>` text is treated as ordinary content. Empirically, with a large system prompt structured `tool_calls` were emitted **0/6** samples; with a minimal prompt, **6/6**. Pure server-side parser brittleness.

### Fix

Add an **opt-in, generic** pair of alternate delimiters, `tool_call_start_alt` / `tool_call_end_alt`, that any tool parser can advertise. When a parser sets them:

- `make_text_state_machine` adds a **separate `tool_unwrapped` state** (`normal`/`reasoning` -> `tool_unwrapped` on `<function=`, back to `normal` on `</function>`).
- The server accumulates the captured text and **reconstructs the wrapped form** (`"<function=" + captured + "</function>"`) before calling the existing `parse_tool_call`. Reconstruction also runs if an EOS ends generation mid-call (no closing `</function>`), keyed on `tool_text`.

Only `qwen3_coder` sets the alt delimiters here. **The well-formed `<tool_call>` path is completely unchanged** — inside the `tool` state there is no `<function=` transition, so wrapped calls behave exactly as before (verified below).

---

## Bug 2 — non-literal object/array params 500 the whole request

`mlx_lm/tool_parsers/qwen3_coder.py` `_convert_param_value` called `ast.literal_eval(param_value)` for object/array/dict/list (and unknown) param types. When a model emits a tool with an **array or object** parameter whose value is multi-line code (unbalanced quotes/brackets) — e.g. an editor tool with an `edits: array` param writing source that contains an unterminated string literal — `ast.literal_eval` raises `SyntaxError: unterminated string literal`. That was **uncaught and 500'd the entire request**: the client sees "Stream ended without finish_reason" and the agent turn dies.

This was latent before the Bug 1 fix because tool calls rarely reached the parser; now that they do, it is hit in practice (reproduced end-to-end: Qwen3-Coder-30B calling an `edit` tool on flask's `config.py`).

### Fix

In `_convert_param_value`, for object/array types try `json.loads` first, then fall back to `ast.literal_eval`, and finally return the **raw string** rather than raising. A best-effort string is far better than a 500. Valid JSON and valid Python literals (e.g. single-quoted dicts) still parse exactly as before.

---

## Files touched

- `mlx_lm/tool_parsers/qwen3_coder.py` — declare `tool_call_start_alt = "<function="`, `tool_call_end_alt = "</function>"` (Bug 1); best-effort fallback in `_convert_param_value` (Bug 2).
- `mlx_lm/tokenizer_utils.py` — plumb the alt delimiters through `TokenizerWrapper` and `load()` (matched on decoded text, so no encoded token tuples needed).
- `mlx_lm/generate.py` — add the `tool_unwrapped` state to `make_text_state_machine`.
- `mlx_lm/server.py` — collect/reconstruct/flush the `tool_unwrapped` state in the response loop.

## Pi-free reproduction

Start the server:

```bash
mlx_lm.server --model mlx-community/Qwen3-Coder-30B-A3B-Instruct-8bit
```

**Bug 1** — feeding the following assistant output (as the model emits it under a heavy system prompt) through the server's state machine yields it verbatim as `content` with `finish_reason: "stop"` and no `tool_calls` before this change:

```
Sure, let me do that.
<function=multiply>
<parameter=a>
12234585
</parameter>
<parameter=b>
48838483920
</parameter>
</function></tool_call>
```

End-to-end curl that tends to elicit the unwrapped form (a heavier system prompt makes it far more likely):

```bash
curl -s http://localhost:8080/v1/chat/completions \
  -H 'Content-Type: application/json' \
  -d '{
    "model": "mlx-community/Qwen3-Coder-30B-A3B-Instruct-8bit",
    "messages": [
      {"role": "system", "content": "You are a coding agent with access to tools. Think carefully, then call the appropriate tool. <long system prompt ...>"},
      {"role": "user", "content": "Multiply 12234585 by 48838483920."}
    ],
    "tools": [
      {"type": "function", "function": {
        "name": "multiply",
        "description": "Multiply two numbers.",
        "parameters": {"type": "object", "required": ["a","b"],
          "properties": {"a": {"type": "number"}, "b": {"type": "number"}}}}}
    ],
    "temperature": 0.0
  }'
```

- **Before:** `choices[0].message.content` contains the raw `<function=...></function>` text, `finish_reason` is `"stop"`, and `tool_calls` is absent.
- **After:** `choices[0].message.tool_calls` contains a structured `multiply` call and `finish_reason` is `"tool_calls"`.

**Bug 2** — an object/array param whose value isn't a valid literal (this is what an `edit`-style tool produces when the model writes real source code):

```python
from mlx_lm.tool_parsers import qwen3_coder

tools = [{"type": "function", "function": {
    "name": "edit",
    "parameters": {"type": "object", "properties": {"edits": {"type": "array"}}}}}]

model_output = (
    "<function=edit>"
    '<parameter=edits>SECRET_KEY = os.environ.get("SECRET_KEY", "dev\nDEBUG = [True</parameter>'
    "</function>"
)
print(qwen3_coder.parse_tool_call(model_output, tools))
```

- **Before:** raises `SyntaxError: unterminated string literal` (uncaught in the server -> HTTP 500, "Stream ended without finish_reason").
- **After:** returns `{"name": "edit", "arguments": {"edits": 'SECRET_KEY = ...'}}` — the raw string, no crash.

## Verification

- Bug 1, failing prompt on `mlx-community/Qwen3-Coder-30B-A3B-Instruct-8bit`: structured `tool_calls` emission **0/6 -> 6/6** (non-streaming and streaming).
- Bug 1 regression, well-formed `<tool_call>...</tool_call>`: **6/6** (unchanged).
- Added `tests/test_server.py::TestServer::test_make_state_machine_unwrapped_tool_call` (Bug 1): drives the state machine token-by-token and asserts a structured tool call for a bare `<function=...></function>` block — bare, with a leading prose sentence, with a trailing stray `</tool_call>`, and truncated (EOS mid-call) — plus a regression case confirming the well-formed wrapped block still yields exactly one call.
- Added `tests/test_tool_parsing.py::TestToolParsing::test_qwen3_coder_non_literal_object_array_params` (Bug 2): asserts an unparseable multi-line-code array param returns the raw string instead of raising, and that valid JSON object/array params still parse.
- Full `tests/test_server.py`, `tests/test_tool_parsing.py`, and `tests/test_tokenizers.py` pass (**37 passed, 28 subtests**). `black` and `isort --profile=black` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
