### PR TITLE
Guard numeric param conversions in Qwen3 Coder tool parser

### DIFF
--- a/mlx_lm/tool_parsers/qwen3_coder.py
+++ b/mlx_lm/tool_parsers/qwen3_coder.py
@@ -54,10 +54,16 @@ def _convert_param_value(param_value: str, param_name: str, param_config: dict) 
         or param_type.startswith("short")
         or param_type.startswith("unsigned")
     ):
-        return int(param_value)
+        try:
+            return int(param_value)
+        except ValueError:
+            return param_value
     elif param_type.startswith("num") or param_type.startswith("float"):
-        float_param_value = float(param_value)
-        int_param_value = int(float_param_value)
+        try:
+            float_param_value = float(param_value)
+            int_param_value = int(float_param_value)
+        except (ValueError, OverflowError):
+            return param_value
         return (
             float_param_value
             if (float_param_value - int_param_value) != 0

--- a/tests/test_tool_parsing.py
+++ b/tests/test_tool_parsing.py
@@ -197,6 +197,58 @@ class TestToolParsing(unittest.TestCase):
         self.assertEqual(tool_call["arguments"]["filters"], {"category": "books"})
         self.assertEqual(tool_call["arguments"]["tags"], ["fiction", "new"])
 
+    def test_qwen3_coder_unparseable_numeric_params_fall_back_to_strings(self):
+        tools = [
+            {
+                "type": "function",
+                "function": {
+                    "name": "search",
+                    "parameters": {
+                        "type": "object",
+                        "properties": {
+                            "count": {"type": "int"},
+                            "ratio": {"type": "float"},
+                        },
+                    },
+                },
+            }
+        ]
+
+        # non-numeric int/float params fall back to the raw string
+        test_case = (
+            "<function=search>"
+            "<parameter=count>not_a_number</parameter>"
+            "<parameter=ratio>not_a_float</parameter>"
+            "</function>"
+        )
+        tool_call = qwen3_coder.parse_tool_call(test_case, tools)
+        self.assertEqual(
+            tool_call["arguments"],
+            {"count": "not_a_number", "ratio": "not_a_float"},
+        )
+
+        # valid numeric input still converts as before
+        test_case = (
+            "<function=search>"
+            "<parameter=count>7</parameter>"
+            "<parameter=ratio>2.5</parameter>"
+            "</function>"
+        )
+        tool_call = qwen3_coder.parse_tool_call(test_case, tools)
+        self.assertEqual(tool_call["arguments"], {"count": 7, "ratio": 2.5})
+
+        # "nan" parses as a float but crashes int() with ValueError
+        test_case = "<function=search>" "<parameter=ratio>nan</parameter>" "</function>"
+        tool_call = qwen3_coder.parse_tool_call(test_case, tools)
+        self.assertEqual(tool_call["arguments"], {"ratio": "nan"})
+
+        # "-inf" parses as a float but crashes int() with OverflowError
+        test_case = (
+            "<function=search>" "<parameter=ratio>-inf</parameter>" "</function>"
+        )
+        tool_call = qwen3_coder.parse_tool_call(test_case, tools)
+        self.assertEqual(tool_call["arguments"], {"ratio": "-inf"})
+
     def test_gemma4(self):
         # Nested object
         test_case = 'call:configure{settings:{enabled:true,name:<|"|>test<|"|>}}'


### PR DESCRIPTION
## Summary

- guard the int/float branches in the same parser against non-numeric model output, mirroring the raw-string fallback #1614 added for the object/array/other-type branch
- also fall back to the raw string for "inf"/"nan" float literals, which pass float() but then crash int() with either OverflowError/ValueError
- cover both cases with a regression test

This is a follow up to PR #1614, which fixed the crash for object/array/custom-typed arguments but not the numeric branches, which was noted in the original issue (#1604). Malformed model output for an int/float-typed tool argument could still crash the request handler.

## Testing

- confirmed the crash reproduces on main for non-numeric and inf/nan numeric arguments, and no longer reproduces on this branch
- `python -m unittest tests.test_tool_parsing`
- `black --check mlx_lm/tool_parsers/qwen3_coder.py tests/test_tool_parsing.py`
- `isort --check-only --profile=black mlx_lm/tool_parsers/qwen3_coder.py tests/test_tool_parsing.py`

Follow up to #1614 / related to #1604