### PR TITLE
Fail early for unsupported KV-cache quantization

### DIFF
--- a/mlx_lm/generate.py
+++ b/mlx_lm/generate.py
@@ -1587,8 +1587,25 @@ class BatchGenerator:
         prefill_batch_size: int = 8,
         prefill_step_size: int = 2048,
         max_kv_size: Optional[int] = None,
+        kv_bits: Optional[int] = None,
+        kv_group_size: int = 64,
+        quantized_kv_start: int = 0,
         stream=None,
     ):
+        if kv_bits is not None and quantized_kv_start != 0:
+            # Validated before any state is set, so a rejected config never
+            # leaves a partially-constructed instance behind (__del__ calls
+            # close(), which needs self._old_wired_limit to already exist).
+            # Per-job caches are created once, empty (offset=0), at insertion
+            # time via _make_new_cache() — maybe_quantize_kv_cache's
+            # offset-threshold gate would never trigger later for a nonzero
+            # quantized_kv_start, since there's no per-step re-check in the
+            # batching path. Only immediate quantization is supported here.
+            raise NotImplementedError(
+                "BatchGenerator only supports quantized_kv_start=0 with kv_bits "
+                "set — delayed/threshold quantization is not implemented for "
+                "the continuous-batching path."
+            )
         self.model = model
         self.max_tokens = max_tokens
         self.sampler = sampler or (lambda x: mx.argmax(x, axis=-1))
@@ -1598,6 +1615,9 @@ class BatchGenerator:
         self.prefill_batch_size = prefill_batch_size
         self.completion_batch_size = max(completion_batch_size, prefill_batch_size)
         self.max_kv_size = max_kv_size
+        self.kv_bits = kv_bits
+        self.kv_group_size = kv_group_size
+        self.quantized_kv_start = quantized_kv_start
 
         self._stream = stream or generation_stream
 
@@ -1631,7 +1651,10 @@ class BatchGenerator:
         return self._stream
 
     def close(self):
-        if self._old_wired_limit is not None:
+        # getattr guards against __del__ firing on an instance whose __init__
+        # raised before this attribute was ever set (e.g. an invalid kv_bits
+        # config) — a bare self._old_wired_limit would AttributeError there.
+        if getattr(self, "_old_wired_limit", None) is not None:
             mx.synchronize(self._stream)
             mx.set_wired_limit(self._old_wired_limit)
             self._old_wired_limit = None
@@ -1732,16 +1755,27 @@ class BatchGenerator:
 
     def _make_new_cache(self):
         if self.max_kv_size is None:
-            return cache.make_prompt_cache(self.model)
+            new_cache = cache.make_prompt_cache(self.model)
+        else:
+            new_cache = [
+                (
+                    RotatingKVCache(max_size=self.max_kv_size)
+                    if isinstance(ci, KVCache)
+                    else ci
+                )
+                for ci in cache.make_prompt_cache(self.model)
+            ]
 
-        return [
-            (
-                RotatingKVCache(max_size=self.max_kv_size)
-                if isinstance(ci, KVCache)
-                else ci
+        if self.kv_bits is not None:
+            # quantized_kv_start is always 0 here (enforced in __init__), so this
+            # quantizes every layer immediately — the cache is empty (offset=0),
+            # so there's no precision to lose. All subsequent update_and_fetch
+            # calls go through the quantized cache classes from this point on;
+            # no further re-quantization is needed anywhere else.
+            maybe_quantize_kv_cache(
+                new_cache, self.quantized_kv_start, self.kv_group_size, self.kv_bits
             )
-            for ci in cache.make_prompt_cache(self.model)
-        ]
+        return new_cache
 
     def _find_uids(self, uids):
         uids = set(uids)

--- a/mlx_lm/generate.py
+++ b/mlx_lm/generate.py
@@ -287,11 +287,59 @@ class GenerationResponse:
     finish_reason: Optional[str] = None
 
 
+def _validate_prompt_cache_quantization(
+    prompt_cache,
+    *,
+    cache_name,
+    kv_group_size,
+    kv_bits,
+):
+    if kv_bits is None:
+        return
+
+    errors = []
+    if not cache.can_quantize_prompt_cache(prompt_cache):
+        for layer, entry in enumerate(prompt_cache):
+            if entry.is_quantization_applicable() and not entry.is_quantizable():
+                errors.append(
+                    f"{cache_name} layer {layer} ({type(entry).__name__}: "
+                    f"{entry.quantization_unsupported_reason()})"
+                )
+
+    for layer, entry in enumerate(prompt_cache):
+        if entry.is_quantized() and (
+            entry.bits != kv_bits or entry.group_size != kv_group_size
+        ):
+            errors.append(
+                f"{cache_name} layer {layer} ({type(entry).__name__}: already "
+                f"quantized with bits={entry.bits}, group_size={entry.group_size}; "
+                f"requested bits={kv_bits}, group_size={kv_group_size})"
+            )
+
+    if errors:
+        raise ValueError(
+            "KV-cache quantization cannot be applied to every cache entry: "
+            + "; ".join(errors)
+            + "."
+        )
+
+
 def maybe_quantize_kv_cache(prompt_cache, quantized_kv_start, kv_group_size, kv_bits):
     if kv_bits is None:
         return
+
+    _validate_prompt_cache_quantization(
+        prompt_cache,
+        cache_name="prompt cache",
+        kv_group_size=kv_group_size,
+        kv_bits=kv_bits,
+    )
     for e, c in enumerate(prompt_cache):
-        if hasattr(c, "to_quantized") and c.offset >= quantized_kv_start:
+        if (
+            c.is_quantization_applicable()
+            and not c.is_quantized()
+            and c.offset >= quantized_kv_start
+        ):
             prompt_cache[e] = c.to_quantized(group_size=kv_group_size, bits=kv_bits)
 
 
@@ -364,6 +412,13 @@ def generate_step(
             model,
             max_kv_size=max_kv_size,
         )
+
+    _validate_prompt_cache_quantization(
+        prompt_cache,
+        cache_name="model prompt cache",
+        kv_group_size=kv_group_size,
+        kv_bits=kv_bits,
+    )
 
     prompt_progress_callback = prompt_progress_callback or (lambda *_: None)
 
@@ -516,6 +571,19 @@ def speculative_generate_step(
     else:
         model_cache = prompt_cache[: len(model.layers)]
         draft_cache = prompt_cache[len(model.layers) :]
+
+    _validate_prompt_cache_quantization(
+        model_cache,
+        cache_name="model prompt cache",
+        kv_group_size=kv_group_size,
+        kv_bits=kv_bits,
+    )
+    _validate_prompt_cache_quantization(
+        draft_cache,
+        cache_name="draft model prompt cache",
+        kv_group_size=kv_group_size,
+        kv_bits=kv_bits,
+    )
 
     if not cache.can_trim_prompt_cache(model_cache):
         types = {type(c).__name__ for c in model_cache if not c.is_trimmable()}
@@ -1731,6 +1799,19 @@ class BatchGenerator:
         for i in range(len(segments)):
             if caches[i] is None:
                 caches[i] = self._make_new_cache()
+            elif self.kv_bits is not None:
+                _validate_prompt_cache_quantization(
+                    caches[i],
+                    cache_name=f"batch request {i} prompt cache",
+                    kv_group_size=self.kv_group_size,
+                    kv_bits=self.kv_bits,
+                )
+                maybe_quantize_kv_cache(
+                    caches[i],
+                    self.quantized_kv_start,
+                    self.kv_group_size,
+                    self.kv_bits,
+                )
 
         for seq, m, c, at, s, lp, sm in zip(
             segments,
@@ -1767,6 +1848,12 @@ class BatchGenerator:
             ]
 
         if self.kv_bits is not None:
+            _validate_prompt_cache_quantization(
+                new_cache,
+                cache_name="batch model prompt cache",
+                kv_group_size=self.kv_group_size,
+                kv_bits=self.kv_bits,
+            )
             # quantized_kv_start is always 0 here (enforced in __init__), so this
             # quantizes every layer immediately — the cache is empty (offset=0),
             # so there's no precision to lose. All subsequent update_and_fetch

--- a/mlx_lm/models/cache.py
+++ b/mlx_lm/models/cache.py
@@ -92,6 +92,16 @@ def can_trim_prompt_cache(cache: List[Any]) -> bool:
     return all(c.is_trimmable() for c in cache)
 
 
+def can_quantize_prompt_cache(cache: List[Any]) -> bool:
+    """
+    Check if every KV-cache entry supports quantization.
+
+    Non-KV state entries are not affected by a KV-cache quantization request,
+    and already-quantized entries count as supported.
+    """
+    return all(not c.is_quantization_applicable() or c.is_quantizable() for c in cache)
+
+
 def trim_prompt_cache(cache: List[Any], num_tokens: int) -> List[Any]:
     """
     Trim the model's cache by the given number of tokens.
@@ -145,6 +155,18 @@ class _BaseCache:
 
     def is_trimmable(self):
         return False
+
+    def is_quantization_applicable(self):
+        return True
+
+    def is_quantizable(self):
+        return False
+
+    def is_quantized(self):
+        return False
+
+    def quantization_unsupported_reason(self):
+        return "KV-cache quantization is not implemented"
 
     def size(self):
         """
@@ -319,6 +341,12 @@ class QuantizedKVCache(_BaseCache):
     def is_trimmable(self):
         return True
 
+    def is_quantizable(self):
+        return True
+
+    def is_quantized(self):
+        return True
+
     def trim(self, n):
         n = min(self.offset, n)
         self.offset -= n
@@ -386,6 +414,9 @@ class KVCache(_BaseCache):
         self.offset = self.keys.shape[2]
 
     def is_trimmable(self):
+        return True
+
+    def is_quantizable(self):
         return True
 
     def trim(self, n):
@@ -554,6 +585,14 @@ class RotatingKVCache(_BaseCache):
 
     def is_trimmable(self):
         return self.offset < self.max_size
+
+    def is_quantizable(self):
+        return self.keep == 0
+
+    def quantization_unsupported_reason(self):
+        if self.keep > 0:
+            return f"keep={self.keep} sink tokens are not supported"
+        return super().quantization_unsupported_reason()
 
     def trim(self, n):
         n = min(self.offset, n)
@@ -802,6 +841,12 @@ class RotatingQuantizedKVCache(_BaseCache):
     def is_trimmable(self):
         return self.offset < self.max_size
 
+    def is_quantizable(self):
+        return True
+
+    def is_quantized(self):
+        return True
+
     def trim(self, n):
         n = min(self.offset, n)
         self.offset -= n
@@ -859,6 +904,9 @@ class ArraysCache(_BaseCache):
         self.cache = [None] * size
         if left_padding:
             self.left_padding = mx.array(left_padding)
+
+    def is_quantization_applicable(self):
+        return False
 
     @property
     def batch_size(self):
@@ -1574,6 +1622,9 @@ class BatchRotatingKVCache(_BaseCache):
     def is_trimmable(self):
         return self._offset < self.max_size
 
+    def is_quantizable(self):
+        return True
+
     def trim(self, n):
         n = min(self._offset, n)
         self._offset -= n
@@ -2001,6 +2052,12 @@ class BatchRotatingQuantizedKVCache(_BaseCache):
 
     def is_trimmable(self):
         return self._offset < self.max_size
+
+    def is_quantizable(self):
+        return True
+
+    def is_quantized(self):
+        return True
 
     def trim(self, n):
         n = min(self._offset, n)

--- a/mlx_lm/models/cache.py
+++ b/mlx_lm/models/cache.py
@@ -229,6 +229,19 @@ class ConcatenateKVCache(_BaseCache):
         return self.keys.nbytes + self.values.nbytes
 
 
+def _empty_quantized(B, n_kv_heads, n_steps, head_dim, group_size, bits, dtype):
+    """Allocate a zero-filled quantized (packed, scales, biases) triple, matching
+    the layout `mx.quantize` produces — used to grow quantized cache buffers in
+    fixed-size chunks (mirrors QuantizedKVCache.update_and_fetch's init_quant)."""
+    el_per_int = 8 * mx.uint32.size // bits
+    shape = (B, n_kv_heads, n_steps)
+    return (
+        mx.zeros((*shape, head_dim // el_per_int), dtype=mx.uint32),
+        mx.zeros((*shape, head_dim // group_size), dtype=dtype),
+        mx.zeros((*shape, head_dim // group_size), dtype=dtype),
+    )
+
+
 class QuantizedKVCache(_BaseCache):
     step = 256
 
@@ -548,8 +561,24 @@ class RotatingKVCache(_BaseCache):
         self._idx -= n
         return n
 
-    def to_quantized(self, group_size: int = 64, bits: int = 4) -> QuantizedKVCache:
-        raise NotImplementedError("RotatingKVCache Quantization NYI")
+    def to_quantized(
+        self, group_size: int = 64, bits: int = 4
+    ) -> "RotatingQuantizedKVCache":
+        if self.keep > 0:
+            raise NotImplementedError(
+                "Quantizing a RotatingKVCache with keep tokens is not supported."
+            )
+        quant_cache = RotatingQuantizedKVCache(
+            self.max_size, keep=self.keep, group_size=group_size, bits=bits
+        )
+        quant_cache.offset = self.offset
+        quant_cache._idx = self._idx
+        if self.keys is not None:
+            quant_cache.keys = mx.quantize(self.keys, group_size=group_size, bits=bits)
+            quant_cache.values = mx.quantize(
+                self.values, group_size=group_size, bits=bits
+            )
+        return quant_cache
 
     def make_mask(
         self, N: int, window_size: Optional[int] = None, return_array: bool = False
@@ -589,6 +618,234 @@ class RotatingKVCache(_BaseCache):
         if self.keys is None:
             return 0
         return self.keys.nbytes + self.values.nbytes
+
+
+class RotatingQuantizedKVCache(_BaseCache):
+    """Quantized counterpart of RotatingKVCache. `keys`/`values` are each a
+    (packed, scales, biases) triple as produced by `mx.quantize`, rather than a
+    single float array. Does not support `keep` (sink) tokens — batching
+    (BatchRotatingKVCache) never supports them either, and mira-mlx never
+    configures them, so this restriction costs nothing in practice."""
+
+    step = 256
+
+    def __init__(self, max_size, keep=0, group_size: int = 64, bits: int = 4):
+        if keep > 0:
+            raise NotImplementedError(
+                "RotatingQuantizedKVCache does not support keep tokens."
+            )
+        self.keep = keep
+        self.keys = None
+        self.values = None
+        self.offset = 0
+        self.max_size = max_size
+        self._idx = 0
+        self.group_size = group_size
+        self.bits = bits
+
+    def _quantize(self, x):
+        return mx.quantize(x, group_size=self.group_size, bits=self.bits)
+
+    def _trim(self, trim_size, v, append=None):
+        if trim_size > 0:
+            v = tree_map(lambda a: a[..., trim_size:, :], v)
+        if append is not None:
+            v = tree_map(lambda a, b: mx.concatenate([a, b], axis=2), v, append)
+        return v
+
+    def _temporal_order(self, v):
+        """
+        Rearrange the cache into temporal order, slicing off the end if unused.
+        """
+        if self._idx == v[0].shape[2]:
+            return v
+        elif self._idx < self.offset:
+            return tree_map(
+                lambda a: mx.concatenate(
+                    [a[..., self._idx :, :], a[..., : self._idx, :]], axis=2
+                ),
+                v,
+            )
+        else:
+            return tree_map(lambda a: a[..., : self._idx, :], v)
+
+    def _update_concat(self, keys, values):
+        qkeys = self._quantize(keys)
+        qvalues = self._quantize(values)
+        if self.keys is None:
+            self.keys = qkeys
+            self.values = qvalues
+        else:
+            # Put the keys/values in temporal order to preserve context
+            self.keys = self._temporal_order(self.keys)
+            self.values = self._temporal_order(self.values)
+            self._idx = self.keys[0].shape[2]
+
+            # The largest size is self.max_size + S - 1 to ensure
+            # every token gets at least self.max_size context
+            trim_size = self._idx - self.max_size + 1
+            self.keys = self._trim(trim_size, self.keys, qkeys)
+            self.values = self._trim(trim_size, self.values, qvalues)
+        self.offset += keys.shape[2]
+        self._idx = self.keys[0].shape[2]
+        return self.keys, self.values
+
+    def _update_in_place(self, keys, values):
+        # May not have hit the max size yet, so potentially keep growing the cache
+        B, n_kv_heads, S, k_head_dim = keys.shape
+        v_head_dim = values.shape[3]
+        prev = self.offset
+        cur_size = self.keys[0].shape[2] if self.keys is not None else 0
+        if self.keys is None or (prev >= cur_size and cur_size < self.max_size):
+            new_size = min(self.step, self.max_size - prev)
+            new_k = _empty_quantized(
+                B,
+                n_kv_heads,
+                new_size,
+                k_head_dim,
+                self.group_size,
+                self.bits,
+                keys.dtype,
+            )
+            new_v = _empty_quantized(
+                B,
+                n_kv_heads,
+                new_size,
+                v_head_dim,
+                self.group_size,
+                self.bits,
+                values.dtype,
+            )
+            if self.keys is not None:
+                self.keys = tree_map(
+                    lambda a, b: mx.concatenate([a, b], axis=2), self.keys, new_k
+                )
+                self.values = tree_map(
+                    lambda a, b: mx.concatenate([a, b], axis=2), self.values, new_v
+                )
+            else:
+                self.keys, self.values = new_k, new_v
+            self._idx = prev
+
+        # Trim if needed
+        trim_size = self.keys[0].shape[2] - self.max_size
+        if trim_size > 0:
+            self.keys = self._trim(trim_size, self.keys)
+            self.values = self._trim(trim_size, self.values)
+            self._idx = self.max_size
+
+        # Rotate
+        if self._idx == self.max_size:
+            self._idx = self.keep  # always 0, keep>0 rejected in __init__
+
+        # Assign (quantize the incoming chunk, then slice-write like QuantizedKVCache)
+        qkeys = self._quantize(keys)
+        qvalues = self._quantize(values)
+        for i in range(3):
+            self.keys[i][..., self._idx : self._idx + S, :] = qkeys[i]
+            self.values[i][..., self._idx : self._idx + S, :] = qvalues[i]
+        self.offset += S
+        self._idx += S
+
+        # If the buffer is not full, slice off the end
+        if self.offset < self.max_size:
+            return (
+                tree_map(lambda a: a[..., : self.offset, :], self.keys),
+                tree_map(lambda a: a[..., : self.offset, :], self.values),
+            )
+        return self.keys, self.values
+
+    def update_and_fetch(self, keys, values):
+        if keys.shape[2] == 1:
+            return self._update_in_place(keys, values)
+        return self._update_concat(keys, values)
+
+    def size(self):
+        return min(self.offset, self.max_size)
+
+    @property
+    def state(self):
+        if self.offset < self.keys[0].shape[2]:
+            return (
+                tree_map(lambda a: a[..., : self.offset, :], self.keys),
+                tree_map(lambda a: a[..., : self.offset, :], self.values),
+            )
+        else:
+            return self.keys, self.values
+
+    @state.setter
+    def state(self, v):
+        self.keys, self.values = v
+
+    @property
+    def meta_state(self):
+        return tuple(
+            map(
+                str,
+                (
+                    self.keep,
+                    self.max_size,
+                    self.offset,
+                    self._idx,
+                    self.group_size,
+                    self.bits,
+                ),
+            )
+        )
+
+    @meta_state.setter
+    def meta_state(self, v):
+        self.keep, self.max_size, self.offset, self._idx, self.group_size, self.bits = (
+            map(int, v)
+        )
+
+    def is_trimmable(self):
+        return self.offset < self.max_size
+
+    def trim(self, n):
+        n = min(self.offset, n)
+        self.offset -= n
+        self._idx -= n
+        return n
+
+    def make_mask(
+        self, N: int, window_size: Optional[int] = None, return_array: bool = False
+    ):
+        # Identical bookkeeping to RotatingKVCache.make_mask — no array access.
+        if N > 1:
+            window_size = window_size or self.max_size
+            offset = min(self.max_size - 1, self.offset)
+            if offset + N > window_size or return_array:
+                return create_causal_mask(N, offset, window_size=window_size)
+            else:
+                return "causal"
+        else:
+            if window_size is None:
+                return None
+            if self.offset >= window_size and self.max_size > window_size:
+                idx = self._idx
+                if idx >= self.max_size:
+                    idx = 0
+                if self.offset < self.max_size:
+                    mask_size = self.offset + 1
+                else:
+                    mask_size = self.max_size
+                mask = mx.arange(mask_size) >= (mask_size - window_size)
+                mask = mx.roll(mask, shift=idx + 1)
+                return mask
+
+    @classmethod
+    def merge(_, caches):
+        return BatchRotatingQuantizedKVCache.merge(caches)
+
+    def empty(self):
+        return self.keys is None
+
+    @property
+    def nbytes(self):
+        if self.keys is None:
+            return 0
+        return tree_reduce(lambda a, x: a + x.nbytes, (self.keys, self.values), 0)
 
 
 class ArraysCache(_BaseCache):
@@ -1324,8 +1581,22 @@ class BatchRotatingKVCache(_BaseCache):
         self.offset -= n
         return n
 
-    def to_quantized(self, group_size: int = 64, bits: int = 4) -> QuantizedKVCache:
-        raise NotImplementedError("BatchRotatingKVCache Quantization NYI")
+    def to_quantized(
+        self, group_size: int = 64, bits: int = 4
+    ) -> "BatchRotatingQuantizedKVCache":
+        quant_cache = BatchRotatingQuantizedKVCache(
+            self.max_size, self.left_padding.tolist(), group_size=group_size, bits=bits
+        )
+        quant_cache.offset = self.offset
+        quant_cache._idx = self._idx
+        quant_cache._offset = self._offset
+        quant_cache.rotated = self.rotated
+        if self.keys is not None:
+            quant_cache.keys = mx.quantize(self.keys, group_size=group_size, bits=bits)
+            quant_cache.values = mx.quantize(
+                self.values, group_size=group_size, bits=bits
+            )
+        return quant_cache
 
     def make_mask(
         self, N: int, window_size: Optional[int] = None, return_array: bool = False
@@ -1482,6 +1753,472 @@ class BatchRotatingKVCache(_BaseCache):
         if self.keys is None:
             return 0
         return self.keys.nbytes + self.values.nbytes
+
+
+class BatchRotatingQuantizedKVCache(_BaseCache):
+    """Quantized counterpart of BatchRotatingKVCache — the class BatchGenerator's
+    continuous-batching path actually calls `update_and_fetch` on once per-job
+    caches are merged into a batch. `keys`/`values` are each a (packed, scales,
+    biases) triple. Never receives `keep` tokens — merge() only ever takes
+    RotatingQuantizedKVCache inputs, which themselves reject keep>0."""
+
+    step = 256
+
+    def __init__(
+        self, max_size, left_padding: List[int], group_size: int = 64, bits: int = 4
+    ):
+        self.keys = None
+        self.values = None
+
+        self.left_padding = mx.array(left_padding)
+        self.offset = mx.array([-l for l in left_padding])
+
+        self.max_size = max_size
+        self.group_size = group_size
+        self.bits = bits
+        self._idx = 0
+        self._offset = 0
+        self.rotated = False
+
+        # Lengths for right_padded inputs to make sure that padding tokens do
+        # not evict valid tokens.
+        self._lengths = None
+
+    def _quantize(self, x):
+        return mx.quantize(x, group_size=self.group_size, bits=self.bits)
+
+    def _trim(self, trim_size, v, append=None):
+        if trim_size > 0:
+            v = tree_map(lambda a: a[..., trim_size:, :], v)
+        if append is not None:
+            v = tree_map(lambda a, b: mx.concatenate([a, b], axis=2), v, append)
+        return v
+
+    def _temporal_order(self):
+        """
+        Rearrange the cache into temporal order.
+        """
+        if self.rotated:
+            self.keys = tree_map(lambda a: mx.roll(a, -self._idx, axis=2), self.keys)
+            self.values = tree_map(
+                lambda a: mx.roll(a, -self._idx, axis=2), self.values
+            )
+            self._idx = self.keys[0].shape[2]
+            self.rotated = False
+
+    def _update_concat(self, keys, values):
+        qkeys = self._quantize(keys)
+        qvalues = self._quantize(values)
+        if self.keys is None:
+            self.keys = qkeys
+            self.values = qvalues
+        else:
+            # Put the keys/values in temporal order to preserve context
+            self._temporal_order()
+
+            # Slice off the end if needed
+            if self.keys[0].shape[2] > self._idx:
+                self.keys = tree_map(lambda a: a[..., : self._idx, :], self.keys)
+                self.values = tree_map(lambda a: a[..., : self._idx, :], self.values)
+
+            # Roll right sequences that are padded to make sure that we don't
+            # trim valid cache entries
+            if self._lengths is not None:
+                roll = mx.maximum(0, self.offset - self._lengths)
+                self.keys = tree_map(
+                    lambda a: dynamic_roll(a, roll[:, None], axis=2), self.keys
+                )
+                self.values = tree_map(
+                    lambda a: dynamic_roll(a, roll[:, None], axis=2), self.values
+                )
+                self.left_padding += roll
+                self.offset -= roll
+
+            # The largest size is self.max_size + S - 1 to ensure
+            # every token gets at least self.max_size context
+            trim_size = self._idx - self.max_size + 1
+            if trim_size > 0:
+                self.left_padding -= trim_size
+            self.keys = self._trim(trim_size, self.keys, qkeys)
+            self.values = self._trim(trim_size, self.values, qvalues)
+        self.offset += keys.shape[2]
+        self._offset += keys.shape[2]
+        self._idx = self.keys[0].shape[2]
+
+        # Make sure left_padding and offset are evaluated
+        self.keys = tree_map(
+            lambda a: mx.depends(a, (self.left_padding, self.offset)), self.keys
+        )
+
+        return self.keys, self.values
+
+    def _update_in_place(self, keys, values):
+        if self._lengths is not None:
+            raise RuntimeError(
+                "finalize() should be called before decoding with "
+                "BatchRotatingQuantizedKVCache"
+            )
+
+        # May not have hit the max size yet, so potentially keep growing the cache
+        B, n_kv_heads, S, k_head_dim = keys.shape
+        v_head_dim = values.shape[3]
+        prev = self._offset
+        cur_size = self.keys[0].shape[2] if self.keys is not None else 0
+        if self.keys is None or (prev >= cur_size and cur_size < self.max_size):
+            new_size = min(self.step, self.max_size - prev)
+            new_k = _empty_quantized(
+                B,
+                n_kv_heads,
+                new_size,
+                k_head_dim,
+                self.group_size,
+                self.bits,
+                keys.dtype,
+            )
+            new_v = _empty_quantized(
+                B,
+                n_kv_heads,
+                new_size,
+                v_head_dim,
+                self.group_size,
+                self.bits,
+                values.dtype,
+            )
+            if self.keys is not None:
+                self.keys = tree_map(
+                    lambda a, b: mx.concatenate([a, b], axis=2), self.keys, new_k
+                )
+                self.values = tree_map(
+                    lambda a, b: mx.concatenate([a, b], axis=2), self.values, new_v
+                )
+            else:
+                self.keys, self.values = new_k, new_v
+            self._idx = prev
+
+        # Trim if needed
+        trim_size = self.keys[0].shape[2] - self.max_size
+        if trim_size > 0:
+            self.keys = self._trim(trim_size, self.keys)
+            self.values = self._trim(trim_size, self.values)
+            self._idx = self.max_size
+            self.left_padding -= trim_size
+
+        # Rotate
+        if self._idx == self.max_size:
+            self.rotated = True
+            self._idx = 0
+        if self.rotated:
+            self.left_padding -= S
+
+        # Assign (quantize the incoming chunk, then slice-write like QuantizedKVCache)
+        qkeys = self._quantize(keys)
+        qvalues = self._quantize(values)
+        for i in range(3):
+            self.keys[i][..., self._idx : self._idx + S, :] = qkeys[i]
+            self.values[i][..., self._idx : self._idx + S, :] = qvalues[i]
+        self._offset += S
+        self.offset += S
+        self._idx += S
+
+        # Make sure left_padding and offset are evaluated
+        self.keys = tree_map(
+            lambda a: mx.depends(a, (self.left_padding, self.offset)), self.keys
+        )
+
+        # If the buffer is not full, slice off the end
+        if self._offset < self.max_size:
+            return (
+                tree_map(lambda a: a[..., : self._offset, :], self.keys),
+                tree_map(lambda a: a[..., : self._offset, :], self.values),
+            )
+        return self.keys, self.values
+
+    def update_and_fetch(self, keys, values):
+        if keys.shape[2] == 1:
+            return self._update_in_place(keys, values)
+        return self._update_concat(keys, values)
+
+    def prepare(self, *, left_padding=None, lengths=None, right_padding=None):
+        if left_padding is not None:
+            if self.keys is not None:
+                raise ValueError(
+                    "Left padding can only be added to an empty "
+                    "BatchRotatingQuantizedKVCache"
+                )
+            left_padding = mx.array(left_padding)
+            self.left_padding += left_padding
+            self.offset -= left_padding
+
+        if right_padding is not None and max(right_padding) > 0:
+            self._lengths = mx.array(lengths) + self.offset
+
+    def finalize(self):
+        if self._lengths is not None:
+            roll = mx.maximum(0, self.offset - self._lengths)
+            self.keys = tree_map(
+                lambda a: dynamic_roll(a, roll[:, None], axis=2), self.keys
+            )
+            self.values = tree_map(
+                lambda a: dynamic_roll(a, roll[:, None], axis=2), self.values
+            )
+            self.left_padding += roll
+            self.offset -= roll
+            self._lengths = None
+
+    @property
+    def state(self):
+        k, v = self.keys, self.values
+        if self._offset < k[0].shape[2]:
+            k = tree_map(lambda a: a[..., : self._offset, :], k)
+            v = tree_map(lambda a: a[..., : self._offset, :], v)
+        return k, v, self.offset, self.left_padding
+
+    @state.setter
+    def state(self, v):
+        self.keys, self.values, self.offset, self.left_padding = v
+
+    @property
+    def meta_state(self):
+        return tuple(
+            map(
+                str,
+                (
+                    self.max_size,
+                    self._offset,
+                    self._idx,
+                    self.rotated,
+                    self.group_size,
+                    self.bits,
+                ),
+            )
+        )
+
+    @meta_state.setter
+    def meta_state(self, v):
+        self.max_size, self._offset, self._idx = map(int, v[:3])
+        self.rotated = bool(v[3])
+        self.group_size, self.bits = map(int, v[4:6])
+
+    def is_trimmable(self):
+        return self._offset < self.max_size
+
+    def trim(self, n):
+        n = min(self._offset, n)
+        self._offset -= n
+        self._idx -= n
+        self.offset -= n
+        return n
+
+    def make_mask(
+        self, N: int, window_size: Optional[int] = None, return_array: bool = False
+    ):
+        # Identical bookkeeping to BatchRotatingKVCache.make_mask — no array access.
+        left_padding = self.left_padding
+        window_size = window_size or self.max_size
+        offset = min(self.max_size - 1, self._offset)
+        rinds = mx.arange(offset + N)
+        linds = mx.arange(offset, offset + N) if offset else rinds
+        linds = linds[:, None]
+        rinds = rinds[None]
+        mask = linds >= rinds
+        mask &= linds < rinds + window_size
+        if (trim_size := self._idx - self.max_size + int(N > 1)) > 0:
+            left_padding = left_padding - trim_size
+
+        rotated = N == 1 and (self.rotated or self._idx >= self.max_size)
+        if rotated:
+            left_padding = left_padding - 1
+
+        mask = mask & (rinds >= mx.expand_dims(left_padding, (1, 2, 3)))
+
+        if rotated:
+            idx = self._idx
+            if idx >= self.max_size:
+                idx = 0
+            mask = mx.roll(mask, shift=idx + 1, axis=-1)
+
+        return mask
+
+    def filter(self, batch_indices):
+        """
+        In-place filter to keep just the given indices in the cache.
+        """
+        if self.keys is not None:
+            self.keys = tree_map(lambda a: a[batch_indices], self.keys)
+            self.values = tree_map(lambda a: a[batch_indices], self.values)
+        self.offset = self.offset[batch_indices]
+        self.left_padding = self.left_padding[batch_indices]
+
+    def extend(self, other):
+        """
+        In-place extend this cache with the other cache.
+        """
+        if self.keys is None and other.keys is None:
+            self.left_padding = mx.concatenate([self.left_padding, other.left_padding])
+            self.offset = mx.concatenate([self.offset, other.offset])
+            return
+
+        if (self.rotated != other.rotated) or self._idx != other._idx:
+            self._temporal_order()
+            other._temporal_order()
+
+        max_idx = max(self._idx, other._idx)
+        L1 = L2 = 0
+        if self.keys is not None:
+            L1 = self.keys[0].shape[2]
+        if other.keys is not None:
+            L2 = other.keys[0].shape[2]
+        max_size = max(L1, L2)
+
+        ref = self.keys if self.keys is not None else other.keys
+        ref_v = self.values if self.values is not None else other.values
+
+        def pad(c):
+            left = max_idx - c._idx
+            if c.keys is None:
+                Bc = c.offset.shape[0]
+                k = tree_map(
+                    lambda a: mx.zeros(
+                        (Bc, *a.shape[1:2], 0, a.shape[-1]), dtype=a.dtype
+                    ),
+                    ref,
+                )
+                v = tree_map(
+                    lambda a: mx.zeros(
+                        (Bc, *a.shape[1:2], 0, a.shape[-1]), dtype=a.dtype
+                    ),
+                    ref_v,
+                )
+            else:
+                k, v = c.keys, c.values
+            right = max_size - k[0].shape[2] - left
+            if right < 0:
+                k = tree_map(lambda a: a[..., :right, :], k)
+                v = tree_map(lambda a: a[..., :right, :], v)
+                right = 0
+            if left != 0 or right != 0:
+                k = tree_map(
+                    lambda a: mx.pad(a, [(0, 0), (0, 0), (left, right), (0, 0)]), k
+                )
+                v = tree_map(
+                    lambda a: mx.pad(a, [(0, 0), (0, 0), (left, right), (0, 0)]), v
+                )
+            left_padding = c.left_padding + left
+            return k, v, c.offset, left_padding
+
+        pa, pb = pad(self), pad(other)
+        self.keys = tree_map(lambda a, b: mx.concatenate([a, b], axis=0), pa[0], pb[0])
+        self.values = tree_map(
+            lambda a, b: mx.concatenate([a, b], axis=0), pa[1], pb[1]
+        )
+        self.offset = mx.concatenate([pa[2], pb[2]])
+        self.left_padding = mx.concatenate([pa[3], pb[3]])
+        self._idx = max_idx
+        self._offset = max(self._offset, other._offset)
+
+    def extract(self, idx):
+        mx.eval(self.left_padding, self.offset)
+        cache = RotatingQuantizedKVCache(
+            self.max_size, group_size=self.group_size, bits=self.bits
+        )
+        padding = max(0, self.left_padding.tolist()[idx])
+        offset = self.offset.tolist()[idx]
+        cache.keys = tree_map(lambda a: a[idx : idx + 1], self.keys)
+        cache.values = tree_map(lambda a: a[idx : idx + 1], self.values)
+        cache._idx = self._idx
+        if self.rotated:
+            cache.keys = tree_map(lambda a: mx.roll(a, -self._idx, axis=2), cache.keys)
+            cache.values = tree_map(
+                lambda a: mx.roll(a, -self._idx, axis=2), cache.values
+            )
+            cache._idx = self.max_size
+        cache.keys = tree_map(
+            lambda a: mx.contiguous(a[:, :, padding : cache._idx]), cache.keys
+        )
+        cache.values = tree_map(
+            lambda a: mx.contiguous(a[:, :, padding : cache._idx]), cache.values
+        )
+        cache.offset = offset
+        cache._idx = cache.keys[0].shape[2]
+        return cache
+
+    @classmethod
+    def merge(cls, caches):
+        if not all(c.max_size == caches[0].max_size for c in caches):
+            raise ValueError(
+                "BatchRotatingQuantizedKVCache can only merge caches with the "
+                "same maximum size"
+            )
+        if not all(
+            (c.group_size, c.bits) == (caches[0].group_size, caches[0].bits)
+            for c in caches
+        ):
+            raise ValueError(
+                "BatchRotatingQuantizedKVCache can only merge caches with the "
+                "same group_size/bits"
+            )
+
+        offsets = [c.offset for c in caches]
+        lengths = [c.size() for c in caches]
+        max_length = max(lengths)
+
+        # No cache has content so make an empty one
+        if max_length == 0:
+            return cls(
+                caches[0].max_size,
+                [0] * len(caches),
+                group_size=caches[0].group_size,
+                bits=caches[0].bits,
+            )
+
+        padding = [max_length - l for l in lengths]
+        B = len(caches)
+        ref = next(c.keys for c in caches if c.keys is not None)
+        H = ref[0].shape[1]
+        dt_p, dt_sb = ref[0].dtype, ref[1].dtype
+
+        def alloc_like(ref_tuple):
+            return tuple(
+                mx.zeros((B, H, max_length, a.shape[-1]), dtype=a.dtype)
+                for a in ref_tuple
+            )
+
+        keys = alloc_like(ref)
+        values = alloc_like(next(c.values for c in caches if c.values is not None))
+        for i, (p, l, c) in enumerate(zip(padding, lengths, caches)):
+            if c.keys is None:
+                continue
+            ok = c._temporal_order(c.keys)
+            ov = c._temporal_order(c.values)
+            for j in range(3):
+                keys[j][i : i + 1, :, p : p + l] = ok[j][..., -l:, :]
+                values[j][i : i + 1, :, p : p + l] = ov[j][..., -l:, :]
+
+        cache = cls(
+            caches[0].max_size,
+            padding,
+            group_size=caches[0].group_size,
+            bits=caches[0].bits,
+        )
+        cache.keys = keys
+        cache.values = values
+        cache.offset = mx.array(offsets)
+        cache._idx = max_length
+        cache._offset = max_length
+
+        return cache
+
+    def size(self):
+        return min(self._offset, self.max_size)
+
+    def empty(self):
+        return self.keys is None
+
+    @property
+    def nbytes(self):
+        if self.keys is None:
+            return 0
+        return tree_reduce(lambda a, x: a + x.nbytes, (self.keys, self.values), 0)
 
 
 class TokenBuffer:

--- a/tests/test_cache_quantization_capability.py
+++ b/tests/test_cache_quantization_capability.py
@@ -1,0 +1,236 @@
+# Copyright © 2026 Apple Inc.
+
+import unittest
+
+import mlx.core as mx
+
+from mlx_lm.generate import (
+    BatchGenerator,
+    generate_step,
+    maybe_quantize_kv_cache,
+    speculative_generate_step,
+)
+from mlx_lm.models.cache import (
+    ArraysCache,
+    ChunkedKVCache,
+    KVCache,
+    QuantizedKVCache,
+    RotatingKVCache,
+    RotatingQuantizedKVCache,
+    can_quantize_prompt_cache,
+)
+
+
+class CacheModel:
+    def __init__(self, num_layers, cache_factory):
+        self.layers = [object() for _ in range(num_layers)]
+        self.cache_factory = cache_factory
+        self.calls = 0
+
+    def make_cache(self):
+        return self.cache_factory()
+
+    def __call__(self, *args, **kwargs):
+        self.calls += 1
+        raise AssertionError("cache validation must run before the model")
+
+
+class TestCacheQuantizationCapability(unittest.TestCase):
+    def test_mixed_cache_is_quantizable(self):
+        prompt_cache = [
+            KVCache(),
+            RotatingKVCache(max_size=16, keep=0),
+            QuantizedKVCache(group_size=32, bits=8),
+            RotatingQuantizedKVCache(
+                max_size=16,
+                group_size=32,
+                bits=8,
+            ),
+            ArraysCache(size=2),
+        ]
+
+        self.assertTrue(can_quantize_prompt_cache(prompt_cache))
+
+    def test_rotating_cache_with_keep_is_not_quantizable(self):
+        prompt_cache = [
+            KVCache(),
+            RotatingKVCache(max_size=16, keep=4),
+        ]
+
+        self.assertFalse(can_quantize_prompt_cache(prompt_cache))
+
+    def test_non_kv_state_is_explicitly_ignored(self):
+        state_cache = ArraysCache(size=2)
+        prompt_cache = [state_cache, KVCache()]
+
+        maybe_quantize_kv_cache(
+            prompt_cache,
+            quantized_kv_start=0,
+            kv_group_size=32,
+            kv_bits=8,
+        )
+
+        self.assertIs(prompt_cache[0], state_cache)
+        self.assertIsInstance(prompt_cache[1], QuantizedKVCache)
+
+    def test_maybe_quantize_does_not_silently_skip_unsupported_entry(self):
+        prompt_cache = [KVCache(), ChunkedKVCache(chunk_size=16)]
+
+        with self.assertRaisesRegex(
+            ValueError,
+            r"prompt cache layer 1 \(ChunkedKVCache: "
+            r"KV-cache quantization is not implemented\)",
+        ):
+            maybe_quantize_kv_cache(
+                prompt_cache,
+                quantized_kv_start=0,
+                kv_group_size=32,
+                kv_bits=8,
+            )
+
+        self.assertIsInstance(prompt_cache[0], KVCache)
+
+    def test_generate_step_fails_before_model_for_keep_cache(self):
+        model = CacheModel(
+            2,
+            lambda: [
+                KVCache(),
+                RotatingKVCache(max_size=16, keep=4),
+            ],
+        )
+
+        with self.assertRaisesRegex(
+            ValueError,
+            r"model prompt cache layer 1 \(RotatingKVCache: "
+            r"keep=4 sink tokens are not supported\)",
+        ):
+            next(
+                generate_step(
+                    mx.array([1]),
+                    model,
+                    max_tokens=0,
+                    kv_bits=8,
+                    kv_group_size=32,
+                )
+            )
+
+        self.assertEqual(model.calls, 0)
+
+    def test_generate_step_rejects_quantized_cache_config_mismatch(self):
+        model = CacheModel(1, lambda: [KVCache()])
+        prompt_cache = [QuantizedKVCache(group_size=32, bits=4)]
+
+        with self.assertRaisesRegex(
+            ValueError,
+            r"already quantized with bits=4, group_size=32; "
+            r"requested bits=8, group_size=32",
+        ):
+            next(
+                generate_step(
+                    mx.array([1]),
+                    model,
+                    max_tokens=0,
+                    prompt_cache=prompt_cache,
+                    kv_bits=8,
+                    kv_group_size=32,
+                )
+            )
+
+        self.assertEqual(model.calls, 0)
+
+    def test_speculative_generate_validates_draft_cache(self):
+        model = CacheModel(1, lambda: [KVCache()])
+        draft_model = CacheModel(1, lambda: [KVCache()])
+        prompt_cache = [
+            KVCache(),
+            RotatingKVCache(max_size=16, keep=4),
+        ]
+
+        with self.assertRaisesRegex(
+            ValueError,
+            r"draft model prompt cache layer 0 \(RotatingKVCache: "
+            r"keep=4 sink tokens are not supported\)",
+        ):
+            next(
+                speculative_generate_step(
+                    mx.array([1]),
+                    model,
+                    draft_model,
+                    max_tokens=1,
+                    prompt_cache=prompt_cache,
+                    kv_bits=8,
+                    kv_group_size=32,
+                )
+            )
+
+        self.assertEqual(model.calls, 0)
+        self.assertEqual(draft_model.calls, 0)
+
+    def test_batch_generator_quantizes_every_mixed_cache_entry(self):
+        model = CacheModel(
+            2,
+            lambda: [
+                KVCache(),
+                RotatingKVCache(max_size=16, keep=0),
+            ],
+        )
+        generator = BatchGenerator(
+            model,
+            kv_bits=8,
+            kv_group_size=32,
+        )
+        try:
+            generator.insert([[1]])
+            prompt_cache = generator._unprocessed_sequences[0][3]
+
+            self.assertIsInstance(prompt_cache[0], QuantizedKVCache)
+            self.assertIsInstance(prompt_cache[1], RotatingQuantizedKVCache)
+            self.assertTrue(all(c.is_quantized() for c in prompt_cache))
+        finally:
+            generator.close()
+
+    def test_batch_generator_does_not_skip_external_cache(self):
+        model = CacheModel(2, lambda: [KVCache(), KVCache()])
+        generator = BatchGenerator(
+            model,
+            kv_bits=8,
+            kv_group_size=32,
+        )
+        prompt_cache = [KVCache(), ChunkedKVCache(chunk_size=16)]
+        try:
+            with self.assertRaisesRegex(
+                ValueError,
+                r"batch request 0 prompt cache layer 1 \(ChunkedKVCache: "
+                r"KV-cache quantization is not implemented\)",
+            ):
+                generator.insert([[1]], caches=[prompt_cache])
+
+            self.assertEqual(len(generator._unprocessed_sequences), 0)
+            self.assertIsInstance(prompt_cache[0], KVCache)
+        finally:
+            generator.close()
+
+    def test_batch_generator_quantizes_external_mixed_cache(self):
+        model = CacheModel(2, lambda: [KVCache(), KVCache()])
+        generator = BatchGenerator(
+            model,
+            kv_bits=8,
+            kv_group_size=32,
+        )
+        prompt_cache = [
+            KVCache(),
+            RotatingKVCache(max_size=16, keep=0),
+        ]
+        try:
+            generator.insert([[1]], caches=[prompt_cache])
+            queued_cache = generator._unprocessed_sequences[0][3]
+
+            self.assertIs(queued_cache, prompt_cache)
+            self.assertIsInstance(queued_cache[0], QuantizedKVCache)
+            self.assertIsInstance(queued_cache[1], RotatingQuantizedKVCache)
+        finally:
+            generator.close()
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_generate.py
+++ b/tests/test_generate.py
@@ -359,6 +359,67 @@ class TestGenerate(unittest.TestCase):
 
         del self.model.make_cache
 
+    def test_batch_sliding_window_quantized(self):
+        """BatchGenerator with max_kv_size AND kv_bits set together — the exact
+        combination mira-mlx always uses (--max-kv-size is always passed), which
+        used to be blocked by BatchRotatingKVCache.to_quantized() raising
+        NotImplementedError. Forces rotation (max_tokens > max_kv_size) and
+        mid-stream job insertion (jobs finish at different times) to exercise
+        RotatingQuantizedKVCache/BatchRotatingQuantizedKVCache's merge/filter/
+        extend/extract paths under real generation, not synthetic tensors."""
+        prompts = [
+            "Write a story about Einstein",
+            "Hi",
+            "What time is it?",
+            "How tall is Mt Everest?",
+        ]
+        prompts = [
+            self.tokenizer.apply_chat_template(
+                [{"role": "user", "content": p}],
+                tokenize=True,
+                add_generation_prompt=True,
+            )
+            for p in prompts
+        ]
+
+        batch_gen = BatchGenerator(
+            self.model,
+            stop_tokens=self.tokenizer.eos_token_ids,
+            max_tokens=10,
+            max_kv_size=4,
+            kv_bits=8,
+            kv_group_size=32,
+            prefill_batch_size=1,
+            prefill_step_size=8,
+            completion_batch_size=2,
+        )
+        uids = batch_gen.insert(prompts)
+        batch_responses = {uid: [] for uid in uids}
+        while responses := batch_gen.next_generated():
+            for r in responses:
+                batch_responses[r.uid].append(r.token)
+
+        for uid in uids:
+            self.assertGreater(
+                len(batch_responses[uid]),
+                0,
+                "quantized+rotating job produced no tokens",
+            )
+            for tok in batch_responses[uid]:
+                self.assertFalse(mx.isnan(mx.array(float(tok))))
+
+    def test_batch_generator_rejects_delayed_quantized_kv_start(self):
+        """quantized_kv_start > 0 isn't supported for the batching path (per-job
+        caches are created once, empty, at insertion — there's no per-step
+        re-check that would ever trigger a delayed threshold)."""
+        with self.assertRaises(NotImplementedError):
+            BatchGenerator(
+                self.model,
+                max_kv_size=8,
+                kv_bits=8,
+                quantized_kv_start=4,
+            )
+
     def test_batch_generate_with_logits_processors(self):
         """Test that batch_generate with logits_processors produces correct results."""
         logit_bias = {0: 2000.0, 1: -2000.0}

--- a/tests/test_prompt_cache.py
+++ b/tests/test_prompt_cache.py
@@ -398,6 +398,45 @@ class TestPromptCache(unittest.TestCase):
             next_toks.append(tok)
         self.assertEqual(len(next_toks), 3)
 
+    def test_rotating_cache_to_quantized_matches_unquantized(self):
+        """The rotating-quantized path must stay numerically faithful, not just
+        non-NaN: after rotation, a quantized rotating cache should track the
+        unquantized rotating reference within the same tolerance QuantizedKVCache
+        gets in test_cache_to_quantized (rtol=4e-2). Guards against a silent
+        numerical regression in the (packed, scales, biases) bookkeeping."""
+        model, tokenizer = self.model, self.tokenizer
+        prompt = tokenizer.encode(
+            "Once upon a time in a small town", return_tensors="mlx"
+        )[0]
+
+        # Two identical warmups (argmax is deterministic, so the KV state is the
+        # same in both) run long enough to force rotation past max_size.
+        def warm():
+            c = [RotatingKVCache(max_size=8) for _ in model.layers]
+            last = None
+            for _, (tok, _) in zip(
+                range(12), generate_step(prompt, model, prompt_cache=c)
+            ):
+                last = tok
+            return c, last
+
+        ref_cache, last_ref = warm()
+        base_cache, last_base = warm()
+        self.assertEqual(last_ref, last_base)  # warmups agree
+        self.assertGreater(ref_cache[0].offset, ref_cache[0].max_size)  # rotated
+
+        # Keep one continuation unquantized (reference), quantize the other, then
+        # feed both the same next token and compare the resulting logits.
+        quant_cache = [c.to_quantized(bits=8, group_size=32) for c in base_cache]
+        for c in quant_cache:
+            self.assertIsInstance(c, RotatingQuantizedKVCache)
+
+        x = mx.array([last_ref])
+        ref_logits = next(generate_step(x, model, prompt_cache=ref_cache))[1]
+        quant_logits = next(generate_step(x, model, prompt_cache=quant_cache))[1]
+        self.assertFalse(bool(mx.any(mx.isnan(quant_logits))))
+        self.assertTrue(mx.allclose(ref_logits, quant_logits, rtol=4e-2))
+
     def test_rotating_quantized_cache_save_load(self):
         cache = [
             RotatingKVCache(max_size=4).to_quantized(bits=8, group_size=32)

--- a/tests/test_prompt_cache.py
+++ b/tests/test_prompt_cache.py
@@ -13,11 +13,13 @@ from mlx_lm.models.cache import (
     ArraysCache,
     BatchKVCache,
     BatchRotatingKVCache,
+    BatchRotatingQuantizedKVCache,
     CacheList,
     ChunkedKVCache,
     KVCache,
     QuantizedKVCache,
     RotatingKVCache,
+    RotatingQuantizedKVCache,
     load_prompt_cache,
     make_prompt_cache,
     save_prompt_cache,
@@ -363,6 +365,96 @@ class TestPromptCache(unittest.TestCase):
             i += 1
             self.assertEqual(tok, toks[i])
             self.assertTrue(mx.allclose(logits, all_logits[i], rtol=4e-2))
+
+    def test_rotating_cache_to_quantized(self):
+        """RotatingKVCache.to_quantized() — previously NotImplementedError.
+        Build up a rotating cache past its max_size (forcing rotation) with a
+        real model, convert to quantized mid-stream, and confirm generation
+        continues producing sane (numerically close) logits."""
+        model, tokenizer = self.model, self.tokenizer
+        prompt = tokenizer.encode(
+            "Once upon a time in a small town", return_tensors="mlx"
+        )[0]
+
+        prompt_cache = [RotatingKVCache(max_size=4) for _ in model.layers]
+        toks = []
+        for _, (tok, logits) in zip(
+            range(8), generate_step(prompt, model, prompt_cache=prompt_cache)
+        ):
+            toks.append(tok)
+        self.assertIsInstance(prompt_cache[0], RotatingKVCache)
+
+        quant_cache = [c.to_quantized(bits=8, group_size=32) for c in prompt_cache]
+        for c in quant_cache:
+            self.assertEqual(c.offset, prompt_cache[0].offset)
+
+        # Generation must continue without error after the mid-stream swap.
+        next_toks = []
+        for _, (tok, logits) in zip(
+            range(3),
+            generate_step(mx.array([toks[-1]]), model, prompt_cache=quant_cache),
+        ):
+            self.assertFalse(bool(mx.any(mx.isnan(logits))))
+            next_toks.append(tok)
+        self.assertEqual(len(next_toks), 3)
+
+    def test_rotating_quantized_cache_save_load(self):
+        cache = [
+            RotatingKVCache(max_size=4).to_quantized(bits=8, group_size=32)
+            for _ in range(2)
+        ]
+        for c in cache:
+            for _ in range(10):  # forces rotation
+                x = mx.random.uniform(shape=(1, 4, 1, 32))
+                c.update_and_fetch(x, x)
+
+        cache_file = os.path.join(self.test_dir, "rotating_quant_cache.safetensors")
+        save_prompt_cache(cache_file, cache)
+        loaded_cache = load_prompt_cache(cache_file)
+        self.assertEqual(len(cache), len(loaded_cache))
+        for c, lc in zip(cache, loaded_cache):
+            self.assertIsInstance(lc, RotatingQuantizedKVCache)
+            self.assertEqual(c.offset, lc.offset)
+            self.assertEqual(c.max_size, lc.max_size)
+            self.assertEqual(c.group_size, lc.group_size)
+            self.assertEqual(c.bits, lc.bits)
+            for i in range(3):
+                self.assertTrue(mx.array_equal(c.state[0][i], lc.state[0][i]))
+                self.assertTrue(mx.array_equal(c.state[1][i], lc.state[1][i]))
+
+    def test_batch_rotating_quantized_kv_cache_merge_filter_extend_extract(self):
+        """The batching-facing surface BatchGenerator actually relies on."""
+        jobs = []
+        for j in range(3):
+            c = RotatingQuantizedKVCache(max_size=8, group_size=32, bits=8)
+            for _ in range(3 + j * 4):  # some jobs exceed max_size, forcing rotation
+                x = mx.random.uniform(shape=(1, 4, 1, 32))
+                c.update_and_fetch(x, x)
+            jobs.append(c)
+
+        batch = RotatingQuantizedKVCache.merge(jobs)
+        self.assertIsInstance(batch, BatchRotatingQuantizedKVCache)
+        self.assertEqual(batch.keys[0].shape[0], 3)
+        for j, c in enumerate(jobs):
+            self.assertEqual(int(batch.offset[j]), c.offset)
+
+        k = mx.random.uniform(shape=(3, 4, 1, 32))
+        bk, bv = batch.update_and_fetch(k, k)
+        self.assertEqual(bk[0].shape[0], 3)
+
+        batch.filter(mx.array([0, 2]))
+        self.assertEqual(batch.keys[0].shape[0], 2)
+
+        extracted = batch.extract(0)
+        self.assertIsInstance(extracted, RotatingQuantizedKVCache)
+        self.assertEqual(extracted.offset, int(batch.offset[0]))
+
+        new_job = RotatingQuantizedKVCache(max_size=8, group_size=32, bits=8)
+        for _ in range(2):
+            x = mx.random.uniform(shape=(1, 4, 1, 32))
+            new_job.update_and_fetch(x, x)
+        batch.extend(RotatingQuantizedKVCache.merge([new_job]))
+        self.assertEqual(batch.keys[0].shape[0], 3)
 
     def test_cache_list(self):
         c = CacheList(KVCache(), KVCache())


### PR DESCRIPTION
## Stack status

Dependent on #1584, branched at `d98dbe2`. This branch contains #1584 plus **one follow-up commit, `aa5614b8`** — that commit is the whole of this PR's contribution: 3 files, +381/-1.

**Please review `aa5614b8` only.** The diff against `main` reads +1358/-380 because it carries #1584's feature underneath; roughly a thousand of those lines belong to that PR, not this one. This will be rebased onto `main` once #1584 lands, at which point the diff collapses to the follow-up commit alone.

Two housekeeping notes for anyone comparing SHAs: this branch was amended after an earlier push (the previous tip `d981a71` is no longer reachable — same tree, corrected author email), and #1584 has advanced to `ff1e837` since `d98dbe2`. `git merge-tree --write-tree` on the two current heads reports **one conflict**, in `mlx_lm/generate.py` — about 16 lines in `BatchGenerator.insert_segments`. It is mechanical: #1584's `3ebafab` added an explanatory comment and this branch added a `_validate_prompt_cache_quantization(...)` call, both immediately before the same `maybe_quantize_kv_cache(...)`; the resolution is to keep both. It appeared because #1584 advanced two commits (`3ebafab`, `ff1e837`) past the `d98dbe2` I branched from. *(Corrected twice: this line first claimed no conflicts, from a legacy three-argument `git merge-tree` grepped for `^<<<<<<<`. That form does report the conflict, but as a diff, so the markers arrive as `+<<<<<<<` and the pattern was one character short — the pipeline exited non-zero for that reason and I discarded the signal by keeping only the count. It then named the method `insert`; it is `insert_segments`.)*

Related to #1573.

## What changed

- Add explicit cache capabilities: whether KV quantization applies, whether a cache can honor it, and whether it is already quantized.
- Validate `generate_step` before the first model call.
- Validate both target and draft caches in speculative generation.
- Validate and quantize both generated and externally supplied caches in `BatchGenerator`; supplied caches previously bypassed quantization entirely.
- Report every offending layer/cache class together, including the specific `RotatingKVCache(keep>0)` limitation from #1584.
- Reject a pre-quantized cache whose bits or group size do not match the request instead of silently retaining the old configuration.
- Continue to leave non-KV recurrent state (`ArraysCache`) untouched explicitly, while rejecting unsupported KV-cache implementations.

There is deliberately no server flag in this change: `mlx_lm.server` does not currently expose `kv_bits`. The validation lives in the library entry points that actually accept the option, so CLI wrappers inherit it without inventing a server configuration surface.

## Why

The old `hasattr(c, "to_quantized")` check cannot distinguish a working implementation from a stub that raises `NotImplementedError`. It also silently skips cache classes with no method. That defers a capability mismatch until a request crosses the quantization threshold and can leave mixed caches only partially quantized.

After #1584, Gemma 4's `keep=0` rotating/full-attention mix is supported, but the generic `--max-kv-size` fallback still creates `RotatingKVCache(keep=4)`. This guard turns that remaining true-negative into an immediate, layer-specific configuration error before inference.

## Security classification

This is a correctness and configuration-validation bug, not a cybersecurity vulnerability. It does not cross a trust boundary, expose data, execute untrusted input, or alter authentication/authorization; the impact is a late exception or an unhonored performance/memory option.

## Validation

- `MLX_ENABLE_TF32=0 python -m pytest -q tests/test_cache_quantization_capability.py tests/test_prompt_cache.py tests/test_generate.py` — **64 passed** on M5 Max / MLX 0.32.0.
- New unit coverage includes the `keep>0` true-negative, Gemma-style mixed-cache true-positive, non-KV state handling, no silent skip, pre-quantized configuration mismatch, target/draft validation, and generated/external continuous-batching caches.
- Pinned `black` and `isort` pre-commit hooks pass.

Without the TF32 control, the same eight pre-existing M5 batch-equivalence failures already documented on #1584 reproduce; the new capability tests pass independently.



