### PR TITLE
Fix rotated flag round-trip in BatchRotatingKVCache.meta_state

### DIFF
--- a/mlx_lm/models/cache.py
+++ b/mlx_lm/models/cache.py
@@ -1312,7 +1312,9 @@ class BatchRotatingKVCache(_BaseCache):
             int,
             v[:3],
         )
-        self.rotated = bool(v[3])
+        # meta_state stringifies, so v[3] is "True"/"False" and bool() would
+        # make both truthy, marking an unrotated cache as rotated on reload.
+        self.rotated = v[3] == "True"
 
     def is_trimmable(self):
         return self._offset < self.max_size

--- a/tests/test_prompt_cache.py
+++ b/tests/test_prompt_cache.py
@@ -530,6 +530,22 @@ class TestPromptCache(unittest.TestCase):
         self.assertEqual(cache_a.offset.tolist(), [6, 7, 6, 1, 4])
         self.assertEqual(cache_a.left_padding.tolist(), [2, 1, 2, 7, 4])
 
+    def test_batch_rotating_kv_cache_meta_state_rotated_round_trip(self):
+        """meta_state stringifies every field, so `rotated` round-trips as
+        "True"/"False". Reading it back with bool() makes both truthy, so a
+        cache that had not rotated is marked rotated on reload."""
+        for rotated in (False, True):
+            cache = BatchRotatingKVCache(max_size=8, left_padding=[0])
+            cache.rotated = rotated
+
+            restored = BatchRotatingKVCache(max_size=1, left_padding=[0])
+            restored.meta_state = cache.meta_state
+
+            self.assertEqual(restored.rotated, rotated)
+            self.assertIsInstance(restored.rotated, bool)
+            self.assertEqual(restored.max_size, cache.max_size)
+            self.assertEqual(restored._idx, cache._idx)
+
     def test_batch_rotating_kv_cache(self):
         cache = BatchRotatingKVCache(max_size=4, left_padding=[2, 0])
         mask = cache.make_mask(4)


### PR DESCRIPTION
`meta_state` stringifies every field, so `rotated` is stored as `"True"` or `"False"`. The setter read it back with `bool()`:

```python
self.rotated = bool(v[3])   # bool("False") is True
```

Both values are truthy as strings, so a cache that had not rotated came back from a saved prompt cache marked as rotated.

Compares against `"True"` instead. The round-trip test covers both values and fails with `bool()`.

Fixes #1250
