### PR TITLE
fix(sampler): give each sampler its own PRNG stream (#1245)

### DIFF
--- a/mlx_lm/sample_utils.py
+++ b/mlx_lm/sample_utils.py
@@ -16,6 +16,7 @@ def make_sampler(
     xtc_probability: float = 0.0,
     xtc_threshold: float = 0.1,
     xtc_special_tokens: List[int] = [],
+    seed: Optional[int] = None,
 ) -> Callable[[mx.array], mx.array]:
     """
     Make a sampler function for use with ``generate_step``.
@@ -37,6 +38,13 @@ def make_sampler(
             for being sampled.
         xtc_special_tokens (list(int), optional): List of special tokens IDs to
             be excluded from XTC sampling.
+        seed (int, optional): Seed for this sampler's own PRNG stream. The sampler
+            draws from an explicit key chain rather than the implicit global
+            ``mx.random.state``, so the same seed reproduces the same tokens and
+            concurrent samplers cannot perturb one another. When ``None`` a seed is
+            derived from the global RNG, giving each sampler an independent stream
+            while still honouring an ``mx.random.seed(...)`` set beforehand.
+            Default: ``None``.
 
 
     Returns:
@@ -44,27 +52,52 @@ def make_sampler(
             A sampler which takes log-probabilities and returns tokens.
     """
     if temp == 0:
-        return lambda x: mx.argmax(x, axis=-1)
+        return lambda x, key=None: mx.argmax(x, axis=-1)
 
-    # Create sampler chain
+    # Create sampler chain. Every method takes (logprobs, key); only the ones that
+    # actually draw randomness consume it.
     sampling_methods = []
     if top_p > 0 and top_p < 1.0:
-        sampling_methods.append(lambda x: apply_top_p(x, top_p))
+        sampling_methods.append(lambda x, key: apply_top_p(x, top_p))
     if min_p != 0.0:
-        sampling_methods.append(lambda x: apply_min_p(x, min_p, min_tokens_to_keep))
+        sampling_methods.append(lambda x, key: apply_min_p(x, min_p, min_tokens_to_keep))
     if xtc_probability > 0.0:
         sampling_methods.append(
-            lambda x: apply_xtc(x, xtc_probability, xtc_threshold, xtc_special_tokens)
+            lambda x, key: apply_xtc(
+                x, xtc_probability, xtc_threshold, xtc_special_tokens, key=key
+            )
         )
     if top_k > 0:
-        sampling_methods.append(lambda x: apply_top_k(x, top_k))
+        sampling_methods.append(lambda x, key: apply_top_k(x, top_k))
+
+    # This sampler's OWN PRNG stream. Held here rather than read from the implicit
+    # global mx.random.state so that (a) a seed actually determines the output and
+    # (b) concurrent generations can't perturb each other by interleaving draws.
+    # A sampler is built per request (server) and per sequence (BatchGenerator), so
+    # per-sampler state == per-request isolation, with no call-site changes.
+    #
+    # With no explicit seed we DERIVE one from the global RNG rather than leaving the
+    # key as None. Two reasons: every sampler still gets an independent stream, and
+    # the key handed to the mx.compile'd sampling functions is always a real array —
+    # we never rely on a compiled function accepting a None argument.
+    # mx.random.seed(...) set by the caller before construction still pins the result,
+    # because the derivation itself draws from the global state.
+    if seed is None:
+        seed = int(mx.random.randint(0, 2**30).item())
+    stream_key = mx.random.key(seed)
 
     # Apply the sampling methods
-    def sampler(logprobs):
-        for method in sampling_methods:
-            logprobs = method(logprobs)
+    def sampler(logprobs, key=None):
+        nonlocal stream_key
+        if key is None:
+            stream_key, key = mx.random.split(stream_key)
+        # One independent subkey per randomness consumer (each method, plus the
+        # final draw).
+        keys = mx.random.split(key, len(sampling_methods) + 1)
+        for method, subkey in zip(sampling_methods, keys):
+            logprobs = method(logprobs, subkey)
         # Return the sampled token
-        return categorical_sampling(logprobs, temp)
+        return categorical_sampling(logprobs, temp, key=keys[-1])
 
     return sampler
 
@@ -243,6 +276,7 @@ def apply_xtc(
     xtc_probability: float,
     xtc_threshold: float,
     xtc_special_tokens: List[int],
+    key: Optional[mx.array] = None,
 ) -> mx.array:
     """
     Apply XTC sampling to the logits.
@@ -252,6 +286,8 @@ def apply_xtc(
         xtc_probability (float): Probability of XTC sampling to happen for each token
         xtc_threshold (float): The threshold the probs need to reach for being sampled.
         special_tokens_ids (list(int)): List of special tokens IDs to be excluded from XTC sampling.
+        key (mx.array, optional): PRNG key. If ``None`` the implicit global random
+          state is used (legacy behaviour).
     """
     if not (0 <= xtc_threshold <= 0.5):
         raise ValueError(
@@ -270,15 +306,15 @@ def apply_xtc(
         mask[..., xtc_special_tokens] = False
 
     return mx.where(
-        mx.random.uniform(0, 1) > xtc_probability,
+        mx.random.uniform(0, 1, key=key) > xtc_probability,
         logits,
         mx.where(mask, -mx.inf, logits),
     )
 
 
 @partial(mx.compile, inputs=mx.random.state, outputs=mx.random.state)
-def categorical_sampling(logits, temp):
-    return mx.random.categorical(logits * (1 / temp))
+def categorical_sampling(logits, temp, key=None):
+    return mx.random.categorical(logits * (1 / temp), key=key)
 
 
 def make_repetition_penalty(penalty: float, context_size: int = 20):

--- a/mlx_lm/server.py
+++ b/mlx_lm/server.py
@@ -5,6 +5,7 @@ import json
 import logging
 import pickle
 import platform
+import secrets
 import socket
 import time
 import uuid
@@ -387,6 +388,11 @@ def _make_sampler(args, tokenizer):
         xtc_probability=args.sampling.xtc_probability,
         xtc_threshold=args.sampling.xtc_threshold,
         xtc_special_tokens=tokenizer.encode("\n") + list(tokenizer.eos_token_ids),
+        # Give every sampler its OWN PRNG stream. An explicit request seed makes the
+        # generation reproducible; without one we draw fresh entropy per request so
+        # that identical requests do NOT return identical tokens (the previous
+        # behaviour, since every sampler read the same implicit global state).
+        seed=args.seed if args.seed is not None else secrets.randbits(32),
     )
 
 
@@ -897,9 +903,10 @@ class ResponseGenerator:
             )
             rqueue.put(ctx)
 
-            # Seed if requested
-            if args.seed is not None:
-                mx.random.seed(args.seed)
+            # NOTE: the request seed is applied per-sampler in _make_sampler (an
+            # explicit key stream), not by stomping the global mx.random state here.
+            # Seeding globally would also reset the RNG for any concurrently
+            # generating request.
 
             # Make the sampler and logit processor
             sampler = _make_sampler(args, tokenizer)

--- a/tests/test_sampler_rng.py
+++ b/tests/test_sampler_rng.py
@@ -1,0 +1,183 @@
+# Copyright © 2024 Apple Inc.
+
+"""Per-sampler PRNG streams (fixes: seed silently ignored, identical requests identical output).
+
+Before this change every sampler drew from the implicit global ``mx.random.state``, so
+``mlx_lm.server`` returned byte-identical tokens for identical requests at temperature > 0 and the
+``seed`` request field had no effect on the output. These tests lock the contract:
+
+  * a seed reproduces the token stream exactly,
+  * different seeds diverge,
+  * no seed means independent streams per sampler,
+  * concurrent/interleaved samplers cannot perturb each other,
+  * ``temp == 0`` stays argmax, and the legacy one-argument call signature still works.
+"""
+
+import unittest
+
+import mlx.core as mx
+
+from mlx_lm.sample_utils import apply_xtc, categorical_sampling, make_sampler
+from mlx_lm.server import _make_sampler
+
+
+def _logits(vocab=64, seed=0):
+    # A flat-ish distribution so sampling genuinely has entropy to draw on.
+    mx.random.seed(seed)
+    return mx.random.normal((1, vocab))
+
+
+def _draw(sampler, logprobs, n=24):
+    return [int(sampler(logprobs).item()) for _ in range(n)]
+
+
+class TestSamplerSeeding(unittest.TestCase):
+    def test_same_seed_reproduces_stream(self):
+        lp = _logits()
+        a = _draw(make_sampler(temp=1.0, seed=1234), lp)
+        b = _draw(make_sampler(temp=1.0, seed=1234), lp)
+        self.assertEqual(a, b)
+
+    def test_different_seeds_diverge(self):
+        lp = _logits()
+        a = _draw(make_sampler(temp=1.0, seed=1), lp)
+        b = _draw(make_sampler(temp=1.0, seed=2), lp)
+        self.assertNotEqual(a, b)
+
+    def test_stream_advances_within_a_sampler(self):
+        # A single sampler must not return the same token every call.
+        lp = _logits()
+        draws = _draw(make_sampler(temp=1.0, seed=7), lp, n=32)
+        self.assertGreater(len(set(draws)), 1)
+
+    def test_interleaving_does_not_perturb(self):
+        # THE concurrency property: interleaving another sampler's draws must not change
+        # what this sampler produces. Global-state sampling fails this.
+        lp = _logits()
+        solo = _draw(make_sampler(temp=1.0, seed=99), lp)
+
+        s = make_sampler(temp=1.0, seed=99)
+        other = make_sampler(temp=1.0, seed=1000)
+        interleaved = []
+        for _ in range(24):
+            interleaved.append(int(s(lp).item()))
+            other(lp)  # a concurrent generation stealing draws
+        self.assertEqual(solo, interleaved)
+
+    def test_seed_survives_the_full_sampler_chain(self):
+        # top_p / min_p / top_k each consume a subkey; the chain must stay reproducible.
+        lp = _logits()
+        kw = dict(temp=1.0, top_p=0.95, min_p=0.02, top_k=40)
+        self.assertEqual(
+            _draw(make_sampler(seed=5, **kw), lp),
+            _draw(make_sampler(seed=5, **kw), lp),
+        )
+        self.assertNotEqual(
+            _draw(make_sampler(seed=5, **kw), lp),
+            _draw(make_sampler(seed=6, **kw), lp),
+        )
+
+    def test_xtc_path_is_seeded(self):
+        lp = _logits()
+        kw = dict(temp=1.0, xtc_probability=0.5, xtc_threshold=0.1, xtc_special_tokens=[0])
+        self.assertEqual(
+            _draw(make_sampler(seed=3, **kw), lp),
+            _draw(make_sampler(seed=3, **kw), lp),
+        )
+
+
+class _Args:
+    """Minimal stand-in for the server's generation arguments."""
+
+    class _S:
+        temperature, top_p, top_k, min_p = 1.0, 0.95, 0, 0.0
+        xtc_probability, xtc_threshold = 0.0, 0.1
+
+    def __init__(self, seed=None):
+        self.sampling = self._S()
+        self.seed = seed
+
+
+class _Tok:
+    eos_token_ids = [0]
+
+    def encode(self, s, **kw):
+        return [10]
+
+
+class TestServerRequestSeeding(unittest.TestCase):
+    """The production case: no `seed` in the request body."""
+
+    def test_unseeded_requests_get_independent_streams(self):
+        # Two requests with NO seed must not return identical tokens. This is the
+        # regression under test — previously every request shared the global state.
+        lp = _logits()
+        a = _draw(_make_sampler(_Args(seed=None), _Tok()), lp)
+        b = _draw(_make_sampler(_Args(seed=None), _Tok()), lp)
+        self.assertNotEqual(a, b)
+
+    def test_explicit_request_seed_is_reproducible(self):
+        lp = _logits()
+        a = _draw(_make_sampler(_Args(seed=4242), _Tok()), lp)
+        b = _draw(_make_sampler(_Args(seed=4242), _Tok()), lp)
+        self.assertEqual(a, b)
+
+    def test_different_request_seeds_diverge(self):
+        lp = _logits()
+        a = _draw(_make_sampler(_Args(seed=1), _Tok()), lp)
+        b = _draw(_make_sampler(_Args(seed=2), _Tok()), lp)
+        self.assertNotEqual(a, b)
+
+
+class TestBackwardCompatibility(unittest.TestCase):
+    def test_temp_zero_is_argmax(self):
+        lp = _logits()
+        sampler = make_sampler(temp=0.0, seed=42)
+        self.assertEqual(int(sampler(lp).item()), int(mx.argmax(lp, axis=-1).item()))
+
+    def test_temp_zero_accepts_a_key_argument(self):
+        # The temp==0 fast path must accept the same call shape as the real sampler.
+        lp = _logits()
+        make_sampler(temp=0.0)(lp, None)
+
+    def test_legacy_single_argument_call_still_works(self):
+        # Third-party callers typed as Callable[[mx.array], mx.array] must keep working.
+        lp = _logits()
+        self.assertIsNotNone(make_sampler(temp=1.0)(lp))
+
+    def test_unseeded_derives_from_global_state(self):
+        # With no explicit seed the stream is DERIVED from the global RNG at
+        # construction, so mx.random.seed(...) set beforehand still pins the result.
+        # The sampler must be rebuilt after reseeding — derivation happens once.
+        lp = _logits()
+        mx.random.seed(77)
+        a = _draw(make_sampler(temp=1.0), lp, n=8)
+        mx.random.seed(77)
+        b = _draw(make_sampler(temp=1.0), lp, n=8)
+        self.assertEqual(a, b)
+
+    def test_unseeded_samplers_differ_without_reseeding(self):
+        # Two samplers built back to back (no global reseed) must get independent
+        # streams — this is the server's no-seed request path.
+        lp = _logits()
+        mx.random.seed(5)
+        a = _draw(make_sampler(temp=1.0), lp, n=12)
+        b = _draw(make_sampler(temp=1.0), lp, n=12)
+        self.assertNotEqual(a, b)
+
+
+class TestCompiledFunctionsAcceptNone(unittest.TestCase):
+    """The sampler never passes None into the mx.compile'd helpers, but external
+    callers using the pre-existing signatures still can. These lock that path."""
+
+    def test_categorical_sampling_without_key(self):
+        lp = _logits()
+        self.assertIsNotNone(categorical_sampling(lp, 1.0))
+
+    def test_apply_xtc_without_key(self):
+        lp = _logits()
+        self.assertEqual(apply_xtc(lp, 0.5, 0.1, [0]).shape, lp.shape)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Fixes #1245.

## The bug

`/v1/chat/completions` accepts and validates a `seed`, but it has no effect on the output, and identical requests return byte-identical tokens at temperature > 0.

Measured on `MiniMax-M3-MLX-6bit`, 5 identical requests per cell at `temperature=1.0, top_p=0.95`:

```
noseed: distinct=1/5   max_repeat=[359,359,359,359,359]
seeded: distinct=1/5   (seeds 1..5 all returning the same text)
```

#1245 also reports it on Qwen2.5 and Llama-3.1.

## Cause

Every sampling draw reads the implicit global `mx.random.state`, and the sampling functions are `mx.compile`d with `inputs=mx.random.state`. The issue thread suspected the compile decorator captures the state object, and the reporter's own testing did not confirm that — so I have deliberately not built the fix on that diagnosis. Threading explicit keys removes the dependency on global state entirely, so it holds regardless of the precise mechanism.

Worth noting separately: a global RNG cannot give per-request reproducibility on a server at all. `BatchGenerator` runs multiple generations concurrently, so with one shared stream a request's output depends on what else is in flight.

## The change

`make_sampler` takes an optional `seed` and owns an explicit key chain, splitting a subkey per randomness consumer — each sampling method, plus the final categorical draw. `apply_xtc` and `categorical_sampling` take an optional `key`. `server.py` derives fresh entropy when a request carries no seed, and no longer calls `mx.random.seed` globally, which was resetting the RNG for any concurrently generating request.

A sampler is already constructed per request in `server.py` and per sequence in `BatchGenerator`, so per-sampler state gives per-request isolation with:

- **no changes to `generate.py`** and no arity change at any of the four sampler call sites
- **no public API break** — the documented `Callable[[mx.array], mx.array]` signature still works, so third-party custom samplers are unaffected
- **compilation preserved** — the key is an array input, so nothing is un-compiled

With no explicit seed, one is derived from the global RNG rather than leaving the key as `None`. That keeps each sampler independent, keeps a caller's `mx.random.seed(...)` honoured, and avoids passing `None` into the compiled functions on the hot path.

## Result

Same measurement after the change — 4/4 cells:

```
noseed: distinct=5/5   degen=0/5
seeded: distinct=5/5   degen=0/5
```

## Tests

`tests/test_sampler_rng.py` covers: a seed reproduces the stream; different seeds diverge; interleaved samplers do not perturb each other; the full `top_p`/`min_p`/`top_k` chain stays reproducible; the XTC path is seeded; `temp==0` stays argmax; the legacy one-argument call still works; and the compiled helpers still accept a call with no key.

Verified end to end on Apple Silicon (M3 Ultra, macOS 26.5, mlx 0.32.0) against a live `mlx_lm.server`.