### PR TITLE
Fix LFM2.5 model loading: make block_ff_dim optional, fall back to intermediate_size

### DIFF
--- a/mlx_lm/models/lfm2.py
+++ b/mlx_lm/models/lfm2.py
@@ -28,16 +28,23 @@ class ModelArgs(BaseModelArgs):
     conv_bias: bool
     conv_L_cache: int
     block_dim: int
-    block_ff_dim: int
     block_multiple_of: int
     block_ffn_dim_multiplier: float
     block_auto_adjust_ff_dim: bool
+    block_ff_dim: Optional[int] = None
+    intermediate_size: Optional[int] = None
     rope_theta: float = 1000000.0
     rope_parameters: Optional[dict] = None
     full_attn_idxs: Optional[List[int]] = None
     layer_types: Optional[List[str]] = None
 
     def __post_init__(self):
+        if self.block_ff_dim is None:
+            if self.intermediate_size is None:
+                raise ValueError(
+                    "Config must specify either 'block_ff_dim' or 'intermediate_size'"
+                )
+            self.block_ff_dim = self.intermediate_size
         if self.rope_parameters is not None and "rope_theta" in self.rope_parameters:
             self.rope_theta = self.rope_parameters["rope_theta"]
         if self.num_key_value_heads is None:

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -443,6 +443,40 @@ class TestModels(unittest.TestCase):
             model, args.model_type, args.vocab_size, args.num_hidden_layers
         )
 
+    def test_lfm2_intermediate_size(self):
+        from mlx_lm.models import lfm2
+
+        # Newer LFM2.5 configs ship intermediate_size instead of block_ff_dim
+        args = lfm2.ModelArgs.from_dict(
+            {
+                "model_type": "lfm2",
+                "hidden_size": 1024,
+                "num_hidden_layers": 4,
+                "num_attention_heads": 4,
+                "num_key_value_heads": 2,
+                "norm_eps": 1e-5,
+                "vocab_size": 10_000,
+                "full_attn_idxs": [0, 1, 2],
+                "rope_theta": 10000,
+                "block_dim": 1024,
+                "block_ffn_dim_multiplier": 1.0,
+                "block_auto_adjust_ff_dim": False,
+                "intermediate_size": 2560,
+                "block_multiple_of": 256,
+                "max_position_embeddings": 1000,
+                "conv_bias": True,
+                "conv_L_cache": 3,
+            }
+        )
+        self.assertEqual(args.block_ff_dim, 2560)
+        model = lfm2.Model(args)
+        self.assertEqual(
+            model.model.layers[0].feed_forward.w1.weight.shape, (2560, 1024)
+        )
+        self.model_test_runner(
+            model, args.model_type, args.vocab_size, args.num_hidden_layers
+        )
+
     def test_lfm2_moe(self):
         from mlx_lm.models import lfm2_moe
 


### PR DESCRIPTION
```
python -m mlx_lm generate --model unsloth/LFM2.5-230M --prompt "2+2=" --max-tokens 20
# TypeError: ModelArgs.__init__() missing 1 required positional argument: 'block_ff_dim'
```

**Root cause.** `ModelArgs` in `mlx_lm/models/lfm2.py` declares `block_ff_dim: int` with no default. Newer LFM2.5 configs (LiquidAI releases and derivatives like `unsloth/LFM2.5-230M`) don't ship that key anymore — they ship `intermediate_size`. In HF transformers, `Lfm2Config` treats `block_ff_dim` as a legacy alias: `self.intermediate_size = kwargs.pop("block_ff_dim", self.intermediate_size)`, and both feed the same auto-adjust pipeline that the `MLP` class here already implements. So older LFM2 configs load fine while every LFM2.5 config crashes in `from_dict`.

**Fix.** Mirror the HF alias semantics: `block_ff_dim` becomes optional and falls back to `intermediate_size` in `__post_init__`; an explicit `block_ff_dim` keeps precedence; a config shipping neither now raises a `ValueError` naming both keys instead of an opaque `TypeError`.

**Verification** (Apple Silicon, mlx 0.32.0, full weights):

- Pre-fix: the command above reproduces the `TypeError`. Post-fix: loads and generates (`2 + 2 = 4`, 179 tok/s).
- Legacy direction unchanged: `LiquidAI/LFM2-350M` (explicit `block_ff_dim: 6656`) resolves identically pre/post fix — same ff_dim, same `w1 (4608, 1024)` weight shape, byte-identical generation.
- Weight-shape ground truth: the LFM2.5-230M safetensors ship `w1 = [2560, 1024]`, matching `ff_dim=2560` passed through with `block_auto_adjust_ff_dim: false`.
- New test `test_lfm2_intermediate_size` uses the real LFM2.5-230M config values through `from_dict` (the failing entry point); full `tests/test_models.py`: 77 passed, 1 skipped.

*Disclosure: I used an AI assistant for parts of the investigation and drafting; I've reviewed and can defend every line, and all proof runs above are real outputs from my machine.*
