### PR TITLE
FalconH1: apply key_multiplier to k_proj (silently dropped via a dead key_proj branch)

### DIFF
--- a/mlx_lm/models/falcon_h1.py
+++ b/mlx_lm/models/falcon_h1.py
@@ -471,9 +471,9 @@ class Model(nn.Module):
                 param *= args.embedding_multiplier
             elif name.endswith("lm_head.weight"):
                 param *= args.lm_head_multiplier
-            elif name.endswith("q_proj.weight") or name.endswith("k_proj.weight"):
+            elif name.endswith("q_proj.weight"):
                 param *= args.attention_in_multiplier
-            elif name.endswith("key_proj.weight"):
+            elif name.endswith("k_proj.weight") or name.endswith("key_proj.weight"):
                 param *= args.attention_in_multiplier * args.key_multiplier
             elif name.endswith("o_proj.weight"):
                 param *= args.attention_out_multiplier


### PR DESCRIPTION
## Bug

`mlx_lm/models/falcon_h1.py` `sanitize()` folds `key_multiplier` only into a weight named `key_proj.weight`:

```python
elif name.endswith("q_proj.weight") or name.endswith("k_proj.weight"):
    param *= args.attention_in_multiplier
elif name.endswith("key_proj.weight"):                 # dead: weight is named k_proj
    param *= args.attention_in_multiplier * args.key_multiplier
```

Falcon-H1 checkpoints name the key projection **`k_proj.weight`**, which matches the *first* branch (only `attention_in_multiplier`, default 1.0). The `key_proj.weight` branch never matches, so **`key_multiplier` is never applied** — and it isn't applied in the attention forward either. HF applies it to the key states (`modeling_falcon_h1`: `key_states = self.k_proj(hidden_states)... * self.key_multiplier`).

For Falcon-H1R-7B `key_multiplier ≈ 0.031`, so the keys end up **~32× too large** → attention scores blow up → softmax collapses toward a hard argmax → the model produces grammatical but degenerate, never-terminating output. This is also baked into every `mlx_lm.convert` output (the fold is saved into the weights), so existing conversions are corrupt and need re-converting after this lands.

## Fix

Split the branch so `k_proj.weight` receives `attention_in_multiplier * key_multiplier`.

## Validation (mlx-lm, bf16 `tiiuae/Falcon-H1R-7B`, greedy, same prompt)

**Before (main):** degenerate, never reaches an answer —
> `<think> We need to parse the problem. ... Wait, the original user message: ... Actually the problem statement seems a bit confusing. Let's rewrite: ... Wait, the original distances: ... Let's read the original:` *(loops until the token cap)*

**After (this PR):** correct —
> `<think> ... 210 miles / 70 mph = 3 hours. ... 240 miles / 80 mph = 3 hours. Total time = 3 + 3 = 6 hours. Thus the trip took 6 hours.`

Same model, prompt, and sampler; the only change is this one branch. (Cross-checked against `transformers`: layer-0 attention output goes from badly mis-scaled to cos 0.999998.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
