### PR TITLE
Fix Qwen3.6 converted RMSNorm double shift

### DIFF
--- a/mlx_lm/models/qwen3_5.py
+++ b/mlx_lm/models/qwen3_5.py
@@ -346,11 +346,9 @@ class TextModel(nn.Module):
         return [ArraysCache(size=2) if l.is_linear else KVCache() for l in self.layers]
 
     def sanitize(self, weights):
-        has_mtp_weights = any("mtp." in k for k in weights)
         has_unsanitized_conv1d = any(
             "conv1d.weight" in k and v.shape[-1] != 1 for k, v in weights.items()
         )
-        should_shift_norm_weights = has_mtp_weights or has_unsanitized_conv1d
         weights = {k: v for k, v in weights.items() if "mtp." not in k}
 
         if self.args.tie_word_embeddings:
@@ -366,7 +364,7 @@ class TextModel(nn.Module):
         for k, v in weights.items():
             if "conv1d.weight" in k and v.shape[-1] != 1:
                 weights[k] = v.moveaxis(2, 1)
-            if should_shift_norm_weights and any(k.endswith(sfx) for sfx in norm_keys):
+            if has_unsanitized_conv1d and any(k.endswith(sfx) for sfx in norm_keys):
                 if v.ndim == 1:
                     weights[k] = v + 1.0
         return weights

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -647,7 +647,9 @@ class TestModels(unittest.TestCase):
             "max_position_embeddings": 64,
         }
         hf_norm_key = "model.language_model.layers.0.input_layernorm.weight"
+        hf_conv_key = "model.language_model.layers.0.linear_attn.conv1d.weight"
         mlx_norm_key = "language_model.model.layers.0.input_layernorm.weight"
+        mlx_conv_key = "language_model.model.layers.0.linear_attn.conv1d.weight"
 
         for model_type, hf_mtp_key in (
             ("qwen3_5", "mtp.fc.weights"),
@@ -663,20 +665,27 @@ class TestModels(unittest.TestCase):
             model = module.Model(args)
 
             base = mx.arange(8, dtype=mx.float32)
+            raw_conv = mx.zeros((4, 1, 3), dtype=mx.float32)
 
-            # Simulate convert sanitize on HF-style keys.
+            # Raw HF Conv1D layout is the reliable signal that RMSNorm weights
+            # are still zero-centered and need the MLX +1 conversion.
             converted = model.sanitize(
                 {
                     hf_norm_key: base,
+                    hf_conv_key: raw_conv,
                     hf_mtp_key: mx.zeros((1,), dtype=mx.float32),
                 }
             )
             self.assertIn(mlx_norm_key, converted)
             self.assertTrue(mx.array_equal(converted[mlx_norm_key], base + 1.0))
+            self.assertEqual(converted[mlx_conv_key].shape, (4, 3, 1))
             self.assertFalse(any("mtp." in k for k in converted))
 
-            # Simulate load sanitize on already-converted keys.
-            loaded = model.sanitize(converted)
+            # MTP can also be present in an already-converted checkpoint. It
+            # must be dropped without shifting converted norm weights again.
+            loaded = model.sanitize(
+                {**converted, hf_mtp_key: mx.zeros((1,), dtype=mx.float32)}
+            )
             self.assertTrue(
                 mx.array_equal(loaded[mlx_norm_key], converted[mlx_norm_key])
             )


### PR DESCRIPTION
## Summary

- use the raw Qwen Conv1D tensor layout as the structural signal that RMSNorm weights still need the MLX `+1` conversion
- stop treating the presence of MTP tensors as evidence that norm weights are zero-centered
- cover dense and MoE Qwen3.5/3.6 conversion, including already-converted checkpoints that still contain MTP tensors

## Root cause

MTP keys are not a reliable checkpoint-format signal. An already-converted VLM/MTP checkpoint can contain MTP tensors while its Conv1D and RMSNorm weights are already in MLX layout. The old predicate shifted every norm by `+1` again, producing incoherent generation.

This implements the maintainer feedback on #1198 without adding a value-distribution heuristic. It also addresses the fresh tensor-level reproduction in #1197.

## Validation

- focused dense and MoE regression: passed
- `black --check mlx_lm/models/qwen3_5.py tests/test_models.py`: passed
- `git diff --check`: passed
- full `tests.test_models`: 75 passed, 1 skipped; the sole failure is the existing, reproducible `test_ssm` numerical comparison in untouched code

Local checkpoint inspection also confirmed the intended raw-conversion case: Qwen3.6 base RMSNorm mean `-0.0238`, with Conv1D shape `(10240, 1, 4)`, so the raw checkpoint still receives the required `+1` conversion.
