### PR TITLE
[kimi_linear] Fix KDA q/k normalization eps to match reference l2norm semantics

### DIFF
--- a/mlx_lm/models/kimi_linear.py
+++ b/mlx_lm/models/kimi_linear.py
@@ -350,8 +350,11 @@ class KimiDeltaAttention(nn.Module):
         v = v_conv.reshape(B, T, self.num_heads, self.head_dim)
 
         inv_scale = self.scale
-        q = (inv_scale**2) * mx.fast.rms_norm(q, None, 1e-6)
-        k = inv_scale * mx.fast.rms_norm(k, None, 1e-6)
+        # Match the reference l2norm: x / sqrt(sum(x^2) + 1e-6). rms_norm adds
+        # eps to mean(x^2), so the equivalent eps is 1e-6 / head_dim.
+        eps = 1e-6 / self.head_dim
+        q = (inv_scale**2) * mx.fast.rms_norm(q, None, eps)
+        k = inv_scale * mx.fast.rms_norm(k, None, eps)
 
         a_logits = self.f_b_proj(self.f_a_proj(x)).reshape(
             B, T, self.num_heads, self.head_dim


### PR DESCRIPTION
The KDA q/k normalization in `kimi_linear` uses `mx.fast.rms_norm(x, None, 1e-6)`. `rms_norm` adds eps to **mean(x²)**, but the reference implementation normalizes with eps added to **sum(x²)** — the official Kimi modeling delegates q/k normalization to FLA's KDA kernels (`use_qk_l2norm_in_kernel=True`), which compute:

```python
# fla/ops/kda/fused_recurrent.py
b_q = b_q / tl.sqrt(tl.sum(b_q * b_q) + 1e-6)
b_k = b_k / tl.sqrt(tl.sum(b_k * b_k) + 1e-6)
```

With `head_dim=128` the effective eps therefore differs by **128×**.

## Fix

```python
eps = 1e-6 / self.head_dim
```

This makes `rms_norm` *exactly* equivalent to the reference l2norm at all magnitudes:

`x / sqrt(mean(x²) + 1e-6/D) == sqrt(D) · x / sqrt(sum(x²) + 1e-6)`

## Impact

Deviation of the full q-preprocessing vs the reference, by activation magnitude (fp32, D=128, max|Δ|/max|ref|):

| amplitude | before (eps=1e-6) | after (eps=1e-6/D) |
|---:|---:|---:|
| 1.0 | 6.2e-07 | 1.0e-07 |
| 0.1 | 7.0e-05 | 1.1e-07 |
| 0.01 | 5.7e-03 | 1.1e-07 |
| 0.001 | 3.3e-01 | 1.1e-07 |
| 0.0001 | **8.7e-01** | 1.5e-07 |

Harmless for typical activation magnitudes, but small-magnitude q/k vectors (possible after the short conv + SiLU) deviate by up to ~87% per component — and because k feeds the recurrent state, the error propagates to *subsequent tokens'* outputs rather than staying local (measured in an end-to-end KDA recurrence harness with mixed near-zero tokens).

<details>
<summary>Repro script</summary>

```python
import mlx.core as mx
import numpy as np

D = 128
scale = D ** -0.5
mx.random.seed(7)

def ref_l2(x):  # reference: eps on sum(x^2)
    return x * mx.rsqrt((x * x).sum(-1, keepdims=True) + 1e-6)

def dev(amp):
    x = mx.random.normal((64, 32, D)) * amp
    ref = scale * ref_l2(x)
    before = (scale ** 2) * mx.fast.rms_norm(x, None, 1e-6)
    after = (scale ** 2) * mx.fast.rms_norm(x, None, 1e-6 / D)
    mx.eval(ref, before, after)
    r = np.array(ref, dtype=np.float64)
    err = lambda y: np.max(np.abs(np.array(y, dtype=np.float64) - r)) / np.max(np.abs(r))
    return err(before), err(after)

for amp in [1.0, 1e-1, 1e-2, 1e-3, 1e-4]:
    print(amp, *dev(amp))
```

</details>

## Testing

- `python -m unittest tests.test_models.TestModels.test_all_models` — OK (includes the `kimi_linear` config)
- Verified against an independently ported KDA reference (FLA/FlashKDA lineage, chunked formulation) across `T ∈ {1, 5, 16, 33, 128, 300}`, with/without initial state, and raw-activation magnitudes `{1.0, 1e-2, 1e-4, mixed near-zero}` — global normalized error ≤ 6e-7 after the fix (was up to 0.87 on the mixed case, with contamination of normal-token outputs through the recurrent state).

Scope: `kimi_linear` only; no other model uses this normalization pattern.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
