### PR TITLE
Fix sharing directories with symlinks

### DIFF
--- a/mlx_lm/share.py
+++ b/mlx_lm/share.py
@@ -44,14 +44,17 @@ class DirectoryEntry:
 
     @classmethod
     def from_path(cls, root, path):
-        entry_type = {
-            (True, False): "directory",
-            (False, True): "symlink",
-            (False, False): "file",
-        }[path.is_dir(), path.is_symlink()]
-        dst = path.readlink() if path.is_symlink() else None
+        if path.is_symlink():
+            entry_type = "symlink"
+            dst = str(path.readlink())
+        elif path.is_dir():
+            entry_type = "directory"
+            dst = None
+        else:
+            entry_type = "file"
+            dst = None
 
-        return cls(entry_type, str(path.relative_to(root)), str(dst))
+        return cls(entry_type, str(path.relative_to(root)), dst)
 
 
 def error(*args, **kwargs):

--- a/tests/test_share.py
+++ b/tests/test_share.py
@@ -1,0 +1,26 @@
+import tempfile
+import unittest
+from pathlib import Path
+
+from mlx_lm.share import DirectoryEntry, get_files
+
+
+class TestShare(unittest.TestCase):
+    def test_get_files_with_directory_symlink(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            root = Path(tmpdir)
+            target = root / "target"
+            target.mkdir()
+            (target / "weights.safetensors").touch()
+            (root / "alias").symlink_to("target", target_is_directory=True)
+
+            _, entries = get_files(root)
+            entries = {entry.path: entry for entry in entries}
+
+            self.assertEqual(entries["alias"].entry_type, "symlink")
+            self.assertEqual(entries["alias"].dst, "target")
+            self.assertIsNone(entries["target"].dst)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
# PR Draft

**Title:** Fix sharing directories with symlinks

`DirectoryEntry.from_path()` currently classifies entries with a lookup keyed by `is_dir()` and `is_symlink()`. A symlink to a directory makes both predicates true, so sharing a model directory that contains one fails with `KeyError((True, True))`.

This changes the classification to check symlinks before directories and keeps `dst=None` for entries that are not symlinks. The new test covers a relative directory symlink through `get_files()`.

Local verification:

- reproduced the pre-fix `KeyError` from the exact class definition
- ran the fixed `DirectoryEntry` and `get_files` definitions against a temporary directory
- ran `compileall` and `git diff --check`
- verified the patch applies cleanly

The full test suite was not run locally because this minimal environment does not have MLX installed. The change and test were prepared with AI assistance and manually inspected.
