### PR TITLE
Fix FunctionGemma parser for escaped braces and multiple calls

### DIFF
--- a/mlx_lm/tool_parsers/function_gemma.py
+++ b/mlx_lm/tool_parsers/function_gemma.py
@@ -5,42 +5,53 @@ from typing import Any, Optional
 
 import regex as re
 
-_tool_call_regex = re.compile(r"call:(\w+)\{(.*?)\}", re.DOTALL)
+# FunctionGemma writes string arguments using <escape> delimiters.  Treat a
+# complete literal as one token while matching braces so source code, YAML, and
+# JSON inside an argument cannot terminate the surrounding function call.
+_FUNCTION_GEMMA_STR = r"<escape>(?:(?!<escape>)[\s\S])*?<escape>"
+
+_tool_call_regex = re.compile(
+    r"call:([\w-]+)(\{(?:[^{}<]|<(?!escape>)|"
+    + _FUNCTION_GEMMA_STR
+    + r"|(?2))*\})",
+    re.DOTALL,
+)
+
+
+def _function_gemma_args_to_json(text: str) -> str:
+    """Convert FunctionGemma's compact arguments into valid JSON."""
+
+    strings = []
+
+    def _capture(match: re.Match) -> str:
+        strings.append(match.group(1))
+        return f"\x00{len(strings) - 1}\x00"
+
+    text = re.sub(r"<escape>(.*?)<escape>", _capture, text, flags=re.DOTALL)
+    text = re.sub(
+        r"(?<=[{,])([A-Za-z_][A-Za-z0-9_-]*):",
+        r'"\1":',
+        text,
+    )
+    for index, value in enumerate(strings):
+        text = text.replace(f"\x00{index}\x00", json.dumps(value))
+    return text
+
+
+def _parse_single(match: re.Match) -> dict:
+    return {
+        "name": match.group(1),
+        "arguments": json.loads(_function_gemma_args_to_json(match.group(2))),
+    }
 
 
 def parse_tool_call(text: str, _: Optional[Any] = None):
-    match = _tool_call_regex.findall(text)
-    if not match:
-        raise ValueError("No function provided.")
-    func_name = match[0][0]
-    args_str = match[0][1]
-    arguments = {}
-    escape = "<escape>"
-    while args_str:
-        split = args_str.index(":")
-        key = args_str[:split]
-        args_str = args_str[split + 1 :]
-        # Parse a string
-        if args_str.startswith(escape):
-            args_str = args_str[len(escape) :]
-            split = args_str.index(escape)
-            arguments[key] = args_str[:split]
-            args_str = args_str[split + len(escape) + 1 :]
-            continue
-        if "," in args_str:
-            split = args_str.index(",")
-        else:
-            split = len(args_str)
-
-        value = args_str[:split]
-        args_str = args_str[split + 1 :]
-
-        try:
-            arguments[key] = json.loads(value)
-        except json.JSONDecodeError:
-            arguments[key] = value
-
-    return dict(name=func_name, arguments=arguments)
+    matches = list(_tool_call_regex.finditer(text))
+    if not matches:
+        raise ValueError("No complete function call provided.")
+    if len(matches) == 1:
+        return _parse_single(matches[0])
+    return [_parse_single(match) for match in matches]
 
 
 tool_call_start = "<start_function_call>"

--- a/tests/test_tool_parsing.py
+++ b/tests/test_tool_parsing.py
@@ -1,4 +1,5 @@
 import unittest
+from random import Random
 from pathlib import Path
 
 from mlx_lm.tool_parsers import (
@@ -274,6 +275,64 @@ class TestToolParsing(unittest.TestCase):
         self.assertEqual(tool_call["name"], "skill_manage")
         self.assertEqual(tool_call["arguments"]["action"], "create")
         self.assertIn("{", tool_call["arguments"]["content"])
+
+    def test_function_gemma_preserves_escaped_source_and_multiple_calls(self):
+        source = '''scene:
+  objects: [{id: red-square, style: {fill: "#ff0000"}}]
+  note: "braces { and } remain source text"'''
+        test_case = (
+            "call:artifact-submit{language:<escape>visman<escape>,"
+            "outputSlot:<escape>scene.red<escape>,source:<escape>"
+            f"{source}<escape>}}"
+            "call:mark-ready{ready:true}"
+        )
+
+        tool_calls = function_gemma.parse_tool_call(test_case, None)
+
+        self.assertEqual(
+            tool_calls,
+            [
+                {
+                    "name": "artifact-submit",
+                    "arguments": {
+                        "language": "visman",
+                        "outputSlot": "scene.red",
+                        "source": source,
+                    },
+                },
+                {"name": "mark-ready", "arguments": {"ready": True}},
+            ],
+        )
+
+    def test_function_gemma_parses_ten_thousand_fixed_source_variants(self):
+        random = Random(42)
+        fragments = [
+            "{", "}", "[", "]", ":", ",", "'", '\"', "\\n", " ",
+            "canvas", "rectangle", "#ff0000", "scene.red", "multiline\\ntext",
+        ]
+        for index in range(10_000):
+            source = "".join(random.choice(fragments) for _ in range(24))
+            test_case = (
+                "call:artifact_submit{language:<escape>visman<escape>,"
+                f"outputSlot:<escape>scene.{index}<escape>,"
+                f"source:<escape>{source}<escape>,"
+                f"metadata:{{attempt:{index},enabled:true}}}}"
+            )
+            with self.subTest(index=index):
+                tool_call = function_gemma.parse_tool_call(test_case, None)
+                self.assertEqual(tool_call["name"], "artifact_submit")
+                self.assertEqual(tool_call["arguments"]["source"], source)
+                self.assertEqual(
+                    tool_call["arguments"]["metadata"],
+                    {"attempt": index, "enabled": True},
+                )
+
+    def test_function_gemma_rejects_truncated_calls(self):
+        with self.assertRaisesRegex(ValueError, "complete function call"):
+            function_gemma.parse_tool_call(
+                "call:artifact_submit{source:<escape>scene: {broken}<escape>",
+                None,
+            )
 
     def test_kimi_k2(self):
         # Single tool call


### PR DESCRIPTION
Port the string-aware balanced-brace approach used by the Gemma 4 parser to FunctionGemma.

This preserves braces, quotes, commas and multiline text inside `<escape>…<escape>` arguments, supports hyphenated function names and multiple calls, and rejects incomplete calls clearly.

Tests cover complete VisMan-like YAML, multiple calls, truncation, and 10,000 fixed-seed source variants.