### PR TITLE
Fix logprobs being silently dropped from streamed responses

### DIFF
--- a/mlx_lm/server.py
+++ b/mlx_lm/server.py
@@ -1402,6 +1402,10 @@ class APIHandler(BaseHTTPRequestHandler):
         tokens = []
         token_logprobs = []
         top_tokens = []
+        # Tokens whose logprobs have already gone out in a stream chunk. The
+        # logprob lists grow in lockstep with `tokens` (or stay empty), so one
+        # offset slices all three.
+        streamed = 0
 
         try:
             for gen in response:
@@ -1449,6 +1453,9 @@ class APIHandler(BaseHTTPRequestHandler):
                     resp = self.generate_response(
                         text,
                         None,
+                        token_logprobs=token_logprobs[streamed:],
+                        top_tokens=top_tokens[streamed:],
+                        tokens=tokens[streamed:],
                         tool_calls=tool_formatter(tool_calls),
                         reasoning_text=reasoning_text,
                     )
@@ -1457,6 +1464,7 @@ class APIHandler(BaseHTTPRequestHandler):
                     reasoning_text = ""
                     text = ""
                     tool_calls = []
+                    streamed = len(tokens)
 
                 if gen.finish_reason is not None:
                     finish_reason = gen.finish_reason
@@ -1474,11 +1482,15 @@ class APIHandler(BaseHTTPRequestHandler):
                 resp = self.generate_response(
                     text,
                     finish_reason,
+                    token_logprobs=token_logprobs[streamed:],
+                    top_tokens=top_tokens[streamed:],
+                    tokens=tokens[streamed:],
                     tool_calls=tool_formatter(tool_calls),
                     reasoning_text=reasoning_text,
                 )
                 self.wfile.write(f"data: {json.dumps(resp)}\n\n".encode())
                 self.wfile.flush()
+                streamed = len(tokens)
                 if (
                     self.stream_options is not None
                     and self.stream_options["include_usage"]

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -355,6 +355,39 @@ class TestServer(unittest.TestCase):
         stop_state, matched = stop_matcher.match(stop_state, stop_matcher._trie, 2)
         self.assertTrue(matched)
 
+    def test_streaming_logprobs_match_non_streaming(self):
+        url = f"http://localhost:{self.port}/v1/chat/completions"
+        post_data = {
+            "model": "chat_model",
+            "max_tokens": 8,
+            "temperature": 0.0,
+            "logprobs": True,
+            "top_logprobs": 3,
+            "messages": [{"role": "user", "content": "Hello!"}],
+        }
+
+        expected = requests.post(url, json=post_data).json()
+        expected = expected["choices"][0]["logprobs"]["content"]
+        self.assertTrue(expected)
+
+        # The same request streamed used to return no logprobs at all: they
+        # were collected per token and then never passed to generate_response.
+        response = requests.post(url, json={**post_data, "stream": True}, stream=True)
+        self.assertEqual(response.status_code, 200)
+
+        streamed = []
+        for line in response.iter_lines():
+            if not line:
+                continue
+            chunk = line.decode("utf-8")
+            if not chunk.startswith("data: ") or chunk == "data: [DONE]":
+                continue
+            logprobs = json.loads(chunk[6:])["choices"][0].get("logprobs")
+            if logprobs:
+                streamed.extend(logprobs["content"])
+
+        self.assertEqual(streamed, expected)
+
     def test_handle_models(self):
         url = f"http://localhost:{self.port}/v1/models"
         response = requests.get(url)


### PR DESCRIPTION
## Problem

`handle_completion` in `mlx_lm/server.py` accumulates logprobs for every token
(`server.py:1438-1442`):

```python
tokens.append(gen.token)
if args.logprobs:
    token_logprobs.append(gen.logprob)
if args.top_logprobs > 0:
    top_tokens.append(gen.top_tokens)
```

The non-streaming response passes them on (`server.py:1496`):

```python
resp = self.generate_response(
    text, finish_reason, len(ctx.prompt), len(tokens), ctx.prompt_cache_count,
    token_logprobs=token_logprobs, top_tokens=top_tokens, tokens=tokens, ...
)
```

The two streaming responses (`server.py:1449` and `1474`) do not:

```python
resp = self.generate_response(
    text, None, tool_calls=..., reasoning_text=...,   # nothing else
)
```

So for an identical request with `logprobs: true, top_logprobs: 3, max_tokens: 8`:

- without `stream`: `choices[0].logprobs.content` has 8 entries, each carrying the
  chosen token, its logprob and 3 alternatives
- with `"stream": true`: no `logprobs` key appears in any chunk

The values are computed per token and then discarded. `logprobs` is accepted and
validated (`server.py:1193`), so the client gets a 200 with no indication the
parameter was ignored: there is no signal at any layer.

If streaming logprobs were deliberately unsupported, the right behaviour would be
a 400. Accepting the parameter and ignoring it is the one option nobody picks on
purpose.

## Why this matters

I hit this routing between a local model and a frontier API. The decision is made
on token-level confidence while the response is still being generated: when the
top two candidates are close: at the token carrying a tool name, or across a
span the small model is unsure about: that request escalates. Without logprobs
on the streaming path you have to wait for the whole completion before you can
act, which defeats the purpose on a backend generating at tens of tokens per
second.

## Fix

Pass the tokens accumulated since the previous chunk:

```python
resp = self.generate_response(
    text, None,
    token_logprobs=token_logprobs[streamed:],
    top_tokens=top_tokens[streamed:],
    tokens=tokens[streamed:],
    ...
)
streamed = len(tokens)
```

The two logprob lists grow in lockstep with `tokens` or stay empty, so a single
offset slices all three. `generate_response` already builds the `logprobs` block
regardless of whether the response is streamed, so nothing changes there.

Non-streaming behaviour is untouched, and a request that does not ask for
logprobs slices empty lists: a no-op.

## Testing

- Added a regression test in `tests/test_server.py` asserting that the logprobs
  reassembled from a stream equal the non-streamed ones for the same request
  (fails on `main`, passes with this change).
- `python -m unittest tests.test_server`: 26 tests, all pass.
- Checked against a running server with the OpenAI Python client on
  Qwen1.5-0.5B, Llama-3.2-1B and LFM2-1.2B, and on the sequential generation path
  via a request with `seed` set. Before: 0 streamed entries in every case. After:
  identical to the non-streamed ones, token strings and `top_logprobs` included.
- `black` / `isort` clean.

Note: the parameters arrived in #806 ("Logprobs info to completion API"), which
added the plumbing and updated the single non-streaming call site; the streaming
ones were never wired up. Separately, `SERVER.md` documents `logprobs` as "an
integer between 1 and 10" while the code takes a bool and puts the integer in
`top_logprobs`: orthogonal to this fix and left untouched here, happy to follow
up.
