### PR TITLE
Fix unbounded ArraysCache metadata graph during decode

### DIFF
--- a/mlx_lm/models/cache.py
+++ b/mlx_lm/models/cache.py
@@ -688,6 +688,15 @@ class ArraysCache(_BaseCache):
         if self.left_padding is not None:
             self.left_padding -= N
 
+        metadata = tuple(
+            value for value in (self.lengths, self.left_padding) if value is not None
+        )
+        if metadata:
+            for index, value in enumerate(self.cache):
+                if value is not None:
+                    self.cache[index] = mx.depends(value, metadata)
+                    break
+
     def make_mask(self, N: int):
         if self.left_padding is not None:
             pos = mx.arange(N)

--- a/mlx_lm/models/cache.py
+++ b/mlx_lm/models/cache.py
@@ -623,11 +623,16 @@ class ArraysCache(_BaseCache):
 
     @property
     def state(self):
-        return self.cache
+        # None can not be seralized so return empty array instead
+        left_padding = mx.array([]) if self.left_padding is None else self.left_padding
+        lengths = mx.array([]) if self.lengths is None else self.lengths
+        return self.cache, left_padding, lengths
 
     @state.setter
     def state(self, v):
-        self.cache = v
+        self.cache, left_padding, lengths = v
+        self.left_padding = left_padding if left_padding.size > 0 else None
+        self.lengths = lengths if lengths.size > 0 else None
 
     def filter(self, batch_indices):
         """
@@ -687,15 +692,6 @@ class ArraysCache(_BaseCache):
             self.lengths -= N
         if self.left_padding is not None:
             self.left_padding -= N
-
-        metadata = tuple(
-            value for value in (self.lengths, self.left_padding) if value is not None
-        )
-        if metadata:
-            for index, value in enumerate(self.cache):
-                if value is not None:
-                    self.cache[index] = mx.depends(value, metadata)
-                    break
 
     def make_mask(self, N: int):
         if self.left_padding is not None:

--- a/tests/test_prompt_cache.py
+++ b/tests/test_prompt_cache.py
@@ -1,6 +1,7 @@
 # Copyright © 2024 Apple Inc.
 
 import copy
+import io
 import os
 import tempfile
 import unittest
@@ -758,26 +759,19 @@ class TestPromptCache(unittest.TestCase):
         self.assertEqual(stepwise[0].shape, (4, 4, 8))
         self.assertEqual(stepwise[1].shape, (4, 4))
 
-    def test_arrays_cache_advance_evaluates_metadata_with_state(self):
+    def test_arrays_cache_advance(self):
         cache = ArraysCache(2, left_padding=[2])
         cache.prepare(lengths=[3])
-        cache[0] = mx.array([0])
-        cache[1] = mx.array([0])
 
         for _ in range(256):
-            cache[0] = cache[0] + 1
             cache.advance(1)
-            mx.eval(cache[0])
+            mx.eval(cache.state)
 
-        for name, metadata in (
-            ("lengths", cache.lengths),
-            ("left-padding", cache.left_padding),
-        ):
-            dot_path = os.path.join(self.test_dir, f"arrays-cache-{name}.dot")
-            mx.export_to_dot(dot_path, metadata)
-            with open(dot_path, encoding="utf-8") as graph:
-                self.assertLessEqual(graph.read().count("->"), 8)
-        self.assertEqual(cache[0].item(), 256)
+        for attr in [cache.lengths, cache.left_padding]:
+            f = io.StringIO()
+            mx.export_to_dot(f, attr)
+            f.seek(0)
+            self.assertEqual(f.read().count("->"), 0)
         self.assertEqual(cache.lengths.item(), 3 - 256)
         self.assertEqual(cache.left_padding.item(), 2 - 256)
 

--- a/tests/test_prompt_cache.py
+++ b/tests/test_prompt_cache.py
@@ -758,6 +758,29 @@ class TestPromptCache(unittest.TestCase):
         self.assertEqual(stepwise[0].shape, (4, 4, 8))
         self.assertEqual(stepwise[1].shape, (4, 4))
 
+    def test_arrays_cache_advance_evaluates_metadata_with_state(self):
+        cache = ArraysCache(2, left_padding=[2])
+        cache.prepare(lengths=[3])
+        cache[0] = mx.array([0])
+        cache[1] = mx.array([0])
+
+        for _ in range(256):
+            cache[0] = cache[0] + 1
+            cache.advance(1)
+            mx.eval(cache[0])
+
+        for name, metadata in (
+            ("lengths", cache.lengths),
+            ("left-padding", cache.left_padding),
+        ):
+            dot_path = os.path.join(self.test_dir, f"arrays-cache-{name}.dot")
+            mx.export_to_dot(dot_path, metadata)
+            with open(dot_path, encoding="utf-8") as graph:
+                self.assertLessEqual(graph.read().count("->"), 8)
+        self.assertEqual(cache[0].item(), 256)
+        self.assertEqual(cache.lengths.item(), 3 - 256)
+        self.assertEqual(cache.left_padding.item(), 2 - 256)
+
     def test_window_mask_with_full_kv_cache(self):
         c = KVCache()
         kv = mx.zeros((1, 1, 32, 128))


### PR DESCRIPTION
## Summary

- bound the lazy graph retained by `ArraysCache.lengths` and
  `ArraysCache.left_padding`
- evaluate metadata together with an existing cache state
- add a regression test covering repeated `advance()` calls

## Problem

`ArraysCache.advance()` performs lazy subtraction on every decode step. The
metadata arrays retain the preceding graph even when the generation loop
evaluates the model state, so long continuous generations accumulate live
Metal resources and can eventually fail with:

```text
RuntimeError: [metal::malloc] Resource limit (499000) exceeded
```

In a minimal reproduction, 256 calls to `advance(1)` leave 1,280 graph edges
behind each metadata array.

## Fix

Make one populated cache state depend on the current metadata arrays. Existing
generation paths already evaluate cache state, which bounds the metadata graph
without adding a separate synchronization on every decode step.

## Testing

- the regression test fails on unpatched `main` with `1280 not less than or
  equal to 8`
- `python -m unittest tests.test_prompt_cache` (23 tests)
- `pre-commit run --files mlx_lm/models/cache.py tests/test_prompt_cache.py`
- 50,000-step synthetic decode: both metadata graphs remain at 0 edges and
  retain the expected values
