### PR TITLE
fix(qwen3_coder): accept float-formatted integers in tool-call args

### DIFF
--- a/mlx_lm/tool_parsers/qwen3_coder.py
+++ b/mlx_lm/tool_parsers/qwen3_coder.py
@@ -54,7 +54,19 @@ def _convert_param_value(param_value: str, param_name: str, param_config: dict) 
         or param_type.startswith("short")
         or param_type.startswith("unsigned")
     ):
-        return int(param_value)
+        try:
+            return int(param_value)
+        except ValueError:
+            # Models sometimes emit a float-formatted integer (e.g. "140.0") for a
+            # parameter the schema declares as an integer. Mirror the numeric branch
+            # below and coerce it instead of raising.
+            float_param_value = float(param_value)
+            int_param_value = int(float_param_value)
+            return (
+                float_param_value
+                if (float_param_value - int_param_value) != 0
+                else int_param_value
+            )
     elif param_type.startswith("num") or param_type.startswith("float"):
         float_param_value = float(param_value)
         int_param_value = int(float_param_value)

--- a/tests/test_tool_parsing.py
+++ b/tests/test_tool_parsing.py
@@ -197,6 +197,57 @@ class TestToolParsing(unittest.TestCase):
         self.assertEqual(tool_call["arguments"]["filters"], {"category": "books"})
         self.assertEqual(tool_call["arguments"]["tags"], ["fiction", "new"])
 
+    def test_qwen3_coder_float_formatted_integer(self):
+        tools = [
+            {
+                "type": "function",
+                "function": {
+                    "name": "read",
+                    "parameters": {
+                        "type": "object",
+                        "properties": {
+                            "filePath": {"type": "string"},
+                            "limit": {"type": "integer"},
+                        },
+                    },
+                },
+            }
+        ]
+
+        # a float-formatted integer for an "integer" parameter is coerced, not rejected
+        test_case = (
+            "<function=read>\n"
+            "<parameter=filePath>\n/x/y.py\n</parameter>\n"
+            "<parameter=limit>\n140.0\n</parameter>\n"
+            "</function>"
+        )
+        tool_call = qwen3_coder.parse_tool_call(test_case, tools)
+        self.assertEqual(tool_call["name"], "read")
+        self.assertEqual(tool_call["arguments"]["filePath"], "/x/y.py")
+        self.assertEqual(tool_call["arguments"]["limit"], 140)
+        self.assertIsInstance(tool_call["arguments"]["limit"], int)
+
+        # a plain integer literal keeps working
+        test_case = (
+            "<function=read>\n"
+            "<parameter=filePath>\n/x/y.py\n</parameter>\n"
+            "<parameter=limit>\n140\n</parameter>\n"
+            "</function>"
+        )
+        tool_call = qwen3_coder.parse_tool_call(test_case, tools)
+        self.assertEqual(tool_call["arguments"]["limit"], 140)
+
+        # a genuinely non-integral value keeps its fractional part rather than
+        # being silently truncated
+        test_case = (
+            "<function=read>\n"
+            "<parameter=filePath>\n/x/y.py\n</parameter>\n"
+            "<parameter=limit>\n140.5\n</parameter>\n"
+            "</function>"
+        )
+        tool_call = qwen3_coder.parse_tool_call(test_case, tools)
+        self.assertEqual(tool_call["arguments"]["limit"], 140.5)
+
     def test_gemma4(self):
         # Nested object
         test_case = 'call:configure{settings:{enabled:true,name:<|"|>test<|"|>}}'


### PR DESCRIPTION
## Summary

`mlx_lm/tool_parsers/qwen3_coder.py :: _convert_param_value` converts a parameter the tool schema declares as `integer` with a bare `int(param_value)`. Qwen3-Coder sometimes emits a **float-formatted integer** — e.g. `140.0` for a `limit` parameter typed `integer` — and `int("140.0")` raises `ValueError`, so the whole tool call is rejected.

The numeric/float branch immediately below already coerces tolerantly in both directions (`float` → `int` when the value is integral). This makes the integer branch mirror it.

```python
elif param_type.startswith("int") or ...:
    try:
        return int(param_value)
    except ValueError:
        float_param_value = float(param_value)
        int_param_value = int(float_param_value)
        return (
            float_param_value
            if (float_param_value - int_param_value) != 0
            else int_param_value
        )
```

## Verification

Reproducer from the issue, against `main` (`e5baded`) and against this branch:

| `limit` value | before | after |
|---|---|---|
| `"140.0"` | `ValueError: invalid literal for int() with base 10: '140.0'` | `140` (`int`) |
| `"140"` | `140` | `140` (`int`) |
| `"140.5"` | `ValueError` | `140.5` (`float`) |
| `"0.0"` | `ValueError` | `0` (`int`) |
| `"-3.0"` | `ValueError` | `-3` (`int`) |
| `"abc"` | `ValueError` | `ValueError` (unchanged) |

Added `test_qwen3_coder_float_formatted_integer` covering the integral-float, plain-int and fractional cases. The existing `qwen3_coder` assertions in `test_parsers` and `test_qwen3_coder_single_quoted_params` still pass. `black --check` and `isort --check-only --profile=black` are clean on both files.

## Scope note

The issue also raises a second point — `server.py` drops an unparseable tool call with only a log warning, returning HTTP 200 with `finish_reason: "tool_calls"` and no tool call, which is what turns the parse failure into a client retry loop. That is a serving-behaviour change, and the related "raw-string fallback for values that parse as nothing at all" question is already tracked separately in #1604, so this PR deliberately stays narrow: it only makes the integer branch as tolerant as the float branch beside it. A genuinely non-numeric value still raises exactly as it does today.

Fixes #1627

🤖 Generated with [Claude Code](https://claude.com/claude-code)
