### PR TITLE
fix(server): build /v1/models body before committing 200 status (#1636)

### DIFF
--- a/mlx_lm/server.py
+++ b/mlx_lm/server.py
@@ -30,6 +30,7 @@ from typing import (
 
 import mlx.core as mx
 from huggingface_hub import scan_cache_dir
+from huggingface_hub.errors import CacheNotFound
 
 from ._version import __version__
 from .generate import (
@@ -1610,9 +1611,6 @@ class APIHandler(BaseHTTPRequestHandler):
         """
         Handle a GET request for the /v1/models endpoint.
         """
-        self._set_completion_headers(200)
-        self.end_headers()
-
         files = ["config.json", "model.safetensors.index.json", "tokenizer_config.json"]
 
         parts = self.path.split("/")
@@ -1630,11 +1628,16 @@ class APIHandler(BaseHTTPRequestHandler):
             file_names = {f.file_path.name for f in repo.refs["main"].files}
             return all(f in file_names for f in files)
 
-        # Scan the cache directory for downloaded mlx models
-        hf_cache_info = scan_cache_dir()
-        downloaded_models = [
-            repo for repo in hf_cache_info.repos if probably_mlx_lm(repo)
-        ]
+        # Scan the cache directory for downloaded mlx models. A missing cache
+        # directory (e.g. air-gapped installs serving a local model path) is not
+        # an error -- it simply means there are no cached models to enumerate.
+        try:
+            hf_cache_info = scan_cache_dir()
+            downloaded_models = [
+                repo for repo in hf_cache_info.repos if probably_mlx_lm(repo)
+            ]
+        except CacheNotFound:
+            downloaded_models = []
 
         # Create a list of available models
         models = [
@@ -1659,8 +1662,13 @@ class APIHandler(BaseHTTPRequestHandler):
                 )
 
         response = {"object": "list", "data": models}
-
         response_json = json.dumps(response).encode()
+
+        # Commit the status only after the (fallible) body has been built, so a
+        # failure while scanning the cache cannot leave a 200 on the wire with a
+        # truncated body.
+        self._set_completion_headers(200)
+        self.end_headers()
         self.wfile.write(response_json)
         self.wfile.flush()
 

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -368,6 +368,26 @@ class TestServer(unittest.TestCase):
         self.assertEqual(model["object"], "model")
         self.assertIn("created", model)
 
+    def test_handle_models_missing_cache(self):
+        # When no Hugging Face cache exists (e.g. air-gapped installs serving a
+        # local model path) scan_cache_dir raises CacheNotFound. The endpoint
+        # must still return a valid 200 response rather than committing the
+        # status before the failure and shipping a truncated body.
+        from unittest.mock import patch
+
+        from huggingface_hub.errors import CacheNotFound
+
+        url = f"http://localhost:{self.port}/v1/models"
+        with patch(
+            "mlx_lm.server.scan_cache_dir",
+            side_effect=CacheNotFound("no cache", cache_dir="/does/not/exist"),
+        ):
+            response = requests.get(url)
+        self.assertEqual(response.status_code, 200)
+        response_body = json.loads(response.text)
+        self.assertEqual(response_body["object"], "list")
+        self.assertIsInstance(response_body["data"], list)
+
 
 class TestServerWithDraftModel(unittest.TestCase):
     @classmethod


### PR DESCRIPTION
### Problem

`handle_models_request()` commits a `200 OK` and ends the headers **before** the
operation that can fail. `scan_cache_dir()` raises `CacheNotFound` when there is
no Hugging Face cache on the host — common for air-gapped or pre-staged installs
that serve a model from a local `--model` path. Because the status is already on
the wire, the client receives an **invalid successful response**: `200` with a
truncated/empty body while the server logs an exception.

Present on current `main` (`e5baded`): headers at ~1613–1614, `scan_cache_dir()`
at ~1634.

### Fix

Build the full response body first — treating a missing cache as simply "no
downloaded models" — and only commit the `200` status once the body is ready. A
local model passed via `--model` is still enumerated, so the air-gapped case now
returns a correct listing instead of a broken 200.

### Test

`test_handle_models_missing_cache` patches `scan_cache_dir` to raise
`CacheNotFound` and asserts the endpoint still returns a valid, parseable `200`
list. It fails before the change (truncated body) and passes after.

Fixes #1636

🤖 Generated with [Claude Code](https://claude.com/claude-code)
