### PR TITLE
Fix per-token Metal buffer-object leak in `ArraysCache.advance()` (qwen3_5/qwen3_next batch decode crashes at the resource limit on long completions)

### DIFF
--- a/mlx_lm/models/cache.py
+++ b/mlx_lm/models/cache.py
@@ -610,6 +610,32 @@ def _try_schedule(*arrays):
         return False
 
 
+class _ArraysCacheFoldLock(type(threading.RLock())):
+    """An RLock that recreates itself across pickle/deepcopy.
+
+    A shallow cache copy keeps the same lock by normal object sharing.
+    Pickle and deepcopy create a new native lock; their memo preserves
+    sharing when an alias graph contains the same lock more than once.
+    """
+
+    def __reduce__(self):
+        return (type(self), ())
+
+
+class _ArraysCacheFieldState:
+    """Mutable bookkeeping shared by shallow aliases of one field.
+
+    ``promotion`` is separate from the pending counter because the two
+    metadata fields can reference the same bool array: stock promoted
+    both logical views together, while each field still applied its own
+    decrement.
+    """
+
+    def __init__(self, advance=0, promoted=False, promotion=None):
+        self.advance = advance
+        self.promotion = [promoted] if promotion is None else promotion
+
+
 class ArraysCache(_BaseCache):
     # ``left_padding`` and ``lengths`` are logically decremented by
     # ``advance()`` on every layer call during decode. Doing that decrement
@@ -683,37 +709,68 @@ class ArraysCache(_BaseCache):
     # machinery): the write lands before the deferred decrement -- the
     # alias-write window above -- where stock's eager decrement landed
     # first. Reads are serialized per cache: a reentrant lock guards the
-    # advance bookkeeping, folds, scheduling, and copies, because
-    # stock's pure attribute reads were trivially thread-safe while
-    # unserialized concurrent folds of one array deadlock on their
-    # thread-local streams. Cross-thread *mutation* (filter/extend/
-    # finalize racing anything) remains unsupported, as in stock.
+    # advance bookkeeping, folds, scheduling, copies, and metadata
+    # serialization, because stock's pure attribute reads were trivially
+    # thread-safe while unserialized concurrent folds of one array deadlock
+    # on their thread-local streams. Shallow aliases share that lock and
+    # their per-field bookkeeping for as long as they share the backing
+    # array; deepcopy preserves that topology within an alias graph.
+    # Cross-thread *mutation* (filter/extend/finalize racing anything)
+    # remains unsupported, as in stock.
 
     def __new__(cls, *args, **kwargs):
         instance = super().__new__(cls)
         instance._left_padding = None
         instance._lengths = None
-        instance._lp_advance = 0
-        instance._len_advance = 0
+        instance._lp_state = _ArraysCacheFieldState()
+        instance._len_state = _ArraysCacheFieldState()
         # bool-metadata promotion trackers: stock's eager subtraction
         # promoted a bool field to int32 on the FIRST advance() -- even a
         # zero or cancelling one -- so validation must remember that
         # independently of the pending total (see _logical_dtype)
-        instance._lp_promoted = False
-        instance._len_promoted = False
         # Serializes the deferred-decrement machinery (advance
-        # bookkeeping, folds, scheduling, copies). Stock's pure
-        # attribute reads were trivially thread-safe; deferred folding
-        # makes reads mutate, and two unserialized folds of the same
-        # array from different threads deadlock on their thread-local
-        # streams. Reentrant: mutators call _sync/_fold under it.
-        instance._fold_lock = threading.RLock()
+        # bookkeeping, folds, scheduling, copies, serialization). The
+        # native lock subclass is pickleable and deepcopy-aware without
+        # adding a wrapper on the per-token advance() hot path.
+        instance._fold_lock = _ArraysCacheFoldLock()
         return instance
 
     def __init__(self, size, left_padding: Optional[List[int]] = None):
         self.cache = [None] * size
         if left_padding:
             self.left_padding = mx.array(left_padding)
+
+    @property
+    def _lp_advance(self):
+        return self._lp_state.advance
+
+    @_lp_advance.setter
+    def _lp_advance(self, value):
+        self._lp_state.advance = value
+
+    @property
+    def _len_advance(self):
+        return self._len_state.advance
+
+    @_len_advance.setter
+    def _len_advance(self, value):
+        self._len_state.advance = value
+
+    @property
+    def _lp_promoted(self):
+        return self._lp_state.promotion[0]
+
+    @_lp_promoted.setter
+    def _lp_promoted(self, value):
+        self._lp_state.promotion[0] = value
+
+    @property
+    def _len_promoted(self):
+        return self._len_state.promotion[0]
+
+    @_len_promoted.setter
+    def _len_promoted(self, value):
+        self._len_state.promotion[0] = value
 
     # Integer metadata dtypes as (bits, signed): used to mirror stock's
     # eager per-call scalar range check in advance() and to wrap the
@@ -858,11 +915,17 @@ class ArraysCache(_BaseCache):
                 # Bound chains from repeatedly assigning lazy expressions
                 _try_schedule(v)
             self._left_padding = v
-            self._lp_advance = 0
             if not same:
                 # Only a genuinely new array resets the bool-promotion
                 # record; re-assigning the backing array is not a reset
-                self._lp_promoted = False
+                promotion = (
+                    self._len_state.promotion
+                    if v is not None and v is self._lengths
+                    else None
+                )
+                self._lp_state = _ArraysCacheFieldState(promotion=promotion)
+            else:
+                self._lp_advance = 0
 
     @property
     def lengths(self):
@@ -890,9 +953,15 @@ class ArraysCache(_BaseCache):
             if v is not None:
                 _try_schedule(v)
             self._lengths = v
-            self._len_advance = 0
             if not same:
-                self._len_promoted = False
+                promotion = (
+                    self._lp_state.promotion
+                    if v is not None and v is self._left_padding
+                    else None
+                )
+                self._len_state = _ArraysCacheFieldState(promotion=promotion)
+            else:
+                self._len_advance = 0
 
     def _sync(self):
         """Fold both pending integer decrements into the stored arrays."""
@@ -915,12 +984,12 @@ class ArraysCache(_BaseCache):
 
     def __copy__(self):
         # A shallow copy shares the backing arrays (as stock's did) --
-        # and the fold lock, so folds on the shared arrays stay
-        # serialized across both objects. Fold first: otherwise the
-        # copied pending counters would apply this cache's decrement
-        # once per object to the shared array. If the fold cannot land
-        # (captured tracer), a copy would escape the trace holding the
-        # transient tracer -- raise like the other guarded mutations.
+        # plus the fold lock and mutable per-field bookkeeping, so a
+        # pending total is folded only once across the alias graph.
+        # Fold first to preserve stock's copy-time visibility. If the
+        # fold cannot land (captured tracer), a copy would escape the
+        # trace holding the transient tracer -- raise like the other
+        # guarded mutations.
         with self._fold_lock:
             self._sync()
             self._require_folded("__copy__")
@@ -932,15 +1001,16 @@ class ArraysCache(_BaseCache):
         # Same guard as __copy__: python's default deepcopy would copy
         # __dict__ directly, letting a deep copy taken mid-trace escape
         # with the transient tracer and the pending counter. The copy
-        # gets its own fold lock (its arrays are independent).
+        # gets an independent lock for an independent array, while a
+        # shared deepcopy memo preserves lock/state sharing within a
+        # copied shallow-alias graph.
         with self._fold_lock:
             self._sync()
             self._require_folded("__deepcopy__")
             new = self.__class__.__new__(self.__class__)
             memo[id(self)] = new
             for k, v in self.__dict__.items():
-                if k != "_fold_lock":
-                    new.__dict__[k] = copy.deepcopy(v, memo)
+                new.__dict__[k] = copy.deepcopy(v, memo)
             return new
 
     def _materialize(self):
@@ -1005,10 +1075,6 @@ class ArraysCache(_BaseCache):
         # "" for an absent field, "<dtype>:<comma-joined values>"
         # otherwise (an empty array stays distinct from None and dtype
         # survives the round trip).
-        if self._left_padding is None and self._lengths is None:
-            return ""
-        self._sync()
-
         def encode(a):
             if a is None:
                 return ""
@@ -1027,7 +1093,11 @@ class ArraysCache(_BaseCache):
                 )
             return dtype + ":" + ",".join(str(x) for x in a.tolist())
 
-        return (encode(self._left_padding), encode(self._lengths))
+        with self._fold_lock:
+            if self._left_padding is None and self._lengths is None:
+                return ""
+            self._sync()
+            return (encode(self._left_padding), encode(self._lengths))
 
     @meta_state.setter
     def meta_state(self, v):
@@ -1059,9 +1129,13 @@ class ArraysCache(_BaseCache):
         self._sync()
         self._require_folded("filter")
         if self._left_padding is not None:
+            promoted = self._lp_promoted
             self._left_padding = self._left_padding[batch_indices]
+            self._lp_state = _ArraysCacheFieldState(promoted=promoted)
         if self._lengths is not None:
+            promoted = self._len_promoted
             self._lengths = self._lengths[batch_indices]
+            self._len_state = _ArraysCacheFieldState(promoted=promoted)
         self._materialize()
 
     def extend(self, other):
@@ -1091,15 +1165,32 @@ class ArraysCache(_BaseCache):
 
             return mx.concatenate([a, b])
 
+        def materialize_promoted_bool(a, promoted):
+            # Stock's first subtraction physically promoted bool metadata
+            # to int32. Preserve that logical dtype before mixed-dtype
+            # concatenation (bool + int8 would otherwise become int8).
+            if a is not None and promoted and a.dtype == mx.bool_:
+                return a.astype(mx.int32)
+            return a
+
         self._sync()
         other._sync()
         self._require_folded("extend")
         other._require_folded("extend")
         self.cache = [cat(c, o) for c, o in zip(self.cache, other.cache)]
-        self._left_padding = cat(self._left_padding, other._left_padding)
-        self._lengths = cat(self._lengths, other._lengths)
-        self._lp_promoted = self._lp_promoted or other._lp_promoted
-        self._len_promoted = self._len_promoted or other._len_promoted
+        self._left_padding = cat(
+            materialize_promoted_bool(self._left_padding, self._lp_promoted),
+            materialize_promoted_bool(other._left_padding, other._lp_promoted),
+        )
+        self._lengths = cat(
+            materialize_promoted_bool(self._lengths, self._len_promoted),
+            materialize_promoted_bool(other._lengths, other._len_promoted),
+        )
+        # Concatenation rebinds both fields. Any logical bool promotion
+        # was materialized above, so the new arrays start with fresh
+        # per-field state and no alias bookkeeping from either input.
+        self._lp_state = _ArraysCacheFieldState()
+        self._len_state = _ArraysCacheFieldState()
         self._materialize()
 
     def extract(self, idx):
@@ -1117,8 +1208,8 @@ class ArraysCache(_BaseCache):
         self._require_folded("finalize")
         self._lengths = None
         self._left_padding = None
-        self._lp_promoted = False
-        self._len_promoted = False
+        self._lp_state = _ArraysCacheFieldState()
+        self._len_state = _ArraysCacheFieldState()
 
     def advance(self, N):
         # Integer bookkeeping only: building this with mx.array arithmetic

--- a/mlx_lm/models/cache.py
+++ b/mlx_lm/models/cache.py
@@ -3,7 +3,9 @@
 import copy
 import operator
 import threading
+import weakref
 from collections import deque
+from contextlib import ExitStack, contextmanager
 from dataclasses import dataclass
 from typing import Any, Dict, List, Optional
 
@@ -611,15 +613,65 @@ def _try_schedule(*arrays):
 
 
 class _ArraysCacheFoldLock(type(threading.RLock())):
-    """An RLock that recreates itself across pickle/deepcopy.
+    """An RLock used by a cache alias group or a metadata-array alias group.
 
-    A shallow cache copy keeps the same lock by normal object sharing.
-    Pickle and deepcopy create a new native lock; their memo preserves
-    sharing when an alias graph contains the same lock more than once.
+    Normal object sharing keeps one lock across aliases. Pickle and deepcopy
+    create a new native lock; their memo preserves sharing when an alias graph
+    contains the same lock more than once.
     """
 
     def __reduce__(self):
         return (type(self), ())
+
+
+class _ArraysCacheArraySync:
+    """Synchronization and physical-promotion state for one backing array."""
+
+    def __init__(self, promotion=None, lock=None):
+        self.promotion = [False] if promotion is None else promotion
+        self.lock = _ArraysCacheFoldLock() if lock is None else lock
+
+
+# Public setters can attach one mx.array to independently constructed caches.
+# Keep synchronization by backing-array identity so their deferred reads cannot
+# concurrently mutate that array on different thread-local MLX streams. The
+# weak registry does not retain arrays after their last real owner is gone.
+_ARRAYS_CACHE_ARRAY_SYNCS = {}
+_ARRAYS_CACHE_ARRAY_SYNCS_LOCK = threading.Lock()
+
+
+def _register_arrays_cache_array(arr, state):
+    if arr is None:
+        return state
+    if not hasattr(state, "array_lock"):
+        # Compatibility with cache pickles produced before array-level locks.
+        state.array_lock = _ArraysCacheFoldLock()
+    key = id(arr)
+    with _ARRAYS_CACHE_ARRAY_SYNCS_LOCK:
+        item = _ARRAYS_CACHE_ARRAY_SYNCS.get(key)
+        if item is not None and item[0]() is arr:
+            sync = item[1]
+            state.promotion = sync.promotion
+            state.array_lock = sync.lock
+            return state
+
+        sync = _ArraysCacheArraySync(state.promotion, state.array_lock)
+
+        def remove(ref, key=key):
+            with _ARRAYS_CACHE_ARRAY_SYNCS_LOCK:
+                current = _ARRAYS_CACHE_ARRAY_SYNCS.get(key)
+                if current is not None and current[0] is ref:
+                    del _ARRAYS_CACHE_ARRAY_SYNCS[key]
+
+        ref = weakref.ref(arr, remove)
+        _ARRAYS_CACHE_ARRAY_SYNCS[key] = (ref, sync)
+        return state
+
+
+def _arrays_cache_field_state(arr=None, advance=0, promoted=False):
+    return _register_arrays_cache_array(
+        arr, _ArraysCacheFieldState(advance=advance, promoted=promoted)
+    )
 
 
 class _ArraysCacheFieldState:
@@ -631,9 +683,10 @@ class _ArraysCacheFieldState:
     decrement.
     """
 
-    def __init__(self, advance=0, promoted=False, promotion=None):
+    def __init__(self, advance=0, promoted=False, promotion=None, array_lock=None):
         self.advance = advance
         self.promotion = [promoted] if promotion is None else promotion
+        self.array_lock = _ArraysCacheFoldLock() if array_lock is None else array_lock
 
 
 class ArraysCache(_BaseCache):
@@ -684,10 +737,13 @@ class ArraysCache(_BaseCache):
     # bool metadata bool, numpy scalar offsets promoting the metadata
     # dtype) are not reproduced. bool metadata arithmetic is reproduced
     # at int32 precision (stock's promotion): the dtype stays bool
-    # through zero-net advance histories, and after the first advance()
-    # on the field -- even a zero or cancelling one, and through a bool
-    # array shared by both fields -- later offsets validate against
-    # int32 exactly as stock's already-promoted array would. A read that encounters a *tracer*
+    # through zero-net advance histories. Physical promotion and fold
+    # synchronization follow the backing array even when public setters
+    # attach it to independently constructed caches; shallow aliases
+    # additionally share their per-field pending counter. After the first
+    # advance() on a bool field -- even a zero or cancelling one -- later
+    # offsets through any of those aliases validate against int32 exactly
+    # as stock's already-promoted array would. A read that encounters a *tracer*
     # -- metadata swapped into a trace by
     # ``mx.compile(..., inputs=vars(cache))`` -- is pure: no fold, no
     # scheduling, like stock's attribute access, and the pending
@@ -711,10 +767,16 @@ class ArraysCache(_BaseCache):
     # first. Reads are serialized per cache: a reentrant lock guards the
     # advance bookkeeping, folds, scheduling, copies, and metadata
     # serialization, because stock's pure attribute reads were trivially
-    # thread-safe while unserialized concurrent folds of one array deadlock
-    # on their thread-local streams. Shallow aliases share that lock and
-    # their per-field bookkeeping for as long as they share the backing
-    # array; deepcopy preserves that topology within an alias graph.
+    # thread-safe while unserialized concurrent folds of one array
+    # deadlock on their thread-local streams. A second, array-identity
+    # lock serializes independently constructed caches that share a
+    # backing array. Shallow aliases share their cache lock and per-field
+    # bookkeeping; deepcopy preserves that topology within an alias
+    # graph. Quiescent generic pickle preserves the same topology, but
+    # pickle does not expose a lifecycle hook that can hold the source
+    # lock for the complete outer Pickler traversal: concurrent generic
+    # pickle is unsupported. ``meta_state`` and ``save_prompt_cache``
+    # remain linearizable complete metadata snapshots.
     # Cross-thread *mutation* (filter/extend/finalize racing anything)
     # remains unsupported, as in stock.
 
@@ -838,7 +900,7 @@ class ArraysCache(_BaseCache):
                 f"for {dtype} metadata"
             )
 
-    def _fold(self, arr_attr, adv_attr):
+    def _fold(self, arr_attr, state_attr):
         """Fold the pending decrement into the backing array -- in place,
         so aliases observe it -- and schedule the evaluation. A no-op on
         tracers (see _try_schedule): the fold stays pending, the counter
@@ -853,46 +915,49 @@ class ArraysCache(_BaseCache):
         in-flight chunk (an asynchronous interrupt or failed subtraction
         between the counter commit and the subtraction drops it)."""
         with self._fold_lock:
-            total = getattr(self, adv_attr)
-            if not total:
-                return
-            arr = getattr(self, arr_attr)
-            if not _try_schedule(arr):
-                return
-            total = self._wrap_advance(total, arr.dtype)
-            setattr(self, adv_attr, total)
-            lo, hi = -(1 << 63), (1 << 63) - 1
-            while True:
-                chunk = min(max(total, lo), hi)
-                total -= chunk
-                setattr(self, adv_attr, total)
-                arr -= chunk
-                setattr(self, arr_attr, arr)
+            state = getattr(self, state_attr)
+            with state.array_lock:
+                total = state.advance
                 if not total:
-                    break
+                    return
+                arr = getattr(self, arr_attr)
+                if not _try_schedule(arr):
+                    return
+                total = self._wrap_advance(total, arr.dtype)
+                state.advance = total
+                lo, hi = -(1 << 63), (1 << 63) - 1
+                while True:
+                    chunk = min(max(total, lo), hi)
+                    total -= chunk
+                    state.advance = total
+                    arr -= chunk
+                    setattr(self, arr_attr, arr)
+                    if not total:
+                        break
+                    mx.async_eval(arr)
                 mx.async_eval(arr)
-            mx.async_eval(arr)
 
     def _fold_lp(self):
-        self._fold("_left_padding", "_lp_advance")
+        self._fold("_left_padding", "_lp_state")
 
     def _fold_len(self):
-        self._fold("_lengths", "_len_advance")
+        self._fold("_lengths", "_len_state")
 
     @property
     def left_padding(self):
         if self._left_padding is None:
             return None
         with self._fold_lock:
-            if self._lp_advance:
-                self._fold_lp()
-            else:
-                # Schedule on every access: external in-place writes
-                # through the returned array are otherwise never
-                # evaluated for metadata nothing consumes (a property
-                # access is not an evaluation).
-                _try_schedule(self._left_padding)
-            return self._left_padding
+            with self._lp_state.array_lock:
+                if self._lp_advance:
+                    self._fold_lp()
+                else:
+                    # Schedule on every access: external in-place writes
+                    # through the returned array are otherwise never
+                    # evaluated for metadata nothing consumes (a property
+                    # access is not an evaluation).
+                    _try_schedule(self._left_padding)
+                return self._left_padding
 
     @left_padding.setter
     def left_padding(self, v):
@@ -911,19 +976,16 @@ class ArraysCache(_BaseCache):
                         "decrement is pending"
                     )
             same = v is self._left_padding
+            state = self._lp_state if same else _arrays_cache_field_state(v)
             if v is not None:
                 # Bound chains from repeatedly assigning lazy expressions
-                _try_schedule(v)
+                with state.array_lock:
+                    _try_schedule(v)
             self._left_padding = v
             if not same:
                 # Only a genuinely new array resets the bool-promotion
                 # record; re-assigning the backing array is not a reset
-                promotion = (
-                    self._len_state.promotion
-                    if v is not None and v is self._lengths
-                    else None
-                )
-                self._lp_state = _ArraysCacheFieldState(promotion=promotion)
+                self._lp_state = state
             else:
                 self._lp_advance = 0
 
@@ -932,11 +994,12 @@ class ArraysCache(_BaseCache):
         if self._lengths is None:
             return None
         with self._fold_lock:
-            if self._len_advance:
-                self._fold_len()
-            else:
-                _try_schedule(self._lengths)
-            return self._lengths
+            with self._len_state.array_lock:
+                if self._len_advance:
+                    self._fold_len()
+                else:
+                    _try_schedule(self._lengths)
+                return self._lengths
 
     @lengths.setter
     def lengths(self, v):
@@ -950,16 +1013,13 @@ class ArraysCache(_BaseCache):
                         "decrement is pending"
                     )
             same = v is self._lengths
+            state = self._len_state if same else _arrays_cache_field_state(v)
             if v is not None:
-                _try_schedule(v)
+                with state.array_lock:
+                    _try_schedule(v)
             self._lengths = v
             if not same:
-                promotion = (
-                    self._lp_state.promotion
-                    if v is not None and v is self._left_padding
-                    else None
-                )
-                self._len_state = _ArraysCacheFieldState(promotion=promotion)
+                self._len_state = state
             else:
                 self._len_advance = 0
 
@@ -967,6 +1027,42 @@ class ArraysCache(_BaseCache):
         """Fold both pending integer decrements into the stored arrays."""
         self._fold_lp()
         self._fold_len()
+
+    @contextmanager
+    def _metadata_locked(self):
+        """Lock this cache and every distinct backing metadata array."""
+        with self._fold_lock:
+            locks = {}
+            if self._left_padding is not None:
+                locks[id(self._lp_state.array_lock)] = self._lp_state.array_lock
+            if self._lengths is not None:
+                locks[id(self._len_state.array_lock)] = self._len_state.array_lock
+            with ExitStack() as stack:
+                for key in sorted(locks):
+                    stack.enter_context(locks[key])
+                yield
+
+    def _register_metadata_arrays(self):
+        if self._left_padding is not None:
+            self._lp_state = _register_arrays_cache_array(
+                self._left_padding, self._lp_state
+            )
+        if self._lengths is not None:
+            self._len_state = _register_arrays_cache_array(
+                self._lengths, self._len_state
+            )
+
+    def __setstate__(self, state):
+        if isinstance(state, tuple) and len(state) == 2:
+            state, slot_state = state
+        else:
+            slot_state = None
+        if state is not None:
+            self.__dict__.update(state)
+        if slot_state is not None:
+            for key, value in slot_state.items():
+                setattr(self, key, value)
+        self._register_metadata_arrays()
 
     def _require_folded(self, op):
         """Guard for mutators: a pending counter after _sync() means the
@@ -990,11 +1086,14 @@ class ArraysCache(_BaseCache):
         # fold cannot land (captured tracer), a copy would escape the
         # trace holding the transient tracer -- raise like the other
         # guarded mutations.
-        with self._fold_lock:
+        with self._metadata_locked():
             self._sync()
             self._require_folded("__copy__")
-            new = self.__class__.__new__(self.__class__)
-            new.__dict__.update(self.__dict__)
+            reducer = self.__reduce_ex__(4)
+            if isinstance(reducer, str):
+                return self
+            new = copy._reconstruct(self, None, *reducer)
+            new._register_metadata_arrays()
             return new
 
     def __deepcopy__(self, memo):
@@ -1004,13 +1103,14 @@ class ArraysCache(_BaseCache):
         # gets an independent lock for an independent array, while a
         # shared deepcopy memo preserves lock/state sharing within a
         # copied shallow-alias graph.
-        with self._fold_lock:
+        with self._metadata_locked():
             self._sync()
             self._require_folded("__deepcopy__")
-            new = self.__class__.__new__(self.__class__)
-            memo[id(self)] = new
-            for k, v in self.__dict__.items():
-                new.__dict__[k] = copy.deepcopy(v, memo)
+            reducer = self.__reduce_ex__(4)
+            if isinstance(reducer, str):
+                return self
+            new = copy._reconstruct(self, memo, *reducer)
+            new._register_metadata_arrays()
             return new
 
     def _materialize(self):
@@ -1093,7 +1193,7 @@ class ArraysCache(_BaseCache):
                 )
             return dtype + ":" + ",".join(str(x) for x in a.tolist())
 
-        with self._fold_lock:
+        with self._metadata_locked():
             if self._left_padding is None and self._lengths is None:
                 return ""
             self._sync()
@@ -1130,12 +1230,14 @@ class ArraysCache(_BaseCache):
         self._require_folded("filter")
         if self._left_padding is not None:
             promoted = self._lp_promoted
-            self._left_padding = self._left_padding[batch_indices]
-            self._lp_state = _ArraysCacheFieldState(promoted=promoted)
+            new = self._left_padding[batch_indices]
+            state = _arrays_cache_field_state(new, promoted=promoted)
+            self._left_padding, self._lp_state = new, state
         if self._lengths is not None:
             promoted = self._len_promoted
-            self._lengths = self._lengths[batch_indices]
-            self._len_state = _ArraysCacheFieldState(promoted=promoted)
+            new = self._lengths[batch_indices]
+            state = _arrays_cache_field_state(new, promoted=promoted)
+            self._lengths, self._len_state = new, state
         self._materialize()
 
     def extend(self, other):
@@ -1178,19 +1280,22 @@ class ArraysCache(_BaseCache):
         self._require_folded("extend")
         other._require_folded("extend")
         self.cache = [cat(c, o) for c, o in zip(self.cache, other.cache)]
-        self._left_padding = cat(
+        new = cat(
             materialize_promoted_bool(self._left_padding, self._lp_promoted),
             materialize_promoted_bool(other._left_padding, other._lp_promoted),
         )
-        self._lengths = cat(
+        state = _arrays_cache_field_state(new)
+        self._left_padding, self._lp_state = new, state
+        new = cat(
             materialize_promoted_bool(self._lengths, self._len_promoted),
             materialize_promoted_bool(other._lengths, other._len_promoted),
         )
-        # Concatenation rebinds both fields. Any logical bool promotion
-        # was materialized above, so the new arrays start with fresh
-        # per-field state and no alias bookkeeping from either input.
-        self._lp_state = _ArraysCacheFieldState()
-        self._len_state = _ArraysCacheFieldState()
+        state = _arrays_cache_field_state(new)
+        self._lengths, self._len_state = new, state
+        # Concatenation rebinds each field together with fresh bookkeeping as
+        # soon as that field succeeds. If the second concatenation raises, the
+        # first field therefore remains coherent and matches stock's partial
+        # mutation order without retaining a shallow alias's pending counter.
         self._materialize()
 
     def extract(self, idx):
@@ -1268,10 +1373,14 @@ class ArraysCache(_BaseCache):
             # field's counter is untouched. Scheduling matters even here:
             # a caller that discards the mask would otherwise leave the
             # fold unevaluated, one node per call.
-            self._fold_lp()
-            return pos >= self._left_padding[:, None]
-        self._fold_len()
-        return pos < self._lengths[:, None]
+            with self._fold_lock:
+                with self._lp_state.array_lock:
+                    self._fold_lp()
+                    return pos >= self._left_padding[:, None]
+        with self._fold_lock:
+            with self._len_state.array_lock:
+                self._fold_len()
+                return pos < self._lengths[:, None]
 
     @classmethod
     def merge(cls, caches):

--- a/mlx_lm/models/cache.py
+++ b/mlx_lm/models/cache.py
@@ -1,6 +1,8 @@
 # Copyright © 2023-2024 Apple Inc.
 
 import copy
+import operator
+import threading
 from collections import deque
 from dataclasses import dataclass
 from typing import Any, Dict, List, Optional
@@ -591,11 +593,121 @@ class RotatingKVCache(_BaseCache):
         return self.keys.nbytes + self.values.nbytes
 
 
+def _try_schedule(*arrays):
+    """Schedule an async evaluation unless it is disallowed: inside a
+    graph transformation (``mx.compile`` traces captured state by
+    temporarily swapping tracers into the captured containers, e.g.
+    ``inputs=vars(cache)``) ``async_eval`` on a tracer raises, and a
+    metadata access must instead behave like stock's plain attribute
+    read -- return the tracer, schedule nothing, and leave any pending
+    fold for the next eager access. Returns False in that case."""
+    try:
+        mx.async_eval(*arrays)
+        return True
+    except ValueError as e:
+        if "graph transformation" not in str(e):
+            raise
+        return False
+
+
 class ArraysCache(_BaseCache):
+    # ``left_padding`` and ``lengths`` are logically decremented by
+    # ``advance()`` on every layer call during decode. Doing that decrement
+    # with mx.array arithmetic (``self.left_padding -= N``) builds one
+    # unevaluated graph node per layer per token. The model only ever
+    # rebuilds a mask from ONE of these caches (``cache[ssm_idx]``), so for
+    # every other layer the chain is dead: it is never evaluated, it grows
+    # without bound, and every link pins the small constant array (and its
+    # live Metal buffer object) that was subtracted. The process then dies
+    # with ``[metal::malloc] Resource limit (499000) exceeded`` -- a count
+    # limit, not bytes -- after a few tens of thousands of decode tokens
+    # (see ml-explore/mlx-lm#1185, #1332; ml-explore/mlx#3564, #3539).
+    #
+    # Fix: track the cumulative decrement as a plain python int per field
+    # (``_lp_advance``/``_len_advance``; nonzero only while the matching
+    # array exists) and fold it into the stored array when that field is
+    # read (property access or ``make_mask``), replaced, or finalized.
+    # ``advance()`` itself creates no graph nodes and never evaluates
+    # anything; folding one field never touches the other. Folds are
+    # applied in place (``-=``, preserving the array object) on the
+    # metadata side and scheduled with ``mx.async_eval``, so no public
+    # operation sequence accumulates unevaluated graph on metadata
+    # nothing consumes.
+    #
+    # Deliberate deviations from the eager decrement (nothing in this
+    # repo relies on them): a decrement becomes visible to aliases of a
+    # metadata array at the next fold of that field, not at ``advance()``
+    # time -- alias reads/writes before that fold interleave accordingly,
+    # and storing the same array object in both fields applies each
+    # field's decrement at its own fold; ``copy.copy`` folds first, so a
+    # shallow copy cannot re-apply pending decrements to the shared
+    # arrays. Deferred totals fold as the dtype-congruent scalar (MLX
+    # converts python int scalars through int64, so uint64 uses the
+    # signed representative modulo 2**64), which lands integer metadata
+    # exactly where stock's per-step subtractions did -- including
+    # totals that overflow the dtype. Offsets outside the scalar range
+    # MLX accepts for the dtype raise a uniform ValueError at
+    # ``advance()``, where stock's eager subtraction rejected them (as
+    # ValueError, or an opaque std::bad_cast at the int64 gate).
+    # Floating totals beyond the int64 gate fold in gate-sized chunks,
+    # each scheduled as it is applied; per-step float *rounding* is not
+    # reproduced. ``operator.index`` normalizes integral offsets
+    # (python bool and numpy integer scalars become python ints, value
+    # preserved) -- stock instead converted exotic offset types through
+    # array promotion, whose dtype side effects (a bool offset keeping
+    # bool metadata bool, numpy scalar offsets promoting the metadata
+    # dtype) are not reproduced. bool metadata arithmetic is reproduced
+    # at int32 precision (stock's promotion): the dtype stays bool
+    # through zero-net advance histories, and after the first advance()
+    # on the field -- even a zero or cancelling one, and through a bool
+    # array shared by both fields -- later offsets validate against
+    # int32 exactly as stock's already-promoted array would. A read that encounters a *tracer*
+    # -- metadata swapped into a trace by
+    # ``mx.compile(..., inputs=vars(cache))`` -- is pure: no fold, no
+    # scheduling, like stock's attribute access, and the pending
+    # decrement folds at the next eager access; a closure-captured
+    # cache holds concrete arrays, so reads inside a trace fold eagerly
+    # with stock-identical values. Compiling a function that *calls*
+    # ``advance()`` is not supported: the decrement is host-side
+    # bookkeeping and runs at trace time only (stock incidentally
+    # recorded it as graph arithmetic -- the same arithmetic that
+    # leaks), so call advance() outside compiled functions. Likewise,
+    # mutating metadata (assignment, ``finalize``, ``filter``,
+    # ``extend``) while a pending decrement cannot fold -- the field is
+    # captured as a tracer -- raises rather than silently discarding
+    # the decrement (``copy.copy`` and ``copy.deepcopy`` guard the same
+    # way -- a copy taken mid-trace would escape holding the transient
+    # tracer); mutate outside compiled functions. In-place item
+    # assignment through a captured tracer read cannot be intercepted
+    # (``__setitem__`` on the returned array bypasses the property
+    # machinery): the write lands before the deferred decrement -- the
+    # alias-write window above -- where stock's eager decrement landed
+    # first. Reads are serialized per cache: a reentrant lock guards the
+    # advance bookkeeping, folds, scheduling, and copies, because
+    # stock's pure attribute reads were trivially thread-safe while
+    # unserialized concurrent folds of one array deadlock on their
+    # thread-local streams. Cross-thread *mutation* (filter/extend/
+    # finalize racing anything) remains unsupported, as in stock.
+
     def __new__(cls, *args, **kwargs):
         instance = super().__new__(cls)
-        instance.left_padding = None
-        instance.lengths = None
+        instance._left_padding = None
+        instance._lengths = None
+        instance._lp_advance = 0
+        instance._len_advance = 0
+        # bool-metadata promotion trackers: stock's eager subtraction
+        # promoted a bool field to int32 on the FIRST advance() -- even a
+        # zero or cancelling one -- so validation must remember that
+        # independently of the pending total (see _logical_dtype)
+        instance._lp_promoted = False
+        instance._len_promoted = False
+        # Serializes the deferred-decrement machinery (advance
+        # bookkeeping, folds, scheduling, copies). Stock's pure
+        # attribute reads were trivially thread-safe; deferred folding
+        # makes reads mutate, and two unserialized folds of the same
+        # array from different threads deadlock on their thread-local
+        # streams. Reentrant: mutators call _sync/_fold under it.
+        instance._fold_lock = threading.RLock()
         return instance
 
     def __init__(self, size, left_padding: Optional[List[int]] = None):
@@ -603,15 +715,255 @@ class ArraysCache(_BaseCache):
         if left_padding:
             self.left_padding = mx.array(left_padding)
 
+    # Integer metadata dtypes as (bits, signed): used to mirror stock's
+    # eager per-call scalar range check in advance() and to wrap the
+    # accumulated total to the dtype's modular range at fold time.
+    _INT_DTYPES = {
+        "int8": (8, True),
+        "int16": (16, True),
+        "int32": (32, True),
+        "int64": (64, True),
+        "uint8": (8, False),
+        "uint16": (16, False),
+        "uint32": (32, False),
+        "uint64": (64, False),
+    }
+
+    @classmethod
+    def _int_spec(cls, dtype):
+        return cls._INT_DTYPES.get(str(dtype).split(".")[-1])
+
+    @classmethod
+    def _wrap_advance(cls, total, dtype):
+        """Wrap an accumulated advance() total to the congruent scalar
+        MLX converts exactly like stock's per-step decrements did.
+        Sequential wrapping subtractions equal one subtraction of the
+        sum modulo 2**bits, so the wrapped fold lands on stock's value
+        even when the raw total overflows the dtype. Python int scalars
+        convert through int64 (mlx python/src/utils.cpp), so uint64
+        takes the *signed* int64 representative -- congruent modulo
+        2**64 and accepted by the conversion. Non-integer dtypes pass
+        through (the fold subtracts them in gate-sized chunks). bool
+        metadata wraps at int32: stock's subtraction promoted it, and
+        int32 wrapping matches the promoted arithmetic (including the
+        two's-complement truncation MLX's C++ cast applies to
+        out-of-range scalars)."""
+        if dtype == mx.bool_:
+            spec = (32, True)
+        else:
+            spec = cls._int_spec(dtype)
+        if spec is None:
+            return total
+        bits, signed = spec
+        total %= 1 << bits
+        if (signed or bits == 64) and total >= 1 << (bits - 1):
+            total -= 1 << bits
+        return total
+
+    @classmethod
+    def _check_advance(cls, N, dtype):
+        """Mirror stock's eager scalar conversion: python ints convert
+        through int64, so every dtype rejects offsets outside int64's
+        range, and integer dtypes narrower than 64 bits are additionally
+        range-checked (uint64 is not: negatives wrap modulo 2**64).
+        Runs per armed field, in stock's field order, because that is
+        where stock's ``-= N`` raised (ValueError, or std::bad_cast at
+        the int64 gate; here it is uniformly ValueError)."""
+        lo, hi = -(1 << 63), (1 << 63) - 1
+        spec = cls._int_spec(dtype)
+        if spec is not None and spec[0] < 64:
+            bits, signed = spec
+            lo = -(1 << (bits - 1)) if signed else 0
+            hi = ((1 << (bits - 1)) if signed else (1 << bits)) - 1
+        if not lo <= N <= hi:
+            raise ValueError(
+                f"ArraysCache.advance offset {N} is out of range "
+                f"for {dtype} metadata"
+            )
+
+    def _fold(self, arr_attr, adv_attr):
+        """Fold the pending decrement into the backing array -- in place,
+        so aliases observe it -- and schedule the evaluation. A no-op on
+        tracers (see _try_schedule): the fold stays pending, the counter
+        untouched. Integer totals fold as one pre-wrapped exact scalar;
+        other dtypes subtract in int64-gate-sized chunks (an accumulated
+        floating total can exceed the scalar range even when every
+        offset was valid), each chunk scheduled as it is applied so a
+        many-chunk fold cannot itself build an unbounded chain. The
+        counter commits chunk-by-chunk, BEFORE each subtraction: a
+        decrement is never applied twice, and a failure mid-fold leaves
+        the unapplied remainder pending except for at most the single
+        in-flight chunk (an asynchronous interrupt or failed subtraction
+        between the counter commit and the subtraction drops it)."""
+        with self._fold_lock:
+            total = getattr(self, adv_attr)
+            if not total:
+                return
+            arr = getattr(self, arr_attr)
+            if not _try_schedule(arr):
+                return
+            total = self._wrap_advance(total, arr.dtype)
+            setattr(self, adv_attr, total)
+            lo, hi = -(1 << 63), (1 << 63) - 1
+            while True:
+                chunk = min(max(total, lo), hi)
+                total -= chunk
+                setattr(self, adv_attr, total)
+                arr -= chunk
+                setattr(self, arr_attr, arr)
+                if not total:
+                    break
+                mx.async_eval(arr)
+            mx.async_eval(arr)
+
+    def _fold_lp(self):
+        self._fold("_left_padding", "_lp_advance")
+
+    def _fold_len(self):
+        self._fold("_lengths", "_len_advance")
+
+    @property
+    def left_padding(self):
+        if self._left_padding is None:
+            return None
+        with self._fold_lock:
+            if self._lp_advance:
+                self._fold_lp()
+            else:
+                # Schedule on every access: external in-place writes
+                # through the returned array are otherwise never
+                # evaluated for metadata nothing consumes (a property
+                # access is not an evaluation).
+                _try_schedule(self._left_padding)
+            return self._left_padding
+
+    @left_padding.setter
+    def left_padding(self, v):
+        # Fold the outgoing array first so earlier aliases still observe
+        # the decrement; otherwise replacement would discard it forever.
+        with self._fold_lock:
+            if self._left_padding is not None:
+                self._fold_lp()
+                if self._lp_advance:
+                    # The fold declined: the outgoing array is a tracer
+                    # (captured by a graph transformation). Proceeding
+                    # would silently discard the decrement.
+                    raise RuntimeError(
+                        "ArraysCache metadata cannot be replaced inside "
+                        "a graph transformation while an advance() "
+                        "decrement is pending"
+                    )
+            same = v is self._left_padding
+            if v is not None:
+                # Bound chains from repeatedly assigning lazy expressions
+                _try_schedule(v)
+            self._left_padding = v
+            self._lp_advance = 0
+            if not same:
+                # Only a genuinely new array resets the bool-promotion
+                # record; re-assigning the backing array is not a reset
+                self._lp_promoted = False
+
+    @property
+    def lengths(self):
+        if self._lengths is None:
+            return None
+        with self._fold_lock:
+            if self._len_advance:
+                self._fold_len()
+            else:
+                _try_schedule(self._lengths)
+            return self._lengths
+
+    @lengths.setter
+    def lengths(self, v):
+        with self._fold_lock:
+            if self._lengths is not None:
+                self._fold_len()
+                if self._len_advance:
+                    raise RuntimeError(
+                        "ArraysCache metadata cannot be replaced inside "
+                        "a graph transformation while an advance() "
+                        "decrement is pending"
+                    )
+            same = v is self._lengths
+            if v is not None:
+                _try_schedule(v)
+            self._lengths = v
+            self._len_advance = 0
+            if not same:
+                self._len_promoted = False
+
+    def _sync(self):
+        """Fold both pending integer decrements into the stored arrays."""
+        self._fold_lp()
+        self._fold_len()
+
+    def _require_folded(self, op):
+        """Guard for mutators: a pending counter after _sync() means the
+        backing array is a tracer (captured by a graph transformation),
+        and rebinding or clearing the field now would silently discard
+        the decrement. Reads stay supported under capture; mutations
+        must run eagerly. Never fires on eager paths, where folds
+        always land."""
+        if self._lp_advance or self._len_advance:
+            raise RuntimeError(
+                f"ArraysCache.{op}: metadata is captured by a graph "
+                "transformation with an advance() decrement pending; "
+                "apply cache mutations outside compiled functions"
+            )
+
+    def __copy__(self):
+        # A shallow copy shares the backing arrays (as stock's did) --
+        # and the fold lock, so folds on the shared arrays stay
+        # serialized across both objects. Fold first: otherwise the
+        # copied pending counters would apply this cache's decrement
+        # once per object to the shared array. If the fold cannot land
+        # (captured tracer), a copy would escape the trace holding the
+        # transient tracer -- raise like the other guarded mutations.
+        with self._fold_lock:
+            self._sync()
+            self._require_folded("__copy__")
+            new = self.__class__.__new__(self.__class__)
+            new.__dict__.update(self.__dict__)
+            return new
+
+    def __deepcopy__(self, memo):
+        # Same guard as __copy__: python's default deepcopy would copy
+        # __dict__ directly, letting a deep copy taken mid-trace escape
+        # with the transient tracer and the pending counter. The copy
+        # gets its own fold lock (its arrays are independent).
+        with self._fold_lock:
+            self._sync()
+            self._require_folded("__deepcopy__")
+            new = self.__class__.__new__(self.__class__)
+            memo[id(self)] = new
+            for k, v in self.__dict__.items():
+                if k != "_fold_lock":
+                    new.__dict__[k] = copy.deepcopy(v, memo)
+            return new
+
+    def _materialize(self):
+        """Schedule evaluation of the metadata arrays. filter/extend run
+        once per batch change, but only one layer's metadata is ever
+        consumed downstream, so batch churn on a long-lived server would
+        otherwise grow an unevaluated chain for every other layer (the
+        same dead-graph pattern as advance(), at per-request rate).
+        async_eval, not eval: a synchronous eval here would block behind
+        whatever the generation loop already queued on the stream."""
+        arrs = [a for a in (self._left_padding, self._lengths) if a is not None]
+        if arrs:
+            _try_schedule(arrs)
+
     @property
     def batch_size(self):
         for c in self.cache:
             if c is not None:
                 return c.shape[0]
-        if self.left_padding is not None:
-            return self.left_padding.size
-        elif self.lengths is not None:
-            return self.lengths.size
+        if self._left_padding is not None:
+            return self._left_padding.size
+        elif self._lengths is not None:
+            return self._lengths.size
         else:
             return 1
 
@@ -634,10 +986,13 @@ class ArraysCache(_BaseCache):
         In-place filter to keep just the given indices in the cache.
         """
         self.cache = [c[batch_indices] if c is not None else None for c in self.cache]
-        if self.left_padding is not None:
-            self.left_padding = self.left_padding[batch_indices]
-        if self.lengths is not None:
-            self.lengths = self.lengths[batch_indices]
+        self._sync()
+        self._require_folded("filter")
+        if self._left_padding is not None:
+            self._left_padding = self._left_padding[batch_indices]
+        if self._lengths is not None:
+            self._lengths = self._lengths[batch_indices]
+        self._materialize()
 
     def extend(self, other):
         """
@@ -666,9 +1021,16 @@ class ArraysCache(_BaseCache):
 
             return mx.concatenate([a, b])
 
+        self._sync()
+        other._sync()
+        self._require_folded("extend")
+        other._require_folded("extend")
         self.cache = [cat(c, o) for c, o in zip(self.cache, other.cache)]
-        self.left_padding = cat(self.left_padding, other.left_padding)
-        self.lengths = cat(self.lengths, other.lengths)
+        self._left_padding = cat(self._left_padding, other._left_padding)
+        self._lengths = cat(self._lengths, other._lengths)
+        self._lp_promoted = self._lp_promoted or other._lp_promoted
+        self._len_promoted = self._len_promoted or other._len_promoted
+        self._materialize()
 
     def extract(self, idx):
         cache = ArraysCache(len(self.cache))
@@ -679,24 +1041,76 @@ class ArraysCache(_BaseCache):
         self.lengths = mx.array(lengths)
 
     def finalize(self):
-        self.lengths = None
-        self.left_padding = None
+        # Fold before clearing so aliases held by callers still observe
+        # the decrements that happened while the fields were live
+        self._sync()
+        self._require_folded("finalize")
+        self._lengths = None
+        self._left_padding = None
+        self._lp_promoted = False
+        self._len_promoted = False
 
     def advance(self, N):
-        if self.lengths is not None:
-            self.lengths -= N
-        if self.left_padding is not None:
-            self.left_padding -= N
+        # Integer bookkeeping only: building this with mx.array arithmetic
+        # leaks one live buffer object per layer per token (see class note).
+        # mx.array offsets are rejected loudly rather than coerced --
+        # coercion would force an eval here, truncate floats, and accept
+        # non-scalars that silently corrupt the deferred arithmetic.
+        # operator.index accepts any integral python scalar and rejects
+        # floats. Type validation runs regardless of whether any metadata
+        # is set, so that contract does not depend on cache state; the
+        # dtype range check below is per armed field, in stock's field
+        # order, because that is exactly where stock's eager subtraction
+        # would have rejected the offset.
+        if isinstance(N, mx.array):
+            raise TypeError("ArraysCache.advance requires a python int, not mx.array")
+        N = operator.index(N)
+        with self._fold_lock:
+            if self._lengths is not None:
+                promoted = self._len_promoted or (
+                    self._lengths is self._left_padding and self._lp_promoted
+                )
+                self._check_advance(N, self._logical_dtype(self._lengths, promoted))
+                self._len_advance += N
+                if self._lengths.dtype == mx.bool_:
+                    self._len_promoted = True
+            if self._left_padding is not None:
+                promoted = self._lp_promoted or (
+                    self._left_padding is self._lengths and self._len_promoted
+                )
+                self._check_advance(
+                    N, self._logical_dtype(self._left_padding, promoted)
+                )
+                self._lp_advance += N
+                if self._left_padding.dtype == mx.bool_:
+                    self._lp_promoted = True
+
+    @staticmethod
+    def _logical_dtype(arr, promoted):
+        # Stock's eager subtraction promoted bool metadata to int32 on
+        # the FIRST advance() -- even a zero or cancelling one, and in
+        # place, so a bool array shared between both fields promoted
+        # both (hence the identity checks at the call sites). With the
+        # fold deferred, the stored dtype stays bool, so later offsets
+        # must validate against the promoted dtype exactly as stock's
+        # stored array would have.
+        if promoted and arr.dtype == mx.bool_:
+            return mx.int32
+        return arr.dtype
 
     def make_mask(self, N: int):
-        if self.left_padding is not None:
-            pos = mx.arange(N)
-            return pos >= self.left_padding[:, None]
-        elif self.lengths is not None:
-            pos = mx.arange(N)
-            return pos < self.lengths[:, None]
-        else:
+        if self._left_padding is None and self._lengths is None:
             return None
+        pos = mx.arange(N)
+        if self._left_padding is not None:
+            # Fold (and schedule) only the field the mask uses; the other
+            # field's counter is untouched. Scheduling matters even here:
+            # a caller that discards the mask would otherwise leave the
+            # fold unevaluated, one node per call.
+            self._fold_lp()
+            return pos >= self._left_padding[:, None]
+        self._fold_len()
+        return pos < self._lengths[:, None]
 
     @classmethod
     def merge(cls, caches):

--- a/mlx_lm/models/cache.py
+++ b/mlx_lm/models/cache.py
@@ -981,6 +981,76 @@ class ArraysCache(_BaseCache):
     def state(self, v):
         self.cache = v
 
+    # dtypes the metadata codec accepts, with the value parser for each.
+    # Deliberately numeric-only: metadata holds padding/length counts.
+    _META_DTYPES = {
+        "int8": int,
+        "int16": int,
+        "int32": int,
+        "int64": int,
+        "uint8": int,
+        "uint16": int,
+        "uint32": int,
+        "uint64": int,
+        "float16": float,
+        "float32": float,
+        "float64": float,
+        "bfloat16": float,
+    }
+
+    @property
+    def meta_state(self):
+        # Metadata is not part of ``state`` (its fields are optional and
+        # ``state`` slots may not be None), so serialize it as strings:
+        # "" for an absent field, "<dtype>:<comma-joined values>"
+        # otherwise (an empty array stays distinct from None and dtype
+        # survives the round trip).
+        if self._left_padding is None and self._lengths is None:
+            return ""
+        self._sync()
+
+        def encode(a):
+            if a is None:
+                return ""
+            if a.ndim != 1:
+                # The encoding is 1-D only -- the shape make_mask/merge/
+                # filter arithmetic assumes. Fail loudly instead of
+                # emitting an entry the decoder cannot parse.
+                raise ValueError(
+                    f"ArraysCache metadata must be 1-D to serialize, "
+                    f"got shape {a.shape}"
+                )
+            dtype = str(a.dtype).split(".")[-1]
+            if dtype not in self._META_DTYPES:
+                raise TypeError(
+                    f"ArraysCache metadata with dtype {a.dtype} cannot be serialized"
+                )
+            return dtype + ":" + ",".join(str(x) for x in a.tolist())
+
+        return (encode(self._left_padding), encode(self._lengths))
+
+    @meta_state.setter
+    def meta_state(self, v):
+        # Files written before metadata serialization carry an empty entry
+        if not v:
+            return
+
+        def decode(s):
+            if not s:
+                return None
+            dtype_name, sep, vals = s.partition(":")
+            cast = self._META_DTYPES.get(dtype_name)
+            if not sep or cast is None:
+                raise ValueError(f"Malformed ArraysCache metadata entry: {s!r}")
+            return mx.array(
+                [cast(x) for x in vals.split(",")] if vals else [],
+                dtype=getattr(mx, dtype_name),
+            )
+
+        lp, ln = v
+        self.left_padding = decode(lp)
+        self.lengths = decode(ln)
+
     def filter(self, batch_indices):
         """
         In-place filter to keep just the given indices in the cache.

--- a/tests/test_prompt_cache.py
+++ b/tests/test_prompt_cache.py
@@ -1422,9 +1422,120 @@ class TestPromptCache(unittest.TestCase):
             alias.advance(1)
         concurrent_property_reads(aliases)
 
+    def test_arrays_cache_external_array_alias_state(self):
+        """Independent caches synchronize folds and logical bool promotion
+        when their public setters receive the same backing array."""
+        shared = mx.array([5])
+        mx.eval(shared)
+        aliases = [ArraysCache(size=1), ArraysCache(size=1)]
+        for alias in aliases:
+            alias.lengths = shared
+            alias.advance(1)
+
+        self.assertIsNot(aliases[0]._len_state, aliases[1]._len_state)
+        self.assertIsNot(aliases[0]._fold_lock, aliases[1]._fold_lock)
+        self.assertIs(
+            aliases[0]._len_state.array_lock,
+            aliases[1]._len_state.array_lock,
+        )
+        self.assertIs(
+            aliases[0]._len_state.promotion,
+            aliases[1]._len_state.promotion,
+        )
+
+        restored = pickle.loads(pickle.dumps(aliases))
+        self.assertIs(restored[0]._lengths, restored[1]._lengths)
+        self.assertIsNot(restored[0]._len_state, restored[1]._len_state)
+        self.assertIs(
+            restored[0]._len_state.array_lock,
+            restored[1]._len_state.array_lock,
+        )
+
+        gate = threading.Barrier(3)
+        arrays = []
+        errors = []
+
+        def read(cache):
+            try:
+                gate.wait()
+                arrays.append(cache.lengths)
+            except Exception as e:
+                errors.append(e)
+
+        threads = [
+            threading.Thread(target=read, args=(cache,), daemon=True)
+            for cache in aliases
+        ]
+        for thread in threads:
+            thread.start()
+        gate.wait()
+        for thread in threads:
+            thread.join(timeout=60)
+        self.assertTrue(all(not thread.is_alive() for thread in threads))
+        self.assertEqual(errors, [])
+        mx.eval(*arrays)
+        self.assertEqual([array.tolist() for array in arrays], [[3], [3]])
+
+        shared = mx.array([True], dtype=mx.bool_)
+        aliases = [ArraysCache(size=1), ArraysCache(size=1)]
+        for alias in aliases:
+            alias.lengths = shared
+        aliases[0].advance(0)
+        self.assertTrue(aliases[1]._len_promoted)
+        with self.assertRaises(ValueError):
+            aliases[1].advance(2**31)
+
+        # left_padding uses the same array-identity synchronization.
+        shared = mx.array([5])
+        aliases = [ArraysCache(size=1), ArraysCache(size=1)]
+        for alias in aliases:
+            alias.left_padding = shared
+        self.assertIs(
+            aliases[0]._lp_state.array_lock,
+            aliases[1]._lp_state.array_lock,
+        )
+
+    def test_arrays_cache_subclass_slot_copy(self):
+        """Custom copy hooks preserve state stored in subclass slots."""
+
+        class Child(ArraysCache):
+            __slots__ = ("tag",)
+
+        cache = Child(size=1)
+        cache.lengths = mx.array([5])
+        cache.tag = {"items": [1]}
+
+        shallow = copy.copy(cache)
+        deep = copy.deepcopy(cache)
+        self.assertIs(shallow.tag, cache.tag)
+        self.assertEqual(deep.tag, cache.tag)
+        self.assertIsNot(deep.tag, cache.tag)
+        self.assertIs(shallow._lengths, cache._lengths)
+        self.assertIsNot(deep._lengths, cache._lengths)
+
+    def test_arrays_cache_failed_extend_detaches_state(self):
+        """A partial extend commit cannot retain an old alias counter."""
+        cache = ArraysCache(size=1, left_padding=[10])
+        cache.lengths = mx.array([30])
+        alias = copy.copy(cache)
+
+        other = ArraysCache(size=1, left_padding=[20])
+        other.lengths = mx.array([[40]])
+        with self.assertRaises(ValueError):
+            cache.extend(other)
+
+        self.assertEqual(cache._left_padding.tolist(), [10, 20])
+        self.assertEqual(alias._left_padding.tolist(), [10])
+        self.assertIsNot(cache._left_padding, alias._left_padding)
+        self.assertIsNot(cache._lp_state, alias._lp_state)
+        cache.advance(1)
+        self.assertEqual(alias.left_padding.tolist(), [10])
+        self.assertEqual(cache.left_padding.tolist(), [9, 19])
+
     def test_arrays_cache_pickle(self):
-        """The deferred state round-trips without trying to pickle a
-        native RLock, including the sharing topology of alias graphs."""
+        """A quiescent cache round-trips without trying to pickle a native
+        RLock, including the sharing topology of alias graphs. Concurrent
+        generic pickle is outside the supported synchronization contract."""
         cache = ArraysCache(size=1)
         cache.lengths = mx.array([5])
         cache.advance(2)
@@ -1436,12 +1547,13 @@ class TestPromptCache(unittest.TestCase):
         cache.lengths = mx.array([5])
         aliases = [cache, copy.copy(cache)]
         cache.advance(1)
-        restored = pickle.loads(pickle.dumps(aliases))
-        self.assertIs(restored[0]._lengths, restored[1]._lengths)
-        self.assertIs(restored[0]._len_state, restored[1]._len_state)
-        self.assertIs(restored[0]._fold_lock, restored[1]._fold_lock)
-        self.assertEqual(restored[0].lengths.tolist(), [4])
-        self.assertEqual(restored[1].lengths.tolist(), [4])
+        for protocol in range(2, pickle.HIGHEST_PROTOCOL + 1):
+            restored = pickle.loads(pickle.dumps(aliases, protocol=protocol))
+            self.assertIs(restored[0]._lengths, restored[1]._lengths)
+            self.assertIs(restored[0]._len_state, restored[1]._len_state)
+            self.assertIs(restored[0]._fold_lock, restored[1]._fold_lock)
+            self.assertEqual(restored[0].lengths.tolist(), [4])
+            self.assertEqual(restored[1].lengths.tolist(), [4])
 
     def test_arrays_cache_metadata_serialization_is_atomic(self):
         """advance() cannot interleave between the two encoded fields."""

--- a/tests/test_prompt_cache.py
+++ b/tests/test_prompt_cache.py
@@ -2,6 +2,7 @@
 
 import copy
 import os
+import pickle
 import tempfile
 import threading
 import unittest
@@ -1035,15 +1036,17 @@ class TestPromptCache(unittest.TestCase):
         self.assertEqual(cache.lengths.tolist(), [4])
         self.assertEqual(cloned.lengths.tolist(), [4])
         self.assertIs(cloned._lengths, cache._lengths)
-        # post-copy advances fold into the shared array at each object's
-        # own fold, so both eventually observe them (stock applied them
-        # eagerly to the same shared array)
+        self.assertIs(cloned._len_state, cache._len_state)
+        # post-copy advances accumulate in shared field state, so either
+        # alias folds the total exactly once into their shared array
         cloned.advance(2)
-        self.assertEqual(cloned.lengths.tolist(), [2])
-        self.assertEqual(cache.lengths.tolist(), [2])
+        cache.advance(1)
+        self.assertEqual(cloned._len_advance, 3)
+        self.assertEqual(cache.lengths.tolist(), [1])
+        self.assertEqual(cloned.lengths.tolist(), [1])
 
         # deepcopy also folds first; the copy is an independent object
-        # with its own counters
+        # with its own counters and lock
         cache = ArraysCache(size=1)
         cache.lengths = mx.array([5])
         cache.advance(1)
@@ -1051,6 +1054,7 @@ class TestPromptCache(unittest.TestCase):
         self.assertEqual(deep.lengths.tolist(), [4])
         self.assertEqual(deep._len_advance, 0)
         self.assertIsNot(deep._lengths, cache._lengths)
+        self.assertIsNot(deep._fold_lock, cache._fold_lock)
         deep.advance(2)
         self.assertEqual(deep.lengths.tolist(), [2])
         self.assertEqual(cache.lengths.tolist(), [4])
@@ -1129,6 +1133,29 @@ class TestPromptCache(unittest.TestCase):
             cache.advance(2**31)
         self.assertEqual(cache._len_advance, 2**31)
         self.assertEqual(cache._lp_advance, 0)
+
+        # shallow aliases share the bool-promotion record as well as the
+        # backing array: once either alias has logically promoted bool to
+        # int32, all aliases validate future offsets against int32
+        cache = ArraysCache(size=1)
+        cache.lengths = mx.array([True], dtype=mx.bool_)
+        cloned = copy.copy(cache)
+        cache.advance(0)
+        with self.assertRaises(ValueError):
+            cloned.advance(2**31)
+
+        # extend must materialize a logical bool->int32 promotion before
+        # mixed-dtype concatenation. Stock concatenates int32 with int8,
+        # accepts 128, and produces this value.
+        cache = ArraysCache(size=1)
+        cache.lengths = mx.array([True], dtype=mx.bool_)
+        cache.advance(0)
+        other = ArraysCache(size=1)
+        other.lengths = mx.array([1], dtype=mx.int8)
+        cache.extend(other)
+        self.assertEqual(cache.lengths.dtype, mx.int32)
+        cache.advance(128)
+        self.assertEqual(cache.lengths.tolist(), [-127, -127])
 
         # batch churn with the metadata never read must not accumulate
         # unevaluated gathers: filter/extend materialize the metadata.
@@ -1337,6 +1364,133 @@ class TestPromptCache(unittest.TestCase):
         self.assertTrue(all(not t.is_alive() for t in threads))
         self.assertEqual(results, [[4], [4]])
         self.assertEqual(cache._len_advance, 0)
+
+    def test_arrays_cache_alias_copy_state(self):
+        """Shallow aliases share pending state and their fold lock. A
+        deepcopy of an alias graph recreates that topology with an
+        independent array/lock group."""
+
+        def concurrent_property_reads(caches):
+            gate = threading.Barrier(3)
+            arrays = []
+            errors = []
+
+            def read(cache):
+                try:
+                    gate.wait()
+                    arrays.append(cache.lengths)
+                except Exception as e:
+                    errors.append(e)
+
+            threads = [
+                threading.Thread(target=read, args=(cache,), daemon=True)
+                for cache in caches
+            ]
+            for thread in threads:
+                thread.start()
+            gate.wait()
+            for thread in threads:
+                thread.join(timeout=60)
+            self.assertTrue(all(not thread.is_alive() for thread in threads))
+            self.assertEqual(errors, [])
+            mx.eval(*arrays)
+            self.assertEqual([array.tolist() for array in arrays], [[3], [3]])
+
+        cache = ArraysCache(size=1)
+        cache.lengths = mx.array([5])
+        aliases = [cache, copy.copy(cache)]
+        self.assertIs(aliases[0]._lengths, aliases[1]._lengths)
+        self.assertIs(aliases[0]._len_state, aliases[1]._len_state)
+        self.assertIs(aliases[0]._fold_lock, aliases[1]._fold_lock)
+        for alias in aliases:
+            alias.advance(1)
+        self.assertEqual(aliases[0]._len_advance, 2)
+        concurrent_property_reads(aliases)
+        self.assertEqual(aliases[0]._len_advance, 0)
+        self.assertEqual(aliases[1]._len_advance, 0)
+
+        cache = ArraysCache(size=1)
+        cache.lengths = mx.array([5])
+        original = [cache, copy.copy(cache)]
+        aliases = copy.deepcopy(original)
+        self.assertIs(aliases[0]._lengths, aliases[1]._lengths)
+        self.assertIs(aliases[0]._len_state, aliases[1]._len_state)
+        self.assertIs(aliases[0]._fold_lock, aliases[1]._fold_lock)
+        self.assertIsNot(aliases[0]._lengths, original[0]._lengths)
+        self.assertIsNot(aliases[0]._fold_lock, original[0]._fold_lock)
+        for alias in aliases:
+            alias.advance(1)
+        concurrent_property_reads(aliases)
+
+    def test_arrays_cache_pickle(self):
+        """The deferred state round-trips without trying to pickle a
+        native RLock, including the sharing topology of alias graphs."""
+        cache = ArraysCache(size=1)
+        cache.lengths = mx.array([5])
+        cache.advance(2)
+        restored = pickle.loads(pickle.dumps(cache))
+        self.assertEqual(restored._len_advance, 2)
+        self.assertEqual(restored.lengths.tolist(), [3])
+
+        cache = ArraysCache(size=1)
+        cache.lengths = mx.array([5])
+        aliases = [cache, copy.copy(cache)]
+        cache.advance(1)
+        restored = pickle.loads(pickle.dumps(aliases))
+        self.assertIs(restored[0]._lengths, restored[1]._lengths)
+        self.assertIs(restored[0]._len_state, restored[1]._len_state)
+        self.assertIs(restored[0]._fold_lock, restored[1]._fold_lock)
+        self.assertEqual(restored[0].lengths.tolist(), [4])
+        self.assertEqual(restored[1].lengths.tolist(), [4])
+
+    def test_arrays_cache_metadata_serialization_is_atomic(self):
+        """advance() cannot interleave between the two encoded fields."""
+        cache = ArraysCache(size=1, left_padding=[10])
+        cache.lengths = mx.array([20])
+        cache.advance(1)
+        left_folded = threading.Event()
+        resume = threading.Event()
+        advance_started = threading.Event()
+        advance_done = threading.Event()
+        serialized = []
+        errors = []
+        real_fold_left = cache._fold_lp
+
+        def pause_after_left_fold():
+            real_fold_left()
+            left_folded.set()
+            if not resume.wait(timeout=60):
+                raise TimeoutError("serialization test did not resume")
+
+        def serialize():
+            try:
+                serialized.append(cache.meta_state)
+            except Exception as e:
+                errors.append(e)
+
+        def advance():
+            advance_started.set()
+            cache.advance(1)
+            advance_done.set()
+
+        cache._fold_lp = pause_after_left_fold
+        save_thread = threading.Thread(target=serialize, daemon=True)
+        save_thread.start()
+        self.assertTrue(left_folded.wait(timeout=60))
+        advance_thread = threading.Thread(target=advance, daemon=True)
+        advance_thread.start()
+        self.assertTrue(advance_started.wait(timeout=60))
+        advance_done.wait(timeout=0.1)
+        resume.set()
+        save_thread.join(timeout=60)
+        advance_thread.join(timeout=60)
+
+        self.assertFalse(save_thread.is_alive())
+        self.assertFalse(advance_thread.is_alive())
+        self.assertEqual(errors, [])
+        self.assertEqual(serialized, [("int32:9", "int32:19")])
+        self.assertEqual(cache.left_padding.tolist(), [8])
+        self.assertEqual(cache.lengths.tolist(), [18])
 
     def test_arrays_cache_metadata_serialization(self):
         cache_file = os.path.join(self.test_dir, "arrays_cache_meta.safetensors")

--- a/tests/test_prompt_cache.py
+++ b/tests/test_prompt_cache.py
@@ -3,9 +3,11 @@
 import copy
 import os
 import tempfile
+import threading
 import unittest
 
 import mlx.core as mx
+import numpy as np
 
 from mlx_lm.generate import generate_step
 from mlx_lm.models.base import create_attention_mask, create_causal_mask
@@ -624,6 +626,8 @@ class TestPromptCache(unittest.TestCase):
         left_padding = mx.array([1, 2])
         for c, lc in zip(cache, loaded_cache):
             self.assertTrue(mx.array_equal(c.left_padding, left_padding))
+            # the loaded cache, not just the source, must carry the padding
+            self.assertTrue(mx.array_equal(lc.left_padding, left_padding))
 
     def test_rotating_cache_updates(self):
         cache = RotatingKVCache(max_size=8)
@@ -661,6 +665,758 @@ class TestPromptCache(unittest.TestCase):
         c2.update_and_fetch(kv, kv)
         c_out = KVCache.merge((c1, c2))
         self.assertEqual(c_out.keys.shape, (2, 4, 4, 4))
+
+    def test_arrays_cache_advance(self):
+        """advance() runs once per layer per decode token and must not
+        accumulate per-call graph state; these checks pin the arithmetic it
+        performs on left_padding/lengths and its interplay with the other
+        ArraysCache operations."""
+        cache = ArraysCache(size=1, left_padding=[2, 0])
+        cache[0] = mx.zeros((2, 4))
+        cache.advance(1)
+        self.assertEqual(cache.left_padding.tolist(), [1, -1])
+        mask = cache.make_mask(4)
+        expected = mx.arange(4)[None] >= mx.array([1, -1])[:, None]
+        self.assertTrue(mx.array_equal(mask, expected))
+        cache.advance(1)
+        cache.advance(1)
+        self.assertEqual(cache.left_padding.tolist(), [-1, -3])
+
+        # lengths-based mask after advancing
+        cache = ArraysCache(size=1)
+        cache.prepare(lengths=[5, 3])
+        cache.advance(2)
+        self.assertEqual(cache.lengths.tolist(), [3, 1])
+        mask = cache.make_mask(4)
+        expected = mx.arange(4)[None] < mx.array([3, 1])[:, None]
+        self.assertTrue(mx.array_equal(mask, expected))
+
+        # in-place item assignment through the properties must reach the
+        # real backing arrays even with a pending advance
+        cache = ArraysCache(size=1, left_padding=[2, 0])
+        cache.advance(1)
+        cache.left_padding[0] = 7
+        self.assertEqual(cache.left_padding.tolist(), [7, -1])
+        cache = ArraysCache(size=1)
+        cache.prepare(lengths=[5, 3])
+        cache.advance(2)
+        cache.lengths[1] = 9
+        self.assertEqual(cache.lengths.tolist(), [3, 9])
+
+        # the batch path arms left_padding even for all-empty merges
+        merged = ArraysCache.merge((ArraysCache(1), ArraysCache(1)))
+        self.assertEqual(merged.left_padding.tolist(), [0, 0])
+        merged[0] = mx.zeros((2, 4))
+        merged.advance(1)
+        merged.filter(mx.array([1]))
+        self.assertEqual(merged.left_padding.tolist(), [-1])
+
+        # extend after both sides have advanced by different amounts
+        a = ArraysCache(size=1, left_padding=[1])
+        b = ArraysCache(size=1, left_padding=[3])
+        a[0] = mx.zeros((1, 4))
+        b[0] = mx.zeros((1, 4))
+        a.advance(1)
+        b.advance(2)
+        a.extend(b)
+        self.assertEqual(a.left_padding.tolist(), [0, 1])
+
+        # repeated filter/extend churn with no intermediate reads (the
+        # continuous-batching pattern) must stay correct; the mutation
+        # methods materialize the metadata so batch churn also cannot
+        # accumulate an unevaluated graph
+        cache = ArraysCache(size=1, left_padding=[1, 2])
+        cache[0] = mx.zeros((2, 4))
+        for _ in range(50):
+            cache.advance(1)
+            other = ArraysCache(size=1, left_padding=[3])
+            other[0] = mx.zeros((1, 4))
+            cache.extend(other)
+            cache.filter(mx.array([0, 1]))
+        self.assertEqual(cache.left_padding.tolist(), [-49, -48])
+
+        # assigning one field must not lose the other's pending decrement
+        cache = ArraysCache(size=1, left_padding=[4])
+        cache.lengths = mx.array([6])
+        cache.advance(2)
+        cache.left_padding = mx.array([9])
+        self.assertEqual(cache.lengths.tolist(), [4])
+        self.assertEqual(cache.left_padding.tolist(), [9])
+
+        # finalize clears the state and advance becomes a no-op
+        cache.finalize()
+        self.assertIsNone(cache.left_padding)
+        self.assertIsNone(cache.lengths)
+        cache.advance(3)
+        self.assertIsNone(cache.left_padding)
+        self.assertIsNone(cache.make_mask(4))
+
+        # deferred visibility (documented deviation from the eager
+        # decrement): an alias shows the pre-advance value until the next
+        # read of that field folds it, then observes it -- same object
+        cache = ArraysCache(size=1, left_padding=[3])
+        alias = cache.left_padding
+        cache.advance(1)
+        self.assertEqual(alias.tolist(), [3])
+        self.assertEqual(cache.left_padding.tolist(), [2])
+        self.assertIs(cache.left_padding, alias)
+        self.assertEqual(alias.tolist(), [2])
+
+        # make_mask() also folds the field it uses, so aliases observe
+        # decrements after mask building too
+        cache = ArraysCache(size=1, left_padding=[3])
+        alias = cache.left_padding
+        cache.advance(1)
+        cache.make_mask(4)
+        self.assertEqual(alias.tolist(), [2])
+
+        # replacing a field with a pending decrement folds the outgoing
+        # array first, so earlier aliases still observe the decrement
+        cache = ArraysCache(size=1, left_padding=[3])
+        alias = cache.left_padding
+        cache.advance(1)
+        cache.left_padding = mx.array([9])
+        self.assertEqual(alias.tolist(), [2])
+        self.assertEqual(cache.left_padding.tolist(), [9])
+
+        # finalize() folds before clearing, with the same guarantee
+        cache = ArraysCache(size=1, left_padding=[3])
+        alias = cache.left_padding
+        cache.advance(1)
+        cache.finalize()
+        self.assertIsNone(cache.left_padding)
+        self.assertEqual(alias.tolist(), [2])
+
+        # storing one array object in both fields: each field applies its
+        # decrement at its own fold (documented deviation from stock's
+        # eager double decrement at advance() time)
+        shared = mx.array([5])
+        cache = ArraysCache(size=1)
+        cache.left_padding = shared
+        cache.lengths = shared
+        cache.advance(1)
+        self.assertEqual(cache.lengths.tolist(), [4])
+        self.assertEqual(cache.left_padding.tolist(), [3])
+
+        # White-box guards for the leak fix itself: advance() rejects
+        # mx.array and float offsets loudly (coercion would eval a lazy
+        # scalar, truncate floats, and accept non-scalars), and it must
+        # never rebind the stored arrays -- the per-call lazy rebind was
+        # the leak.
+        cache = ArraysCache(size=1, left_padding=[2, 0])
+        stored = cache._left_padding
+        for bad in (mx.array(1), mx.array([1]), mx.array([[1]]), 1.5):
+            with self.assertRaises(TypeError):
+                cache.advance(bad)
+        cache.advance(1)
+        cache.advance(1)
+        self.assertIsInstance(cache._lp_advance, int)
+        self.assertEqual(cache._lp_advance, 2)
+        self.assertIs(cache._left_padding, stored)
+        self.assertEqual(cache.left_padding.tolist(), [0, -2])
+
+        # validation is state-independent: unarmed and finalized caches
+        # reject the same arguments
+        for bad in (mx.array(1), mx.array([1]), 1.5):
+            with self.assertRaises(TypeError):
+                ArraysCache(size=1).advance(bad)
+        finalized = ArraysCache(size=1, left_padding=[1])
+        finalized.finalize()
+        with self.assertRaises(TypeError):
+            finalized.advance(mx.array(1))
+
+        # numpy integer scalars normalize through operator.index --
+        # value preserved (documented: stock's array-promotion dtype
+        # side effects for numpy offsets are not reproduced)
+        cache = ArraysCache(size=1, left_padding=[5])
+        cache.advance(np.int64(2))
+        cache.advance(np.uint8(1))
+        self.assertEqual(cache.left_padding.tolist(), [2])
+        self.assertIsInstance(cache._lp_advance, int)
+
+        # a discarded metadata read must not accumulate unevaluated folds:
+        # each fold is applied in place and scheduled for evaluation
+        # (regression: fold-on-read chained one 4-byte scalar per read)
+        cache = ArraysCache(size=1)
+        cache.prepare(lengths=[1])
+        cache.lengths
+        mx.synchronize()
+        base_mem = mx.get_active_memory()
+        for _ in range(2048):
+            cache.advance(1)
+            cache.lengths
+        mx.synchronize()
+        self.assertLess(mx.get_active_memory() - base_mem, 4096)
+
+        # discarded make_mask() results must not accumulate unevaluated
+        # folds either
+        cache = ArraysCache(size=1, left_padding=[0])
+        cache.make_mask(1)
+        mx.synchronize()
+        base_mem = mx.get_active_memory()
+        for _ in range(2048):
+            cache.advance(1)
+            cache.make_mask(1)
+        mx.synchronize()
+        self.assertLess(mx.get_active_memory() - base_mem, 4096)
+
+        # repeated public mutations must not accumulate unevaluated graph
+        # either: item assignment through the property and reassignment of
+        # lazy expressions are both scheduled for evaluation
+        cache = ArraysCache(size=1, left_padding=[0])
+        mx.synchronize()
+        base_mem = mx.get_active_memory()
+        for i in range(2048):
+            cache.left_padding[0] = i
+        mx.synchronize()
+        self.assertLess(mx.get_active_memory() - base_mem, 4096)
+        self.assertEqual(cache.left_padding.tolist(), [2047])
+
+        cache = ArraysCache(size=1, left_padding=[0])
+        mx.synchronize()
+        base_mem = mx.get_active_memory()
+        for _ in range(2048):
+            cache.left_padding = cache.left_padding - 1
+        mx.synchronize()
+        self.assertLess(mx.get_active_memory() - base_mem, 4096)
+        self.assertEqual(cache.left_padding.tolist(), [-2048])
+
+        # with both fields populated, consuming only one must not rebind
+        # the other's backing array (a rebind per read is an unbounded
+        # lazy chain when that field is never read)
+        cache = ArraysCache(size=1, left_padding=[2, 1])
+        cache.prepare(lengths=[5, 3])
+        stored = cache._left_padding
+        for _ in range(5):
+            cache.advance(1)
+            cache.lengths
+        self.assertIs(cache._left_padding, stored)
+        self.assertEqual(cache._lp_advance, 5)
+        self.assertEqual(cache.lengths.tolist(), [0, -2])
+        self.assertEqual(cache.left_padding.tolist(), [-3, -4])
+
+        # make_mask() straight after advance() (no property read in
+        # between) must apply the pending offset; it folds the field it
+        # uses in place (metadata-side subtraction, identical overflow
+        # behavior to stock) and leaves the other field's counter alone
+        cache = ArraysCache(size=1, left_padding=[2, 0])
+        stored = cache._left_padding
+        cache.advance(1)
+        mask = cache.make_mask(4)
+        self.assertEqual(cache._lp_advance, 0)
+        self.assertIs(cache._left_padding, stored)
+        expected = mx.arange(4)[None] >= mx.array([1, -1])[:, None]
+        self.assertTrue(mx.array_equal(mask, expected))
+
+        cache = ArraysCache(size=1)
+        cache.prepare(lengths=[5, 3])
+        cache.advance(2)
+        mask = cache.make_mask(4)
+        self.assertEqual(cache._len_advance, 0)
+        expected = mx.arange(4)[None] < mx.array([3, 1])[:, None]
+        self.assertTrue(mx.array_equal(mask, expected))
+
+        # integer totals that overflow the dtype fold to stock's modular
+        # result: sequential in-range subtractions wrap, and the deferred
+        # fold must land on the same value (regression: the raw coalesced
+        # total was rejected by MLX's scalar conversion)
+        cache = ArraysCache(size=1)
+        cache.left_padding = mx.array([0], dtype=mx.int32)
+        cache.advance(2**31 - 1)
+        cache.advance(1)
+        self.assertEqual(cache.left_padding.tolist(), [-(2**31)])
+
+        cache = ArraysCache(size=1)
+        cache.lengths = mx.array([0], dtype=mx.int64)
+        cache.advance(2**62)
+        cache.advance(2**62)
+        self.assertEqual(cache.lengths.tolist(), [-(2**63)])
+
+        # sub-32-bit metadata wraps by the same modular rule
+        cache = ArraysCache(size=1)
+        cache.lengths = mx.array([0], dtype=mx.int8)
+        for _ in range(3):
+            cache.advance(100)
+        self.assertEqual(cache.lengths.tolist(), [-44])
+
+        cache = ArraysCache(size=1)
+        cache.lengths = mx.array([5], dtype=mx.uint8)
+        cache.advance(200)
+        cache.advance(200)
+        self.assertEqual(cache.lengths.tolist(), [117])
+
+        # uint64 metadata: MLX converts python int scalars through
+        # int64, so stock accepts negatives (wrapping modulo 2**64) and
+        # rejects >= 2**63; the fold uses the congruent *signed*
+        # representative so accumulated totals stay convertible
+        cache = ArraysCache(size=1)
+        cache.lengths = mx.array([0], dtype=mx.uint64)
+        cache.advance(2**62)
+        cache.advance(2**62)
+        self.assertEqual(cache.lengths.tolist(), [2**63])
+        cache = ArraysCache(size=1)
+        cache.lengths = mx.array([1], dtype=mx.uint64)
+        cache.advance(-1)
+        self.assertEqual(cache.lengths.tolist(), [2])
+
+        # the int64 scalar gate applies to floating metadata too (stock
+        # rejects the python int before looking at the array dtype);
+        # accumulated floating totals beyond the gate fold in gate-sized
+        # chunks instead of failing the scalar conversion
+        cache = ArraysCache(size=1)
+        cache.lengths = mx.array([0.0], dtype=mx.float32)
+        cache.advance(2**62)
+        cache.advance(2**62)
+        self.assertEqual(cache.lengths.tolist(), [float(-(2**63))])
+
+        # a floating total spanning several gate-sized chunks folds to
+        # the deterministic chunked value
+        cache = ArraysCache(size=1)
+        cache.lengths = mx.array([0.0], dtype=mx.float32)
+        cache.advance(2**63 - 1)
+        cache.advance(2**63 - 1)
+        self.assertEqual(cache.lengths.tolist(), [float(-(2**64))])
+
+        # a many-chunk fold schedules each chunk as it applies -- the
+        # fold itself must not rebuild an unbounded unevaluated chain
+        cache = ArraysCache(size=1)
+        cache.lengths = mx.array([0.0], dtype=mx.float32)
+        cache.lengths
+        mx.synchronize()
+        base_mem = mx.get_active_memory()
+        for _ in range(2048):
+            cache.advance(2**63 - 1)
+        cache.lengths
+        mx.synchronize()
+        self.assertLess(mx.get_active_memory() - base_mem, 4096)
+
+        # offsets outside the dtype's scalar range raise at the
+        # advance() call, where stock's eager subtraction rejected them
+        # (uniformly ValueError here; stock's int64-gate rejection
+        # surfaced as an opaque std::bad_cast)
+        cache = ArraysCache(size=1)
+        cache.left_padding = mx.array([0], dtype=mx.int32)
+        with self.assertRaises(ValueError):
+            cache.advance(2**31)
+        with self.assertRaises(ValueError):
+            cache.advance(-(2**31) - 1)
+        cache = ArraysCache(size=1)
+        cache.lengths = mx.array([0], dtype=mx.uint16)
+        with self.assertRaises(ValueError):
+            cache.advance(-1)
+        cache = ArraysCache(size=1)
+        cache.lengths = mx.array([0], dtype=mx.uint64)
+        with self.assertRaises(ValueError):
+            cache.advance(2**63)
+        cache = ArraysCache(size=1)
+        cache.lengths = mx.array([0.0], dtype=mx.float32)
+        with self.assertRaises(ValueError):
+            cache.advance(2**63)
+
+        # the range check is per armed field in stock's field order: an
+        # offset valid for lengths but not for left_padding leaves the
+        # lengths decrement applied, exactly like stock's sequential
+        # eager subtractions did
+        cache = ArraysCache(size=1)
+        cache.lengths = mx.array([0], dtype=mx.int64)
+        cache.left_padding = mx.array([0], dtype=mx.int32)
+        with self.assertRaises(ValueError):
+            cache.advance(2**31)
+        self.assertEqual(cache.lengths.tolist(), [-(2**31)])
+        self.assertEqual(cache.left_padding.tolist(), [0])
+
+        # a shallow copy shares the backing arrays (as stock's does);
+        # folding before copying prevents the pending decrement from
+        # being applied once per object to the shared array
+        cache = ArraysCache(size=1)
+        cache.lengths = mx.array([5])
+        cache.advance(1)
+        cloned = copy.copy(cache)
+        self.assertEqual(cache.lengths.tolist(), [4])
+        self.assertEqual(cloned.lengths.tolist(), [4])
+        self.assertIs(cloned._lengths, cache._lengths)
+        # post-copy advances fold into the shared array at each object's
+        # own fold, so both eventually observe them (stock applied them
+        # eagerly to the same shared array)
+        cloned.advance(2)
+        self.assertEqual(cloned.lengths.tolist(), [2])
+        self.assertEqual(cache.lengths.tolist(), [2])
+
+        # deepcopy also folds first; the copy is an independent object
+        # with its own counters
+        cache = ArraysCache(size=1)
+        cache.lengths = mx.array([5])
+        cache.advance(1)
+        deep = copy.deepcopy(cache)
+        self.assertEqual(deep.lengths.tolist(), [4])
+        self.assertEqual(deep._len_advance, 0)
+        self.assertIsNot(deep._lengths, cache._lengths)
+        deep.advance(2)
+        self.assertEqual(deep.lengths.tolist(), [2])
+        self.assertEqual(cache.lengths.tolist(), [4])
+
+        # bool metadata -- which stock's arithmetic silently promotes to
+        # int32 -- keeps its dtype through zero-net advance histories
+        # (documented deviation); a nonzero net decrement promotes on
+        # fold at int32 precision with stock's values
+        cache = ArraysCache(size=1)
+        cache.left_padding = mx.array([True], dtype=mx.bool_)
+        cache.advance(0)
+        self.assertEqual(cache.left_padding.dtype, mx.bool_)
+        self.assertEqual(cache.left_padding.tolist(), [True])
+        cache.advance(2)
+        cache.advance(-1)
+        self.assertEqual(cache.left_padding.dtype, mx.int32)
+        self.assertEqual(cache.left_padding.tolist(), [0])
+
+        # bool offsets are normalized by operator.index (documented:
+        # stock's bool-scalar subtraction kept bool metadata bool)
+        cache = ArraysCache(size=1)
+        cache.left_padding = mx.array([False], dtype=mx.bool_)
+        cache.advance(True)
+        self.assertEqual(cache.left_padding.dtype, mx.int32)
+        self.assertEqual(cache.left_padding.tolist(), [-1])
+
+        # after the first advance() on bool metadata, later offsets
+        # validate against the promoted int32 dtype, exactly as stock's
+        # already-promoted stored array would
+        cache = ArraysCache(size=1)
+        cache.lengths = mx.array([True], dtype=mx.bool_)
+        cache.advance(1)
+        with self.assertRaises(ValueError):
+            cache.advance(2**31)
+        self.assertEqual(cache.lengths.tolist(), [0])
+
+        # ... including zero and cancelling histories: stock promoted
+        # the stored array on the first subtraction regardless of the
+        # offset's value
+        cache = ArraysCache(size=1)
+        cache.lengths = mx.array([True], dtype=mx.bool_)
+        cache.advance(1)
+        cache.advance(-1)
+        with self.assertRaises(ValueError):
+            cache.advance(2**31)
+        cache = ArraysCache(size=1)
+        cache.lengths = mx.array([True], dtype=mx.bool_)
+        cache.advance(0)
+        with self.assertRaises(ValueError):
+            cache.advance(2**31)
+
+        # assigning a fresh bool array resets the promotion (stock's new
+        # array had not been subtracted from yet); the first offset then
+        # passes only the int64 gate, as stock's bool conversion did
+        cache.lengths = mx.array([True], dtype=mx.bool_)
+        cache.advance(2**31)
+        self.assertEqual(cache.lengths.tolist(), [-2147483647])
+
+        # re-assigning the SAME backing array is not a reset: the flag is
+        # the only record of stock's physical promotion
+        cache = ArraysCache(size=1)
+        cache.lengths = mx.array([True], dtype=mx.bool_)
+        cache.advance(0)
+        cache.lengths = cache.lengths
+        with self.assertRaises(ValueError):
+            cache.advance(2**31)
+
+        # a bool array shared by both fields promotes both: stock's
+        # in-place promotion of the shared object made the second
+        # field's subtraction range-check as int32
+        shared = mx.array([True], dtype=mx.bool_)
+        cache = ArraysCache(size=1)
+        cache.left_padding = shared
+        cache.lengths = shared
+        with self.assertRaises(ValueError):
+            cache.advance(2**31)
+        self.assertEqual(cache._len_advance, 2**31)
+        self.assertEqual(cache._lp_advance, 0)
+
+        # batch churn with the metadata never read must not accumulate
+        # unevaluated gathers: filter/extend materialize the metadata.
+        # The state slots are consumed every forward pass (mx.eval below)
+        # but most layers' metadata never is
+        cache = ArraysCache(size=1, left_padding=[1, 2])
+        cache.prepare(lengths=[5, 6])
+        cache[0] = mx.zeros((2, 4))
+        mx.eval(cache[0], cache._left_padding, cache._lengths)
+        mx.synchronize()
+        base_mem = mx.get_active_memory()
+        for _ in range(1024):
+            cache.filter(mx.array([0, 1]))
+            mx.eval(cache[0])
+        mx.synchronize()
+        self.assertLess(mx.get_active_memory() - base_mem, 4096)
+
+    def test_arrays_cache_compile_captured_reads(self):
+        """mx.compile captures state by temporarily swapping tracers into
+        the captured containers; a metadata read during tracing must stay
+        pure -- no fold, no async_eval (disallowed on tracers), counters
+        intact -- exactly like stock's plain attribute access. The
+        captured array observes a pending decrement at the next eager
+        fold of the field (the documented deferred-visibility window)."""
+        cache = ArraysCache(size=1, left_padding=[4])
+        cache.advance(1)
+
+        def read(x):
+            return x + cache.left_padding
+
+        compiled = mx.compile(read, inputs=vars(cache))
+        out = compiled(mx.array([0]))
+        # the traced read did not fold: pending decrement intact, the
+        # pre-advance value used
+        self.assertEqual(out.tolist(), [4])
+        self.assertEqual(cache._lp_advance, 1)
+        # an eager fold lands the decrement in place; the compiled
+        # function reads the captured array's current value from then on
+        self.assertEqual(cache.left_padding.tolist(), [3])
+        self.assertEqual(compiled(mx.array([0])).tolist(), [3])
+
+        # make_mask inside a trace behaves the same way
+        cache = ArraysCache(size=1, left_padding=[1])
+        cache.advance(1)
+
+        def mask(x):
+            return cache.make_mask(x.shape[-1])
+
+        compiled = mx.compile(mask, inputs=vars(cache))
+        m = compiled(mx.zeros((1, 2)))
+        self.assertEqual(m.tolist(), [[False, True]])
+        self.assertEqual(cache._lp_advance, 1)
+        self.assertEqual(cache.left_padding.tolist(), [0])
+
+    def test_arrays_cache_closure_captured_reads(self):
+        """Purity during tracing applies only when the read encounters a
+        tracer (metadata swapped in by mx.compile(..., inputs=...)). A
+        closure-captured cache holds concrete arrays, so a read inside a
+        trace folds eagerly -- producing exactly the values stock's
+        eager decrement produced."""
+        cache = ArraysCache(size=1, left_padding=[4])
+        cache.advance(1)
+        out = mx.compile(lambda x: x + cache.left_padding)(mx.array([0]))
+        self.assertEqual(out.tolist(), [3])
+        self.assertEqual(cache._lp_advance, 0)
+        self.assertEqual(cache.left_padding.tolist(), [3])
+
+        cache = ArraysCache(size=1, left_padding=[4])
+        cache.advance(1)
+        out = mx.vmap(lambda x: x + cache.left_padding)(mx.zeros((2, 1)))
+        self.assertEqual(out.tolist(), [[3.0], [3.0]])
+        self.assertEqual(cache._lp_advance, 0)
+        self.assertEqual(cache.left_padding.tolist(), [3])
+
+    def test_arrays_cache_compiled_advance_not_recorded(self):
+        """Documented limitation: advance() is host-side bookkeeping and
+        runs at trace time only, so a compiled function that calls it
+        does not record the decrement in the traced graph -- call
+        advance() outside compiled functions. (Stock incidentally
+        recorded it as lazy graph arithmetic; that arithmetic is the
+        leak this class exists to avoid.) The trace-time call itself is
+        not lost: it stays pending and folds at the next eager read."""
+        cache = ArraysCache(size=1, left_padding=[5])
+
+        def step(x):
+            cache.advance(1)
+            return x + cache.left_padding
+
+        compiled = mx.compile(step, inputs=vars(cache), outputs=vars(cache))
+        outs = [compiled(mx.array([0])).item() for _ in range(3)]
+        self.assertEqual(outs, [5, 5, 5])
+        self.assertEqual(cache._lp_advance, 1)
+        self.assertEqual(cache.left_padding.tolist(), [4])
+
+    def test_arrays_cache_captured_mutation_guard(self):
+        """Replacing metadata inside a graph transformation while a
+        decrement is pending raises instead of silently discarding the
+        decrement (the fold cannot land in a tracer). Only the raise and
+        the preserved counter are asserted: an exception inside a traced
+        function leaves the captured containers mid-swap -- an MLX-level
+        property of compile, not specific to this class -- so the cache
+        is not usable afterwards."""
+        cache = ArraysCache(size=1, left_padding=[3])
+        cache.advance(1)
+
+        def replace(x):
+            cache.left_padding = x
+            return x
+
+        compiled = mx.compile(replace, inputs=vars(cache))
+        with self.assertRaises(RuntimeError):
+            compiled(mx.array([9]))
+        self.assertEqual(cache._lp_advance, 1)
+
+        # copy.copy and copy.deepcopy guard the same way: a copy taken
+        # mid-trace would escape holding the transient tracer
+        for copier in (copy.copy, copy.deepcopy):
+            cache = ArraysCache(size=1, left_padding=[3])
+            cache.advance(1)
+
+            def clone(x):
+                copier(cache)
+                return x
+
+            compiled = mx.compile(clone, inputs=vars(cache))
+            with self.assertRaises(RuntimeError):
+                compiled(mx.array([0]))
+            self.assertEqual(cache._lp_advance, 1)
+
+    def test_arrays_cache_captured_item_assignment(self):
+        """Documented window: in-place item assignment through a captured
+        tracer read cannot fold first (__setitem__ on the returned array
+        bypasses the property machinery and the mutation guard), so the
+        write lands before the deferred decrement -- the alias-write
+        window. Stock applied the decrement eagerly, so its assignment
+        landed after it."""
+        cache = ArraysCache(size=1, left_padding=[3])
+        cache.advance(1)
+
+        def mutate(x):
+            cache.left_padding[0] = x[0]
+            return cache.left_padding
+
+        compiled = mx.compile(mutate, inputs=vars(cache), outputs=vars(cache))
+        out = compiled(mx.array([9]))
+        self.assertEqual(out.tolist(), [9])
+        self.assertEqual(cache._lp_advance, 1)
+        self.assertEqual(cache.left_padding.tolist(), [8])  # stock: [9]
+
+    def test_arrays_cache_fold_failure_keeps_remainder(self):
+        """The fold counter commits chunk-by-chunk: a failure mid-fold
+        (injected into the intermediate scheduling call) leaves exactly
+        the unapplied remainder pending -- never double-applied, never
+        lost -- and a later fold completes it."""
+        cache = ArraysCache(size=1)
+        cache.lengths = mx.array([0.0], dtype=mx.float32)
+        for _ in range(3):
+            cache.advance(2**63 - 1)
+
+        real_async_eval = mx.async_eval
+        calls = [0]
+
+        def fail_second(*args):
+            calls[0] += 1
+            if calls[0] == 2:
+                raise RuntimeError("injected scheduling failure")
+            return real_async_eval(*args)
+
+        mx.async_eval = fail_second
+        try:
+            with self.assertRaises(RuntimeError):
+                cache.lengths
+        finally:
+            mx.async_eval = real_async_eval
+        # one chunk committed, two remain pending
+        self.assertEqual(cache._len_advance, 2 * (2**63 - 1))
+        # the next fold applies exactly the remainder
+        self.assertEqual(cache.lengths.tolist(), [float(-(3 * 2**63))])
+        self.assertEqual(cache._len_advance, 0)
+
+    def test_arrays_cache_concurrent_reads(self):
+        """Stock reads were pure attribute access and therefore trivially
+        safe from multiple threads; deferred folding makes reads mutate,
+        so the fold machinery is serialized per cache (unserialized
+        concurrent folds of one array deadlock on their thread-local
+        streams). Two concurrent readers racing one pending decrement
+        must both complete and observe the folded value exactly once."""
+        cache = ArraysCache(size=1)
+        cache.lengths = mx.array([5])
+        mx.eval(cache.lengths)
+        cache.advance(1)
+
+        results = []
+        gate = threading.Barrier(3)
+
+        def read():
+            gate.wait()
+            results.append(cache.lengths.tolist())
+
+        threads = [threading.Thread(target=read, daemon=True) for _ in range(2)]
+        for t in threads:
+            t.start()
+        gate.wait()
+        for t in threads:
+            t.join(timeout=60)
+        self.assertTrue(all(not t.is_alive() for t in threads))
+        self.assertEqual(results, [[4], [4]])
+        self.assertEqual(cache._len_advance, 0)
+
+    def test_arrays_cache_metadata_serialization(self):
+        cache_file = os.path.join(self.test_dir, "arrays_cache_meta.safetensors")
+
+        # metadata round-trips, folding pending advances at save time
+        cache = ArraysCache(size=1, left_padding=[3, 1])
+        cache[0] = mx.zeros((2, 2))
+        cache.prepare(lengths=[5, 4])
+        cache.advance(2)
+        save_prompt_cache(cache_file, [cache])
+        loaded = load_prompt_cache(cache_file)[0]
+        self.assertEqual(loaded.left_padding.tolist(), [1, -1])
+        self.assertEqual(loaded.lengths.tolist(), [3, 2])
+        mask = loaded.make_mask(4)
+        expected = mx.arange(4)[None] >= mx.array([1, -1])[:, None]
+        self.assertTrue(mx.array_equal(mask, expected))
+
+        # absent fields stay absent through a round trip
+        cache = ArraysCache(size=1)
+        cache[0] = mx.zeros((1, 2))
+        save_prompt_cache(cache_file, [cache])
+        loaded = load_prompt_cache(cache_file)[0]
+        self.assertIsNone(loaded.left_padding)
+        self.assertIsNone(loaded.lengths)
+
+        # dtype survives the round trip
+        cache = ArraysCache(size=1)
+        cache[0] = mx.zeros((1, 2))
+        cache.lengths = mx.array([5], dtype=mx.int64)
+        save_prompt_cache(cache_file, [cache])
+        loaded = load_prompt_cache(cache_file)[0]
+        self.assertEqual(loaded.lengths.dtype, mx.int64)
+        self.assertEqual(loaded.lengths.tolist(), [5])
+
+        # the codec keeps an empty metadata array distinct from an absent
+        # field (zero-row caches cannot go through save_prompt_cache --
+        # safetensors rejects empty state arrays -- so this is pinned at
+        # the meta_state level)
+        cache = ArraysCache(size=1, left_padding=[1])
+        cache[0] = mx.zeros((1, 2))
+        cache.filter(mx.array([], dtype=mx.int32))
+        restored = ArraysCache(size=1)
+        restored.meta_state = cache.meta_state
+        self.assertIsNotNone(restored.left_padding)
+        self.assertEqual(restored.left_padding.size, 0)
+        self.assertIsNone(restored.lengths)
+
+        # float metadata round-trips through the codec
+        cache = ArraysCache(size=1)
+        cache.lengths = mx.array([2.5], dtype=mx.float32)
+        restored = ArraysCache(size=1)
+        restored.meta_state = cache.meta_state
+        self.assertEqual(restored.lengths.dtype, mx.float32)
+        self.assertEqual(restored.lengths.tolist(), [2.5])
+
+        # malformed or truncated entries raise instead of loading as
+        # empty metadata; dtype names are whitelisted
+        restored = ArraysCache(size=1)
+        for bad in (("int32", ""), ("nosuchdtype:1", ""), ("eval:1", "")):
+            with self.assertRaises(ValueError):
+                restored.meta_state = bad
+
+        # non-numeric metadata dtypes fail loudly at save time
+        cache = ArraysCache(size=1)
+        cache.lengths = mx.array([True], dtype=mx.bool_)
+        with self.assertRaises(TypeError):
+            cache.meta_state
+
+        # non-1-D metadata fails loudly at save time too, rather than
+        # emitting an entry the decoder cannot parse (a 0-d filter index
+        # is the public route to scalar metadata)
+        cache = ArraysCache(size=1, left_padding=[1])
+        cache[0] = mx.zeros((1, 2))
+        cache.filter(mx.array(0))
+        with self.assertRaises(ValueError):
+            cache.meta_state
+        cache = ArraysCache(size=1)
+        cache.lengths = mx.array([[1, 2]])
+        with self.assertRaises(ValueError):
+            cache.meta_state
 
     def test_extend_with_empty_and_nonempty_batch_caches(self):
         """Extending a batch cache when one side has keys=None should use the


### PR DESCRIPTION
Closes #1641. Related crash reports share the error signature but likely not this exact site: #1332's DeepSeek-V4 path implicates `PoolingCache`/`RotatingKVCache` rather than `ArraysCache` (a sibling instance of the same lazy-metadata pattern, if so — not fixed here), and #1185 / #831 / ml-explore/mlx#3564 / ml-explore/mlx#3539 are triaged in the issue.

## What was happening

`advance()` decremented `left_padding`/`lengths` with lazy mx.array arithmetic once per GatedDeltaNet layer per decoded token. Only `cache[ssm_idx]` ever has its mask rebuilt, so for every other SSM layer the resulting graph chain is dead — never evaluated, never detached — and each node pins a live 4-byte Metal buffer object. That's (#SSM layers − 1) objects per decode token; the Metal allocator counts objects (not bytes) against the per-process resource limit, so any single completion over ~499000/(#SSM−1) tokens (~14.1k on Qwen3.5-122B, 36 SSM layers) kills the process with `[metal::malloc] Resource limit (499000) exceeded`. Byte telemetry stays flat and `mx.clear_cache()` can't help. Full mechanism, file:line walkthrough, and an 84-second no-download repro are in #1641.

## The fix (commit 1)

Track the cumulative `advance()` decrement as a Python int **per metadata field** (`_lp_advance`/`_len_advance`), folded into the stored array when that field is read (property access or `make_mask`), replaced, or finalized — so a workload where both fields coexist (uneven batched prefill) but only one is consumed cannot chain nodes onto the unread one. Folds are applied **in place** (`-=`, preserving the array object) **on the metadata side** and scheduled with `mx.async_eval`, so no public operation sequence — discarded reads, discarded masks, repeated item assignment, repeated lazy reassignment, batch churn — accumulates unevaluated graph on metadata nothing consumes, and nothing blocks on the generation stream. `advance()` itself creates zero graph nodes and evaluates nothing; it validates its argument **unconditionally** (regardless of whether metadata is set): `mx.array` offsets raise `TypeError` (silently coercing one would force an eval and accept size-1 non-scalars) and `operator.index` rejects floats (stock silently float-drifted the metadata). Offsets outside the scalar range MLX accepts for the metadata dtype raise `ValueError` at `advance()`, per armed field in stock's field order — exactly where stock's eager subtraction rejected them. The check mirrors MLX's conversion precisely (python int scalars convert through int64, per `python/src/utils.cpp`): the int64 gate applies to *every* dtype including floating, integer dtypes narrower than 64 bits are range-checked besides, and uint64 accepts negatives, which wrap modulo 2^64 (stock's gate rejections surfaced as an opaque `std::bad_cast`; here it is uniformly `ValueError`).

**Arithmetic scope:** deferred totals fold as the dtype-congruent scalar. Sequential wrapping subtractions equal one subtraction of the sum modulo 2^bits, so integer metadata folds to exactly stock's per-step value — including totals that overflow the dtype, where stock's sequential in-range subtractions wrap; uint64 uses the congruent *signed* representative, since that is what the int64 conversion accepts. Floating totals that exceed the int64 gate (individually valid offsets can sum past it) fold in gate-sized chunks rather than failing the scalar conversion, each chunk scheduled as it is applied so a many-chunk fold cannot itself build an unbounded chain; per-step float *rounding* is not reproduced — a dtype nothing in the pipeline produces; documented in the class note. Fold counters commit chunk-by-chunk, before each subtraction: a decrement is never applied twice, and a failure mid-fold leaves the unapplied remainder pending except for at most the single in-flight chunk (an asynchronous interrupt between counter commit and subtraction drops it).

`filter()`/`extend()` additionally schedule materialization of the metadata after mutating it (`mx.async_eval`, so batch reorganization never waits behind a queued forward pass). Each successful `extend()` field concatenation commits its replacement array and fresh bookkeeping together: if a later field fails, the earlier stock-compatible partial mutation stays coherent instead of retaining a shallow alias's old counter. These operations run once per batch composition change, and their lazy gather/concat nodes are the same dead-chain pattern at per-request rate (present upstream too): on a long-lived server under continuous batching, request churn would otherwise still grow an unevaluated chain for every layer whose metadata the mask path never reads.

**Documented deviations from the eager decrement** (deferred visibility; nothing in this repo relies on the old timing): a decrement becomes visible to aliases of a metadata array at the *next fold of that field* — property access, `make_mask`, replacement, or `finalize()` (the latter two fold the outgoing array first, so a decrement is never silently discarded) — rather than at `advance()` time. An alias inspected before any fold shows the pre-advance value, alias reads/writes before the fold interleave accordingly, and one array object stored in both fields applies each field's decrement at its own fold. The stale-until-fold sequence, fold-through-`make_mask`, fold-on-replacement, fold-on-finalize, and the shared-object case are each pinned by tests as documented behavior.

Further documented deviations and limitations, all pinned by tests:

- A read that encounters a **tracer** — metadata swapped into a trace by `mx.compile(..., inputs=vars(cache))` — is pure: no fold, no scheduling (`async_eval` is disallowed on tracers), matching stock's plain attribute read; the pending decrement folds at the next *eager* access, after which the captured array shows it. Without this, a captured read would raise mid-trace and could lose a pending decrement on the error path. A **closure-captured** cache holds concrete arrays during tracing (`mx.compile` without `inputs=`, `mx.vmap`), so those reads fold eagerly — producing exactly the values stock's eager decrement produced.
- Compiling a function that **calls `advance()`** is not supported: the decrement is host-side bookkeeping and runs at trace time only, so the compiled graph contains no subtraction (the trace-time call is not lost — it stays pending and folds at the next eager read). Stock incidentally supported this because its decrement was lazy graph arithmetic — the same arithmetic that leaks. Call `advance()` outside compiled functions.
- **Mutating** captured metadata (assignment, `finalize`, `filter`, `extend`) while a pending decrement cannot fold — the field is a tracer — raises `RuntimeError` rather than silently discarding the decrement; the never-silently-discarded guarantee holds. This guard cannot fire on eager paths, where folds always land. One mutation cannot be intercepted: **in-place item assignment** through a captured tracer read (`__setitem__` on the returned array bypasses the property machinery) — it falls into the documented alias-write window, the write landing before the deferred decrement where stock's eager decrement landed first; pinned by a test.
- `copy.copy` and `copy.deepcopy` fold before copying. A shallow copy shares the backing arrays, reentrant cache lock, pending counters, per-array fold lock, and bool-promotion record; this is one alias group, so either object folds a shared field's total exactly once. A standalone deep copy gets independent arrays, bookkeeping, and locks. When an entire shallow-alias graph is deep-copied together, Python's shared memo preserves the copied array aliases and their copied bookkeeping/lock topology. Reconstruction follows Python's reduction protocol rather than copying only `__dict__`, so state in subclass `__slots__` is preserved too. If the fold cannot land (captured tracer, decrement pending), both copiers raise like the other guarded mutations — a copy taken mid-trace would otherwise escape holding the transient tracer and fail on any later use.
- **Reads serialize per cache alias group and per backing-array identity**: stock's pure attribute reads were trivially thread-safe, while deferred folding makes reads mutate. A pickleable reentrant cache lock guards advance bookkeeping and a weak identity registry associates a second reentrant lock with each live metadata array, so two independently constructed caches whose public setters receive the same array cannot fold it concurrently on different thread-local streams. `meta_state`/`save_prompt_cache` acquire the relevant locks for a complete linearizable two-field snapshot. Generic pickle preserves array/state/lock alias topology only for a **quiescent source graph**; concurrent generic pickle is explicitly unsupported because the outer Pickler traversal continues after any owning-object reducer hook returns. Cross-thread *mutation* (`filter`/`extend`/`finalize` racing anything) remains unsupported, as in stock. The registry holds arrays weakly; a 2,000-array retention probe returned exactly to its zero baseline.
- bool metadata arithmetic is reproduced at **int32 precision** (stock's promotion): the dtype stays bool through zero-net advance histories, but validation tracks stock's promotion faithfully — after the *first* `advance()` on a bool field (even a zero or cancelling one, through a bool array shared by both fields, through a shallow cache alias, or through independently constructed caches assigned the same array), later offsets validate against int32 exactly as stock's already-promoted stored array would; assigning a genuinely new array resets the tracking (re-assigning the same backing object does not — the flag is the only record of stock's physical promotion). `extend()` materializes this logical promotion before concatenation, so a promoted bool field combined with a narrow integer remains int32 like stock rather than being narrowed by dtype promotion. Offsets are normalized by `operator.index` (python bool and numpy integer scalars become python ints, value preserved) — stock's array-promotion side effects for exotic offset types (a bool offset keeping bool metadata bool; numpy scalar offsets promoting the metadata dtype) are not reproduced.

## Serialization fix (commit 2, pre-existing bug)

`ArraysCache.state` serializes only the state slots, so `save_prompt_cache` silently dropped `left_padding`/`lengths` — a loaded cache had `None` metadata and `make_mask()` returned `None`. (`BatchKVCache`/`BatchRotatingKVCache` already round-trip `left_padding` via `state`.) Metadata now round-trips through `meta_state` as `<dtype>:<comma-joined values>` with `""` for absent fields, folding any pending decrement at save time. Decoding is strict: the delimiter is required and the dtype must come from an explicit numeric whitelist with per-dtype value parsing, so truncated or malformed file metadata raises instead of silently loading as empty metadata. Unsupported physical metadata dtypes (bool, complex) fail loudly at save — including a logically promoted bool whose zero-net history intentionally leaves the physical dtype bool — as does non-1-D metadata (a 0-d `filter` index is the public route to a scalar field), rather than emitting an entry the decoder cannot parse. The encoding keeps an empty metadata array distinct from an absent field, though a zero-row cache cannot pass through `save_prompt_cache` at all — safetensors rejects empty state arrays — so that distinction is pinned at the codec level. Files written before this change carry an empty `meta_state` entry and load unchanged. The existing batch-cache serialization test asserted on the *source* cache rather than the loaded one, which is why this never surfaced — the test now checks both.

## Measurements (advance-only build; see validation status below)

Measured on Qwen3.5-122B-A10B-6bit, M5 Max 128 GB, macOS 26.5.2, mlx 0.32.0:

| | stock 0.31.3 | measured fix build |
|---|---|---|
| live-object slope inside a request | +35.001 / decode token | **+0.000** (zero size-class drift) |
| single 16.5k-token completion | crash at 14,179 tokens | **survives, 2,725 objects total, flat** |
| greedy decode vs stock | — | **token-identical (64/64)** |
| tiny-model endurance, 205k decode tokens | (crashes at ~10.3k) | **flat** (+0.007/tok, KV-block noise) |

**Validation status, stated precisely:** the 122B Metal measurements above were taken with the initial integer-bookkeeping implementation of the `advance()` fix — the mechanism this PR is built on and the dominant leak — and remain historical measurements of that build. The complete PR tip `985af30` has now been executed on Metal after the final alias/copy/partial-extend hardening: `test_prompt_cache.py` **37/37** on Metal and with `DEVICE=cpu`; the companion MLX probe tip `cb83965c` has `test_memory.py` **4/4**, `test_zero_copy.py` **7/7**, and full Python discovery at **790 passed / 45 skipped**. The independently assigned shared-array race passed **200/200** Metal trials; another **200/200** stress with two caches swapping the same arrays between fields produced only linearizable `3/3` and `4/4` snapshots. Bool promotion propagated across independent caches; multi-level subclass slot copy/deepcopy, failed-extend detachment, quiescent pickle protocols 2–5, pre-array-lock pickle state, and independent-array-alias pickle topology passed. (MLX array pickling itself rejects protocols 0–1.) A 2,000-array registry-retention probe returned from 2,000 entries exactly to zero. Full mlx-lm discovery ran 200 tests: 9 persistent failures previously reproduced on exact base, 3 missing-optional-dependency errors (`datasets`, `lm_eval`, `requests`), and 1 skip. A fresh 1,000-token/49-SSM `BatchGenerator` run was flat at **+0.000 live buffers/token** and 106 tok/s. The earlier 10,000 discarded reads, 10,000 discarded masks, 2,000 filter-churn iterations, 2,048-chunk float fold, and 12,800 randomized integer comparisons remain applicable. Slopes were measured with the allocator count probes proposed in ml-explore/mlx#3942 (the API requested in #1185); the repro script in #1641 reproduces the crash on stock pip installs in 84 s.

## Tests (commits 3–5)

- `test_arrays_cache_advance` (no Metal required; runs on whatever device CI selects): semantics-equivalence guards — property values, `make_mask`, all-empty `merge` (the server path that arms the leak), `filter`/`extend` with pending advances on both sides, repeated filter/extend churn with no intermediate reads (the continuous-batching pattern), field assignment, in-place item assignment with a pending advance, `finalize` — plus the pinned deferred-visibility semantics (stale-until-fold, fold via read/`make_mask`/replacement/`finalize`, shared-object folding) and white-box guards: per-field counters stay Python ints, `advance()` raises `TypeError` for mx.array/float offsets on armed, unarmed, and finalized caches alike, `advance()` never rebinds the stored arrays, `make_mask()` folds only the field it uses, consuming one metadata field never touches the other, and 2048-iteration loops of discarded reads, discarded masks, item assignment, and lazy reassignment each stay within a 4 KB active-memory bound instead of chaining. Dtype boundary cases pin the congruent fold against stock's values (int32 `2**31-1` + `1` → `INT32_MIN`, int64 `2**62` twice → `INT64_MIN`, int8/uint8 wraparound, uint64 totals crossing `2**63` and negative offsets wrapping modulo 2^64, floating totals past the int64 gate folding chunked to deterministic values, a 2048-chunk fold staying within the 4 KB memory bound) and the per-field range validation (out-of-range offsets raise `ValueError` for every dtype class incl. uint64, float, and bool-after-first-advance validating as int32 — through zero and cancelling histories, reset by fresh assignment, propagated across a shared bool array and shallow alias, and materialized before mixed-dtype extension; an offset valid for one field but not the other leaves the first field's decrement applied, in stock's order). Shallow-copy semantics (fold-before-copy, shared backing array/bookkeeping, post-copy advances visible to both objects) and the bool-metadata deviations (zero-net dtype preservation, `advance(True)` normalization, int32-precision folds) are pinned. A 1024-iteration `filter` churn loop with the state consumed every pass but the metadata never read stays within the same 4 KB bound — it fails if the materialization in `filter`/`extend` is removed, which the value-equivalence churn test alone would not catch.
- `test_arrays_cache_compile_captured_reads`: `mx.compile` with `inputs=vars(cache)` — a property read and a `make_mask` during tracing stay pure (no raise, counters intact, stale value used), and the captured array observes the decrement after the next eager fold.
- `test_arrays_cache_closure_captured_reads`: closure-captured reads inside `mx.compile` (no `inputs=`) and `mx.vmap` fold eagerly with stock-identical values.
- `test_arrays_cache_compiled_advance_not_recorded`: pins the documented limitation — a compiled function calling `advance()` records no decrement in the traced graph; the trace-time call stays pending and folds at the next eager read.
- `test_arrays_cache_captured_mutation_guard`: replacing — or `copy.copy`-ing — captured metadata during tracing with a decrement pending raises `RuntimeError` and preserves the counter (mid-trace exceptions leave compile's captured containers mid-swap — an MLX-level property — so only the raise and counter are asserted).
- `test_arrays_cache_captured_item_assignment`: pins the documented alias-write window — an item write through a captured tracer read lands before the deferred decrement.
- `test_arrays_cache_fold_failure_keeps_remainder`: injects a scheduling failure mid-fold and asserts the counter holds exactly the unapplied remainder, which the next fold completes.
- `test_arrays_cache_concurrent_reads`: two threads racing one pending decrement both complete (bounded joins) and observe the folded value exactly once — the unserialized fold deadlocked here.
- `test_arrays_cache_alias_copy_state`: shallow aliases share the backing array, lock, counter, and promotion state; concurrent property reads fold their combined advances once. Deep-copying a shallow-alias graph preserves the copied array/lock/state topology while remaining independent from the original graph.
- `test_arrays_cache_external_array_alias_state`: independently constructed caches assigned the same metadata array retain separate pending counters/cache locks but share the backing-array fold lock and bool-promotion record; concurrent reads complete with one fold per counter. The same topology is checked after quiescent pickle.
- `test_arrays_cache_subclass_slot_copy`: shallow and deep copies retain subclass slot state while preserving their expected shared/independent array topology.
- `test_arrays_cache_failed_extend_detaches_state`: when the `left_padding` concatenation succeeds and the `lengths` concatenation fails, the committed first field has fresh state; a shallow alias cannot consume the target's later decrement.
- `test_arrays_cache_pickle`: populated cache state and pending counters round-trip through a pickleable lock; an entire shallow-alias graph retains one copied array/lock/state group across protocols 2–5. The test explicitly records that concurrent generic pickle is outside the supported contract.
- `test_arrays_cache_metadata_serialization_is_atomic`: an event-controlled interleaving pauses after folding `left_padding`, races `advance()`, and proves the serialized pair is a linearizable `9/19`, never the torn `9/18`.
- Eager standalone `copy.deepcopy` (folds first, independent counters/arrays/lock), self-assignment preserving the bool-promotion record, and numpy integer-scalar offset normalization are pinned in `test_arrays_cache_advance`.
- `test_arrays_cache_metadata_serialization`: save/load round-trip with pending folds; absent fields and dtype preservation; codec-level round-trip keeping empty (zero-row) metadata distinct from absent; strict decoding (malformed or non-whitelisted entries raise; non-numeric dtypes rejected at save; scalar metadata from a 0-d `filter` index and 2-D metadata rejected at save); mask reconstruction on the loaded cache; the existing batch serialization test now asserts on the loaded cache.
- `pre-commit` (black 25.1.0, isort) clean.
