### PR TITLE
fix(tool_parsers/mistral): parse the classic [TOOL_CALLS] JSON-array format

### DIFF
--- a/mlx_lm/tool_parsers/mistral.py
+++ b/mlx_lm/tool_parsers/mistral.py
@@ -11,10 +11,39 @@ tool_call_start = "[TOOL_CALLS]"
 tool_call_end = ""
 
 
+def _parse_json_array(text: str):
+    """Parse the classic ``[TOOL_CALLS][{"name": ..., "arguments": {...}}]``
+    payload emitted by Mistral Nemo, Mistral Small 2409, Ministral and
+    Mixtral v0.3.  Returns ``None`` if ``text`` is not such an array."""
+    text = text.strip()
+    if not text.startswith("["):
+        return None
+    try:
+        calls = json.loads(text)
+    except json.JSONDecodeError:
+        return None
+    if not isinstance(calls, list) or not calls:
+        return None
+    if not all(isinstance(c, dict) and isinstance(c.get("name"), str) for c in calls):
+        return None
+    parsed = []
+    for call in calls:
+        tool_call = dict(name=call["name"], arguments=call.get("arguments") or {})
+        # Preserve the model's own call id so the follow-up ``tool`` message
+        # can be matched back to this call.
+        if isinstance(call.get("id"), str):
+            tool_call["id"] = call["id"]
+        parsed.append(tool_call)
+    return parsed
+
+
 def parse_tool_call(text: str, tools: Any | None = None):
     match = _tool_call_regex.search(text)
-    if match is None:
-        raise ValueError(f"Could not parse tool call from: {text}")
-    func_name = match.group(1)
-    func_args = json.loads(match.group(2))
-    return dict(name=func_name, arguments=func_args)
+    if match is not None:
+        func_name = match.group(1)
+        func_args = json.loads(match.group(2))
+        return dict(name=func_name, arguments=func_args)
+    parsed = _parse_json_array(text)
+    if parsed is not None:
+        return parsed
+    raise ValueError(f"Could not parse tool call from: {text}")

--- a/tests/test_tool_parsing.py
+++ b/tests/test_tool_parsing.py
@@ -329,6 +329,28 @@ class TestToolParsing(unittest.TestCase):
         tool_calls = minimax_m2.parse_tool_call(test_case, None)
         self.assertEqual(expected, tool_calls)
 
+    def test_mistral_json_array(self):
+        # Mistral Nemo, Mistral Small 2409, Ministral and Mixtral v0.3 emit a
+        # JSON array after "[TOOL_CALLS]" rather than the "name[ARGS]{...}"
+        # form used by Mistral 3 / Magistral / Devstral.
+        test_case = (
+            ' [{"name": "search", "arguments": {"query": "weather"}, "id": "abcdefghi"}, '
+            '{"name": "read_file", "arguments": {"path": "/tmp/test.txt"}}]'
+        )
+        expected = [
+            {"name": "search", "arguments": {"query": "weather"}, "id": "abcdefghi"},
+            {"name": "read_file", "arguments": {"path": "/tmp/test.txt"}},
+        ]
+        self.assertEqual(expected, mistral.parse_tool_call(test_case, None))
+
+    def test_mistral_rejects_unparseable(self):
+        for test_case in (
+            '[{"name": "read_file", "arguments": {"pa',  # truncated
+            "I will call the read_file tool.",  # plain prose
+        ):
+            with self.assertRaises(ValueError):
+                mistral.parse_tool_call(test_case, None)
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
### Problem

`mlx_lm/tool_parsers/mistral.py` only understands one of the two tool-call formats that Mistral models emit:

```python
_tool_call_regex = re.compile(r"\s*(\w+)\[ARGS\]\s*(\{.*\})", re.DOTALL)
```

That `name[ARGS]{...}` form is what **Mistral 3 / Magistral / Devstral** produce. The classic Mistral tool-call format — still used by **Mistral Nemo, Mistral Small 2409, Ministral and Mixtral v0.3** — is a JSON *array* right after the same `[TOOL_CALLS]` marker:

```
[TOOL_CALLS][{"name": "read_file", "arguments": {"path": "/tmp/test.txt"}, "id": "abcdefghi"}]
```

Both families are routed to this parser, because `_infer_tool_parser` keys off the shared marker:

https://github.com/ml-explore/mlx-lm/blob/main/mlx_lm/tokenizer_utils.py#L569-L570

Confirmed against the published templates — neither contains `[ARGS]`:

| model | `[TOOL_CALLS]` | `[ARGS]` | emitted form |
|---|---|---|---|
| `mistralai/Mistral-Nemo-Instruct-2407` | 1 | 0 | `[TOOL_CALLS][` + `tool_call.function\|tojson` |
| `mistralai/Mistral-Small-Instruct-2409` | 1 | 0 | `[TOOL_CALLS] [` + `tool_call.function\|tojson` |

So on those models the regex never matches, `parse_tool_call` raises `ValueError`, and `ToolCallFormatter.__call__` swallows it:

https://github.com/ml-explore/mlx-lm/blob/main/mlx_lm/server.py#L78-L86

The client gets a `200` whose `tool_calls` is `[]` — while `finish_reason` is still flipped to `"tool_calls"` — with the only diagnostic being a server-side "likely truncated mid-generation" warning that misattributes the cause.

### Fix

Fall back to parsing the JSON array when the `[ARGS]` regex does not match. The existing path is untouched, the model's own call `id` is preserved so the follow-up `tool` message can be matched back, and genuinely malformed text still raises `ValueError` so the truncation warning keeps working.

### Verification

`python -m unittest tests.test_tool_parsing -v` → 7 passed (5 existing + 2 new).

Old vs. new, same inputs:

| input | before | after |
|---|---|---|
| `multiply[ARGS]{"a": 1}` | parsed | parsed (unchanged) |
| `[{"name": "read_file", "arguments": {...}, "id": "abc"}]` | `ValueError` | parsed, id kept |
| two calls in one array | `ValueError` | both parsed |
| leading space before `[` (Small 2409) | `ValueError` | parsed |
| `{"arguments": {}}` no-arg call | `ValueError` | parsed |
| truncated mid-generation | `ValueError` | `ValueError` (unchanged) |
| plain prose | `ValueError` | `ValueError` (unchanged) |

### Note on #1639

While diagnosing this I checked the model in that report, `lmstudio-community/Mistral-Small-3.2-24B-Instruct-2506-MLX-8bit`. Its `chat_template.jinja` has **no** tool support at all — no `[AVAILABLE_TOOLS]`, no `[TOOL_CALLS]`, no `tool` role, and it raises on any role other than user/system/assistant. So `tools` are silently dropped before the model ever sees them, which is why it replies in prose; that one is a conversion-side problem, not mlx-lm. This PR fixes the adjacent mlx-lm-side gap that the same investigation turned up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
