### PR TITLE
Fix divide-by-zero in BatchGenerator.stats()

### DIFF
--- a/mlx_lm/generate.py
+++ b/mlx_lm/generate.py
@@ -1654,10 +1654,16 @@ class BatchGenerator:
             gen_time = total_time - self._prompt_time_counter
             stats.prompt_tokens += self._prompt_tokens_counter
             stats.prompt_time += self._prompt_time_counter
-            stats.prompt_tps = stats.prompt_tokens / stats.prompt_time
+            stats.prompt_tps = (
+                stats.prompt_tokens / stats.prompt_time if stats.prompt_time else 0.0
+            )
             stats.generation_tokens += self._gen_tokens_counter
             stats.generation_time += gen_time
-            stats.generation_tps = stats.generation_tokens / stats.generation_time
+            stats.generation_tps = (
+                stats.generation_tokens / stats.generation_time
+                if stats.generation_time
+                else 0.0
+            )
             stats.peak_memory = max(stats.peak_memory, mx.get_peak_memory() / 1e9)
 
     def insert(

--- a/tests/test_generate.py
+++ b/tests/test_generate.py
@@ -502,6 +502,21 @@ class TestGenerate(unittest.TestCase):
         self.assertEqual(responses[uid1].finish_reason, "stop")
         self.assertEqual(responses[uid2].finish_reason, "stop")
 
+    def test_batch_stats_zero_time_no_divide_by_zero(self):
+        # No time accrued should give 0.0 tps, not a ZeroDivisionError
+        gen = BatchGenerator(self.model)
+        with gen.stats() as stats:
+            pass
+        self.assertEqual(stats.prompt_tps, 0.0)
+        self.assertEqual(stats.generation_tps, 0.0)
+
+    def test_batch_stats_does_not_mask_exceptions(self):
+        # A body exception should propagate, not be masked by the stats finally-block
+        gen = BatchGenerator(self.model)
+        with self.assertRaises(ValueError):
+            with gen.stats():
+                raise ValueError("boom")
+
     def test_batch_continued_generation(self):
         for rotating in [False, True]:
             if rotating:


### PR DESCRIPTION
## Summary
The `BatchGenerator.stats()` computes `prompt_tps`/`generation_tps` in its `finally` block without guarding a zero denominator:

```python
stats.prompt_tps = stats.prompt_tokens / stats.prompt_time
...
stats.generation_tps = stats.generation_tokens / stats.generation_time
```
When no prompt/generation time has accrued, prompt_time (or generation_time) is 0, so this raises ZeroDivisionError. Because it runs in a finally, it also masks the original exception whenever the with gen.stats() body raises before prompt processing completes. The real traceback is replaced by a confusing "division by zero".

## Reproduction
```python
from mlx_lm.generate import BatchGenerator
from mlx_lm.utils import load

model, tok = load("mlx-community/SmolLM-135M-Instruct-4bit")
gen = BatchGenerator(model, stop_tokens=[[t] for t in tok.eos_token_ids])

# 1) A stats context that accrues no time
try:
    with gen.stats():
        pass
    print("case 1: no error")
except Exception as e:
    print("case 1:", type(e).__name__)

# 2) A real error raised inside the body
try:
    with gen.stats():
        raise ValueError("boom")
except Exception as e:
    print("case 2:", type(e).__name__)
```
On `main`:
```
case 1: ZeroDivisionError
case 2: ZeroDivisionError   # the real ValueError is masked
```
With this change:
```
case 1: no error
case 2: ValueError
```
## Fix
Fall back to 0.0 tps when the elapsed time is zero (matching the BatchStats default of tps: float = 0). This keeps the finally block from raising, so a zero-work stats context no longer crashes and a body exception now propagates unmasked.

## Testing
Added two regression tests in `tests/test_generate.py`:
- `test_batch_stats_zero_time_no_divide_by_zero`: a zero-work stats context yields `0.0` tps instead of raising.
- `test_batch_stats_does_not_mask_exceptions`:  an exception in the body propagates instead of being masked.