### PR TITLE
Add opt-in q4_0 lattice calibration to quantization

### DIFF
--- a/mlx_lm/convert.py
+++ b/mlx_lm/convert.py
@@ -14,6 +14,7 @@ from .utils import (
     quantize_model,
     save,
     upload_to_hub,
+    validate_calibration,
 )
 
 
@@ -97,6 +98,7 @@ def convert(
         Union[Callable[[str, nn.Module, dict], Union[bool, dict]], str]
     ] = None,
     trust_remote_code: bool = False,
+    q_calibration: str = "standard",
 ):
     # Check the save path is empty
     if isinstance(mlx_path, str):
@@ -107,6 +109,9 @@ def convert(
             f"Cannot save to the path {mlx_path} as it already exists."
             " Please delete the file/directory or specify a new path to save to."
         )
+
+    if quantize:
+        validate_calibration(q_calibration, q_group_size, q_bits, q_mode)
 
     print("[INFO] Loading")
     model, tokenizer, config = load(
@@ -156,6 +161,7 @@ def convert(
             q_bits,
             mode=q_mode,
             quant_predicate=quant_predicate,
+            calibration=q_calibration,
         )
 
     if dequantize:
@@ -204,6 +210,16 @@ def configure_parser() -> argparse.ArgumentParser:
         help="Group size for quantization.",
         type=int,
         default=None,
+    )
+    parser.add_argument(
+        "--q-calibration",
+        choices=["standard", "q4_0"],
+        default="standard",
+        help=(
+            "How the quantization grid is derived. 'q4_0' reproduces the Q4_0 grid "
+            "for checkpoints already trained against it, instead of deriving a new "
+            "one. Requires --q-bits 4, --q-group-size 32 and affine mode."
+        ),
     )
     parser.add_argument(
         "--q-bits",

--- a/mlx_lm/utils.py
+++ b/mlx_lm/utils.py
@@ -715,8 +715,7 @@ def upload_to_hub(path: str, upload_repo: str):
     else:
         provenance = ""
 
-    card.text = dedent(
-        f"""
+    card.text = dedent(f"""
         # {upload_repo}
         {provenance}
         ## Use with mlx
@@ -740,8 +739,7 @@ def upload_to_hub(path: str, upload_repo: str):
 
         response = generate(model, tokenizer, prompt=prompt, verbose=True)
         ```
-        """
-    )
+        """)
     card.save(card_path)
 
     api = HfApi()
@@ -814,6 +812,108 @@ def save_model(
         )
 
 
+Q4_0_GROUP_SIZE = 32
+Q4_0_BITS = 4
+# The grid spans [-8, 7]: the scale is extremum / -8 and the affine bias that recentres
+# it is -8 * scale.
+_Q4_0_NEGATIVE_EXTENT = 8
+
+
+def q4_0_quantize(w: mx.array):
+    """Reproduce the Q4_0 grid for one weight tensor.
+
+    Per 32-element group along the input axis the scale comes from the *signed* element of
+    largest magnitude, ``d = extremum / -8``. Using ``-abs(w).max() / 8`` instead flips the
+    sign on every group whose extremum is negative -- close to half of them -- which
+    silently yields a different grid rather than an error.
+
+    Returns MLX's affine triplet: packed 4-bit codes, ``scales = d`` and ``biases = -8 * d``.
+    """
+    if w.ndim != 2 or w.shape[-1] % Q4_0_GROUP_SIZE != 0:
+        raise ValueError(
+            "q4_0_quantize expects a 2-D weight whose last dimension is a multiple of "
+            f"{Q4_0_GROUP_SIZE}, got shape {w.shape}."
+        )
+    rows, cols = w.shape[0], w.shape[-1]
+    groups = cols // Q4_0_GROUP_SIZE
+    grouped = w.reshape(rows * groups, Q4_0_GROUP_SIZE).astype(mx.float32)
+
+    imax = mx.argmax(mx.abs(grouped), axis=-1, keepdims=True)
+    extremum = mx.take_along_axis(grouped, imax, axis=-1)
+    scales = extremum / -_Q4_0_NEGATIVE_EXTENT
+
+    is_zero = scales == 0
+    inverse = mx.where(
+        is_zero, mx.array(0.0), 1 / mx.where(is_zero, mx.array(1.0), scales)
+    )
+
+    # grouped * inverse lands in [-8, 8], so adding 8.5 is always positive and floor()
+    # equals the reference encoder's truncation. Rounding half-to-even would disagree on ties.
+    codes = mx.clip(mx.floor(grouped * inverse + 8.5), 0, 15).astype(mx.uint32)
+
+    # Pack 8 consecutive codes per uint32, low nibble first. The nibbles never overlap, so
+    # summing the shifted codes is exactly a bitwise or.
+    per_word = 32 // Q4_0_BITS
+    shifts = (mx.arange(per_word, dtype=mx.uint32) * Q4_0_BITS).reshape(1, 1, per_word)
+    packed = mx.sum(codes.reshape(rows, cols // per_word, per_word) << shifts, axis=2)
+
+    scale_grid = scales.reshape(rows, groups).astype(w.dtype)
+    return (
+        packed.astype(mx.uint32),
+        scale_grid,
+        (scale_grid * -_Q4_0_NEGATIVE_EXTENT).astype(w.dtype),
+    )
+
+
+def validate_calibration(calibration, group_size, bits, mode):
+    """Check a calibration request without loading anything.
+
+    A calibration fixes its own grid geometry, so a conflicting request is an error rather
+    than something to silently override. Callable early so large models fail fast.
+    """
+    if calibration not in ("standard", "q4_0"):
+        raise ValueError(f"Unknown calibration {calibration!r}.")
+    if calibration == "q4_0" and (
+        (bits or Q4_0_BITS) != Q4_0_BITS
+        or (group_size or Q4_0_GROUP_SIZE) != Q4_0_GROUP_SIZE
+        or mode != "affine"
+    ):
+        raise ValueError(
+            "q4_0 calibration requires bits 4, group size 32 and affine mode, got "
+            f"bits {bits}, group size {group_size}, mode {mode}."
+        )
+
+
+def _apply_q4_0_calibration(model, originals):
+    """Overwrite standard-derived grids with the Q4_0 grid on eligible linears.
+
+    Every captured path must have become a 4-bit/group-32 affine module. Anything else
+    means the conversion did not do what the calibration assumed, so raise rather than
+    write arrays into a module shaped for a different grid.
+    """
+    modules = dict(tree_flatten(model.leaf_modules(), is_leaf=nn.Module.is_module))
+    for path, weight in originals.items():
+        module = modules.get(path)
+        if module is None or not hasattr(module, "scales"):
+            raise ValueError(
+                f"q4_0 calibration expected {path!r} to be quantized, but it was not."
+            )
+        geometry = (
+            getattr(module, "bits", None),
+            getattr(module, "group_size", None),
+            getattr(module, "mode", "affine"),
+        )
+        if geometry != (Q4_0_BITS, Q4_0_GROUP_SIZE, "affine"):
+            raise ValueError(
+                f"q4_0 calibration expected {path!r} to be 4-bit/group-32 affine, "
+                f"got bits/group_size/mode {geometry}."
+            )
+        packed, scales, biases = q4_0_quantize(weight)
+        module.weight = packed
+        module.scales = scales
+        module.biases = biases
+
+
 def quantize_model(
     model: nn.Module,
     config: dict,
@@ -821,6 +921,7 @@ def quantize_model(
     bits: Optional[int],
     mode: str = "affine",
     quant_predicate: Optional[Callable[[str, nn.Module], Union[bool, dict]]] = None,
+    calibration: str = "standard",
 ) -> Tuple[nn.Module, dict]:
     """
     Applies quantization to the model weights.
@@ -835,10 +936,20 @@ def quantize_model(
           each layer based on the path. Accepts the layer `path` and the
           `module`. Returns either a bool to signify quantize/no quantize or
           a dict of quantization parameters to pass to `to_quantized`.
+        calibration (str): How the quantization grid is derived. ``"standard"``
+          derives it from the weights as usual. ``"q4_0"`` instead reproduces the
+          Q4_0 grid, for checkpoints whose weights were already trained against it.
+          Requires 4 bits, group size 32 and affine mode. Only `nn.Linear` is
+          calibrated; other quantizable modules still land on the same 4-bit/group-32
+          affine grid but derive it the standard way. The output is ordinary affine
+          quantization either way, so this affects accuracy, not loadability.
 
     Returns:
         Tuple: Tuple containing quantized model and config.
     """
+    validate_calibration(calibration, group_size, bits, mode)
+    if calibration == "q4_0":
+        bits, group_size = Q4_0_BITS, Q4_0_GROUP_SIZE
 
     def defaults_for_mode(mode, group_size, bits):
         mode_defaults = {
@@ -863,6 +974,8 @@ def quantize_model(
         fine_grained_config = False
         quantized_config["quantization"] = quant_params
 
+    originals = {}
+
     def wrapped_predicate(path, module):
         if not hasattr(module, "to_quantized"):
             return False
@@ -872,9 +985,29 @@ def quantize_model(
         if quant_predicate is not None:
             bool_or_params = quant_predicate(path, module)
         if isinstance(bool_or_params, dict):
+            if calibration == "q4_0":
+                # A calibration fixes its own geometry, so a per-layer recipe asking for
+                # something else cannot be honoured. Rejecting beats silently installing
+                # 4-bit/group-32 arrays into, say, a 6-bit module.
+                incompatible = {
+                    k: v
+                    for k, v in bool_or_params.items()
+                    if (k == "bits" and v != Q4_0_BITS)
+                    or (k == "group_size" and v != Q4_0_GROUP_SIZE)
+                    or (k == "mode" and v != "affine")
+                }
+                if incompatible:
+                    raise ValueError(
+                        f"q4_0 calibration cannot honour per-layer parameters {incompatible} "
+                        f"for {path!r}; it requires bits 4, group size 32 and affine mode."
+                    )
             quantized_config["quantization"][path] = bool_or_params
         elif fine_grained_config and bool_or_params:
             quantized_config["quantization"][path] = quant_params
+        # Capture here rather than in a separate traversal: predicates are not required to
+        # be pure, and evaluating one twice can disagree between the two passes.
+        if calibration == "q4_0" and bool_or_params and isinstance(module, nn.Linear):
+            originals[path] = module.weight
         return bool_or_params
 
     nn.quantize(
@@ -884,6 +1017,9 @@ def quantize_model(
         mode=mode,
         class_predicate=wrapped_predicate,
     )
+
+    if originals:
+        _apply_q4_0_calibration(model, originals)
     # support hf model tree #957
     quantized_config["quantization_config"] = quantized_config["quantization"]
 

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -265,5 +265,201 @@ class TestTrustRemoteCode(unittest.TestCase):
         self.assertEqual(loaded_config["model_type"], "llama")
 
 
+class TestQ4_0Calibration(unittest.TestCase):
+    """The q4_0 grid: scale from the *signed* element of largest magnitude."""
+
+    def _negative_extremum_group(self):
+        # extremum = -4 -> d = -4 / -8 = 0.5, code = floor(w / 0.5 + 8.5)
+        weights = [0.0] * 32
+        weights[0] = -4.0
+        weights[2] = 0.5
+        weights[3] = -0.5
+        weights[4] = 3.5
+        expected = [8] * 32  # w == 0 -> floor(8.5)
+        expected[0] = 0  # floor(-8 + 8.5)
+        expected[2] = 9  # floor(1 + 8.5)
+        expected[3] = 7  # floor(-1 + 8.5)
+        expected[4] = 15  # floor(7 + 8.5)
+        return weights, expected
+
+    def _unpack(self, packed):
+        words = packed.flatten().tolist()
+        return [(w >> (4 * i)) & 0xF for w in words for i in range(8)]
+
+    def test_hand_computable_codes_scales_and_biases(self):
+        weights, expected = self._negative_extremum_group()
+        w = mx.array(weights).reshape(1, 32)
+
+        packed, scales, biases = utils.q4_0_quantize(w)
+
+        self.assertEqual(self._unpack(packed), expected)
+        self.assertEqual(scales.tolist(), [[0.5]])
+        self.assertEqual(biases.tolist(), [[-4.0]])
+
+    def test_uses_signed_extremum_not_abs_max(self):
+        """The regression that matters: -abs(w).max()/8 flips the sign on nearly half
+        of all groups, silently producing a different grid."""
+        weights, _ = self._negative_extremum_group()
+        w = mx.array(weights).reshape(1, 32)
+
+        packed, scales, _ = utils.q4_0_quantize(w)
+
+        self.assertEqual(scales.tolist(), [[0.5]])
+        self.assertEqual(self._unpack(packed)[0], 0)
+
+        # -abs max would give d = -0.5, sending the same element to code 15.
+        wrong_scale = -max(abs(v) for v in weights) / 8
+        self.assertEqual(wrong_scale, -0.5)
+        self.assertEqual(min(15, int(weights[0] / wrong_scale + 8.5)), 15)
+
+    def test_positive_extremum_and_clipping(self):
+        weights = [0.0] * 32
+        weights[0] = 4.0
+        weights[1] = -3.5
+        w = mx.array(weights).reshape(1, 32)
+
+        packed, scales, biases = utils.q4_0_quantize(w)
+        codes = self._unpack(packed)
+
+        self.assertEqual(scales.tolist(), [[-0.5]])
+        self.assertEqual(biases.tolist(), [[4.0]])
+        self.assertEqual(codes[0], 0)
+        self.assertEqual(codes[1], 15)
+        self.assertTrue(all(0 <= c <= 15 for c in codes))
+
+    def test_all_zero_group_does_not_divide_by_zero(self):
+        w = mx.zeros((1, 32))
+
+        packed, scales, biases = utils.q4_0_quantize(w)
+
+        self.assertEqual(scales.tolist(), [[0.0]])
+        self.assertEqual(biases.tolist(), [[0.0]])
+        self.assertEqual(self._unpack(packed), [8] * 32)
+
+    def test_scales_are_per_group_across_rows(self):
+        values = [0.0] * 128
+        values[0] = -4.0  # row 0, group 0 -> 0.5
+        values[32] = 2.0  # row 0, group 1 -> -0.25
+        values[64] = 8.0  # row 1, group 0 -> -1.0
+        values[96] = -1.0  # row 1, group 1 -> 0.125
+        w = mx.array(values).reshape(2, 64)
+
+        _, scales, biases = utils.q4_0_quantize(w)
+
+        self.assertEqual(scales.tolist(), [[0.5, -0.25], [-1.0, 0.125]])
+        self.assertEqual(biases.tolist(), [[-4.0, 2.0], [8.0, -1.0]])
+
+    def test_dequantizes_onto_the_intended_lattice(self):
+        weights, expected = self._negative_extremum_group()
+        w = mx.array(weights).reshape(1, 32)
+
+        packed, scales, biases = utils.q4_0_quantize(w)
+        restored = mx.dequantize(
+            packed, scales=scales, biases=biases, group_size=32, bits=4, mode="affine"
+        )
+
+        scale = scales.tolist()[0][0]
+        want = [(c - 8) * scale for c in expected]
+        self.assertTrue(mx.allclose(restored.flatten(), mx.array(want)).item())
+
+    def test_rejects_incompatible_settings(self):
+        model = nn.Sequential(nn.Linear(32, 8))
+        for kwargs in (
+            {"bits": 8, "group_size": 32},
+            {"bits": 4, "group_size": 64},
+        ):
+            with self.assertRaises(ValueError):
+                utils.quantize_model(
+                    model, {}, calibration="q4_0", mode="affine", **kwargs
+                )
+
+    def test_accepts_omitted_settings(self):
+        model = nn.Sequential(nn.Linear(32, 8))
+        _, config = utils.quantize_model(
+            model, {}, group_size=None, bits=None, calibration="q4_0"
+        )
+        self.assertEqual(config["quantization"]["bits"], 4)
+        self.assertEqual(config["quantization"]["group_size"], 32)
+        self.assertEqual(config["quantization"]["mode"], "affine")
+
+    def test_calibrated_linear_matches_direct_derivation(self):
+        mx.random.seed(0)
+        linear = nn.Linear(64, 16, bias=True)
+        original = mx.array(linear.weight)
+        model = nn.Sequential(linear)
+
+        model, _ = utils.quantize_model(model, {}, None, None, calibration="q4_0")
+
+        want_w, want_s, want_b = utils.q4_0_quantize(original)
+        self.assertTrue(mx.array_equal(model.layers[0].weight, want_w).item())
+        self.assertTrue(mx.array_equal(model.layers[0].scales, want_s).item())
+        self.assertTrue(mx.array_equal(model.layers[0].biases, want_b).item())
+
+    def test_predicate_is_evaluated_once_per_module(self):
+        """A predicate is not required to be pure; evaluating it twice can disagree
+        between the capture and conversion passes and corrupt a module."""
+        calls = {}
+
+        def counting_predicate(path, module):
+            calls[path] = calls.get(path, 0) + 1
+            return True
+
+        model = nn.Sequential(nn.Linear(32, 8), nn.Linear(32, 8))
+        utils.quantize_model(
+            model,
+            {},
+            None,
+            None,
+            calibration="q4_0",
+            quant_predicate=counting_predicate,
+        )
+
+        self.assertTrue(calls)
+        self.assertTrue(all(n == 1 for n in calls.values()), calls)
+
+    def test_incompatible_per_layer_parameters_are_rejected(self):
+        def mixed_predicate(path, module):
+            return {"bits": 6, "group_size": 64}
+
+        model = nn.Sequential(nn.Linear(64, 8))
+        with self.assertRaises(ValueError):
+            utils.quantize_model(
+                model,
+                {},
+                None,
+                None,
+                calibration="q4_0",
+                quant_predicate=mixed_predicate,
+            )
+
+    def test_compatible_per_layer_parameters_are_allowed(self):
+        def matching_predicate(path, module):
+            return {"bits": 4, "group_size": 32}
+
+        model = nn.Sequential(nn.Linear(32, 8))
+        model, _ = utils.quantize_model(
+            model,
+            {},
+            None,
+            None,
+            calibration="q4_0",
+            quant_predicate=matching_predicate,
+        )
+        self.assertEqual(model.layers[0].bits, 4)
+        self.assertEqual(model.layers[0].group_size, 32)
+
+    def test_helper_rejects_unsupported_shapes(self):
+        with self.assertRaises(ValueError):
+            utils.q4_0_quantize(mx.zeros((1, 20)))
+        with self.assertRaises(ValueError):
+            utils.q4_0_quantize(mx.zeros((2, 2, 32)))
+
+    def test_unknown_calibration_is_rejected(self):
+        with self.assertRaises(ValueError):
+            utils.quantize_model(
+                nn.Sequential(nn.Linear(32, 8)), {}, None, None, calibration="nope"
+            )
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Proposed changes

Adds an opt-in **calibration** to quantization that reproduces a checkpoint's existing `Q4_0` grid instead of deriving a new one.

### The problem

Some checkpoints ship weights that were already trained against a specific quantization grid — Google's Gemma 4 QAT releases are the motivating case. `nn.quantize` derives a fresh grid from those weights by min/max, discarding the alignment they were trained for. The converted model then sits further from the original than it needs to, at the same bit width and the same file size.

The grid is recoverable: 32-element groups scaled by the **signed** element of largest magnitude, `d = extremum / -8`, expressible as ordinary affine `scales = d`, `biases = -8 * d`.

### What this changes

```bash
mlx_lm.convert --hf-path google/gemma-4-12B-it-qat-q4_0-unquantized -q --q-calibration q4_0
```

- `quantize_model(..., calibration="standard" | "q4_0")`
- `convert(..., q_calibration=...)` — appended after existing parameters, so positional callers are unaffected
- `--q-calibration` CLI flag
- `utils.q4_0_quantize(w)` exposed for direct use

`q4_0` resolves to 4 bits / group size 32 / affine and **rejects** conflicting values rather than silently overriding them, failing before the model is loaded. Per-layer predicate parameters that conflict are rejected by path, and each calibrated module's geometry is verified after conversion rather than assumed.

**This is a derivation, not a storage format.** Output is ordinary affine 4-bit; converted models load and run through the existing path unchanged, with no decode-side change.

### Evidence

Each converted model compared against its own bfloat16 reference over 200 chat-formatted prompts, teacher-forced. Mean KL divergence per token position (lower is better) and exact top-1 agreement, stock group-32 conversion vs this calibration **at identical file size**:

| model | KL, stock | KL, calibrated | top-1, stock | top-1, calibrated |
|---|---|---|---|---|
| Gemma 4 E2B | 0.0220 | **0.0175** | 95.7% | **96.2%** |
| Gemma 4 E4B | 0.0160 | **0.0112** | 96.6% | **97.2%** |
| Gemma 4 12B | 0.1219 | **0.0631** | 92.8% | **94.3%** |
| Gemma 4 31B | 0.0321 | **0.0205** | 96.5% | **96.9%** |

Correctness is established independently of those measurements: the derivation reproduces Google's own shipped `Q4_0` GGUF **exactly** — 100% of codes and scales across 721M weights on 12B — and `q4_0_quantize` was then checked tensor-by-tensor against that verified artifact on E2B: **275 tensors, 0 mismatches**.

Worth noting for anyone reproducing this: simply passing `--q-group-size 32` does **not** get you there. It costs ~11% more disk and, on the dense models measured, buys nothing — 12B actually got slightly worse (0.1048 → 0.1219). The gain is in how the grid is derived, not in the group size.

### Scope and limits, stated plainly

- **Only `nn.Linear` is calibrated.** Other quantizable modules still land on the same 4-bit/group-32 affine grid but derive it the standard way. Affects accuracy, not loadability; documented in the docstring.
- **No benefit on mixture-of-experts.** The same measurement on Gemma 4 26B-A4B showed no significant change (0.0707 → 0.0680, overlapping confidence intervals). No claim is made there.
- **Opt-in only.** No model-name or fingerprint auto-detection.
- Single-run measurements on one prompt corpus with a fixed seed.

### Notes for review

- A mirrored change for `mlx-swift-lm` is prepared so the two conversion paths stay in step.
- `tests/test_models.py::test_ssm` and 8 cases in `tests/test_generate.py` fail on this branch, but they fail identically on a clean `main` — pre-existing and unrelated.

## Checklist

- [x] I have read the CONTRIBUTING document
- [x] `black` clean via pre-commit
- [x] Tests added
- [x] Documentation updated (docstrings + CLI help)

Tests: 14 added to `tests/test_utils.py` covering hand-computable codes/scales/biases, positive and negative extrema, clipping at both ends, degenerate all-zero groups, per-group scaling across rows, dequantization onto the intended lattice, rejection of incompatible global and per-layer settings, shape validation, that the predicate is evaluated exactly once per module, and one pinning the signed-extremum rule apart from `-abs(w).max()/8` — the error that silently produces a different grid on roughly half of all groups.


---

**Published weights using this path** — 4-bit MLX conversions of the Gemma 4 QAT checkpoints, which load with released `mlx-lm` (they are ordinary affine 4-bit; none of this PR is needed to *use* them):

- [gemma-4-E2B-it-qat-q4_0-mlx](https://huggingface.co/goodolclint/gemma-4-E2B-it-qat-q4_0-mlx)
- [gemma-4-E4B-it-qat-q4_0-mlx](https://huggingface.co/goodolclint/gemma-4-E4B-it-qat-q4_0-mlx)
- [gemma-4-12B-it-qat-q4_0-mlx](https://huggingface.co/goodolclint/gemma-4-12B-it-qat-q4_0-mlx)
- [gemma-4-31B-it-qat-q4_0-mlx](https://huggingface.co/goodolclint/gemma-4-31B-it-qat-q4_0-mlx)

Each was produced by this branch and verified bit-identical to Google's shipped `Q4_0` grid before upload.