### PR TITLE
Fix MiniMax M2 nullable tool arguments

### DIFF
--- a/mlx_lm/tool_parsers/minimax_m2.py
+++ b/mlx_lm/tool_parsers/minimax_m2.py
@@ -86,15 +86,11 @@ def _extract_types_from_schema(schema: Any) -> list[str]:
 
 
 def _convert_param_value_with_types(value: str, param_types: list[str]) -> Any:
-    if value.lower() == "null":
+    if value.lower() in ("null", "none", "nil"):
         return None
 
     # Normalize types
     normalized_types = [t.lower() for t in param_types]
-
-    # Try null first if it's in the list
-    if "null" in normalized_types or value.lower() in ("null", "none", "nil"):
-        return None
 
     # Try each type in order of preference (most specific first, string as fallback)
     # Priority: integer > number > boolean > object > array > string

--- a/tests/test_tool_parsing.py
+++ b/tests/test_tool_parsing.py
@@ -329,6 +329,38 @@ class TestToolParsing(unittest.TestCase):
         tool_calls = minimax_m2.parse_tool_call(test_case, None)
         self.assertEqual(expected, tool_calls)
 
+    def test_minimax_m2_nullable_arguments(self):
+        tools = [
+            {
+                "type": "function",
+                "function": {
+                    "name": "search",
+                    "parameters": {
+                        "type": "object",
+                        "properties": {
+                            "query": {"anyOf": [{"type": "string"}, {"type": "null"}]},
+                            "limit": {"type": ["integer", "null"]},
+                            "cursor": {"type": ["string", "null"]},
+                        },
+                    },
+                },
+            }
+        ]
+        test_case = (
+            '<invoke name="search">\n'
+            '<parameter name="query">weather</parameter>\n'
+            '<parameter name="limit">10</parameter>\n'
+            '<parameter name="cursor">null</parameter>\n'
+            "</invoke>"
+        )
+
+        tool_call = minimax_m2.parse_tool_call(test_case, tools)
+
+        self.assertEqual(
+            {"query": "weather", "limit": 10, "cursor": None},
+            tool_call["arguments"],
+        )
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary

- preserve non-null MiniMax M2 tool arguments when their schema also allows `null`
- continue mapping explicit `null`, `none`, and `nil` values to Python `None`
- add regression coverage for nullable string and integer arguments

## Why

The converter checked whether `null` appeared anywhere in a parameter's allowed types and returned `None` before inspecting the actual value. As a result, values such as `"weather"` and `"10"` were discarded for nullable parameters.

## Tests

- `uv run python -m unittest tests.test_tool_parsing` (6 passed)
- `uvx pre-commit run --files mlx_lm/tool_parsers/minimax_m2.py tests/test_tool_parsing.py` (Black and isort passed)
