### PR TITLE
Serve fully cached repos without a Hub round-trip

### DIFF
--- a/mlx_lm/utils.py
+++ b/mlx_lm/utils.py
@@ -29,8 +29,14 @@ if os.getenv("MLXLM_USE_MODELSCOPE", "False").lower() == "true":
         from modelscope import snapshot_download
     except ImportError:
         raise ImportError("Run `pip install modelscope` to use ModelScope.")
+
+    # ModelScope's snapshot_download has no local_files_only fast path.
+    _supports_local_files_only = False
 else:
     from huggingface_hub import snapshot_download
+    from huggingface_hub.errors import LocalEntryNotFoundError
+
+    _supports_local_files_only = True
 
 # For large models with lots of files
 resource.setrlimit(resource.RLIMIT_NOFILE, (2048, 4096))
@@ -249,6 +255,22 @@ def _download(
 
     if not model_path.exists():
         allow_patterns = allow_patterns or DEFAULT_ALLOW_PATTERNS
+        if _supports_local_files_only:
+            # The common case is a repo that is already fully cached. Serving it
+            # from the cache first avoids the API round-trip snapshot_download
+            # otherwise makes to check the repo for updates. Fall through to the
+            # online path whenever the cache cannot satisfy the request.
+            try:
+                return Path(
+                    snapshot_download(
+                        path_or_hf_repo,
+                        revision=revision,
+                        allow_patterns=allow_patterns,
+                        local_files_only=True,
+                    )
+                )
+            except LocalEntryNotFoundError:
+                pass
         model_path = Path(
             snapshot_download(
                 path_or_hf_repo,

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -4,6 +4,7 @@ import json
 import os
 import tempfile
 import unittest
+import unittest.mock
 from pathlib import Path
 
 import mlx.core as mx
@@ -263,6 +264,45 @@ class TestTrustRemoteCode(unittest.TestCase):
         model, loaded_config = utils.load_model(self.model_path, strict=False)
         self.assertIsInstance(model, nn.Module)
         self.assertEqual(loaded_config["model_type"], "llama")
+
+
+class TestDownloadLocalFirst(unittest.TestCase):
+    """_download should serve a cached repo without hitting the network."""
+
+    def test_cached_repo_skips_network(self):
+        calls = []
+
+        def fake_snapshot_download(repo, **kwargs):
+            calls.append(kwargs.get("local_files_only", False))
+            return "/tmp/cached"
+
+        with unittest.mock.patch.object(
+            utils, "snapshot_download", fake_snapshot_download
+        ):
+            path = utils._download("some/repo")
+
+        self.assertEqual(path, Path("/tmp/cached"))
+        # Exactly one call, and it asked for the cache only.
+        self.assertEqual(calls, [True])
+
+    def test_falls_back_to_network_when_not_cached(self):
+        calls = []
+
+        def fake_snapshot_download(repo, **kwargs):
+            local_only = kwargs.get("local_files_only", False)
+            calls.append(local_only)
+            if local_only:
+                raise utils.LocalEntryNotFoundError("not cached")
+            return "/tmp/downloaded"
+
+        with unittest.mock.patch.object(
+            utils, "snapshot_download", fake_snapshot_download
+        ):
+            path = utils._download("some/repo")
+
+        self.assertEqual(path, Path("/tmp/downloaded"))
+        # Tried the cache first, then fell back to the network.
+        self.assertEqual(calls, [True, False])
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Proposed changes

Fixes #1649.

`_download()` called `snapshot_download()` without `local_files_only`, so a repo
that is already fully cached still paid a Hub API round-trip to check for
updates before serving from the cache. `load()` calls `_download()` twice — once
for weights, once for tokenizer files — so every invocation paid it twice, for
the CLI and for library users alike, not only on first download.

This tries `local_files_only=True` first and falls back to the existing online
call on `LocalEntryNotFoundError`, so behaviour is unchanged whenever the cache
cannot satisfy the request.

### Why

`huggingface_hub` 1.26.0, warm cache, median of 5 calls on an already-cached repo:

| | per call | per `load()` (2 calls) |
|---|---:|---:|
| before (network check) | 147.2 ms | ~294 ms |
| after (local first) | 0.26 ms | ~0.5 ms |
| | **565x** | |

Reproducer is in #1649. The absolute number is latency to the Hub, so it grows
on a slow link — and on a flaky one the current code blocks until the check
times out, where this returns immediately.

### How

- Try the cache first, fall back on `LocalEntryNotFoundError` only.
- Gated on `_supports_local_files_only`, because ModelScope's `snapshot_download`
  takes no such argument. On ModelScope the behaviour is byte-for-byte unchanged.
- `hf_repo_to_path()` in the same file already uses `local_files_only=True`, so
  this follows an established pattern rather than introducing one.

**Alternative rejected:** catching a broader exception. `LocalEntryNotFoundError`
is what a cache miss raises (verified against 1.26.0); catching more would
silently swallow real Hub errors and turn them into a redundant second attempt.

### Validation

```bash
python -m unittest tests.test_utils      # 11 passed
pre-commit run --files mlx_lm/utils.py tests/test_utils.py   # black, isort
```

Two tests added:
- `test_cached_repo_skips_network` — a cached repo results in exactly one
  `snapshot_download` call, made with `local_files_only=True`.
- `test_falls_back_to_network_when_not_cached` — a `LocalEntryNotFoundError`
  produces a second call without `local_files_only`.

I checked the tests are not vacuous by flipping the new argument to `False`:
both fail. With the fix in place, all 11 pass.

---

Supersedes #1571, which was opened against an older `main`. This is the same fix
rebuilt on current `main`, with the measurement and tests added.
