### PR TITLE
Align quantized_kv_start defaults with the CLI

### DIFF
--- a/mlx_lm/generate.py
+++ b/mlx_lm/generate.py
@@ -307,7 +307,7 @@ def generate_step(
     prefill_step_size: int = 2048,
     kv_bits: Optional[int] = None,
     kv_group_size: int = 64,
-    quantized_kv_start: int = 0,
+    quantized_kv_start: int = DEFAULT_QUANTIZED_KV_START,
     prompt_progress_callback: Optional[Callable[[int, int], None]] = None,
     input_embeddings: Optional[mx.array] = None,
 ) -> Generator[Tuple[mx.array, mx.array], None, None]:
@@ -333,7 +333,11 @@ def generate_step(
           None implies no cache quantization. Default: ``None``.
         kv_group_size (int): Group size for KV cache quantization. Default: ``64``.
         quantized_kv_start (int): Step to begin using a quantized KV cache.
-           when ``kv_bits`` is non-None. Default: ``0``.
+           when ``kv_bits`` is non-None. Default: ``DEFAULT_QUANTIZED_KV_START``
+           (``5000``), matching the CLI. Quantizing from the first token costs
+           decode throughput while saving no meaningful memory on short
+           contexts, so quantization is deferred until the cache is long
+           enough for the trade to pay off. Pass ``0`` to quantize immediately.
         prompt_progress_callback (Callable[[int, int], None]): A call-back which takes the
            prompt tokens processed so far and the total number of prompt tokens.
         input_embeddings (mx.array, optional): Input embeddings to use instead of or in
@@ -474,7 +478,7 @@ def speculative_generate_step(
     prefill_step_size: int = 512,
     kv_bits: Optional[int] = None,
     kv_group_size: int = 64,
-    quantized_kv_start: int = 0,
+    quantized_kv_start: int = DEFAULT_QUANTIZED_KV_START,
 ) -> Generator[Tuple[mx.array, mx.array, bool], None, None]:
     """
     A generator producing token ids based on the given prompt from the model.
@@ -499,7 +503,8 @@ def speculative_generate_step(
           None implies no cache quantization. Default: ``None``.
         kv_group_size (int): Group size for KV cache quantization. Default: ``64``.
         quantized_kv_start (int): Step to begin using a quantized KV cache.
-           when ``kv_bits`` is non-None. Default: ``0``.
+           when ``kv_bits`` is non-None. Default: ``DEFAULT_QUANTIZED_KV_START``
+           (``5000``), see ``generate_step``.
 
     Yields:
         Tuple[mx.array, mx.array, bool]: One token, a vector of log probabilities,

--- a/tests/test_generate.py
+++ b/tests/test_generate.py
@@ -845,5 +845,37 @@ class TestGenerate(unittest.TestCase):
         self.assertIsNone(response.token_ids)
 
 
+class TestQuantizedKVStartDefault(unittest.TestCase):
+    """The library defaults must not disagree with the CLI's own default."""
+
+    def _default(self, fn):
+        import inspect
+
+        return inspect.signature(fn).parameters["quantized_kv_start"].default
+
+    def test_generate_step_matches_cli_default(self):
+        from mlx_lm.generate import DEFAULT_QUANTIZED_KV_START, generate_step
+
+        self.assertEqual(self._default(generate_step), DEFAULT_QUANTIZED_KV_START)
+
+    def test_speculative_generate_step_matches_cli_default(self):
+        from mlx_lm.generate import (
+            DEFAULT_QUANTIZED_KV_START,
+            speculative_generate_step,
+        )
+
+        self.assertEqual(
+            self._default(speculative_generate_step), DEFAULT_QUANTIZED_KV_START
+        )
+
+    def test_cache_prompt_shares_the_same_constant(self):
+        from mlx_lm.cache_prompt import (
+            DEFAULT_QUANTIZED_KV_START as CACHE_PROMPT_DEFAULT,
+        )
+        from mlx_lm.generate import DEFAULT_QUANTIZED_KV_START
+
+        self.assertEqual(CACHE_PROMPT_DEFAULT, DEFAULT_QUANTIZED_KV_START)
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Proposed changes

Fixes #1651.

`generate_step()` and `speculative_generate_step()` defaulted `quantized_kv_start`
to `0`, while the CLI already ships `DEFAULT_QUANTIZED_KV_START = 5000`. A caller
passing `kv_bits=` without `quantized_kv_start` therefore got different behaviour
depending on whether they came through the library or the CLI. This uses the
existing constant as the default in both functions and documents the trade-off
it encodes.

### Why

`mlx-community/Qwen3-0.6B-4bit`, `kv_bits=8`, 8-token prompt, median of 3,
Apple M4 Pro (14-core), macOS 26.6:

| new tokens | `start=0` (before) | `start=5000` (after) | speed | peak mem before | peak mem after |
|---:|---:|---:|---:|---:|---:|
| 64   | 325.4 tok/s | 375.4 tok/s | +15.4% | 367.2 MB | 367.7 MB |
| 128  | 314.2 tok/s | 382.3 tok/s | +21.7% | 367.2 MB | 367.7 MB |
| 256  | 336.3 tok/s | 381.9 tok/s | +13.6% | 367.4 MB | 421.7 MB |
| 512  | 335.9 tok/s | 368.1 tok/s |  +9.6% | 371.2 MB | 471.7 MB |
| 1024 | 322.8 tok/s | 341.9 tok/s |  +5.9% | 408.2 MB | 576.8 MB |

### The trade-off, stated plainly

**This is not a free win.** The new default is 6-22% faster to decode, but it
uses more memory once generations get long — 169 MB more at 1024 tokens. Below
roughly 256 generated tokens the memory is a wash (367 MB either way) and the
speed difference is the whole story; past that, the old default genuinely buys
memory back.

So the argument here is **consistency, not superiority**: the CLI already
encodes 5000 as the intended default via a shared constant, and the library
silently disagreeing with it is the part that looks like a bug. If you would
rather keep `0` and document the difference instead, say so and I will close
this in favour of a docs-only change — I raised both options in #1651.

**This changes behaviour for existing callers** who pass `kv_bits=` and rely on
the current `0`. They can restore it explicitly with `quantized_kv_start=0`,
which the updated docstring now calls out.

### Validation

```bash
python -m unittest tests.test_generate tests.test_prompt_cache tests.test_utils
# 60 passed
pre-commit run --files mlx_lm/generate.py tests/test_generate.py   # black, isort
```

Three tests added, pinning both function defaults to `DEFAULT_QUANTIZED_KV_START`
and asserting `cache_prompt.py` still shares the same value — so the two cannot
drift apart again silently.

I checked the tests are not vacuous by reverting `generate_step`'s default to
`0`: the suite fails. With the change in place, all 60 pass.

---

Supersedes #1567, which was opened against an older `main`. Same change, rebuilt
on current `main`, with the measurements and tests added.
