### PR TITLE
Enable readline for the chat prompt and persist history

### DIFF
--- a/mlx_lm/cli_ui.py
+++ b/mlx_lm/cli_ui.py
@@ -1,10 +1,20 @@
 # Copyright © 2024 Apple Inc.
 
+import os
 import re
 import shutil
 import sys
 from contextlib import contextmanager
 from functools import lru_cache
+
+try:
+    # Importing readline is what makes input() honour the \x01/\x02
+    # non-printing markers corridor_input() emits, and what provides history
+    # and line editing. It is unavailable on some platforms (e.g. Windows
+    # without pyreadline), so the prompt must keep working without it.
+    import readline
+except ImportError:
+    readline = None
 
 import mlx.core as mx
 from rich.box import ROUNDED
@@ -249,6 +259,32 @@ class TrainUI:
         )
 
 
+CHAT_HISTORY_FILE = os.path.expanduser("~/.mlx_lm_chat_history")
+CHAT_HISTORY_LENGTH = 1000
+
+
+def load_chat_history(path: str = CHAT_HISTORY_FILE) -> None:
+    """Restore prompt history from a previous session, if there is one."""
+    if readline is None:
+        return
+    readline.set_history_length(CHAT_HISTORY_LENGTH)
+    try:
+        readline.read_history_file(path)
+    except (OSError, PermissionError):
+        # No history yet, or it is unreadable. Neither is worth failing over.
+        pass
+
+
+def save_chat_history(path: str = CHAT_HISTORY_FILE) -> None:
+    """Persist prompt history for the next session."""
+    if readline is None:
+        return
+    try:
+        readline.write_history_file(path)
+    except (OSError, PermissionError):
+        pass
+
+
 class ChatUI:
     """Helper class for rendering the chat UI and streaming responses."""
 
@@ -259,6 +295,7 @@ class ChatUI:
 
     def __enter__(self):
         if self._rank == 0:
+            load_chat_history()
             rows = [("model", str(self._args.model))]
             if self._args.adapter_path:
                 rows.append(("adapter", str(self._args.adapter_path)))
@@ -273,6 +310,8 @@ class ChatUI:
         return self
 
     def __exit__(self, *exc):
+        if self._rank == 0:
+            save_chat_history()
         return False
 
     def prompt(self) -> str:

--- a/tests/test_chat.py
+++ b/tests/test_chat.py
@@ -1,7 +1,10 @@
 import argparse
+import os
+import tempfile
 import unittest
 from unittest.mock import MagicMock, patch
 
+from mlx_lm import cli_ui
 from mlx_lm.chat import setup_arg_parser
 
 
@@ -169,6 +172,60 @@ class TestChat(unittest.TestCase):
         self.assertEqual(len(call_args), 1)
         self.assertEqual(call_args[0]["role"], "user")
         self.assertEqual(call_args[0]["content"], "What is the weather?")
+
+
+class TestChatHistory(unittest.TestCase):
+    """Prompt history is persisted across sessions, on rank 0 only."""
+
+    def setUp(self):
+        self.tmp = tempfile.TemporaryDirectory()
+        self.path = os.path.join(self.tmp.name, "history")
+
+    def tearDown(self):
+        self.tmp.cleanup()
+
+    def test_round_trip(self):
+        if cli_ui.readline is None:
+            self.skipTest("readline unavailable on this platform")
+        cli_ui.readline.clear_history()
+        cli_ui.readline.add_history("hello there")
+        cli_ui.save_chat_history(self.path)
+
+        cli_ui.readline.clear_history()
+        self.assertEqual(cli_ui.readline.get_current_history_length(), 0)
+
+        cli_ui.load_chat_history(self.path)
+        self.assertEqual(cli_ui.readline.get_history_item(1), "hello there")
+
+    def test_missing_file_is_not_an_error(self):
+        cli_ui.load_chat_history(os.path.join(self.tmp.name, "does-not-exist"))
+
+    def test_unwritable_path_is_not_an_error(self):
+        cli_ui.save_chat_history(os.path.join(self.tmp.name, "no", "such", "dir"))
+
+    def test_history_is_skipped_without_readline(self):
+        with patch.object(cli_ui, "readline", None):
+            cli_ui.load_chat_history(self.path)
+            cli_ui.save_chat_history(self.path)
+        self.assertFalse(os.path.exists(self.path))
+
+    def test_only_rank_zero_touches_history(self):
+        args = MagicMock()
+        args.model, args.adapter_path = "m", None
+        args.max_tokens, args.system_prompt = 10, None
+
+        with patch.object(cli_ui, "load_chat_history") as load, patch.object(
+            cli_ui, "save_chat_history"
+        ) as save:
+            with cli_ui.ChatUI(args, rank=1):
+                pass
+            load.assert_not_called()
+            save.assert_not_called()
+
+            with cli_ui.ChatUI(args, rank=0):
+                pass
+            load.assert_called_once()
+            save.assert_called_once()
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Proposed changes

Fixes #1653.

`corridor_input()` wraps its ANSI escapes in `\x01` / `\x02` — readline's
markers for non-printing characters — but nothing imported `readline`, so those
two bytes were written to the terminal verbatim and the prompt had no history or
line editing.

This imports `readline` (guarded, it is absent on some platforms) and
loads/saves `~/.mlx_lm_chat_history` around the chat session, on rank 0 only.

### Why

Under a real PTY (reproducer in #1653):

| | raw `0x01` emitted | raw `0x02` emitted | history | line editing |
|---|---|---|---|---|
| before | yes | yes | no | no |
| after | no | no | yes, persisted | yes |

The markers already in `corridor_input()` are evidence this was the intent — they
are inert without `readline`.

### How

- `import readline` in a `try/except ImportError`, falling back to `None`. Every
  history helper no-ops when it is `None`, so platforms without it keep working
  exactly as they do today.
- `load_chat_history()` in `ChatUI.__enter__`, `save_chat_history()` in
  `__exit__`, both behind the existing `rank == 0` gate so distributed workers
  never touch the file.
- History capped at 1000 entries; unreadable/unwritable paths are ignored rather
  than raising, so a bad `$HOME` cannot break the chat.

### Scope — deliberately smaller than #1382

This replaces #1382, which bundled four things and stalled. Rebuilt on current
`main` against the newer `ChatUI`, keeping only what stands up:

| from #1382 | here | why |
|---|---|---|
| readline history + line editing | **kept** | the part @nastya236 called "a great idea", and it fixes the marker leak |
| distributed `broadcast_string` | **dropped** | @nastya236 asked "did you have this issue?" and the honest answer was no — it was speculative. `ChatUI.prompt()` on current `main` is already rank-aware. |
| markdown prompt by default | **dropped** | @nastya236 wanted time to think; it was blocking the rest |
| `sample_utils` top_k message | **dropped** | already fixed on `main` |

354 lines became 96.

### Validation

```bash
python -m unittest tests.test_chat tests.test_generate tests.test_utils   # 44 passed
pre-commit run --files mlx_lm/cli_ui.py tests/test_chat.py                # black, isort
```

Five tests added: history round-trips through a file, a missing file and an
unwritable path are both non-fatal, everything no-ops when `readline` is `None`,
and rank 1 never touches the history while rank 0 does.

I checked they are not vacuous by removing the `save_chat_history()` call from
`__exit__`: the suite fails. With the change in place, all 44 pass.

### Note

Ctrl+D still raises `EOFError` out of the chat loop rather than exiting
cleanly. That is a separate small fix and I left it out to keep this focused —
happy to send it after this lands.

---

Supersedes #1382. Thanks @nastya236 for the review there — the questions about
the distributed path are what led to dropping it. The demo videos from that
thread still show the history/line-editing behaviour this PR keeps.
