### PR TITLE
fix(generate): guard per-sequence logits_processors against None in batched generation

### DIFF
--- a/mlx_lm/generate.py
+++ b/mlx_lm/generate.py
@@ -1425,7 +1425,7 @@ class GenerationBatch:
             processed_logits = []
             for e in range(len(self.uids)):
                 sample_logits = logits[e : e + 1]
-                for processor in self.logits_processors[e]:
+                for processor in (self.logits_processors[e] or []):
                     sample_logits = processor(token_context[e], sample_logits)
                 processed_logits.append(sample_logits)
             logits = mx.concatenate(processed_logits, axis=0)


### PR DESCRIPTION
### Problem

In a mixed batch — some sequences carrying `logits_processors` (e.g. repetition or frequency penalties), others not — the absent entries are `None`. The per-sequence step loop in `GenerationBatch` then does:

```python
for processor in self.logits_processors[e]:
```

which raises `TypeError: 'NoneType' object is not iterable` and kills the generation thread. The HTTP thread keeps answering `GET /health` with 200 while every completion hangs indefinitely, so the failure is invisible to a health check and the server has to be restarted.

The practical effect is that `--decode-concurrency` above 1 is unsafe whenever concurrent requests use different sampling settings, which is the normal case for a shared server.

### Reproduction

Start `mlx_lm.server --decode-concurrency 2` and send two concurrent chat completions where one sets `repetition_penalty` (or `frequency_penalty`) and the other does not, so they land in the same batch.

### Fix

One line, mirroring the guard the sibling `samplers` path already uses twelve lines below in the same method:

```python
sample_sampler = self.samplers[e] or self.fallback_sampler
```

```diff
-                for processor in self.logits_processors[e]:
+                for processor in (self.logits_processors[e] or []):
```

### Relationship to existing issues and PRs

- #1472 and #1505 report this crash. #1505 generalizes it: *any* uncaught exception in `_generate` leaves the server answering 200s while generation is dead.
- #1230 proposed fixing the **writer** (`[None]` → `[[]]`) and was closed unmerged.
- #1225 proposes fuller per-slot `samplers`/`logits_processors` bookkeeping in `filter`/`extend` and is still open.

This patch is deliberately the **reader-side** guard instead. It is one line, it cannot regress a caller that legitimately passes `None`, it matches the established pattern immediately below it, and it is orthogonal to #1225 — if that lands, this becomes redundant rather than conflicting. It is offered as a minimal stop-gap for a crash that has been reported repeatedly and is still reproducible on `main`.
