### PR TITLE
Add optional gradient clipping and non-finite guard to the LoRA trainer

### DIFF
--- a/mlx_lm/LORA.md
+++ b/mlx_lm/LORA.md
@@ -362,6 +362,29 @@ If you are unsure of the format to use, the `chat` or `completions` are good to
 start with. For custom requirements on the format of the dataset, use the
 `text` format to assemble the content yourself.
 
+## NaN Loss
+
+By default there is no guard on the size of the gradient, so a single batch
+that overflows can put the weights in a state the run never recovers from and
+every later iteration reports `nan`.
+
+Use `--grad-clip <N>` to bound the global gradient norm to `N` (`1.0` is a
+common choice). This does two things:
+
+1. Gradients whose norm exceeds `N` are scaled down to `N`.
+2. If the norm comes out `inf` or `nan`, the gradient for that step is zeroed
+   so the non-finite values never reach the weights. Note that a momentum
+   optimizer such as Adam still moves the weights on that step using its
+   existing state; this bounds the damage of a bad batch rather than making the
+   step a complete no-op.
+
+Both are off unless you pass the flag, so the default behavior is unchanged.
+Steps with a non-finite norm are reported as a warning alongside the loss.
+
+If a run still diverges with clipping on, the usual next levers are a lower
+learning rate, adding warmup via `lr_schedule`, and lowering the LoRA `scale`
+in `lora_parameters`.
+
 ## Memory Issues
 
 Fine-tuning a large model with LoRA requires a machine with a decent amount

--- a/mlx_lm/examples/lora_config.yaml
+++ b/mlx_lm/examples/lora_config.yaml
@@ -50,6 +50,10 @@ steps_per_eval: 200
 # Number of micro-steps to accumulate before each optimizer update.
 grad_accumulation_steps: 1
 
+# Clip the global gradient norm to this value and skip the update when the norm
+# is not finite. Null disables both.
+grad_clip: null
+
 # Load path to resume training with the given adapter weights.
 resume_adapter_file: null
 

--- a/mlx_lm/lora.py
+++ b/mlx_lm/lora.py
@@ -71,6 +71,7 @@ CONFIG_DEFAULTS = {
     "config": None,
     "grad_checkpoint": False,
     "grad_accumulation_steps": 1,
+    "grad_clip": None,
     "clear_cache_threshold": 0,
     "lr_schedule": None,
     "lora_parameters": {"rank": 8, "dropout": 0.0, "scale": 20.0},
@@ -150,6 +151,14 @@ def build_parser():
         "--grad-accumulation-steps",
         type=int,
         help="Number of steps to accumulate before each optimizer update.",
+    )
+    parser.add_argument(
+        "--grad-clip",
+        type=float,
+        help=(
+            "Clip the global gradient norm to this value and skip the update "
+            "when the norm is not finite. Off by default."
+        ),
     )
     parser.add_argument(
         "--resume-adapter-file",
@@ -279,6 +288,7 @@ def train_model(
         max_seq_length=args.max_seq_length,
         grad_checkpoint=args.grad_checkpoint,
         grad_accumulation_steps=args.grad_accumulation_steps,
+        grad_clip=args.grad_clip,
     )
 
     # Initialize the selected optimizer

--- a/mlx_lm/tuner/trainer.py
+++ b/mlx_lm/tuner/trainer.py
@@ -5,11 +5,13 @@ import time
 from dataclasses import dataclass, field
 from functools import partial
 from pathlib import Path
+from typing import Optional
 
 import mlx.core as mx
 import mlx.nn as nn
 import numpy as np
 from mlx.nn.utils import average_gradients
+from mlx.optimizers import clip_grad_norm
 from mlx.utils import tree_flatten, tree_map
 
 from ..cli_ui import TrainUI, rprint
@@ -73,6 +75,15 @@ class TrainingArgs:
         default=1,
         metadata={
             "help": "Number of steps to accumulate gradients before applying an optimizer update."
+        },
+    )
+    grad_clip: Optional[float] = field(
+        default=None,
+        metadata={
+            "help": (
+                "Clip the global gradient norm to this value. Also skips the "
+                "optimizer update when the norm is not finite. Disabled by default."
+            )
         },
     )
     clear_cache_threshold: int = field(
@@ -241,6 +252,9 @@ def train(
     if grad_accum_steps < 1:
         raise ValueError("grad_accumulation_steps must be at least 1")
 
+    if args.grad_clip is not None and args.grad_clip <= 0:
+        raise ValueError("grad_clip must be positive")
+
     state = [model.state, optimizer.state, mx.random.state]
 
     @partial(mx.compile, inputs=state, outputs=state)
@@ -250,14 +264,29 @@ def train(
         if prev_grad is not None:
             grad = tree_map(lambda x, y: x + y, grad, prev_grad)
 
+        grad_norm = None
         if do_update:
             grad = average_gradients(grad)
             if grad_accum_steps > 1:
                 grad = tree_map(lambda x: x / grad_accum_steps, grad)
+            if args.grad_clip is not None:
+                # Clip the accumulated and averaged gradient, not each
+                # micro-batch, so accumulation stays equivalent to a large batch.
+                grad, grad_norm = clip_grad_norm(grad, args.grad_clip)
+                # A batch that overflows makes the norm inf or nan, and
+                # clip_grad_norm propagates that to every entry, so clipping
+                # alone would still poison the weights. Zero the gradient for
+                # that step instead. Note this is not a full no-op: a momentum
+                # optimizer still moves the weights by its existing state. It
+                # does keep the non-finite values out of them.
+                # mx.where keeps the check in the compiled graph; a Python
+                # branch on grad_norm would sync the device every step.
+                keep = mx.isfinite(grad_norm)
+                grad = tree_map(lambda g: mx.where(keep, g, 0), grad)
             optimizer.update(model, grad)
             grad = None
 
-        return lvalue, toks, grad
+        return lvalue, toks, grad, grad_norm
 
     model.train()
     losses = 0
@@ -266,6 +295,8 @@ def train(
     trained_tokens = 0
     train_time = 0
     grad_accum = None
+    max_grad_norm = mx.array(0.0)
+    n_nonfinite = mx.array(0, mx.int32)
 
     ui = TrainUI(args.iters, rank=rank)
     with ui:
@@ -318,7 +349,7 @@ def train(
 
                 tic = time.perf_counter()
 
-            lvalue, toks, grad_accum = step(
+            lvalue, toks, grad_accum, grad_norm = step(
                 batch,
                 grad_accum,
                 it % grad_accum_steps == 0,
@@ -327,7 +358,11 @@ def train(
             losses += lvalue
             n_tokens += toks
             steps += 1
-            mx.eval(state, losses, n_tokens, grad_accum)
+            if grad_norm is not None:
+                # Kept as arrays so tracking them adds no extra device sync.
+                max_grad_norm = mx.maximum(max_grad_norm, grad_norm)
+                n_nonfinite += mx.logical_not(mx.isfinite(grad_norm)).astype(mx.int32)
+            mx.eval(state, losses, n_tokens, grad_accum, max_grad_norm, n_nonfinite)
             _clear_cache(args.clear_cache_threshold)
             train_time += time.perf_counter() - tic
 
@@ -346,17 +381,29 @@ def train(
                 ui.report_train(it, train_loss, tokens_sec, trained_tokens)
 
                 if training_callback is not None:
-                    training_callback.on_train_loss_report(
-                        {
-                            "iteration": it,
-                            "train_loss": train_loss,
-                            "learning_rate": learning_rate,
-                            "iterations_per_second": it_sec,
-                            "tokens_per_second": tokens_sec,
-                            "trained_tokens": trained_tokens,
-                            "peak_memory": peak_mem,
-                        }
-                    )
+                    report = {
+                        "iteration": it,
+                        "train_loss": train_loss,
+                        "learning_rate": learning_rate,
+                        "iterations_per_second": it_sec,
+                        "tokens_per_second": tokens_sec,
+                        "trained_tokens": trained_tokens,
+                        "peak_memory": peak_mem,
+                    }
+                    if args.grad_clip is not None:
+                        report["max_grad_norm"] = max_grad_norm.item()
+                        report["non_finite_grad_steps"] = n_nonfinite.item()
+                    training_callback.on_train_loss_report(report)
+
+                if args.grad_clip is not None:
+                    skipped = n_nonfinite.item()
+                    if skipped > 0:
+                        rprint(
+                            f"[WARNING] Iter {it}: zeroed the gradient on {skipped} "
+                            "step(s) with a non-finite norm."
+                        )
+                    max_grad_norm = mx.array(0.0)
+                    n_nonfinite = mx.array(0, mx.int32)
 
                 losses = 0
                 n_tokens = 0

--- a/tests/test_tuner_grad_clip.py
+++ b/tests/test_tuner_grad_clip.py
@@ -1,0 +1,238 @@
+# Copyright © 2025 Apple Inc.
+
+import tempfile
+import unittest
+from pathlib import Path
+
+import mlx.core as mx
+import mlx.nn as nn
+import mlx.optimizers as opt
+import numpy as np
+from mlx.utils import tree_flatten
+
+from mlx_lm.tuner.trainer import TrainingArgs, TrainingCallback, train
+
+
+class Tiny(nn.Module):
+    """Small model so these tests run without loading real weights."""
+
+    def __init__(self, vocab_size=32, dims=16):
+        super().__init__()
+        self.embed = nn.Embedding(vocab_size, dims)
+        self.out = nn.Linear(dims, vocab_size, bias=False)
+
+    def __call__(self, x):
+        return self.out(self.embed(x))
+
+
+class Recorder(TrainingCallback):
+    def __init__(self):
+        self.reports = []
+
+    def on_train_loss_report(self, info):
+        self.reports.append(info)
+
+    def on_val_loss_report(self, info):
+        pass
+
+
+NORMAL_TOKEN = 1
+POISON_TOKEN = 7
+
+
+def constant_batches(length=8, poison_at=None):
+    """Deterministic batch stream in the shape iterate_batches yields.
+
+    A poisoned batch is marked in the token ids rather than by a Python flag,
+    because step() is wrapped in mx.compile: a Python-side branch would be
+    traced once and then baked into every later iteration.
+    """
+
+    def gen(
+        dataset, batch_size, max_seq_length, loop=False, seed=None, comm_group=None
+    ):
+        it = 0
+        while True:
+            it += 1
+            token = POISON_TOKEN if it == poison_at else NORMAL_TOKEN
+            tokens = mx.full((batch_size, length), token, dtype=mx.int32)
+            yield tokens, mx.array([[0, length]] * batch_size)
+            if not loop:
+                break
+
+    return gen
+
+
+def spiking_loss(kind="nan"):
+    """Loss that overflows only on a batch marked with POISON_TOKEN, simulating
+    a single batch whose gradient is not finite. The branch is a mx.where on
+    the batch contents so it survives compilation."""
+    bad = float("nan") if kind == "nan" else float("inf")
+
+    def loss(model, batch, lengths):
+        logits = model(batch[:, :-1])
+        ce = nn.losses.cross_entropy(logits, batch[:, 1:]).astype(mx.float32).mean()
+        poisoned = mx.any(batch == POISON_TOKEN)
+        ce = ce * mx.where(poisoned, mx.array(bad), mx.array(1.0))
+        return ce, mx.array(batch.size)
+
+    return loss
+
+
+def weights_of(model):
+    return {k: np.asarray(v) for k, v in tree_flatten(model.trainable_parameters())}
+
+
+class TestGradClip(unittest.TestCase):
+    def setUp(self):
+        mx.random.seed(0)
+        self.dataset = [([1] * 8, 0)] * 8
+        # train() always saves the final adapter, so keep it out of the repo.
+        self.tmp_dir = tempfile.TemporaryDirectory()
+        self.addCleanup(self.tmp_dir.cleanup)
+
+    def _train(self, model, optimizer, iters=4, loss=None, poison_at=None, **kwargs):
+        cb = Recorder()
+        args = TrainingArgs(
+            batch_size=2,
+            iters=iters,
+            val_batches=0,
+            steps_per_report=1,
+            steps_per_eval=10**9,
+            steps_per_save=10**9,
+            max_seq_length=8,
+            adapter_file=Path(self.tmp_dir.name) / "adapters.safetensors",
+            **kwargs,
+        )
+        train(
+            model=model,
+            optimizer=optimizer,
+            train_dataset=self.dataset,
+            val_dataset=None,
+            args=args,
+            iterate_batches=constant_batches(poison_at=poison_at),
+            training_callback=cb,
+            **({"loss": loss} if loss else {}),
+        )
+        return cb
+
+    def test_default_is_off(self):
+        """No grad_clip means no norm tracking and no reporting keys."""
+        model = Tiny()
+        cb = self._train(model, opt.Adam(learning_rate=1e-3))
+        self.assertTrue(cb.reports)
+        for r in cb.reports:
+            self.assertNotIn("max_grad_norm", r)
+            self.assertNotIn("non_finite_grad_steps", r)
+
+    def test_clip_matches_unclipped_when_norm_is_small(self):
+        """A clip bound above the actual norm must not change the trajectory."""
+        mx.random.seed(0)
+        a = Tiny()
+        self._train(a, opt.SGD(learning_rate=1e-3), loss=None)
+
+        mx.random.seed(0)
+        b = Tiny()
+        cb = self._train(b, opt.SGD(learning_rate=1e-3), grad_clip=1e9)
+
+        for k, v in weights_of(a).items():
+            self.assertTrue(np.allclose(v, weights_of(b)[k], atol=1e-6), k)
+        self.assertLess(max(r["max_grad_norm"] for r in cb.reports), 1e9)
+
+    def test_clip_bounds_the_norm(self):
+        """With a tight bound, the update is smaller than without one."""
+        mx.random.seed(0)
+        loose = Tiny()
+        self._train(loose, opt.SGD(learning_rate=1.0), iters=1)
+
+        mx.random.seed(0)
+        tight = Tiny()
+        cb = self._train(tight, opt.SGD(learning_rate=1.0), iters=1, grad_clip=1e-4)
+
+        mx.random.seed(0)
+        start = weights_of(Tiny())
+        moved_loose = max(
+            np.abs(v - start[k]).max() for k, v in weights_of(loose).items()
+        )
+        moved_tight = max(
+            np.abs(v - start[k]).max() for k, v in weights_of(tight).items()
+        )
+        self.assertGreater(moved_loose, moved_tight)
+        self.assertGreater(cb.reports[0]["max_grad_norm"], 1e-4)
+
+    def test_nan_gradient_does_not_reach_the_weights(self):
+        """The motivating case: one bad batch must not poison the run."""
+        for kind in ("nan", "inf"):
+            with self.subTest(kind=kind):
+                mx.random.seed(0)
+                model = Tiny()
+                cb = self._train(
+                    model,
+                    opt.Adam(learning_rate=1e-3),
+                    iters=4,
+                    loss=spiking_loss(kind=kind),
+                    poison_at=2,
+                    grad_clip=1.0,
+                )
+                for k, v in weights_of(model).items():
+                    self.assertTrue(np.isfinite(v).all(), f"{k} went non-finite")
+                self.assertEqual(sum(r["non_finite_grad_steps"] for r in cb.reports), 1)
+
+    def test_nan_gradient_poisons_the_weights_without_the_guard(self):
+        """Control for the test above: without grad_clip the weights are lost.
+        This is current behavior on main, and the reason for the flag."""
+        mx.random.seed(0)
+        model = Tiny()
+        self._train(
+            model,
+            opt.Adam(learning_rate=1e-3),
+            iters=4,
+            loss=spiking_loss(),
+            poison_at=2,
+        )
+        self.assertFalse(
+            all(np.isfinite(v).all() for v in weights_of(model).values()),
+            "expected unguarded training to go non-finite",
+        )
+
+    def test_training_continues_after_a_bad_batch(self):
+        """A skipped step must not stop later steps from learning."""
+        mx.random.seed(0)
+        model = Tiny()
+        before = weights_of(model)
+        self._train(
+            model,
+            opt.Adam(learning_rate=1e-3),
+            iters=6,
+            loss=spiking_loss(),
+            poison_at=2,
+            grad_clip=1.0,
+        )
+        after = weights_of(model)
+        self.assertTrue(any(not np.allclose(before[k], after[k]) for k in before))
+        self.assertTrue(all(np.isfinite(v).all() for v in after.values()))
+
+    def test_rejects_non_positive_clip(self):
+        for bad in (0.0, -1.0):
+            with self.subTest(value=bad):
+                with self.assertRaises(ValueError):
+                    self._train(Tiny(), opt.Adam(learning_rate=1e-3), grad_clip=bad)
+
+    def test_clips_accumulated_gradient_once(self):
+        """With accumulation the bound applies to the averaged gradient, so the
+        reported norm is on the same scale as without accumulation."""
+        mx.random.seed(0)
+        cb = self._train(
+            Tiny(),
+            opt.SGD(learning_rate=1e-3),
+            iters=4,
+            grad_clip=1e9,
+            grad_accumulation_steps=2,
+        )
+        norms = [r["max_grad_norm"] for r in cb.reports if r["max_grad_norm"] > 0]
+        self.assertTrue(norms)
+        self.assertTrue(all(np.isfinite(n) for n in norms))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Closes #1658 (opened for discussion; opening the PR since the implementation is done and tested, happy to change either design decision).

### Summary

The LoRA trainer has no bound on gradient size and no guard against non-finite gradients. One batch whose gradient overflows puts the LoRA weights into NaN permanently, and every later iteration reports `nan` with no warning and no recovery path.

This adds `grad_clip` to `TrainingArgs` and `--grad-clip` to `mlx_lm.lora`. Off by default, so no existing run changes behavior.

### High-level changes

- `mlx_lm/tuner/trainer.py`: `grad_clip: Optional[float] = None` on `TrainingArgs`; clipping plus a non-finite guard inside the compiled `step()`; `max_grad_norm` and `non_finite_grad_steps` surfaced to training callbacks; a warning when a step is dropped.
- `mlx_lm/lora.py`: `--grad-clip` flag and its `CONFIG_DEFAULTS` entry.
- `mlx_lm/LORA.md`: a "NaN Loss" section.
- `mlx_lm/examples/lora_config.yaml`: `grad_clip: null`.
- `tests/test_tuner_grad_clip.py`: 8 tests driving the real `train()`.

Clipping is applied to the already-accumulated and averaged gradient, immediately before `optimizer.update`, so it composes with `grad_accumulation_steps` and `average_gradients` rather than clipping each micro-batch separately.

### Why clipping alone is not enough

`clip_grad_norm` propagates non-finite values rather than removing them. A NaN in one entry makes the norm NaN, which scales every parameter to NaN. An `inf` norm makes the normalizer `0`, and `inf * 0` is NaN, so infinite gradients also poison every parameter:

| grads | total_norm | clipped result |
|---|---|---|
| `[nan, 1.0]`, `[2.0, 3.0]` | nan | all four entries nan |
| `[inf, 1.0]`, `[2.0, 3.0]` | inf | `[nan, 0.0]`, `[0.0, 0.0]` |

So clipping covers large-but-finite gradients, a different failure from the one that motivated the issue. The guard zeroes the gradient when the norm is not finite:

```python
grad, grad_norm = clip_grad_norm(grad, args.grad_clip)
keep = mx.isfinite(grad_norm)
grad = tree_map(lambda g: mx.where(keep, g, 0), grad)
```

`mx.where` keeps the check inside the compiled graph. A Python branch on `grad_norm` would force a device sync every iteration.

This is not a full no-op: a momentum optimizer still moves the weights from its existing state, and AdamW applies weight decay independently of the gradient (measured 1.07e-07 relative at lr=5e-6; exactly 0 with Adam or `weight_decay=0.0`). The non-finite values never reach the weights, which is the guarantee. Documented in `LORA.md` and in a code comment.

### Evaluation

**The default is inert.** 30 iterations, same seed, `main` at e5baded vs this branch with no `--grad-clip`:

```
main   losses: 4.169967 4.170533 4.171922 4.167962 4.160542 4.160848
branch losses: 4.169967 4.170533 4.171922 4.167962 4.160542 4.160848
```

Losses bit-identical. Weights differ by 2.98e-08, but `main` differs from *itself* across two runs by exactly the same 2.98e-08, so that is run-to-run nondeterminism, not this change.

**It catches a real overflow and the run recovers.** Qwen3-1.7B, LoRA rank 8 over 16 layers, batch 4, max_seq 2048, AdamW, cosine + warmup 100. This config previously died at iter 10 with `Train loss nan` and never recovered. With `--grad-clip 1.0`:

```
Iter 10: Train loss 1.3797, LR 4.500e-07, grad_norm 4.232,         skipped 0
Iter 20: Train loss 1.4634, LR 9.500e-07, grad_norm 4.200,         skipped 0
Iter 30: Train loss 1.4008, LR 1.450e-06, grad_norm 5044.074,      skipped 0
Iter 40: SKIPPED non-finite batch (loss 1.2308621406555176, norm nan) -- weights untouched
Iter 40: Train loss 1.2680, LR 1.950e-06, grad_norm 177650662.281, skipped 1
Iter 50: Train loss 1.1788, LR 2.450e-06, grad_norm 2.361,         skipped 1
Iter 60: Train loss 1.0549, LR 2.950e-06, grad_norm 1.511,         skipped 1
```

Two things worth noting. The loss was **finite (1.2309) while the norm was NaN**, so the overflow is in the backward pass and is invisible to loss-watching; by the time the loss prints `nan` the weights are already lost. And the norm escalated `4.2 → 5044 → 1.78e8 → nan` with clipping active the whole time, so clipping alone would not have saved this run. One skip in 60 iterations, and the lowest loss of the run came after it.

**Per-iteration cost is below measurement noise.** 5 interleaved pairs of 40 iterations on a synthetic model: median 32.09 ms without, 33.78 ms with, stdev 15.33 and 10.19. I am not claiming a number from that; the difference is inside the noise floor. The added work is one `square().sum()` tree-reduce plus a `where` per parameter, all inside the existing compiled graph.

Environment: mlx 0.32.0, M2 Pro 32 GB, macOS 26.5.2.

### Risks

- The main technical risk was whether `clip_grad_norm` survives `mx.compile`, since it introduces a data-dependent value. Verified it does, including across a step with a 1000x gradient spike, and the real run above is 60+ compiled iterations with no tracing error.
- Behavior change when the flag is unset: none, per the equivalence check above.
- The zeroed step is not a complete no-op with a momentum optimizer, as described above. This is the one behavior a user could find surprising, hence documenting it rather than hiding it.
- `--grad-clip <= 0` raises `ValueError` rather than silently doing nothing.

### Tests

```
python -m unittest tests.test_tuner_grad_clip tests.test_tuner_trainer tests.test_finetune
Ran 24 tests in 0.285s -- OK
```

The new tests drive the real `train()` rather than a reimplementation, and include a control asserting that **without** the flag the weights do go non-finite, so the guard is tested against the actual current behavior. Note that a bad batch has to be marked in the batch data rather than by a Python-side counter, since `mx.compile` traces the loss once and would otherwise bake the overflow into every later iteration.

### Open questions

1. Do you want the non-finite guard in this change, or clipping only? Clipping alone would not have saved the run above, which is why both are here, but the guard is the less standard half and I would rather ask.
2. One flag for both, or a separate flag for the guard?

Happy to split, rename, or drop either half.

### Pre-merge

Nothing required beyond review. No new dependencies, no migration, no config changes for existing users.

### Post-merge

If you want, `--grad-clip 1.0` could be mentioned in the LoRA docs as a first thing to try when a fine-tune reports `nan`, since #49 and #361 both drew several reports of that symptom.

### Not in this PR

Two adjacent things I found while diagnosing this and deliberately left out:

- `iterate_batches` gates its seeding on `if seed:`, so an explicit `seed=0` is silently ignored, and `0` is the default in `CONFIG_DEFAULTS`. Filed as #1660. Note batch order for a normal CLI run is still reproducible, since `run()` seeds global numpy before training; this only bites when calling the API directly with `seed=0`, or when something else draws from numpy in between.
- `CacheDataset.itemlen` does `len(self._data[idx])`, and all three dataset classes return the raw record from `__getitem__`, so for `{"text": ...}` it returns 1 for every row and the length sort in `iterate_batches` never sorts. That is a throughput and memory issue, not a correctness one. I measured 31.6% extra padded compute on one 8786-row dataset and will open it separately.

