### PR TITLE
Add Apertus tool parser

### DIFF
--- a/mlx_lm/tokenizer_utils.py
+++ b/mlx_lm/tokenizer_utils.py
@@ -253,6 +253,9 @@ class BPEStreamingDetokenizer(StreamingDetokenizer):
 def _infer_thinking(tokenizer):
     vocab = tokenizer.get_vocab()
     THINK_TOKENS = [
+        # Apertus has <think>/</think> in its vocabulary but never emits them,
+        # so its own markers must be checked first.
+        ("<|inner_prefix|>", "<|inner_suffix|>"),
         ("<think>", "</think>"),
         ("<longcat_think>", "</longcat_think>"),
     ]
@@ -566,6 +569,8 @@ def _infer_tool_parser(chat_template):
         return "qwen3_coder"
     elif "<|tool_calls_section_begin|>" in chat_template:
         return "kimi_k2"
+    elif "<|tools_prefix|>" in chat_template:
+        return "apertus"
     elif "[TOOL_CALLS]" in chat_template:
         return "mistral"
     elif "<tool_call>" in chat_template and "tool_call.name" in chat_template:

--- a/mlx_lm/tool_parsers/apertus.py
+++ b/mlx_lm/tool_parsers/apertus.py
@@ -1,0 +1,35 @@
+# Copyright © 2026 Apple Inc.
+"""
+Modified from:
+https://github.com/vllm-project/vllm/blob/main/vllm/tool_parsers/apertus_tool_parser.py
+"""
+
+import json
+from typing import Any
+
+tool_call_start = "<|tools_prefix|>"
+tool_call_end = "<|tools_suffix|>"
+
+
+def parse_tool_call(text: str, tools: Any | None = None):
+    # Apertus emits an array of single key objects mapping the function name to
+    # its arguments, e.g.
+    #   [{"get_weather": {"location": "London"}}, {"get_time": {}}]
+    calls = json.loads(text)
+    if not isinstance(calls, list):
+        calls = [calls]
+
+    tool_calls = []
+    for call in calls:
+        if not isinstance(call, dict) or not call:
+            continue
+        name, arguments = next(iter(call.items()))
+        # A call with no arguments can come back as null, but clients expect an
+        # object.
+        if arguments is None:
+            arguments = {}
+        tool_calls.append(dict(name=name, arguments=arguments))
+
+    if not tool_calls:
+        raise ValueError(f"Could not parse tool call from: {text}")
+    return tool_calls

--- a/tests/test_tokenizers.py
+++ b/tests/test_tokenizers.py
@@ -10,6 +10,7 @@ from mlx_lm.tokenizer_utils import (
     NaiveStreamingDetokenizer,
     SPMStreamingDetokenizer,
     TokenizerWrapper,
+    _infer_thinking,
 )
 from mlx_lm.utils import load_tokenizer
 
@@ -109,6 +110,35 @@ class TestTokenizers(unittest.TestCase):
         self.assertIsNone(tokenizer.think_end)
         self.assertIsNone(tokenizer.think_start_id)
         self.assertIsNone(tokenizer.think_end_id)
+
+    def test_thinking_marker_precedence(self):
+        # Apertus carries unused <think> tokens alongside the markers it
+        # actually emits, so its own markers have to win.
+        class Tokenizer:
+            def __init__(self, vocab):
+                self._vocab = vocab
+
+            def get_vocab(self):
+                return self._vocab
+
+        apertus_vocab = {
+            "<|inner_prefix|>": 32,
+            "<|inner_suffix|>": 33,
+            "<think>": 69,
+            "</think>": 70,
+        }
+        think_start, think_end, start_ids, end_ids = _infer_thinking(
+            Tokenizer(apertus_vocab)
+        )
+        self.assertEqual(think_start, "<|inner_prefix|>")
+        self.assertEqual(think_end, "<|inner_suffix|>")
+        self.assertEqual(start_ids, (32,))
+        self.assertEqual(end_ids, (33,))
+
+        think_start, _, _, _ = _infer_thinking(Tokenizer({"<think>": 1, "</think>": 2}))
+        self.assertEqual(think_start, "<think>")
+
+        self.assertEqual(_infer_thinking(Tokenizer({})), (None, None, None, None))
 
     def test_find_token(self):
         # Check that _find returns a valid index when

--- a/tests/test_tool_parsing.py
+++ b/tests/test_tool_parsing.py
@@ -2,6 +2,7 @@ import unittest
 from pathlib import Path
 
 from mlx_lm.tool_parsers import (
+    apertus,
     function_gemma,
     gemma4,
     glm47,
@@ -312,6 +313,61 @@ class TestToolParsing(unittest.TestCase):
             },
         ]
         self.assertEqual(tool_calls, expected)
+
+    def test_apertus(self):
+        # Single tool call
+        test_case = '[{"multiply": {"a": 12234585, "b": 48838483920}}]'
+        tool_calls = apertus.parse_tool_call(test_case, None)
+        expected = [
+            {"name": "multiply", "arguments": {"a": 12234585, "b": 48838483920}}
+        ]
+        self.assertEqual(tool_calls, expected)
+
+        # Multiple tool calls
+        test_case = (
+            '[{"get_weather": {"location": "London"}}, '
+            '{"get_time": {"location": "London"}}]'
+        )
+        tool_calls = apertus.parse_tool_call(test_case, None)
+        expected = [
+            {"name": "get_weather", "arguments": {"location": "London"}},
+            {"name": "get_time", "arguments": {"location": "London"}},
+        ]
+        self.assertEqual(tool_calls, expected)
+
+        # Nested arguments
+        test_case = (
+            '[{"complex_function": {"nested": {"inner": "value"}, "list": ["a", "b"]}}]'
+        )
+        tool_calls = apertus.parse_tool_call(test_case, None)
+        expected = [
+            {
+                "name": "complex_function",
+                "arguments": {"nested": {"inner": "value"}, "list": ["a", "b"]},
+            }
+        ]
+        self.assertEqual(tool_calls, expected)
+
+        # Null arguments are normalized so clients receive an empty object
+        test_case = '[{"get_time": null}]'
+        tool_calls = apertus.parse_tool_call(test_case, None)
+        self.assertEqual(tool_calls, [{"name": "get_time", "arguments": {}}])
+
+        # A bare object rather than an array
+        test_case = '{"get_time": {}}'
+        tool_calls = apertus.parse_tool_call(test_case, None)
+        self.assertEqual(tool_calls, [{"name": "get_time", "arguments": {}}])
+
+        # Entries which cannot be a tool call are skipped
+        test_case = '[{"get_time": {}}, {}, "junk"]'
+        tool_calls = apertus.parse_tool_call(test_case, None)
+        self.assertEqual(tool_calls, [{"name": "get_time", "arguments": {}}])
+
+        # Nothing parseable raises, as does a call truncated mid generation
+        with self.assertRaises(ValueError):
+            apertus.parse_tool_call("[]", None)
+        with self.assertRaises(ValueError):
+            apertus.parse_tool_call('[{"get_weather": {"location": "London"}', None)
 
     def test_minimax_m2(self):
         test_case = (


### PR DESCRIPTION
Apertus emits tool calls as an array of single key objects wrapped in
`<|tools_prefix|>` … `<|tools_suffix|>`:

```
<|tools_prefix|>[{"get_weather": {"location": "London"}}]<|tools_suffix|>
```

This adds a parser for that format and infers it from the chat template, so
Apertus models work without an explicit `tool_parser_type` in
`tokenizer_config.json`. Before this, `_infer_tool_parser` returned `None` for
Apertus, `has_tool_calling` stayed `False`, and the server rejected any request
carrying `tools`.

It also fixes reasoning detection for the same models. Apertus delimits
deliberation with `<|inner_prefix|>` … `<|inner_suffix|>`, but it *also* carries
unused `<think>`/`</think>` tokens in its vocabulary (ids 69/70). Since
`_infer_thinking` scans the vocab, it matched the unused pair, so the reasoning
state was never reachable and deliberation came back as `content` instead of
`reasoning`. The Apertus pair is now checked first.

Both changes are in one PR because they enable the same models and touch the
same file, following #810, which added the LongCat tool parser and its
`THINK_TOKENS` entry together.

### Provenance

**Derived from vLLM.** `parse_tool_call` is adapted from vLLM's Apache-2.0
licensed
[`apertus_tool_parser.py`](https://github.com/vllm-project/vllm/blob/main/vllm/tool_parsers/apertus_tool_parser.py)
— specifically its non-streaming `extract_tool_calls`, whose structure it keeps:
wrapping a non-list payload, skipping entries that aren't non-empty objects, and
`next(iter(obj.items()))` to split the single key into name and arguments.
Reduced to the batch path, since mlx-lm buffers the whole tool region and parses
it once, so vLLM's streaming diff machinery has no analogue here. The header
follows `kimi_k2.py`, which is likewise a "Modified from" vLLM port. Flagging the
Apache-2.0 → MIT direction explicitly in case you'd prefer different attribution.

**Informed by SGLang, but not derived from it.** No code is taken from SGLang's
[`apertus2509_detector.py`](https://github.com/sgl-project/sglang/blob/main/python/sglang/srt/function_call/apertus2509_detector.py);
its equivalent helper is written differently. What it contributed is one
behavioural decision — normalizing null arguments to `{}`, so clients never
receive `"arguments": "null"` — and corroboration of two facts: the wire format,
and the reasoning marker names, which match its `Apertus2509Detector` in
`reasoning_parser.py`. Both facts were also verified directly against Apertus'
chat template and vocabulary rather than taken on trust.

Deliberately **not** carried over from either: partial-JSON recovery for calls
truncated mid-generation (vLLM's `test_incomplete_tool_call`). No mlx-lm parser
does this, and since tool regions are parsed once rather than incrementally, a
truncated call raises and is logged by the server instead.

### Note on `<|tools_suffix|>`

Worth flagging for future reference: Apertus lists `<|tools_suffix|>` in
`eos_token_id` (`[2, 68, 72]`), so its tool-call end marker is also an EOS
token. This works on current `main` because stop-sequence matching
(`StopSequenceMatcher`) is separate from the text state machine. It did *not*
work in 0.31.3, where EOS ids were folded into the tool state's transition trie
as stop edges — the duplicate `(72,)` overwrote the tool-end transition, so tool
calls were parsed into a buffer and then silently discarded (HTTP 200, empty
assistant message). No change is needed for this, but it's a real constraint on
that part of the design.

### Testing

- `tests/test_tool_parsing.py::test_apertus` — single and multiple calls, nested
  arguments, null arguments, bare object instead of an array, unparseable
  entries skipped, and `ValueError` on nothing-parseable and on a call truncated
  mid generation.
- `tests/test_tokenizers.py::test_thinking_marker_precedence` — locks in that
  Apertus' markers win over the unused `<think>` pair. Uses a stub vocab so it
  needs no network, following `test_find_token`'s precedent of testing internals.
- `tests/test_tool_parsing.py`, `tests/test_server.py` (25 tests), and the
  targeted tokenizer tests pass locally. `pre-commit` (black, isort) clean.
- Verified end to end against `mlx_lm.server` with
  `tokimoa/apertus-v1.5-8b-mlx-8bit`: `tool_calls` emitted with
  `finish_reason: "tool_calls"` on both the batch and streaming paths, and a
  1032-char `reasoning` field correctly separated from `content` with
  `enable_thinking: true`.
- Template inference confirmed on both `swiss-ai/Apertus-v1.5-8B` and the
  quantized `tokimoa/apertus-v1.5-8b-mlx-8bit`, neither of which carries a
  `tool_parser_type` key.

Not run locally: the full `tests/test_tokenizers.py` suite, which downloads
several multi-GB models.


### Follow-up, deliberately not in this PR

`_infer_thinking` resolves markers by scanning the vocabulary, which makes it
order-dependent for any model shipping unused marker tokens — Apertus is the
first case, but it won't be the last, and the failure is silent (reasoning
appears as content). Keying off the chat template, as `_infer_tool_parser` does,
would be more robust. Worth raising as an issue rather than expanding this PR.
