### PR TITLE
Fix evaluate crash on tasks with no stop sequences

### DIFF
--- a/mlx_lm/evaluate.py
+++ b/mlx_lm/evaluate.py
@@ -35,7 +35,10 @@ def _rstrip_until(s, untils):
     l = len(s)
     f = [s.find(u) for u in untils]
     f = [l if x < 0 else x for x in f]
-    return s[: min(f)]
+    # A task may legitimately specify no stop sequences -- ifeval sets
+    # `until: []` because the completion is meant to run to max_gen_toks --
+    # and there is then nothing to truncate at.
+    return s[: min(f, default=l)]
 
 
 def _lstrip(s, pattern):

--- a/tests/test_evaluate.py
+++ b/tests/test_evaluate.py
@@ -5,7 +5,7 @@ from unittest.mock import MagicMock, patch
 
 import mlx.core as mx
 
-from mlx_lm.evaluate import MLXLM
+from mlx_lm.evaluate import MLXLM, _rstrip_until
 
 
 class TestMLXLM(unittest.TestCase):
@@ -53,6 +53,26 @@ class TestMLXLM(unittest.TestCase):
         self.assertEqual(len(call_args_list[0][0][0]), 2)  # First batch: 2 items
         self.assertEqual(len(call_args_list[1][0][0]), 2)  # Second batch: 2 items
         self.assertEqual(len(call_args_list[2][0][0]), 1)  # Third batch: 1 item
+
+
+class TestRstripUntil(unittest.TestCase):
+    def test_truncates_at_first_stop_sequence(self):
+        self.assertEqual(_rstrip_until("abc<eos>def", ["<eos>"]), "abc")
+
+    def test_truncates_at_the_earliest_of_several(self):
+        self.assertEqual(_rstrip_until("abc\n\nQ:", ["Q:", "\n\n"]), "abc")
+
+    def test_returns_the_whole_string_when_nothing_matches(self):
+        self.assertEqual(_rstrip_until("abc", ["<eos>"]), "abc")
+
+    def test_no_stop_sequences(self):
+        # Tasks may legitimately specify none: lm-eval's ifeval (and every one
+        # of its multilingual variants) sets `until: []` so the completion runs
+        # to max_gen_toks. There is then nothing to truncate at.
+        self.assertEqual(_rstrip_until("abc", []), "abc")
+
+    def test_no_stop_sequences_on_empty_string(self):
+        self.assertEqual(_rstrip_until("", []), "")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
### Problem

`_rstrip_until` in `mlx_lm/evaluate.py` calls `min()` on the list of stop-sequence positions. When a task specifies no stop sequences the list is empty and it raises:

```
ValueError: min() iterable argument is empty
```

lm-eval's `ifeval` does exactly that — `until: []` in `ifeval.yaml`, because the completion is meant to run to `max_gen_toks` (1280) rather than stop at a marker. Every multilingual variant (`ifeval_ca`, `ifeval_es`, …) sets it too. So:

```
mlx_lm.evaluate --model <any> --task ifeval
```

fails outright instead of producing a score.

### Fix

With no stop sequences there is nothing to truncate at, so the completion is returned whole. `min(f, default=l)` does that; the non-empty case is unchanged.

### Tests

Added `TestRstripUntil` to `tests/test_evaluate.py` covering truncation at the first stop sequence, the earliest of several, no match, the empty-`untils` case, and empty-`untils` on an empty string.

```
$ python -m pytest tests/test_evaluate.py -q
......                                                                   [100%]
6 passed
```