### PR TITLE
Save the best-validation-loss adapter, and add optional early stopping

### DIFF
--- a/mlx_lm/LORA.md
+++ b/mlx_lm/LORA.md
@@ -22,6 +22,7 @@ LoRA (QLoRA).[^qlora] LoRA fine-tuning works with the following model families:
   - [Generate](#Generate)
 - [Fuse](#Fuse)
 - [Data](#Data)
+- [Choosing the Best Checkpoint](#Choosing-the-Best-Checkpoint)
 - [Memory Issues](#Memory-Issues)
 
 ## Run
@@ -361,6 +362,40 @@ How can I assistant you today.<|im_end|>
 If you are unsure of the format to use, the `chat` or `completions` are good to
 start with. For custom requirements on the format of the dataset, use the
 `text` format to assemble the content yourself.
+
+## Choosing the Best Checkpoint
+
+Training reports validation loss periodically but the weights saved in
+`adapters.safetensors` are the ones training *ended* on, which are not
+necessarily the best. If validation loss bottoms out partway through a long run,
+the final adapter is worse than one you already had.
+
+By default the adapter with the lowest validation loss is also written to
+`best_adapters.safetensors` alongside it, so you can pick whichever you want:
+
+```shell
+mlx_lm.generate --adapter-path adapters/best_adapters.safetensors ...
+```
+
+`adapters.safetensors` still always holds the final weights, so nothing changes
+for existing workflows. Pass `--no-save-best` to skip the extra file.
+
+To stop a run once it stops improving, use `--patience N`: training ends after
+`N` consecutive validations with no improvement. Since patience counts
+validations rather than iterations, its meaning depends on `--steps-per-eval`.
+`--min-delta` sets how much validation loss must drop to count as an
+improvement, which is useful when the loss is noisy or nearly flat:
+
+```shell
+mlx_lm.lora \
+    --model <path_to_model> \
+    --train \
+    --data <path_to_data> \
+    --patience 3 \
+    --min-delta 0.01
+```
+
+Early stopping is off unless `--patience` is given.
 
 ## Memory Issues
 

--- a/mlx_lm/examples/lora_config.yaml
+++ b/mlx_lm/examples/lora_config.yaml
@@ -50,6 +50,18 @@ steps_per_eval: 200
 # Number of micro-steps to accumulate before each optimizer update.
 grad_accumulation_steps: 1
 
+# Also save the adapter with the lowest validation loss to
+# best_adapters.safetensors. Needs a validation set.
+save_best: true
+
+# Stop after this many validations without an improvement in validation loss.
+# Null disables early stopping.
+patience: null
+
+# Minimum decrease in validation loss to count as an improvement, for both
+# patience and save_best.
+min_delta: 0.0
+
 # Load path to resume training with the given adapter weights.
 resume_adapter_file: null
 

--- a/mlx_lm/lora.py
+++ b/mlx_lm/lora.py
@@ -72,6 +72,9 @@ CONFIG_DEFAULTS = {
     "grad_checkpoint": False,
     "grad_accumulation_steps": 1,
     "clear_cache_threshold": 0,
+    "save_best": True,
+    "patience": None,
+    "min_delta": 0.0,
     "lr_schedule": None,
     "lora_parameters": {"rank": 8, "dropout": 0.0, "scale": 20.0},
     "mask_prompt": False,
@@ -150,6 +153,32 @@ def build_parser():
         "--grad-accumulation-steps",
         type=int,
         help="Number of steps to accumulate before each optimizer update.",
+    )
+    parser.add_argument(
+        "--no-save-best",
+        dest="save_best",
+        action="store_false",
+        default=None,
+        help=(
+            "Do not save the adapter with the lowest validation loss to "
+            "best_adapters.safetensors."
+        ),
+    )
+    parser.add_argument(
+        "--patience",
+        type=int,
+        help=(
+            "Stop training after this many validations without an improvement "
+            "in validation loss. Off by default."
+        ),
+    )
+    parser.add_argument(
+        "--min-delta",
+        type=float,
+        help=(
+            "Minimum decrease in validation loss to count as an improvement "
+            "for --patience and for saving the best adapter."
+        ),
     )
     parser.add_argument(
         "--resume-adapter-file",
@@ -279,6 +308,9 @@ def train_model(
         max_seq_length=args.max_seq_length,
         grad_checkpoint=args.grad_checkpoint,
         grad_accumulation_steps=args.grad_accumulation_steps,
+        save_best=args.save_best,
+        patience=args.patience,
+        min_delta=args.min_delta,
     )
 
     # Initialize the selected optimizer

--- a/mlx_lm/tuner/trainer.py
+++ b/mlx_lm/tuner/trainer.py
@@ -5,6 +5,7 @@ import time
 from dataclasses import dataclass, field
 from functools import partial
 from pathlib import Path
+from typing import Optional
 
 import mlx.core as mx
 import mlx.nn as nn
@@ -79,6 +80,33 @@ class TrainingArgs:
         default=0,
         metadata={
             "help": "Clear the allocator cache between steps if it grows too large."
+        },
+    )
+    save_best: bool = field(
+        default=True,
+        metadata={
+            "help": (
+                "Also save the adapter with the lowest validation loss to "
+                "best_adapters.safetensors. Requires a validation set."
+            )
+        },
+    )
+    patience: Optional[int] = field(
+        default=None,
+        metadata={
+            "help": (
+                "Stop training after this many validations without an "
+                "improvement in validation loss. Disabled by default."
+            )
+        },
+    )
+    min_delta: float = field(
+        default=0.0,
+        metadata={
+            "help": (
+                "Minimum decrease in validation loss to count as an "
+                "improvement for patience and for saving the best adapter."
+            )
         },
     )
 
@@ -241,6 +269,14 @@ def train(
     if grad_accum_steps < 1:
         raise ValueError("grad_accumulation_steps must be at least 1")
 
+    if args.patience is not None:
+        if args.patience < 1:
+            raise ValueError("patience must be at least 1")
+        if val_dataset is None:
+            # Silently never stopping would be worse than saying so. save_best
+            # needs a validation loss too, but no-ops harmlessly without one.
+            raise ValueError("patience requires a validation set")
+
     state = [model.state, optimizer.state, mx.random.state]
 
     @partial(mx.compile, inputs=state, outputs=state)
@@ -266,6 +302,11 @@ def train(
     trained_tokens = 0
     train_time = 0
     grad_accum = None
+    best_val_loss = float("inf")
+    best_it = None
+    n_no_improve = 0
+    stopped_early = False
+    best_adapter_file = Path(args.adapter_file).parent / "best_adapters.safetensors"
 
     ui = TrainUI(args.iters, rank=rank)
     with ui:
@@ -315,6 +356,29 @@ def train(
                             "val_time": val_time,
                         }
                     )
+
+                # Capture the best weights here rather than inferring them
+                # later from save timing: steps_per_eval and steps_per_save
+                # are independent, so the most recent periodic save is not
+                # necessarily the iteration that validated best.
+                if val_loss < best_val_loss - args.min_delta:
+                    best_val_loss = val_loss
+                    best_it = it
+                    n_no_improve = 0
+                    if args.save_best and rank == 0:
+                        best_weights = dict(tree_flatten(model.trainable_parameters()))
+                        mx.save_safetensors(str(best_adapter_file), best_weights)
+                        ui.report_save(best_adapter_file)
+                else:
+                    n_no_improve += 1
+                    if args.patience is not None and n_no_improve >= args.patience:
+                        rprint(
+                            f"[INFO] Stopping early at iter {it}: no improvement in "
+                            f"validation loss for {n_no_improve} validation(s). "
+                            f"Best was {best_val_loss:.3f} at iter {best_it}."
+                        )
+                        stopped_early = True
+                        break
 
                 tic = time.perf_counter()
 
@@ -373,7 +437,18 @@ def train(
                 mx.save_safetensors(str(checkpoint), adapter_weights)
                 ui.report_save(checkpoint)
 
-    # Save final weights
+    # Save final weights. This always writes the weights training ended on,
+    # even when it stopped early, so args.adapter_file keeps its meaning. The
+    # best checkpoint, if any, is a separate file.
     if rank == 0:
         adapter_weights = dict(tree_flatten(model.trainable_parameters()))
         mx.save_safetensors(str(args.adapter_file), adapter_weights)
+        if best_it is not None and best_it != it:
+            msg = (
+                f"[INFO] Lowest validation loss was {best_val_loss:.3f} at iter "
+                f"{best_it}, while {args.adapter_file} holds the weights from "
+                f"iter {it}."
+            )
+            if args.save_best:
+                msg += f" The best weights are in {best_adapter_file}."
+            rprint(msg)

--- a/tests/test_tuner_early_stopping.py
+++ b/tests/test_tuner_early_stopping.py
@@ -1,0 +1,226 @@
+# Copyright © 2025 Apple Inc.
+
+import tempfile
+import unittest
+from pathlib import Path
+
+import mlx.core as mx
+import mlx.nn as nn
+import mlx.optimizers as opt
+import numpy as np
+
+from mlx_lm.tuner.trainer import TrainingArgs, TrainingCallback, train
+
+
+class Tiny(nn.Module):
+    def __init__(self, vocab_size=32, dims=16):
+        super().__init__()
+        self.embed = nn.Embedding(vocab_size, dims)
+        self.out = nn.Linear(dims, vocab_size, bias=False)
+
+    def __call__(self, x):
+        return self.out(self.embed(x))
+
+
+class Recorder(TrainingCallback):
+    def __init__(self):
+        self.val = []
+
+    def on_train_loss_report(self, info):
+        pass
+
+    def on_val_loss_report(self, info):
+        self.val.append(info)
+
+
+def batches(
+    dataset, batch_size, max_seq_length, loop=False, seed=None, comm_group=None
+):
+    while True:
+        tokens = mx.full((batch_size, 8), 1, dtype=mx.int32)
+        yield tokens, mx.array([[0, 8]] * batch_size)
+        if not loop:
+            break
+
+
+def scripted_loss(val_losses):
+    """Drives validation loss through a fixed sequence so the improvement logic
+    can be tested without depending on real optimization dynamics.
+
+    train() calls the loss for training steps and for validation; only the
+    validation calls happen while model.training is False.
+    """
+    seq = list(val_losses)
+    state = {"i": 0}
+
+    def loss(model, batch, lengths):
+        ntoks = mx.array(batch.size)
+        if not model.training:
+            i = min(state["i"], len(seq) - 1)
+            state["i"] += 1
+            return mx.array(seq[i]), ntoks
+        logits = model(batch[:, :-1])
+        ce = nn.losses.cross_entropy(logits, batch[:, 1:]).astype(mx.float32).mean()
+        return ce, ntoks
+
+    return loss
+
+
+class TestEarlyStopping(unittest.TestCase):
+    def setUp(self):
+        mx.random.seed(0)
+        self.data = [([1] * 8, 0)] * 8
+        self.tmp = tempfile.TemporaryDirectory()
+        self.addCleanup(self.tmp.cleanup)
+        self.adapter = Path(self.tmp.name) / "adapters.safetensors"
+        self.best = Path(self.tmp.name) / "best_adapters.safetensors"
+
+    def _train(self, iters=6, steps_per_eval=1, loss=None, **kwargs):
+        cb = Recorder()
+        args = TrainingArgs(
+            batch_size=2,
+            iters=iters,
+            val_batches=1,
+            steps_per_report=10**9,
+            steps_per_eval=steps_per_eval,
+            steps_per_save=10**9,
+            max_seq_length=8,
+            adapter_file=self.adapter,
+            **kwargs,
+        )
+        train(
+            model=Tiny(),
+            optimizer=opt.Adam(learning_rate=1e-3),
+            train_dataset=self.data,
+            val_dataset=self.data,
+            args=args,
+            iterate_batches=batches,
+            training_callback=cb,
+            **({"loss": loss} if loss else {}),
+        )
+        return cb
+
+    def test_best_adapter_saved_on_improvement(self):
+        self._train(loss=scripted_loss([1.0, 0.5, 0.4]))
+        self.assertTrue(self.best.exists())
+        self.assertTrue(self.adapter.exists())
+
+    def test_best_adapter_not_written_when_disabled(self):
+        self._train(loss=scripted_loss([1.0, 0.5]), save_best=False)
+        self.assertFalse(self.best.exists())
+        self.assertTrue(self.adapter.exists())
+
+    def test_best_differs_from_final_when_val_loss_rises(self):
+        """The motivating case: validation bottoms out and then degrades, so the
+        final adapter is not the best one."""
+        self._train(iters=6, loss=scripted_loss([1.0, 0.3, 2.0, 3.0, 4.0, 5.0]))
+        best = mx.load(str(self.best))
+        final = mx.load(str(self.adapter))
+        differs = any(
+            not np.array_equal(np.asarray(best[k]), np.asarray(final[k])) for k in best
+        )
+        self.assertTrue(differs, "best checkpoint should differ from the final one")
+
+    def test_patience_stops_early(self):
+        cb = self._train(iters=20, loss=scripted_loss([1.0, 2.0, 3.0, 4.0]), patience=2)
+        # Validations at iter 1 (1.0), 2 (2.0), 3 (3.0): two non-improving in a
+        # row trips patience, so training ends well before iters=20.
+        self.assertLess(len(cb.val), 20)
+        self.assertTrue(self.adapter.exists())
+
+    def test_patience_not_tripped_while_improving(self):
+        cb = self._train(
+            iters=5, loss=scripted_loss([1.0, 0.9, 0.8, 0.7, 0.6]), patience=2
+        )
+        self.assertEqual(len(cb.val), 5)
+
+    def test_min_delta_requires_meaningful_improvement(self):
+        """Tiny improvements should not reset the patience counter."""
+        cb = self._train(
+            iters=20,
+            loss=scripted_loss([1.0, 0.9999, 0.9998, 0.9997]),
+            patience=2,
+            min_delta=0.01,
+        )
+        self.assertLess(len(cb.val), 20)
+
+    def test_short_run_without_periodic_save(self):
+        """Regression: iters < steps_per_save must still save, and must not
+        raise for an unbound adapter_weights."""
+        self._train(iters=2, steps_per_eval=1, loss=scripted_loss([1.0, 0.5]))
+        self.assertTrue(self.adapter.exists())
+        self.assertTrue(self.best.exists())
+
+    def test_best_tracked_when_eval_and_save_cadences_differ(self):
+        """Regression: the best checkpoint must come from a validated iteration,
+        not from whenever the last periodic save happened."""
+        cb = Recorder()
+        args = TrainingArgs(
+            batch_size=2,
+            iters=6,
+            val_batches=1,
+            steps_per_report=10**9,
+            steps_per_eval=2,
+            steps_per_save=3,  # deliberately not a multiple of steps_per_eval
+            max_seq_length=8,
+            adapter_file=self.adapter,
+        )
+        train(
+            model=Tiny(),
+            optimizer=opt.Adam(learning_rate=1e-3),
+            train_dataset=self.data,
+            val_dataset=self.data,
+            args=args,
+            iterate_batches=batches,
+            training_callback=cb,
+            loss=scripted_loss([1.0, 0.2, 5.0, 6.0]),
+        )
+        self.assertTrue(self.best.exists())
+
+    def test_rejects_bad_patience(self):
+        for bad in (0, -1):
+            with self.subTest(value=bad):
+                with self.assertRaises(ValueError):
+                    self._train(patience=bad)
+
+    def test_patience_requires_validation_set(self):
+        args = TrainingArgs(
+            batch_size=2,
+            iters=2,
+            adapter_file=self.adapter,
+            max_seq_length=8,
+            patience=2,
+        )
+        with self.assertRaises(ValueError):
+            train(
+                model=Tiny(),
+                optimizer=opt.Adam(learning_rate=1e-3),
+                train_dataset=self.data,
+                val_dataset=None,
+                args=args,
+                iterate_batches=batches,
+            )
+
+    def test_save_best_without_validation_set_is_a_noop(self):
+        args = TrainingArgs(
+            batch_size=2,
+            iters=2,
+            adapter_file=self.adapter,
+            max_seq_length=8,
+            steps_per_report=10**9,
+            steps_per_save=10**9,
+        )
+        train(
+            model=Tiny(),
+            optimizer=opt.Adam(learning_rate=1e-3),
+            train_dataset=self.data,
+            val_dataset=None,
+            args=args,
+            iterate_batches=batches,
+        )
+        self.assertTrue(self.adapter.exists())
+        self.assertFalse(self.best.exists())
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
@awni this picks up #331, which you reviewed in July 2025 with one inline suggestion and "please address then we can merge". That comment was never addressed and the PR has been idle since; #509 later tried to finish it and was closed without review. Credit for the original approach goes to @hansvdam, and I'm happy to close this if they'd rather come back and finish it themselves.

Opening a fresh PR rather than pushing to that branch because it's a year stale, and because the diagnosis below led to a different implementation than either earlier attempt.

### The underlying problem is broader than early stopping

Validation loss is computed, reported, and then discarded. Every save is `it % steps_per_save`, so validation loss never influences which checkpoint survives. `adapters.safetensors` therefore holds the weights training *ended* on, not the best ones. Even a user who wants all their iterations wants the best checkpoint kept.

So this PR does two things, and the first stands on its own:

1. Track the lowest validation loss and write those weights to `best_adapters.safetensors`. `adapters.safetensors` still always holds the final weights, so nothing changes for existing workflows. `--no-save-best` disables it.
2. `--patience N` stops after N validations without improvement; `--min-delta` sets how much the loss must drop to count. Early stopping is off unless `--patience` is passed.

### Why not the approach in #331

#331 inferred the best weights from save timing, skipping the final save so "the last checkpoint is the best model". Two problems, both of which are why this PR captures the best weights in memory at the moment validation improves instead:

1. **The last periodic save isn't necessarily the best-validated iteration.** `steps_per_eval` defaults to 200 and `steps_per_save` to 100, and the two are independent. Any `steps_per_eval` that isn't a multiple of `steps_per_save` can leave `adapters.safetensors` holding weights from an iteration that was never validated.
2. **`NameError` on short runs.** `adapter_weights` is only bound inside `if it % args.steps_per_save == 0`. With `--iters 50` and the default `--save-every 100` no periodic save happens, so the final save references an unbound name.

Capturing on improvement also means the final save can stay unconditional, which addresses your inline point on #331 about making sure the last model is still saved when early stopping never triggers. Here that's automatic: the two files are independent, so no configuration loses the final weights.

There are regression tests for both issues above (`test_short_run_without_periodic_save`, `test_best_tracked_when_eval_and_save_cadences_differ`).

### Evaluation

Validation loss from a real LoRA run (Qwen3-1.7B, 8786 rows, batch 4, lr 5e-6 cosine + warmup):

| Iter | Val loss | Δ |
|---|---|---|
| 0 | 1.4537 | (base) |
| 200 | 0.7359 | −0.7178 |
| 400 | 0.7085 | −0.0274 |
| 600 | 0.6958 | −0.0127 |

96% of the improvement lands in the first 200 of 3000 iterations; iterations 600-3000 are ~6.5 hours on this machine for maybe 0.02-0.03 more.

To be straight about what this does and doesn't show: that run flattened, but I stopped it before validation loss actually rose, so it demonstrates wasted compute rather than a measurably worse final artifact. The degradation case is covered in tests (`test_best_differs_from_final_when_val_loss_rises`, driving validation loss down and then up and asserting the two files differ) but I don't yet have it from a long real run. I'd rather say so than overclaim.

```
python -m unittest tests.test_tuner_early_stopping tests.test_tuner_trainer tests.test_finetune
Ran 28 tests in 0.937s -- OK
```

### Design decisions worth your call

- **`save_best` defaults to on.** There's no reason to prefer a worse checkpoint, and it's additive: a new file appears, nothing existing changes. Happy to default it off if you'd rather every new file be opt-in.
- **Separate file rather than overwriting `adapters.safetensors`.** Safer, no surprises, but users must know to pick it up. The alternative is friendlier and a behavior change; your call.
- **Patience counts validations, not iterations**, so its meaning depends on `--steps-per-eval`. Documented in LORA.md.
- **Distributed:** only rank 0 writes, as before. The stop decision uses the validation loss, which `evaluate` already averages across ranks via `all_sum`, so every rank breaks on the same iteration. I've reasoned this through but have not tested on multiple machines.

### Risks

- `--patience` without a validation set raises `ValueError` rather than silently never stopping. `save_best` without one is a harmless no-op.
- One extra ~20 MB write per improvement, which in practice is a handful of writes per run.
- No behavior change unless `--patience` is passed, apart from the additional `best_adapters.safetensors` file.

### Pre-merge

Nothing beyond review. No new dependencies. If you take this, #331 and #509 can be closed as superseded.

### Post-merge

Worth mentioning `best_adapters.safetensors` in release notes, since users currently assume `adapters.safetensors` is the model to ship.
