### PR TITLE
Add prompt checkpoints for hybrid caches

### DIFF
--- a/mlx_lm/server.py
+++ b/mlx_lm/server.py
@@ -40,7 +40,7 @@ from .generate import (
     make_text_state_machine,
     stream_generate,
 )
-from .models.cache import LRUPromptCache, make_prompt_cache
+from .models.cache import can_trim_prompt_cache, LRUPromptCache, make_prompt_cache
 from .sample_utils import make_logits_processors, make_sampler
 from .utils import _parse_size, load, sharded_load
 
@@ -48,6 +48,16 @@ from .utils import _parse_size, load, sharded_load
 def get_system_fingerprint():
     gpu_arch = mx.device_info()["architecture"]
     return f"{__version__}-{mx.__version__}-{platform.platform()}-{gpu_arch}"
+
+
+def _split_for_checkpoints(segments, segment_types, checkpoint_size):
+    checkpointed_segments = []
+    checkpointed_types = []
+    for segment, segment_type in zip(segments, segment_types):
+        for start in range(0, len(segment), checkpoint_size):
+            checkpointed_segments.append(segment[start : start + checkpoint_size])
+            checkpointed_types.append(segment_type)
+    return checkpointed_segments, checkpointed_types
 
 
 class ToolCallFormatter:
@@ -602,6 +612,16 @@ class ResponseGenerator:
 
         return prompt, segments, segment_types, initial_state
 
+    def _add_hybrid_checkpoints(self, segments, segment_types):
+        cache = make_prompt_cache(self.model_provider.model)
+        if self.model_provider.draft_model is not None:
+            cache += make_prompt_cache(self.model_provider.draft_model)
+        if can_trim_prompt_cache(cache):
+            return segments, segment_types
+        return _split_for_checkpoints(
+            segments, segment_types, self.cli_args.prefill_step_size
+        )
+
     def _make_state_machine(self, model_key, tokenizer, stop_words):
         """Make (and cache) a StopSequenceMatcher and TextStateMachine."""
         cache_key = (model_key, tuple(stop_words))
@@ -673,6 +693,9 @@ class ResponseGenerator:
                     try:
                         prompt, segments, segment_types, initial_state = self._tokenize(
                             current_tokenizer, request, args
+                        )
+                        segments, segment_types = self._add_hybrid_checkpoints(
+                            segments, segment_types
                         )
                     except Exception as e:
                         rqueue.put(e)

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -17,6 +17,7 @@ from mlx_lm.server import (
     Response,
     ResponseGenerator,
     SamplingArguments,
+    _split_for_checkpoints,
     _make_sampler,
 )
 from mlx_lm.utils import load
@@ -566,6 +567,14 @@ class TestKeepalive(unittest.TestCase):
 
 
 class TestLRUPromptCache(unittest.TestCase):
+    def test_split_for_checkpoints(self):
+        segments, types = _split_for_checkpoints(
+            [[1, 2, 3, 4, 5], [6, 7]], ["system", "user"], 2
+        )
+
+        self.assertEqual(segments, [[1, 2], [3, 4], [5], [6, 7]])
+        self.assertEqual(types, ["system", "system", "system", "user"])
+
     def test_caching(self):
         cache = LRUPromptCache(max_size=10)
 
@@ -615,6 +624,20 @@ class TestLRUPromptCache(unittest.TestCase):
         c[0].update_and_fetch(*get_kv(8))
         cache.insert_cache(model, tokens, c)
         self.assertEqual(len(cache), 2)
+
+    def test_nontrimmable_cache_uses_saved_prefix_after_branch(self):
+        cache = LRUPromptCache(max_size=10)
+        model = ("test", None, None)
+
+        # A recurrent state cannot be trimmed to the branch point. Keep a
+        # checkpoint before it and replay only the suffix after that checkpoint.
+        cache.insert_cache(model, [1, 2, 3], [MockCache("prefix", False)])
+        cache.insert_cache(model, [1, 2, 3, 4, 9], [MockCache("longer", False)])
+
+        cached, rest = cache.fetch_nearest_cache(model, [1, 2, 3, 4, 8])
+
+        self.assertEqual(cached, [MockCache("prefix", False)])
+        self.assertEqual(rest, [4, 8])
 
     def test_lru(self):
         cache = LRUPromptCache(max_size=2)


### PR DESCRIPTION
## Why this matters

Modern hybrid models combine attention KV cache with recurrent state (for example, Mamba or Gated DeltaNet layers). A recurrent state at token *T* summarizes every preceding token, so it cannot be safely trimmed back to an arbitrary branch point the way attention KV can.

Without an earlier exact state, a request that diverges from a cached prompt must prefill from the beginning. This is most visible in multi-turn chat, tool-use, and agent workloads that share a long system prompt or conversation prefix.

## Solution

For a cache containing any non-trimmable layer, split each prompt segment at the existing `prefill_step_size` boundary. The server already saves a cache at each segment boundary and already knows how to select the nearest valid shorter prefix. This change gives it exact recurrent-state checkpoints to select:

1. Save complete hybrid state every prefill chunk.
2. On a diverged prompt, restore the newest checkpoint fully inside the shared prefix.
3. Replay only tokens after that checkpoint.

No recurrent state is trimmed, reset, or combined with KV state from a different history. Fully trimmable KV-only models keep their existing cache behavior.

## Benefit

With the default 2,048-token prefill chunk, a branch can reuse the checkpoint immediately before its divergence and reprocess at most one chunk before the changed suffix. For example, a change after 30K tokens in a 32K-token prompt can reuse the 28,672-token checkpoint and prefill roughly 3.3K tokens instead of 32K: about 90% fewer prompt tokens processed for that request.

The exact saving depends on where the branch falls and cache capacity. The important guarantee is correctness: every restored recurrent state exactly matches the token prefix it represents.

## Scope

- Applies only to server batching with a cache that contains a non-trimmable layer.
- Uses the existing `prefill_step_size` as the checkpoint interval; no new option or cache format.
- Keeps the existing LRU cache limits and cache-type eviction policy.

## Tests

- `python -m py_compile mlx_lm/server.py tests/test_server.py`
- `git diff --check`
- Added coverage for checkpoint segmentation and for selecting a saved non-trimmable prefix after a branch.

The runtime MLX suite requires Apple Silicon.