### PR TITLE
Validate per-prompt max_tokens in batch_generate

### DIFF
--- a/mlx_lm/generate.py
+++ b/mlx_lm/generate.py
@@ -1992,7 +1992,7 @@ def batch_generate(
           won't be updated in-place.
        verbose (bool): If ``True``, print tokens and timing information.
           Default: ``False``.
-       max_tokens (Union[int, List[int]): Maximum number of output tokens. This
+       max_tokens (Union[int, List[int]]): Maximum number of output tokens. This
           can be per prompt if a list is provided.
        return_prompt_caches (bool): Return the prompt caches in the batch
           responses. Default: ``False``.
@@ -2004,7 +2004,16 @@ def batch_generate(
           for importance weighting. Default: ``False``.
        kwargs: The remaining options get passed to :obj:`BatchGenerator`.
           See :obj:`BatchGenerator` for more details.
+
+    Raises:
+       ValueError: If a list of ``max_tokens`` values does not have the same
+          length as ``prompts``.
     """
+
+    if isinstance(max_tokens, int):
+        max_tokens = [max_tokens] * len(prompts)
+    elif len(max_tokens) != len(prompts):
+        raise ValueError("max_tokens must have the same length as prompts")
 
     gen = BatchGenerator(
         model,
@@ -2015,9 +2024,6 @@ def batch_generate(
     fin = 0
     if verbose:
         print(f"[batch_generate] Finished processing 0/{num_samples} ...", end="\r")
-
-    if isinstance(max_tokens, int):
-        max_tokens = [max_tokens] * len(prompts)
 
     uids = gen.insert(prompts, max_tokens, caches=prompt_caches)
     results = {uid: [] for uid in uids}

--- a/tests/test_generate.py
+++ b/tests/test_generate.py
@@ -20,6 +20,24 @@ from mlx_lm.sample_utils import make_logits_processors, make_sampler
 from mlx_lm.utils import load
 
 
+class TestBatchGenerateValidation(unittest.TestCase):
+    def test_rejects_mismatched_max_tokens(self):
+        prompts = [[1], [2]]
+
+        for max_tokens in ([2], [2, 5, 8]):
+            with self.subTest(max_tokens=max_tokens):
+                with self.assertRaisesRegex(
+                    ValueError,
+                    "max_tokens must have the same length as prompts",
+                ):
+                    batch_generate(
+                        object(),
+                        object(),
+                        prompts,
+                        max_tokens=max_tokens,
+                    )
+
+
 class TestGenerate(unittest.TestCase):
 
     @classmethod


### PR DESCRIPTION
## Summary

- reject `max_tokens` lists whose length differs from the prompt count
- perform validation before constructing `BatchGenerator`
- document and test the invalid-input behavior

## Motivation

`batch_generate` accepts one token limit per prompt, but if the supplied list
has a different length, `BatchGenerator.insert_segments` uses `zip`, which can
silently drop trailing prompts or ignore extra limits. Returning fewer
generations than requested without an error is difficult for callers to
diagnose.

Scalar limits and correctly sized lists retain their existing behavior.

## Test plan

- `python -m unittest tests.test_generate.TestBatchGenerateValidation -v`
- `black --check mlx_lm/generate.py tests/test_generate.py`
- `git diff --check`
