### PR TITLE
Raise clear error when LoRA config uses 'alpha' instead of 'scale'

### DIFF
--- a/mlx_lm/tuner/utils.py
+++ b/mlx_lm/tuner/utils.py
@@ -54,6 +54,14 @@ def linear_to_lora_layers(
         use_dora (bool): If True, uses DoRA instead of LoRA.
           Default: ``False``
     """
+    if "scale" not in config:
+        hint = ""
+        if "alpha" in config:
+            hint = (
+                " Found 'alpha' instead — mlx-lm's LoRA config uses 'scale', "
+                "not 'alpha' (unlike some other LoRA frameworks). See LORA.md."
+            )
+        raise KeyError(f"LoRA config is missing required key 'scale'.{hint}")
 
     def to_lora(layer):
         if not use_dora and hasattr(layer, "to_lora"):


### PR DESCRIPTION
Fixes #1670

## What
Raises a clear `KeyError` message when a LoRA config uses `alpha` instead
of `scale`, instead of the previous bare `KeyError: 'scale'` with no context.

## Why
mlx-lm's LoRA config format requires `scale`, but many LoRA tutorials and
other frameworks (e.g. PEFT) use `alpha` for a related concept. This is an
easy mistake to make with a confusing failure mode.

## Testing
Verified the syntax compiles cleanly. I wasn't able to run the full
reproduction locally due to an unrelated MLX/macOS 26.2 compatibility
issue on my machine (metallib load failure, independent of this change) —
happy to confirm behavior further if needed, or a maintainer can verify.
