### PR TITLE
Fix ChunkedKVCache dropping valid tokens during decode (llama4)

### DIFF
--- a/mlx_lm/models/cache.py
+++ b/mlx_lm/models/cache.py
@@ -739,11 +739,19 @@ class ChunkedKVCache(_BaseCache):
         self.start_position = 0
 
     def maybe_trim_front(self):
-        # Maintain the cache below the chunk size
-        if self.keys is not None and self.keys.shape[2] >= self.chunk_size:
-            self.start_position += self.keys.shape[2] - self.chunk_size
-            self.keys = self.keys[..., -self.chunk_size :, :]
-            self.values = self.values[..., -self.chunk_size :, :]
+        # Maintain the cache below the chunk size. Compare against the number of
+        # *valid* cached tokens (offset - start_position), not self.keys.shape[2]:
+        # the buffer is over-allocated in blocks of `step` and valid tokens are
+        # front-filled at [0:valid], so using the padded buffer size trims away
+        # live tokens (keeping unfilled padding) and corrupts start_position.
+        if self.keys is None:
+            return
+        valid = self.offset - self.start_position
+        if valid > self.chunk_size:
+            trim = valid - self.chunk_size
+            self.start_position += trim
+            self.keys = self.keys[..., trim:valid, :]
+            self.values = self.values[..., trim:valid, :]
 
     def update_and_fetch(self, keys, values):
         prev = self.offset - self.start_position

--- a/mlx_lm/models/cache.py
+++ b/mlx_lm/models/cache.py
@@ -739,11 +739,7 @@ class ChunkedKVCache(_BaseCache):
         self.start_position = 0
 
     def maybe_trim_front(self):
-        # Maintain the cache below the chunk size. Compare against the number of
-        # *valid* cached tokens (offset - start_position), not self.keys.shape[2]:
-        # the buffer is over-allocated in blocks of `step` and valid tokens are
-        # front-filled at [0:valid], so using the padded buffer size trims away
-        # live tokens (keeping unfilled padding) and corrupts start_position.
+        # Maintain the cache below the chunk size.
         if self.keys is None:
             return
         valid = self.offset - self.start_position

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -3119,6 +3119,57 @@ class TestModels(unittest.TestCase):
                     config["num_hidden_layers"],
                 )
 
+    def test_llama4_chunked_kv_cache(self):
+        # Regression test for ChunkedKVCache.maybe_trim_front: it must trim on
+        # the number of valid cached tokens, not on the padded buffer size.
+        # When the chunk size is smaller than the cache allocation step, the old
+        # logic dropped live tokens on the first decode step, so incremental
+        # generation diverged from a single full forward pass.
+        from mlx_lm.models import llama4
+
+        args = llama4.ModelArgs.from_dict(
+            {
+                "model_type": "llama4",
+                "vocab_size": 1000,
+                "num_hidden_layers": 4,
+                "text_config": {
+                    "attention_bias": False,
+                    "attention_chunk_size": 4,
+                    "head_dim": 32,
+                    "hidden_size": 128,
+                    "interleave_moe_layer_step": 2,
+                    "intermediate_size": 128,
+                    "intermediate_size_mlp": 128,
+                    "max_position_embeddings": 1000,
+                    "model_type": "llama4",
+                    "num_attention_heads": 4,
+                    "num_experts_per_tok": 1,
+                    "num_hidden_layers": 4,
+                    "num_key_value_heads": 2,
+                    "num_local_experts": 2,
+                    "rms_norm_eps": 1e-4,
+                    "rope_scaling": None,
+                    "rope_theta": 1000,
+                    "use_qk_norm": True,
+                    "vocab_size": 1000,
+                },
+            }
+        )
+        model = llama4.Model(args)
+        model.update(tree_map(lambda p: p.astype(mx.float32), model.parameters()))
+
+        # A sequence several chunks long so the trim path runs repeatedly.
+        tokens = mx.array([list(range(1, 13))])
+        full = model(tokens)
+
+        cache = make_prompt_cache(model)
+        step = [model(tokens[:, :1], cache=cache)]
+        for i in range(1, tokens.shape[1]):
+            step.append(model(tokens[:, i : i + 1], cache=cache))
+        step = mx.concatenate(step, axis=1)
+
+        self.assertTrue(mx.allclose(full, step, atol=1e-3, rtol=1e-3))
+
     def test_ssm(self):
         for batch_size in [1, 2]:
             for n_group in [1, 4]:


### PR DESCRIPTION
## Summary

`ChunkedKVCache.maybe_trim_front` (used only by Llama 4) decides how much of the
KV cache to trim by comparing `self.keys.shape[2]` — the **padded** buffer size,
which is over-allocated in blocks of `step` (256) — against `chunk_size`. But
valid tokens are front-filled at `[0 : offset - start_position]`, so once the
padded buffer reaches `chunk_size` the trim slices off the live tokens and keeps
the unfilled padding, and `start_position` is advanced by the wrong amount.

After the padded buffer crosses `chunk_size`, every Llama 4 decode step then
attends over corrupted keys, so incremental generation diverges from a single
full forward pass. The generic model test only checks output *shapes*, so it does
not catch this. The repo's own Llama 4 test config (`attention_chunk_size=8`,
cache `step=256`) triggers it on the first decode step; a real Llama 4
(`attention_chunk_size=8192`) triggers it on long contexts once the padded buffer
reaches 8192.

## Reproduction

With random weights, comparing a single forward pass to token-by-token decode
over a 12-token (multi-chunk) sequence, `max |Δlogit|`:

| | before | after |
|---|---:|---:|
| `attention_chunk_size=4` | 3.4 | 1.3e-06 |
| `attention_chunk_size=8` | 2.8 | 1.2e-06 |

Position 0 (prefill) was already correct; every decoded position was wrong. A
dense control model matches to ~1e-6 both before and after, confirming the
invariant and the harness. Verified across `batch > 1`, longer sequences, and
several chunk sizes (multiple chunk-boundary crossings).

## Fix

Trim on the number of **valid** tokens (`offset - start_position`) and keep the
most recent `chunk_size` valid tokens. Those always contain the current chunk
(its start is `>= offset - chunk_size`), and the existing block-position mask
excludes any older tokens still in the window.

## Test

Adds `test_llama4_chunked_kv_cache`: builds Llama 4 with a small
`attention_chunk_size` and asserts that incremental decode matches a single
forward pass over a multi-chunk sequence. It fails on `main` and passes with the
fix. `tests/test_models.py` and `tests/test_prompt_cache.py` remain green.
