### PR TITLE
Fuse MoE gate/up projections into one gather_qmm at load time

### DIFF
--- a/mlx_lm/models/switch_layers.py
+++ b/mlx_lm/models/switch_layers.py
@@ -178,7 +178,7 @@ class SwitchGLU(nn.Module):
             return
         gate, up = self.gate_proj, self.up_proj
         for k in ("weight", "scales", "biases", "bias"):
-            if getattr(gate, k, None) is not None:
+            if gate.get(k) is not None:
                 setattr(gate, k, mx.concatenate([gate[k], up[k]], axis=1))
         del self.gate_proj, self.up_proj
         self.gate_up_proj = gate

--- a/mlx_lm/models/switch_layers.py
+++ b/mlx_lm/models/switch_layers.py
@@ -173,6 +173,17 @@ class SwitchGLU(nn.Module):
         self.down_proj = SwitchLinear(hidden_dims, input_dims, num_experts, bias=bias)
         self.activation = activation
 
+    def fuse_gate_up(self):
+        if "gate_up_proj" in self:
+            return
+        gate, up = self.gate_proj, self.up_proj
+        for k in ("weight", "scales", "biases", "bias"):
+            if getattr(gate, k, None) is not None:
+                setattr(gate, k, mx.concatenate([gate[k], up[k]], axis=1))
+        del self.gate_proj, self.up_proj
+        self.gate_up_proj = gate
+        mx.eval(gate.parameters())
+
     def __call__(self, x, indices) -> mx.array:
         x = mx.expand_dims(x, (-2, -3))
 
@@ -185,8 +196,12 @@ class SwitchGLU(nn.Module):
             x, idx, inv_order = _gather_sort(x, indices)
         if self.training:
             idx = mx.stop_gradient(idx)
-        x_up = self.up_proj(x, idx, sorted_indices=do_sort)
-        x_gate = self.gate_proj(x, idx, sorted_indices=do_sort)
+        if "gate_up_proj" in self:
+            x_gate_up = self.gate_up_proj(x, idx, sorted_indices=do_sort)
+            x_gate, x_up = mx.split(x_gate_up, 2, axis=-1)
+        else:
+            x_up = self.up_proj(x, idx, sorted_indices=do_sort)
+            x_gate = self.gate_proj(x, idx, sorted_indices=do_sort)
         x = self.down_proj(
             self.activation(x_up, x_gate),
             idx,

--- a/mlx_lm/utils.py
+++ b/mlx_lm/utils.py
@@ -513,8 +513,8 @@ def load(
             executing a custom Python file specified in their config.
             Default: ``False``.
         fuse (bool): If ``True``, fuse eligible projections (e.g. MoE
-            gate/up) after loading. Skipped when ``adapter_path`` is given.
-            Default: ``True``.
+            gate/up) after loading. Skipped when ``adapter_path`` is given
+            or ``lazy`` is ``True``. Default: ``True``.
     Returns:
         Union[Tuple[nn.Module, TokenizerWrapper], Tuple[nn.Module, TokenizerWrapper, Dict[str, Any]]]:
             A tuple containing the loaded model, tokenizer and, if requested, the model config.
@@ -534,7 +534,7 @@ def load(
     if adapter_path is not None:
         model = load_adapters(model, adapter_path)
         model.eval()
-    elif fuse:
+    elif fuse and not lazy:
         fusible = [m for _, m in model.named_modules() if hasattr(m, "fuse_gate_up")]
         for m in fusible:
             m.fuse_gate_up()

--- a/mlx_lm/utils.py
+++ b/mlx_lm/utils.py
@@ -488,6 +488,7 @@ def load(
     return_config: bool = False,
     revision: Optional[str] = None,
     trust_remote_code: bool = False,
+    fuse: bool = True,
 ) -> Union[
     Tuple[nn.Module, TokenizerWrapper],
     Tuple[nn.Module, TokenizerWrapper, Dict[str, Any]],
@@ -511,6 +512,9 @@ def load(
         trust_remote_code (bool): If ``True``, allow loading models that require
             executing a custom Python file specified in their config.
             Default: ``False``.
+        fuse (bool): If ``True``, fuse eligible projections (e.g. MoE
+            gate/up) after loading. Skipped when ``adapter_path`` is given.
+            Default: ``True``.
     Returns:
         Union[Tuple[nn.Module, TokenizerWrapper], Tuple[nn.Module, TokenizerWrapper, Dict[str, Any]]]:
             A tuple containing the loaded model, tokenizer and, if requested, the model config.
@@ -530,6 +534,10 @@ def load(
     if adapter_path is not None:
         model = load_adapters(model, adapter_path)
         model.eval()
+    elif fuse:
+        fusible = [m for _, m in model.named_modules() if hasattr(m, "fuse_gate_up")]
+        for m in fusible:
+            m.fuse_gate_up()
     tokenizer = load_tokenizer(
         model_path, tokenizer_config, eos_token_ids=config.get("eos_token_id", None)
     )

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -578,6 +578,33 @@ class TestModels(unittest.TestCase):
             args.n_layers,
         )
 
+    def test_switch_glu_fuse_gate_up(self):
+        from mlx_lm.models.switch_layers import SwitchGLU
+
+        mx.random.seed(0)
+        for quantize, bias in [(False, False), (False, True), (True, False)]:
+            with self.subTest(quantize=quantize, bias=bias):
+                glu = SwitchGLU(64, 128, 4, bias=bias)
+                if quantize:
+                    nn.quantize(glu, group_size=32, bits=8)
+
+                inputs = []
+                for n in (4, 48):  # below and above the sorted-path threshold
+                    x = mx.random.normal((1, n, 64))
+                    inds = mx.random.randint(0, 4, (1, n, 2)).astype(mx.uint32)
+                    inputs.append((x, inds, glu(x, inds)))
+
+                glu.fuse_gate_up()
+                glu.fuse_gate_up()  # idempotent
+                self.assertIn("gate_up_proj", glu)
+                self.assertNotIn("gate_proj", glu)
+                self.assertNotIn("up_proj", glu)
+
+                for x, inds, y_ref in inputs:
+                    self.assertTrue(
+                        mx.allclose(glu(x, inds), y_ref, atol=1e-5, rtol=1e-4)
+                    )
+
     def test_qwen3_moe(self):
         from mlx_lm.models import qwen3_moe
 


### PR DESCRIPTION
## Proposed changes

`SwitchGLU` runs `gate_proj` and `up_proj` as two `gather_qmm` calls on the
same input. This adds `SwitchGLU.fuse_gate_up()`, which concatenates the two
weights along the output axis into a single projection, and enables it by
default in `load()` (skipped when `adapter_path` is given, opt-out with
`fuse=False`).

Decode on Apple silicon is kernel-launch bound (~10 µs per dispatch measured
on M5 Pro), so removing one dependent kernel per layer per step pays directly:

- Qwen3-30B-A3B-4bit, M5 Pro 24 GB, ctx 512 decode: **84.8 → 89.2 tok/s (+5.2%)**
- prefill: +3.0% at 512 tokens, neutral at 2048 (compute-bound there)
- prefill logits bit-exact (maxdiff 0.0), identical memory (17.25 GB)

Applies to every MoE model built on `SwitchGLU`. Some HF checkpoints
(qwen3.5-moe, qwen3-vl-moe) already ship fused `gate_up_proj` weights that
`sanitize()` splits apart — with this change the fused execution is recovered
at load time without touching any checkpoint format.

The fuse pass in `load()` collects the `SwitchGLU` modules before fusing so
the replaced gate/up buffers are freed as it goes; fusing while holding the
full `named_modules()` list transiently retains every original `up_proj`
(~5 GB on a 48-layer model).

Verified: new `test_switch_glu_fuse_gate_up` covers fp/quantized, bias, and
both the sorted and unsorted dispatch paths; `tests/test_models.py` passes
(`test_ssm` fails identically on clean main on this machine, unrelated).

## Checklist

- [x] I have read the CONTRIBUTING document
- [x] I have run `pre-commit run --all-files` to format my code
- [x] I have added tests that prove my fix is effective or that my feature works