### PR TITLE
Fix uneven pipeline layer partitioning

### DIFF
--- a/mlx_lm/models/pipeline.py
+++ b/mlx_lm/models/pipeline.py
@@ -20,11 +20,14 @@ class PipelineMixin:
         # rank=pipeline_size-1 gets the first
         self.pipeline_rank = group.rank()
         self.pipeline_size = group.size()
-        layers_per_rank = len(self.layers) // self.pipeline_size
-        extra = len(self.layers) - layers_per_rank * self.pipeline_size
-        if self.pipeline_rank < extra:
-            layers_per_rank += 1
-        self.start_idx = (self.pipeline_size - self.pipeline_rank - 1) * layers_per_rank
+        num_layers = len(self.layers)
+        layers_per_rank, extra = divmod(num_layers, self.pipeline_size)
+        # Convert the reverse pipeline rank to the corresponding forward
+        # partition, then use a prefix sum. Multiplying by a rank-local shard
+        # size creates gaps whenever the division has a remainder.
+        partition = self.pipeline_size - self.pipeline_rank - 1
+        self.start_idx = partition * layers_per_rank + min(partition, extra)
+        layers_per_rank += partition < extra
         self.end_idx = self.start_idx + layers_per_rank
         self.layers = self.layers[: self.end_idx]
         # Keep the layer numbers the same for model loading

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -1,0 +1,34 @@
+# Copyright © 2026 Apple Inc.
+
+from mlx_lm.models.pipeline import PipelineMixin
+
+
+class _Group:
+    def __init__(self, rank, size):
+        self._rank = rank
+        self._size = size
+
+    def rank(self):
+        return self._rank
+
+    def size(self):
+        return self._size
+
+
+class _Pipeline(PipelineMixin):
+    def __init__(self, layers):
+        super().__init__()
+        self.layers = layers
+
+
+def test_pipeline_partition_covers_non_divisible_layer_count_exactly_once():
+    assigned = []
+    for rank in range(3):
+        pipeline = _Pipeline(list(range(10)))
+        pipeline.pipeline(_Group(rank, 3))
+        assigned.extend(
+            layer for layer in pipeline.pipeline_layers if layer is not None
+        )
+
+    assert sorted(assigned) == list(range(10))
+    assert len(assigned) == len(set(assigned))


### PR DESCRIPTION
## What changed

Use prefix-sum partition boundaries when distributing pipeline layers in reverse rank order.

## Root cause

The previous start offset multiplied the reverse rank by that rank's local shard size. When the layer count had a remainder, those local sizes differed and the resulting ranges contained gaps. For 10 layers across 3 ranks, layers 6 and 7 were omitted.

## Validation

- Regression covers 10 layers across 3 ranks and asserts complete, non-overlapping coverage.
- `pytest -q tests/test_pipeline.py`

Fixes #1688