### PR TITLE
Fix perplexity all-samples mode

### DIFF
--- a/mlx_lm/perplexity.py
+++ b/mlx_lm/perplexity.py
@@ -35,13 +35,13 @@ def load_data(
 
     perm = np.random.permutation(len(dataset)).tolist()
 
-    num_tokens = sequence_length * num_samples if num_samples > 0 else float("inf")
+    num_tokens = sequence_length * num_samples if num_samples > 0 else None
     data = []
-    i = 0
-    while len(data) < num_tokens:
-        tokens, _ = dataset.process(dataset[perm[i]])
-        i += 1
+    for index in perm:
+        tokens, _ = dataset.process(dataset[index])
         data.extend(tokens)
+        if num_tokens is not None and len(data) >= num_tokens:
+            break
 
     data = mx.array(data[: (len(data) // sequence_length) * sequence_length])
     data = data.reshape(-1, sequence_length)

--- a/tests/test_perplexity.py
+++ b/tests/test_perplexity.py
@@ -1,0 +1,32 @@
+# Copyright © 2026 Apple Inc.
+
+from mlx_lm import perplexity
+
+
+class _Dataset:
+    values = [[1, 2, 3], [4, 5], [6, 7, 8, 9]]
+
+    def __len__(self):
+        return len(self.values)
+
+    def __getitem__(self, index):
+        return self.values[index]
+
+    def process(self, value):
+        return value, None
+
+
+def test_load_data_all_samples_consumes_finite_dataset_once(monkeypatch):
+    monkeypatch.setattr(
+        perplexity, "load_dataset", lambda args, tokenizer: (_Dataset(), None, None)
+    )
+    monkeypatch.setattr(
+        perplexity.np.random,
+        "permutation",
+        lambda size: perplexity.np.arange(size),
+    )
+
+    data = perplexity.load_data(None, "fixture", num_samples=-1, sequence_length=4)
+
+    assert data.shape == (2, 4)
+    assert data.tolist() == [[1, 2, 3, 4], [5, 6, 7, 8]]


### PR DESCRIPTION
## What changed

Iterate the shuffled finite dataset once for the documented `--num-samples -1` mode and retain only complete sequences.

## Root cause

All-samples mode set the target token count to infinity, so the loop inevitably indexed beyond the finite permutation.

## Validation

- Finite three-record dataset regression passes and returns two complete sequences.

Fixes #1690