### PR TITLE
Fix Python and runtime dependency metadata

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -31,6 +31,9 @@ setup(
         "protobuf",
         "pyyaml",
         "jinja2",
+        "huggingface-hub",
+        "regex",
+        "tqdm",
     ],
     packages=[
         "mlx_lm",
@@ -40,7 +43,7 @@ setup(
         "mlx_lm.tool_parsers",
         "mlx_lm.chat_templates",
     ],
-    python_requires=">=3.8",
+    python_requires=">=3.10",
     extras_require={
         "test": ["datasets", "lm-eval"],
         "train": ["datasets", "tqdm"],


### PR DESCRIPTION
## What changed

- Set `python_requires` to Python 3.10 or newer.
- Declare direct runtime imports `huggingface-hub`, `regex`, and `tqdm` as direct dependencies.

## Root cause

The package advertised Python 3.8 while `transformers>=5.7.0` requires Python 3.10. Runtime modules also relied on dependencies being installed transitively.

## Validation

- Verified metadata contains the corrected Python floor and direct dependencies.

Fixes #1692