### PR TITLE
Return accurate generation error status

### DIFF
--- a/mlx_lm/server.py
+++ b/mlx_lm/server.py
@@ -1370,10 +1370,16 @@ class APIHandler(BaseHTTPRequestHandler):
                 args,
                 progress_callback=keepalive_callback,
             )
-        except Exception as e:
-            self._set_completion_headers(404)
+        except (AssertionError, ValueError) as error:
+            self._set_completion_headers(400)
             self.end_headers()
-            self.wfile.write(json.dumps({"error": str(e)}).encode())
+            self.wfile.write(json.dumps({"error": str(error)}).encode())
+            return
+        except Exception:
+            logging.exception("Generation request failed")
+            self._set_completion_headers(500)
+            self.end_headers()
+            self.wfile.write(json.dumps({"error": "Internal server error"}).encode())
             return
 
         # Prepare the headers

--- a/mlx_lm/utils.py
+++ b/mlx_lm/utils.py
@@ -279,12 +279,8 @@ def load_config(model_path: Path) -> dict:
 
     generation_config_file = model_path / "generation_config.json"
     if generation_config_file.exists():
-        generation_config = {}
-        try:
-            with open(generation_config_file, "r") as f:
-                generation_config = json.load(f)
-        except json.JSONDecodeError:
-            pass
+        with open(generation_config_file, "r") as f:
+            generation_config = json.load(f)
 
         if eos_token_id := generation_config.get("eos_token_id", False):
             config["eos_token_id"] = eos_token_id
@@ -715,8 +711,7 @@ def upload_to_hub(path: str, upload_repo: str):
     else:
         provenance = ""
 
-    card.text = dedent(
-        f"""
+    card.text = dedent(f"""
         # {upload_repo}
         {provenance}
         ## Use with mlx
@@ -740,8 +735,7 @@ def upload_to_hub(path: str, upload_repo: str):
 
         response = generate(model, tokenizer, prompt=prompt, verbose=True)
         ```
-        """
-    )
+        """)
     card.save(card_path)
 
     api = HfApi()

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -248,6 +248,38 @@ class TestServer(unittest.TestCase):
             json.loads(requests.post(url, json=post_data).text)["choices"][0]["text"],
         )
 
+    def test_generation_failure_is_internal_server_error(self):
+        url = f"http://localhost:{self.port}/v1/completions"
+        original_generate = self.response_generator.generate
+        self.response_generator.generate = lambda *args, **kwargs: (
+            _ for _ in ()
+        ).throw(RuntimeError("sensitive detail"))
+        try:
+            response = requests.post(
+                url, json={"model": "default_model", "prompt": "hello"}
+            )
+        finally:
+            self.response_generator.generate = original_generate
+
+        self.assertEqual(response.status_code, 500)
+        self.assertEqual(response.json(), {"error": "Internal server error"})
+
+    def test_invalid_generation_request_is_bad_request(self):
+        url = f"http://localhost:{self.port}/v1/completions"
+        original_generate = self.response_generator.generate
+        self.response_generator.generate = lambda *args, **kwargs: (
+            _ for _ in ()
+        ).throw(ValueError("invalid generation option"))
+        try:
+            response = requests.post(
+                url, json={"model": "default_model", "prompt": "hello"}
+            )
+        finally:
+            self.response_generator.generate = original_generate
+
+        self.assertEqual(response.status_code, 400)
+        self.assertEqual(response.json(), {"error": "invalid generation option"})
+
     def test_handle_chat_completions(self):
         url = f"http://localhost:{self.port}/v1/chat/completions"
         chat_post_data = {

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -2,6 +2,7 @@
 
 import json
 import os
+import json
 import tempfile
 import unittest
 from pathlib import Path
@@ -16,6 +17,16 @@ HF_MODEL_PATH = "mlx-community/Qwen1.5-0.5B-Chat-4bit"
 
 
 class TestUtils(unittest.TestCase):
+
+    def test_load_config_rejects_malformed_generation_config(self):
+        with tempfile.TemporaryDirectory() as directory:
+            model_path = Path(directory)
+            (model_path / "config.json").write_text("{}")
+            (model_path / "generation_config.json").write_text("{invalid")
+
+            with self.assertRaises(json.JSONDecodeError):
+                utils.load_config(model_path)
+
     @classmethod
     def setUpClass(cls):
         cls.test_dir_fid = tempfile.TemporaryDirectory()


### PR DESCRIPTION
## What changed

- Return 400 for invalid generation requests and sanitized 500 responses for unexpected failures.
- Reject malformed `generation_config.json` instead of silently discarding it.

## Root cause

A broad exception handler mapped every generation failure to HTTP 404. A separate JSON decode handler swallowed malformed optional model configuration, silently changing generation behavior.

## Validation

- Focused HTTP status and malformed-config regressions pass.

Fixes #1693