### PR TITLE
Require opt-in for sharded tokenizer code

### DIFF
--- a/mlx_lm/utils.py
+++ b/mlx_lm/utils.py
@@ -540,6 +540,12 @@ def load(
         return model, tokenizer
 
 
+def _sharded_tokenizer_config(tokenizer_config, trust_remote_code):
+    config = dict(tokenizer_config or {})
+    config.setdefault("trust_remote_code", trust_remote_code)
+    return config
+
+
 def sharded_load(
     repo,
     pipeline_group: Optional[mx.distributed.Group] = None,
@@ -614,7 +620,7 @@ def sharded_load(
     # Load and shard the model, and load the weights
     tokenizer = load_tokenizer(
         model_path,
-        tokenizer_config or {"trust_remote_code": True},
+        _sharded_tokenizer_config(tokenizer_config, trust_remote_code),
         eos_token_ids=config.get("eos_token_id", None),
     )
     model, _ = load_model(

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -16,6 +16,20 @@ HF_MODEL_PATH = "mlx-community/Qwen1.5-0.5B-Chat-4bit"
 
 
 class TestUtils(unittest.TestCase):
+
+    def test_sharded_tokenizer_remote_code_requires_opt_in(self):
+        self.assertEqual(
+            utils._sharded_tokenizer_config(None, False),
+            {"trust_remote_code": False},
+        )
+        self.assertEqual(
+            utils._sharded_tokenizer_config({}, True),
+            {"trust_remote_code": True},
+        )
+        self.assertEqual(
+            utils._sharded_tokenizer_config({"trust_remote_code": False}, True),
+            {"trust_remote_code": False},
+        )
     @classmethod
     def setUpClass(cls):
         cls.test_dir_fid = tempfile.TemporaryDirectory()


### PR DESCRIPTION
## What changed

Derive the sharded tokenizer's `trust_remote_code` setting from the existing explicit opt-in instead of enabling it when tokenizer configuration is omitted.

## Root cause

`tokenizer_config or {"trust_remote_code": True}` crossed the remote-code trust boundary by default and also replaced an explicitly supplied empty configuration with the unsafe default.

## Validation

- Regression covers default false, explicit opt-in, and an explicit tokenizer override.

Fixes #1694