### PR TITLE
fix(server): fail closed on unregistered model IDs

### DIFF
--- a/mlx_lm/server.py
+++ b/mlx_lm/server.py
@@ -367,9 +367,34 @@ class ModelProvider:
             self.load("default_model", None, "default_model")
 
     def load(self, model_path, adapter_path=None, draft_model_path=None):
-        model_path = self._model_map.get(model_path, model_path)
-        adapter_path = self._adapter_map.get(model_path, adapter_path)
-        draft_model_path = self._draft_model_map.get(draft_model_path, draft_model_path)
+        # Request IDs are registered aliases (e.g. "default_model"), not free-form
+        # Hub/local paths. Falling through let clients force arbitrary downloads.
+        if model_path not in self._model_map:
+            raise ValueError(
+                f"Unknown model {model_path!r}. "
+                f"Available models: {sorted(self._model_map)}"
+            )
+        if draft_model_path is not None and draft_model_path not in self._draft_model_map:
+            raise ValueError(
+                f"Unknown draft_model {draft_model_path!r}. "
+                f"Available draft models: {sorted(self._draft_model_map)}"
+            )
+        if adapter_path is not None and adapter_path not in self._adapter_map:
+            raise ValueError(
+                f"Unknown adapters {adapter_path!r}. "
+                f"Available adapters: {sorted(self._adapter_map)}"
+            )
+
+        # Resolve adapter against the request model id before rewriting the path
+        # (so CLI --adapter-path registered under "default_model" is not dropped).
+        if adapter_path is None:
+            adapter_path = self._adapter_map.get(model_path)
+        else:
+            adapter_path = self._adapter_map[adapter_path]
+
+        model_path = self._model_map[model_path]
+        if draft_model_path is not None:
+            draft_model_path = self._draft_model_map[draft_model_path]
 
         model_key = (model_path, adapter_path, draft_model_path)
         if self.model_key != model_key:

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -14,6 +14,7 @@ from mlx_lm.models.cache import KVCache
 from mlx_lm.server import (
     APIHandler,
     LRUPromptCache,
+    ModelProvider,
     Response,
     ResponseGenerator,
     SamplingArguments,
@@ -758,6 +759,70 @@ class TestMakeSampler(unittest.TestCase):
         token = sampler(logits)
         mx.eval(token)
         self.assertEqual(token.shape, (1,))
+
+
+class TestModelProviderFailClosed(unittest.TestCase):
+    """Request model/draft/adapter IDs must be registered aliases, not paths."""
+
+    def _provider(self, *, adapter_path=None, draft_model=None):
+        cli_args = type(
+            "obj",
+            (object,),
+            {
+                "model": "local/registered-model",
+                "adapter_path": adapter_path,
+                "draft_model": draft_model,
+                "pipeline": False,
+                "trust_remote_code": False,
+                "chat_template": None,
+                "use_default_chat_template": False,
+            },
+        )
+        return ModelProvider(cli_args)
+
+    def test_rejects_unregistered_model(self):
+        provider = self._provider()
+        loads = []
+
+        def fake_load(*args):
+            loads.append(args)
+
+        provider._load = fake_load
+        with self.assertRaisesRegex(ValueError, "Unknown model"):
+            provider.load("attacker/malicious-repo")
+        self.assertEqual(loads, [])
+
+    def test_rejects_unregistered_draft_model(self):
+        provider = self._provider(draft_model="local/draft")
+        loads = []
+        provider._load = lambda *args: loads.append(args)
+        with self.assertRaisesRegex(ValueError, "Unknown draft_model"):
+            provider.load("default_model", None, "attacker/draft")
+        self.assertEqual(loads, [])
+
+    def test_rejects_unregistered_adapters(self):
+        provider = self._provider(adapter_path="local/adapter")
+        loads = []
+        provider._load = lambda *args: loads.append(args)
+        with self.assertRaisesRegex(ValueError, "Unknown adapters"):
+            provider.load("default_model", "/tmp/evil-adapter", None)
+        self.assertEqual(loads, [])
+
+    def test_resolves_registered_default_and_cli_adapter(self):
+        provider = self._provider(adapter_path="local/adapter", draft_model=None)
+        loads = []
+
+        def fake_load(model_path, adapter_path=None, draft_model_path=None):
+            loads.append((model_path, adapter_path, draft_model_path))
+            provider.model_key = (model_path, adapter_path, draft_model_path)
+            provider.model = "model"
+            provider.tokenizer = "tok"
+
+        provider._load = fake_load
+        model, tokenizer = provider.load("default_model", None, "default_model")
+        self.assertEqual(model, "model")
+        self.assertEqual(tokenizer, "tok")
+        self.assertEqual(loads, [("local/registered-model", "local/adapter", None)])
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- `ModelProvider.load` treated unknown request `model` / `draft_model` / `adapters` values as Hub or local paths (`dict.get(key, key)`), so a client could force arbitrary `snapshot_download` / path loads against a running `mlx_lm.server`.
- Fail closed: only accept registered aliases from the CLI maps, then resolve them.
- Resolve the CLI `--adapter-path` against the request model id (fixes the silent drop that open #1249 also targets; this PR additionally rejects free-form adapter paths).

## Test plan
- [x] `pytest tests/test_server.py::TestModelProviderFailClosed` (4 passed)
- Tip parent: `254d153`

Commit is SSH-signed.


Made with [Cursor](https://cursor.com)