### PR TITLE
Exclude trailing padding token from the fine-tuning loss

### DIFF
--- a/mlx_lm/tuner/trainer.py
+++ b/mlx_lm/tuner/trainer.py
@@ -89,8 +89,9 @@ def default_loss(model, batch, lengths):
 
     logits = model(inputs)
 
+    # The last real target is at index length - 1; beyond that is padding.
     steps = mx.arange(1, targets.shape[1] + 1)
-    mask = mx.logical_and(steps >= lengths[:, 0:1], steps <= lengths[:, 1:])
+    mask = mx.logical_and(steps >= lengths[:, 0:1], steps < lengths[:, 1:])
 
     ce = nn.losses.cross_entropy(logits, targets) * mask
     ntoks = mask.sum()

--- a/tests/test_finetune.py
+++ b/tests/test_finetune.py
@@ -15,7 +15,7 @@ from mlx.utils import tree_flatten
 from mlx_lm import lora, tuner
 from mlx_lm.tuner.dora import DoRAEmbedding, DoRALinear
 from mlx_lm.tuner.lora import LoRAEmbedding, LoRALinear
-from mlx_lm.tuner.trainer import evaluate
+from mlx_lm.tuner.trainer import default_loss, evaluate, iterate_batches
 from mlx_lm.tuner.utils import build_schedule
 
 
@@ -445,6 +445,50 @@ class TestScheduleConfig(unittest.TestCase):
             comm_group=ANY,
         )
         self.assertEqual(mock_default_loss.call_count, 3)
+
+
+class TestDefaultLoss(unittest.TestCase):
+    vocab_size = 32
+
+    def setUp(self):
+        class Model(nn.Module):
+            def __init__(self, vocab_size):
+                super().__init__()
+                self.embed = nn.Embedding(vocab_size, 8)
+                self.out = nn.Linear(8, vocab_size)
+
+            def __call__(self, x):
+                return self.out(self.embed(x))
+
+        mx.random.seed(0)
+        self.model = Model(self.vocab_size)
+        mx.eval(self.model.parameters())
+
+    def make_batch(self):
+        # A four token prompt followed by a three token completion. The rows are
+        # shorter than pad_to, so iterate_batches right pads them with zeros.
+        dataset = [([3 + i, 4, 5, 6, 7, 8, 9], 4) for i in range(2)]
+        return next(iterate_batches(dataset=dataset, batch_size=2, max_seq_length=2048))
+
+    def test_padding_is_not_counted(self):
+        batch, lengths = self.make_batch()
+        _, ntoks = default_loss(self.model, batch, lengths)
+        expected = sum(
+            length - offset
+            for offset, length in zip(lengths[:, 0].tolist(), lengths[:, 1].tolist())
+        )
+        self.assertEqual(ntoks.item(), expected)
+
+    def test_loss_ignores_padding_values(self):
+        batch, lengths = self.make_batch()
+        repadded = mx.where(
+            mx.arange(batch.shape[1])[None, :] < lengths[:, 1:],
+            batch,
+            mx.array(self.vocab_size - 1, batch.dtype),
+        )
+        loss, _ = default_loss(self.model, batch, lengths)
+        other, _ = default_loss(self.model, repadded, lengths)
+        self.assertEqual(loss.item(), other.item())
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
### Problem

`default_loss` counts one padding position per sequence. `iterate_batches` right pads
each row with zeros and reports `lengths[:, 1] = L`, the number of real tokens, but the
mask selects `L - offset + 1` targets and the extra one is the pad value `0`.

So every fine-tuned sequence is trained to predict token id 0 after its last token, and
`ntoks` is one too high. With `--mask-prompt` that padded position is a large share of
the signal: a six token prompt with a three token answer counts four targets per row
instead of three.

### Root cause

`mlx_lm/tuner/trainer.py:92`

```python
steps = mx.arange(1, targets.shape[1] + 1)
mask = mx.logical_and(steps >= lengths[:, 0:1], steps <= lengths[:, 1:])
```

`targets[k] == batch[k + 1]`, so `steps[k]` is the index of `targets[k]` in the
un-shifted row. Real tokens occupy `0..L-1`, so the last valid target index is `L - 1`
and `steps <= L` reaches one past the end.

### Fix

`steps <= lengths[:, 1:]` becomes `steps < lengths[:, 1:]`.

`step == L` is in range only when `targets.shape[1] >= L`, which happens only if the row
was padded, so this cannot drop a real target. Rows truncated to `max_seq_length` have
no padding column and come out unchanged. Reported train and validation loss will move
slightly, since `ntoks` is the denominator.

### Verification

Four rows, six token prompt and three token answer, driven through the real
`iterate_batches` and `default_loss`. Before:

```
ntoks counted by default_loss : 16
real completion targets       : 12

loss with padding filled by 0  : 4.781232
loss with padding filled by 77 : 4.754244
```

After:

```
ntoks counted by default_loss : 12
real completion targets       : 12

loss with padding filled by 0  : 4.745682
loss with padding filled by 77 : 4.745682
```

The second pair is the invariant worth holding: changing only the bytes in the padding
region must not change the loss.

The two new tests fail on main,

```
$ python -m pytest tests/test_finetune.py -k TestDefaultLoss -q
E       AssertionError: 8 != 6
E       AssertionError: 3.734814167022705 != 3.6676673889160156
2 failed, 15 deselected
```

and pass with the fix:

```
2 passed, 15 deselected in 6.35s
```

`test_finetune.py`, `test_tuner_trainer.py`, `test_tuner_utils.py` and `test_losses.py`
give 29 passed. `test_datsets.py::TestDatasets::test_hf` fails on an unmodified checkout
too, `huggingface_hub` rejects the bare `billsum` name.

A 20 iteration LoRA run on `mlx-community/Qwen2.5-0.5B-Instruct-4bit` with
`--mask-prompt` trains normally, val 2.249 to 0.585.
