### PR TITLE
Honor partial_rotary_factor in glm

### DIFF
--- a/mlx_lm/models/glm.py
+++ b/mlx_lm/models/glm.py
@@ -25,6 +25,7 @@ class ModelArgs(BaseModelArgs):
     max_position_embeddings: Optional[int] = None
     attention_bias: bool = False
     rope_theta: float = 10000
+    partial_rotary_factor: float = 0.5
     tie_word_embeddings: bool = True
 
 
@@ -56,7 +57,11 @@ class GLMAttention(nn.Module):
             self.num_attention_heads * self.head_dim, self.hidden_size, bias=False
         )
 
-        self.rope = nn.RoPE(dims=self.head_dim, traditional=True, base=args.rope_theta)
+        self.rope = nn.RoPE(
+            dims=int(self.head_dim * args.partial_rotary_factor),
+            traditional=True,
+            base=args.rope_theta,
+        )
 
     def __call__(
         self,

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -517,6 +517,42 @@ class TestModels(unittest.TestCase):
             model, args.model_type, args.vocab_size, args.num_hidden_layers
         )
 
+    def test_glm_partial_rotary(self):
+        from mlx_lm.models import glm
+
+        config = {
+            "model_type": "glm",
+            "hidden_size": 128,
+            "num_hidden_layers": 2,
+            "intermediate_size": 128,
+            "num_attention_heads": 4,
+            "rms_norm_eps": 1e-5,
+            "vocab_size": 1000,
+            "head_dim": 32,
+            "num_key_value_heads": 2,
+        }
+
+        def rotary_split(args):
+            # Returns the parts of a head that RoPE does and does not touch, by
+            # rotating the same vector at two different positions.
+            attn = glm.Model(args).model.layers[0].self_attn
+            x = mx.random.normal((1, 1, 3, attn.head_dim))
+            here, later = attn.rope(x, offset=0), attn.rope(x, offset=7)
+            moved = mx.any(mx.abs(here - later) > 1e-6, axis=(0, 1, 2))
+            return moved.tolist()
+
+        # glm-4-9b omits partial_rotary_factor, so transformers supplies 0.5 and
+        # only the first half of each head is rotated.
+        moved = rotary_split(glm.ModelArgs.from_dict(config))
+        self.assertEqual(sum(moved), 16)
+        self.assertEqual(moved, [True] * 16 + [False] * 16)
+
+        # glm-edge sets it to 1.0 and every dimension is rotated.
+        moved = rotary_split(
+            glm.ModelArgs.from_dict({**config, "partial_rotary_factor": 1.0})
+        )
+        self.assertEqual(sum(moved), 32)
+
     def test_gemma(self):
         from mlx_lm.models import gemma
 


### PR DESCRIPTION
### Problem

`GLMAttention` builds its RoPE over the whole `head_dim`, so `glm` checkpoints that
expect a partial rotary get every dimension rotated. `glm4.py:75` already reads
`partial_rotary_factor`; `glm.py` never had the field.

### Root cause

`mlx_lm/models/glm.py:58`

```python
self.rope = nn.RoPE(dims=self.head_dim, traditional=True, base=args.rope_theta)
```

`ModelArgs` had no `partial_rotary_factor`, so `BaseModelArgs.from_dict` dropped the key
when a config carried one.

The value is not optional in practice. `configuration_glm.py:77` does
`kwargs.setdefault("partial_rotary_factor", 0.5)`, so transformers supplies 0.5 even for
a config that never mentions it:

```
>>> GlmConfig(head_dim=128, num_attention_heads=32).rope_parameters
{'rope_theta': 10000.0, 'partial_rotary_factor': 0.5, 'rope_type': 'default'}
```

`apply_rotary_pos_emb` then rotates only that prefix and concatenates the rest back
untouched (`modeling_glm.py:203`, `:211`):

```python
q_rot, q_pass = q[..., :rotary_dim], q[..., rotary_dim:]
...
q_embed = torch.cat([q_embed, q_pass], dim=-1)
```

Checkpoints I read off the hub, all `model_type: glm`:

| repo | head_dim | partial_rotary_factor | rotary dims wanted | mlx-lm rotates |
|---|---|---|---|---|
| `THUDM/glm-4-9b-chat-hf` | 128 | absent, so 0.5 | 64 | 128 |
| `THUDM/glm-4-9b-hf` | 128 | absent, so 0.5 | 64 | 128 |
| `mlx-community/glm-4-9b-chat-1m-4bit` | 128 | absent, so 0.5 | 64 | 128 |
| `THUDM/glm-edge-1.5b-chat` | 128 | 1.0 | 128 | 128 |
| `THUDM/glm-edge-4b-chat` | 128 | 1.0 | 128 | 128 |

### Fix

Add `partial_rotary_factor: float = 0.5` to `ModelArgs` and size the RoPE with it. The
default matches the `setdefault`, so the GLM-4-9B family picks up 64 rotated dims. The
glm-edge checkpoints set 1.0 explicitly and come out exactly as they do today.

This changes generation output for existing GLM-4-9B checkpoints. That is the point of
the change, but it is worth saying plainly, since anyone comparing against a previous
mlx-lm run will see different text.

### Verification

`mlx.nn.RoPE(dims=...)` has the passthrough behaviour the reference needs, so sizing it
is enough; no split and concatenate is required in the model:

```
>>> r = nn.RoPE(dims=64, traditional=True, base=10000.0); x = mx.random.normal((1,1,3,128))
tail[64:] position-invariant with dims=64 : True
head[:64] changes with position           : True
with dims=128, tail[64:] invariant        : False
```

The new test rotates the same vector at two offsets and counts which components move,
so it checks the rotary actually applied rather than a shape. On main:

```
$ python -m pytest tests/test_models.py -k test_glm_partial_rotary -q
>       self.assertEqual(sum(moved), 16)
E       AssertionError: 32 != 16
1 failed, 78 deselected
```

with the fix:

```
1 passed, 78 deselected in 0.78s
```

Full module:

```
$ python -m pytest tests/test_models.py -q
78 passed, 1 skipped, 52 subtests passed in 5.74s
```

The existing `glm` entry in `test_all_models` goes through `model_test_runner`, which
asserts shapes and dtypes only, which is why this went unnoticed.

This is my second open PR on this repo; the other is #1697 and touches unrelated code.
