### PR TITLE
Copy on ArraysCache.extract instead of returning a view extract slice…

### DIFF
--- a/mlx_lm/models/cache.py
+++ b/mlx_lm/models/cache.py
@@ -672,7 +672,7 @@ class ArraysCache(_BaseCache):
 
     def extract(self, idx):
         cache = ArraysCache(len(self.cache))
-        cache.cache = [c[idx : idx + 1] for c in self.cache]
+        cache.cache = [mx.contiguous(c[idx : idx + 1]) for c in self.cache]
         return cache
 
     def prepare(self, lengths=None, **kwargs):


### PR DESCRIPTION
Fixes a crucial memory leak in the DSA path.

Copy on ArraysCache.extract instead of returning a view extract sliced each state with a bare c[idx : idx + 1], which is a view whose graph inputs pin the whole batched array. Extracted caches get inserted back into a later batch, where extend concatenates them, so generation batch N retains the slice it was built from and through it batch N-1: a chain of full batched states, one link per turn. It is all refcount-live, so nothing reclaims it and mx.clear_cache() does not help.

BatchKVCache.extract and BatchRotatingKVCache.extract already wrap their slices in mx.contiguous. ArraysCache was the only batched cache that did not, so it shows up on models whose per-sequence recurrent state is large -- kimi_linear, qwen3_next, mamba2, falcon_h1 and rwkv7 all hold their state in ArraysCache.

Build a batched ArraysCache, extract one row, drop the parent. With the view the parent stays fully resident (1.56MiB of 1.56MiB); with the copy it releases to exactly one row (0.78MiB).