### PR TITLE
fix(gemma3n): share KV independently of the cache (#1674)

### DIFF
--- a/mlx_lm/models/gemma3n.py
+++ b/mlx_lm/models/gemma3n.py
@@ -120,22 +120,21 @@ class Gemma3nAttention(nn.Module):
         x: mx.array,
         mask: Optional[mx.array] = None,
         cache: Optional[Any] = None,
-    ) -> mx.array:
+        shared_kv: Optional[tuple] = None,
+        offset: Optional[Any] = None,
+    ):
         B, L, _ = x.shape
 
         queries = self.q_proj(x)
         queries = queries.reshape(B, L, -1, self.head_dim)
         queries = self.q_norm(queries)
 
-        offset = 0
-        if self.is_kv_shared_layer and cache is not None:
-            # For shared layers, retrieve KV from the designated cache layer
-            keys, values = cache.state
-            offset = cache.offset
-
+        if shared_kv is not None:
+            # KV-shared layers reuse the keys/values and the RoPE offset of the
+            # designated source layer, whether or not a cache is present.
+            keys, values = shared_kv
         else:
-            if cache is not None:
-                offset = cache.offset
+            offset = cache.offset if cache is not None else 0
             keys = self.k_proj(x).reshape(B, L, -1, self.head_dim)
             keys = self.k_norm(keys)
             keys = keys.transpose(0, 2, 1, 3)
@@ -157,7 +156,7 @@ class Gemma3nAttention(nn.Module):
 
         output = output.transpose(0, 2, 1, 3).reshape(B, L, -1)
 
-        return self.o_proj(output)
+        return self.o_proj(output), (keys, values), offset
 
 
 @partial(mx.compile, shapeless=True)
@@ -328,6 +327,8 @@ class Gemma3nDecoderLayer(nn.Module):
         mask: Optional[mx.array] = None,
         cache: Optional[Any] = None,
         per_layer_input: Optional[mx.array] = None,
+        shared_kv: Optional[tuple] = None,
+        offset: Optional[Any] = None,
     ):
         predictions = self.altup.predict(x)
         active_prediction = predictions[self.config.altup_active_idx]
@@ -335,10 +336,12 @@ class Gemma3nDecoderLayer(nn.Module):
         active_prediction_normed = self.input_layernorm(active_prediction)
         laurel_output = self.laurel(active_prediction_normed)
 
-        attn = self.self_attn(
+        attn, kvs, offset = self.self_attn(
             active_prediction_normed,
             mask,
             cache,
+            shared_kv=shared_kv,
+            offset=offset,
         )
 
         attn = self.post_attention_layernorm(attn)
@@ -366,7 +369,7 @@ class Gemma3nDecoderLayer(nn.Module):
 
         corrected_predictions[1:] = corrected_predictions[1:] + first_prediction
 
-        return corrected_predictions
+        return corrected_predictions, kvs, offset
 
 
 @partial(mx.compile, shapeless=True)
@@ -491,6 +494,9 @@ class LanguageModel(nn.Module):
         h = mx.stack(h_list, axis=0)
         mags = mx.mean(h[1:] ** 2, axis=-1, keepdims=True) ** 0.5
         h[1:] = h[1:] * (target_magnitude / mx.maximum(mags, mx.finfo(h0.dtype).min))
+        # Save each layer's keys/values and RoPE offset so the KV-shared layers
+        # can pick up the ones from their source layer.
+        intermediates = [(None, None)] * len(self.layers)
         for i, layer in enumerate(self.layers):
             per_layer_input = per_layer_inputs[:, :, i, :]
 
@@ -501,12 +507,18 @@ class LanguageModel(nn.Module):
             else:
                 mask = sliding_window_mask
 
-            h = layer(
+            shared_kv, offset = intermediates[self.layer_idx_to_cache_idx[i]]
+
+            h, kvs, offset = layer(
                 h,
                 mask,
                 cache[self.layer_idx_to_cache_idx[i]],
                 per_layer_input,
+                shared_kv=shared_kv,
+                offset=offset,
             )
+
+            intermediates[i] = (kvs, offset)
 
         # Per-layer inputs to single output
         target_magnitude = mx.mean(h[0] ** 2, axis=-1, keepdims=True) ** 0.5

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -1727,6 +1727,72 @@ class TestModels(unittest.TestCase):
             mx.allclose(direct.astype(mx.float32), explicit.astype(mx.float32))
         )
 
+    def test_gemma3n_kv_sharing_is_cache_independent(self):
+        """KV-shared layers must reuse the source layer's keys/values and RoPE
+        offset whether or not a cache is present, so a no-cache forward (LoRA
+        training, evaluation) agrees with generation."""
+        from mlx_lm.models import gemma3n
+
+        def build(num_kv_shared_layers):
+            args = gemma3n.ModelArgs(
+                model_type="gemma3n",
+                text_config={
+                    "model_type": "gemma3n",
+                    "hidden_size": 128,
+                    "num_hidden_layers": 4,
+                    "intermediate_size": 128,
+                    "num_attention_heads": 4,
+                    "head_dim": 32,
+                    "rms_norm_eps": 1e-5,
+                    "vocab_size": 1000,
+                    "num_key_value_heads": 2,
+                    "num_kv_shared_layers": num_kv_shared_layers,
+                    "vocab_size_per_layer_input": 1000,
+                    "sliding_window": 8,
+                    "max_position_embeddings": 1000,
+                    "rope_local_base_freq": 1.0,
+                    "rope_theta": 1000.0,
+                    "final_logit_softcapping": 1.0,
+                    "layer_types": [
+                        "sliding_attention",
+                        "full_attention",
+                        "sliding_attention",
+                        "full_attention",
+                    ],
+                    "activation_sparsity_pattern": [0.5, 0.5, 0.5, 0.5],
+                    "hidden_size_per_layer_input": 256,
+                    "altup_num_inputs": 4,
+                    "altup_coef_clip": 1.0,
+                    "altup_correct_scale": True,
+                    "altup_active_idx": 0,
+                    "laurel_rank": 8,
+                },
+            )
+            return gemma3n.Model(args)
+
+        tokens = [1, 2, 3, 4, 5, 6]
+        inputs = mx.array([tokens])
+
+        # num_kv_shared_layers=0 turns sharing off and is the control: it agreed
+        # on both checks before this behavior was fixed.
+        for num_kv_shared_layers in (2, 0):
+            model = build(num_kv_shared_layers)
+
+            # A forward with no cache must match a forward with a fresh cache.
+            no_cache = model(inputs)
+            cached = model(inputs, cache=make_prompt_cache(model))
+            self.assertTrue(mx.allclose(no_cache, cached, atol=1e-4, rtol=1e-4))
+
+            # Prefilling the prompt in one step must match decoding it token by
+            # token, which pins the RoPE offset the shared layers query with.
+            cache = make_prompt_cache(model)
+            prefill = model(inputs, cache=cache)[:, -1, :]
+
+            cache = make_prompt_cache(model)
+            for token in tokens:
+                incremental = model(mx.array([[token]]), cache=cache)[:, -1, :]
+            self.assertTrue(mx.allclose(prefill, incremental, atol=1e-4, rtol=1e-4))
+
     def test_gpt_bigcode(self):
         from mlx_lm.models import gpt_bigcode
 


### PR DESCRIPTION
Closes #1674.

### Problem

In `Gemma3nAttention.__call__`, KV-shared layers only reused the source layer's keys/values **when a cache was present**:

```python
offset = 0
if self.is_kv_shared_layer and cache is not None:
    keys, values = cache.state
    offset = cache.offset
else:
    ...   # shared layers ALSO land here when cache is None
```

Coupling KV sharing to the cache produces two distinct defects.

**1. No-cache forwards don't share KV** (the reported issue). Generation always runs with a cache, so it is unaffected, but any cache-free forward — `mlx_lm.evaluate`/perplexity and, notably, **LoRA fine-tuning** — falls into the `else` branch and computes the shared layers' own `k_proj`/`v_proj`. The model being trained is not the model used at inference. For reference, `transformers` threads a `shared_kv_states` dict through the forward and never consults a cache for this, and it does not even build `k_proj`/`v_proj` on shared layers.

**2. With a cache, the shared layers rotate their queries at the wrong offset.** `cache` here is the *source* layer's cache, and by the time a shared layer runs, that layer has already called `update_and_fetch`, so `cache.offset` is `offset + L`, not `offset`. The concrete layers rotate their queries at `offset`. So prefilling a prompt in one step does not agree with decoding it token by token.

Both are visible on the `gemma3n` config already in `tests/test_models.py` (random weights, so magnitudes are arbitrary — the point is that quantities which must agree don't):

| check (`num_kv_shared_layers=2`) | before | after |
|---|---|---|
| `max abs(model(x) - model(x, cache=fresh))` | 1.736722 | 0.0 |
| `max abs(prefill_6_tokens - decode_6x1_tokens)` | 0.868520 | 0.0 |

With `num_kv_shared_layers=0` (sharing off) both are `0.0` before and after, which is the control that pins the KV-shared path as the cause.

### Change

Thread the source layer's `(keys, values)` and its RoPE offset through the decoder loop instead of recovering them from a cache — the same shape `gemma4_text` already uses (`Attention.__call__(..., shared_kv=..., offset=...)` returning `(out, (keys, values), offset)`, with `Gemma4TextModel` keeping an `intermediates` list). `Gemma3nModel` already computes `layer_idx_to_cache_idx`, which is exactly the "source layer of the same type" mapping, so it doubles as the index into `intermediates` and no new bookkeeping is needed.

Sharing now behaves identically with and without a cache, and the shared layers rotate their queries at the same offset as the layer whose K/V they reuse.

Deliberately **not** changed: shared layers keep their (now unused in the shared path) `k_proj`/`v_proj`/`k_norm`/`v_norm` parameters, so weight loading is untouched. Dropping them the way `gemma4_text` does would change what `strict=True` accepts and belongs in a separate change.

### Tests

New `test_gemma3n_kv_sharing_is_cache_independent` asserts both invariants, for `num_kv_shared_layers` of 2 and 0.

Verified with `mlx-cuda` 0.30.0 on the CPU backend (no Apple hardware available here):

- new test: **fails on `main`** (`assertTrue(mx.allclose(no_cache, cached, ...))` → `array(False)`), **passes** with this change.
- full `tests/test_models.py`: 78 tests, the same 3 errors before and after (`test_bitnet`, `test_gated_delta`, `test_gated_delta_masked` — custom-Metal-kernel tests that don't run on this backend). No new failures; `test_all_models` covers `gemma3n` and passes.
- `black` 25.1.0 and `isort` 6.0.0 (`--profile=black`) report both files unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
