### PR TITLE
pythonic tool parser: parse every call in a multi-call block

### DIFF
--- a/mlx_lm/tool_parsers/pythonic.py
+++ b/mlx_lm/tool_parsers/pythonic.py
@@ -13,36 +13,48 @@ Parses assistant responses containing tool calls in formats like:
 """
 
 
-_tool_call_regex = re.compile(r"\[(\w+)\((.*?)\)\]", re.DOTALL)
+# The block is a LIST of calls: [f1(a=1), f2(b="x")]. Match each call
+# individually (quote-aware, so ')' inside a string arg doesn't terminate
+# the call) — a single non-greedy search over the whole block merges the
+# args of call 1..n together and silently drops calls 2..n.
+_tool_block_regex = re.compile(r"\[(.*)\]", re.DOTALL)
+_single_call_regex = re.compile(
+    r"(\w+)\(((?:[^()\"']|\"(?:[^\"\\]|\\.)*\"|'(?:[^'\\]|\\.)*')*)\)",
+    re.DOTALL,
+)
 _tool_args_regex = re.compile(r'(\w+)=(?:"([^"]*)"|([^,]+))(?:,\s*|$)', re.DOTALL)
 
 
 def parse_tool_call(text: str, tools: Any | None = None):
-    match = _tool_call_regex.search(text)
-    if not match:
+    block = _tool_block_regex.search(text)
+    if not block:
         raise ValueError("No function provided.")
 
-    func_name = match.group(1)
-    args_str = match.group(2)
+    calls = []
+    for match in _single_call_regex.finditer(block.group(1)):
+        func_name = match.group(1)
+        args_str = match.group(2)
 
-    arguments = {}
-    if args_str:
-        matches = _tool_args_regex.findall(args_str)
-        for pair in matches:
-            key = pair[0].strip()
-            # pair[1] is quoted value, pair[2] is unquoted value
-            value = pair[1] if pair[1] else pair[2].strip()
+        arguments = {}
+        if args_str:
+            for pair in _tool_args_regex.findall(args_str):
+                key = pair[0].strip()
+                # pair[1] is quoted value, pair[2] is unquoted value
+                value = pair[1] if pair[1] else pair[2].strip()
 
-            # Try to parse the value using ast.literal_eval
-            try:
-                value = ast.literal_eval(value)
-            except (ValueError, SyntaxError):
-                # If parsing fails, keep as string
-                pass
+                # Try to parse the value using ast.literal_eval
+                try:
+                    value = ast.literal_eval(value)
+                except (ValueError, SyntaxError):
+                    # If parsing fails, keep as string
+                    pass
 
-            arguments[key] = value
+                arguments[key] = value
+        calls.append(dict(name=func_name, arguments=arguments))
 
-    return dict(name=func_name, arguments=arguments)
+    if not calls:
+        raise ValueError("No function provided.")
+    return calls[0] if len(calls) == 1 else calls
 
 
 tool_call_start = "<|tool_call_start|>"

--- a/tests/test_tool_parsing.py
+++ b/tests/test_tool_parsing.py
@@ -16,6 +16,24 @@ from mlx_lm.tool_parsers import (
 
 
 class TestToolParsing(unittest.TestCase):
+    def test_pythonic_multiple_calls(self):
+        # The pythonic block is a list of calls; every call must survive.
+        # A single non-greedy search merged the args of call 1..n and
+        # silently dropped calls 2..n.
+        calls = pythonic.parse_tool_call('[get_weather(city="SF"), get_time(tz="PST")]')
+        self.assertEqual(
+            calls,
+            [
+                {"name": "get_weather", "arguments": {"city": "SF"}},
+                {"name": "get_time", "arguments": {"tz": "PST"}},
+            ],
+        )
+        # A ')' inside a quoted argument must not terminate the call.
+        call = pythonic.parse_tool_call('[run(cmd="echo )")]')
+        self.assertEqual(call, {"name": "run", "arguments": {"cmd": "echo )"}})
+        with self.assertRaises(ValueError):
+            pythonic.parse_tool_call("no calls here")
+
     def test_parsers(self):
         test_cases = [
             ("call:multiply{a:12234585,b:48838483920}", function_gemma),


### PR DESCRIPTION
The pythonic format's block is a list of calls, e.g. `[f1(a=1), f2(b="x")]`, but `parse_tool_call` used a single non-greedy search over the whole block. For multi-call payloads it returned one call named `f1` whose argument string was `a=1), f2(b="x` — the arguments of all calls merged together and calls 2..n silently dropped. Every other family parser in `tool_parsers/` drains multi-call payloads; pythonic was the only one that could not.

This matches each call individually with a quote-aware pattern (a `)` inside a quoted argument does not terminate the call). Single-call blocks still return a bare dict, so existing behavior and tests are unchanged; multi-call blocks return a list, which the server's tool-call formatter already flattens.

Found while replaying multi-token commits from speculative decoding through the streaming parsers: a single delta carrying several complete calls is exactly the shape that triggered this.

Tests: multi-call, quoted-paren argument, and no-call regression cases added to `tests/test_tool_parsing.py`; existing parser cases pass unchanged (6 passed, 22 subtests).