### PR TITLE
stream_generate: return cleanly when no tokens are generated

### DIFF
--- a/mlx_lm/generate.py
+++ b/mlx_lm/generate.py
@@ -704,6 +704,9 @@ def stream_generate(
         )
     with wired_limit(model, [generation_stream]):
         tic = time.perf_counter()
+        # max_tokens=0 (or a generator that yields nothing) must not reach
+        # the final response, which reads the loop variables.
+        token = None
         for n, (token, logprobs, from_draft) in enumerate(token_generator):
             if n == 0:
                 prompt_time = time.perf_counter() - tic
@@ -730,6 +733,8 @@ def stream_generate(
             )
 
         detokenizer.finalize()
+        if token is None:
+            return
         yield GenerationResponse(
             text=detokenizer.last_segment,
             token=token,

--- a/tests/test_generate.py
+++ b/tests/test_generate.py
@@ -46,6 +46,17 @@ class TestGenerate(unittest.TestCase):
         )
         self.assertEqual(text, "!!!!!")
 
+    def test_stream_generate_zero_max_tokens(self):
+        prompt = self.tokenizer.apply_chat_template(
+            [{"role": "user", "content": "Write a story about Einstein"}],
+            tokenize=True,
+            add_generation_prompt=True,
+        )
+        responses = list(
+            stream_generate(self.model, self.tokenizer, prompt, max_tokens=0)
+        )
+        self.assertEqual(responses, [])
+
     def test_stream_generate_max_tokens(self):
         prompt = self.tokenizer.apply_chat_template(
             [{"role": "user", "content": "Write a story about Einstein"}],


### PR DESCRIPTION
With `max_tokens=0` (or any token generator that yields nothing) the final `GenerationResponse` in `stream_generate` reads `token` / `logprobs` / `n` before the loop has ever bound them, raising `UnboundLocalError`.

Return after finalizing the detokenizer instead, so callers see an empty stream.

Test: `max_tokens=0` yields no responses (added next to the existing `max_tokens` test).