### PR TITLE
Add opt-in acceptance rules for speculative decoding (accept_rule)

### DIFF
--- a/mlx_lm/generate.py
+++ b/mlx_lm/generate.py
@@ -1,10 +1,11 @@
-# Copyright © 2023-2024 Apple Inc.
+# Copyright © 2023-2026 Apple Inc.
 
 import argparse
 import contextlib
 import copy
 import functools
 import json
+import math
 import sys
 import time
 from collections import deque
@@ -209,6 +210,16 @@ def setup_arg_parser():
         type=int,
         help="Number of tokens to draft when using speculative decoding.",
         default=3,
+    )
+    parser.add_argument(
+        "--accept-rule",
+        type=str,
+        choices=["exact", "residual", "block"],
+        help="Draft-token acceptance rule for speculative decoding. "
+        "'residual' and 'block' raise the acceptance rate at temperature > 0 "
+        "without changing the sampled distribution; they require plain "
+        "temperature sampling.",
+        default="exact",
     )
     return parser
 
@@ -461,6 +472,108 @@ def generate_step(
         n += 1
 
 
+def _sampling_logprobs(logprobs: mx.array, temp: float) -> mx.array:
+    """Log-probabilities of the distribution actually sampled from at the
+    given temperature, i.e. the log-softmax of ``logprobs / temp``."""
+    logprobs = logprobs.astype(mx.float32)
+    if temp != 1.0:
+        logprobs = logprobs * (1.0 / temp)
+    return logprobs - mx.logsumexp(logprobs, axis=-1, keepdims=True)
+
+
+def _acceptance_probs(
+    target_logprobs: mx.array, draft_logprobs: mx.array, draft_tokens: List[int]
+) -> mx.array:
+    """Per-token speculative sampling acceptance probabilities
+    ``min(1, p(x) / q(x))`` for drafts ``x ~ q``.
+
+    The ratio is computed in log space, ``exp(min(log p - log q, 0))``, so
+    that tokens whose probabilities are far below any fixed linear-space
+    floor are still accepted at the correct rate.
+    """
+    idx = mx.array(draft_tokens, mx.uint32)[:, None]
+    t = mx.take_along_axis(target_logprobs, idx, axis=-1).squeeze(-1)
+    d = mx.take_along_axis(draft_logprobs, idx, axis=-1).squeeze(-1)
+    return mx.exp(mx.minimum(t - d, 0.0))
+
+
+def _residual_sample(
+    target_logprobs: mx.array, draft_logprobs: mx.array, scale: float = 1.0
+) -> int:
+    """Sample the correction token from the normalized residual
+    ``relu(scale * p - q)``.
+
+    ``scale`` is the block-verification cumulative ratio; ``1.0`` gives the
+    standard per-token rejection sampling residual. If the residual has no
+    mass (``scale * p <= q`` everywhere), fall back to a plain sample from
+    the target distribution.
+    """
+    residual = mx.maximum(scale * mx.exp(target_logprobs) - mx.exp(draft_logprobs), 0.0)
+    if mx.sum(residual).item() <= 0.0:
+        return mx.random.categorical(target_logprobs).item()
+    return mx.random.categorical(mx.log(residual)).item()
+
+
+def _block_verify(
+    target_logprobs: mx.array, draft_logprobs: mx.array, draft_tokens: List[int]
+) -> Tuple[int, Optional[int]]:
+    """Block verification (Sun et al., https://arxiv.org/abs/2403.10444).
+
+    Instead of independent per-token accept/reject coin flips, the drafted
+    block is verified through the cumulative likelihood ratio of its
+    prefixes, ``p_cum_i = min(p_cum_{i-1} * p_i(x_i) / q_i(x_i), 1)``. A
+    prefix of length ``i`` passes when a uniform draw falls below its
+    threshold: ``h_k = p_cum_k`` for the full block, and
+    ``h_i = S_i / (S_i + 1 - p_cum_i)`` with
+    ``S_i = sum(relu(p_cum_i * p_{i+1} - q_{i+1}))`` otherwise. The accepted
+    length is the LARGEST passing prefix, so a later position can rescue an
+    earlier failure; this accepts at least as many tokens in expectation as
+    per-token rejection sampling while committing tokens with exactly the
+    target distribution.
+
+    ``target_logprobs`` holds ``k + 1`` rows and ``draft_logprobs`` the
+    ``k`` rows the drafts were sampled from, both already at the sampling
+    temperature. Returns the accepted length and the correction token
+    (sampled from the scaled residual ``relu(p_cum * p - q)``), or ``None``
+    for the correction when the full block was accepted.
+    """
+    k = len(draft_tokens)
+    etas = mx.random.uniform(shape=(k,))
+    idx = mx.array(draft_tokens, mx.uint32)[:, None]
+    t = mx.take_along_axis(target_logprobs[:k], idx, axis=-1).squeeze(-1)
+    d = mx.take_along_axis(draft_logprobs, idx, axis=-1).squeeze(-1)
+    mx.eval(etas)
+    etas = etas.tolist()
+    log_ratios = (t - d).tolist()
+    log_p_cum = 0.0
+    p_cums = [1.0]
+    tau = 0
+    for i in range(k):
+        log_p_cum = min(log_p_cum + log_ratios[i], 0.0)
+        p_cum = math.exp(log_p_cum)
+        p_cums.append(p_cum)
+        if i == k - 1:
+            h = p_cum
+        else:
+            s = mx.sum(
+                mx.maximum(
+                    p_cum * mx.exp(target_logprobs[i + 1])
+                    - mx.exp(draft_logprobs[i + 1]),
+                    0.0,
+                )
+            ).item()
+            denom = s + (1.0 - p_cum)
+            h = 1.0 if denom <= 0.0 else s / denom
+        if etas[i] <= h:
+            tau = i + 1
+    if tau == k:
+        return tau, None
+    correction = _residual_sample(
+        target_logprobs[tau], draft_logprobs[tau], scale=p_cums[tau]
+    )
+    return tau, correction
+
+
 def speculative_generate_step(
     prompt: mx.array,
     model: nn.Module,
@@ -475,6 +588,7 @@ def speculative_generate_step(
     kv_bits: Optional[int] = None,
     kv_group_size: int = 64,
     quantized_kv_start: int = 0,
+    accept_rule: str = "exact",
 ) -> Generator[Tuple[mx.array, mx.array, bool], None, None]:
     """
     A generator producing token ids based on the given prompt from the model.
@@ -500,11 +614,48 @@ def speculative_generate_step(
         kv_group_size (int): Group size for KV cache quantization. Default: ``64``.
         quantized_kv_start (int): Step to begin using a quantized KV cache.
            when ``kv_bits`` is non-None. Default: ``0``.
+        accept_rule (str): How to decide which draft tokens to accept. One of:
+
+          - ``"exact"``: accept a draft token only when it matches the token
+            sampled from the target model (the default, unchanged behavior).
+          - ``"residual"``: speculative rejection sampling — accept a draft
+            token ``x ~ q`` with probability ``min(1, p(x) / q(x))`` and
+            resample rejections from ``relu(p - q)`` normalized.
+          - ``"block"``: block verification (Sun et al.,
+            https://arxiv.org/abs/2403.10444) — verify the whole drafted
+            block through cumulative likelihood ratios; accepts at least as
+            many tokens in expectation as ``"residual"``.
+
+          All three rules commit tokens distributed exactly as the target
+          model's sampling distribution; ``"residual"`` and ``"block"`` only
+          raise the acceptance rate at temperature > 0. They require the
+          sampled distribution and are therefore only supported with plain
+          temperature samplers from :func:`make_sampler` (no top-p / min-p /
+          top-k / xtc). With greedy sampling all rules coincide with
+          ``"exact"``. Default: ``"exact"``.
 
     Yields:
         Tuple[mx.array, mx.array, bool]: One token, a vector of log probabilities,
           and a bool indicating if the token was generated by the draft model
     """
+    if accept_rule not in ("exact", "residual", "block"):
+        raise ValueError(
+            f"accept_rule must be one of 'exact', 'residual', or 'block', "
+            f"got {accept_rule!r}"
+        )
+    accept_temp = 0.0
+    if accept_rule != "exact":
+        accept_temp = 0.0 if sampler is None else getattr(sampler, "temp", None)
+        if accept_temp is None:
+            raise ValueError(
+                f"accept_rule {accept_rule!r} requires the distribution the "
+                "tokens are sampled from, which is only available for plain "
+                "temperature samplers made by make_sampler (no top_p, min_p, "
+                "top_k, or xtc). Use a supported sampler or accept_rule='exact'."
+            )
+        if accept_temp == 0.0:
+            # With greedy sampling every rule reduces to exact matching
+            accept_rule = "exact"
 
     y = prompt.astype(mx.uint32)
     prev_tokens = None
@@ -582,14 +733,41 @@ def speculative_generate_step(
         cache.trim_prompt_cache(draft_cache, max(num_draft - num_accept - 1, 0))
 
     def _draft_generate(y, num_draft):
+        keep_logprobs = accept_rule != "exact"
         if num_draft == 0:
-            return mx.array([], mx.uint32)
-        ys = []
+            return mx.array([], mx.uint32), None
+        ys, lps = [], []
         for _ in range(num_draft):
-            y, _ = _step(draft_model, draft_cache, y)
+            y, logprobs = _step(draft_model, draft_cache, y)
             mx.async_eval(y)
             ys.append(y)
-        return mx.concatenate(ys)
+            if keep_logprobs:
+                lps.append(logprobs)
+        return mx.concatenate(ys), (
+            mx.concatenate(lps, axis=0) if keep_logprobs else None
+        )
+
+    def _verify(draft_tokens, draft_logprobs, tokens, logprobs):
+        num_draft = len(draft_tokens)
+        target_lp = _sampling_logprobs(logprobs, accept_temp)
+        draft_lp = _sampling_logprobs(draft_logprobs, accept_temp)
+        if accept_rule == "block":
+            n, correction = _block_verify(target_lp, draft_lp, draft_tokens)
+        else:
+            probs = _acceptance_probs(target_lp[:num_draft], draft_lp, draft_tokens)
+            us = mx.random.uniform(shape=(num_draft,))
+            mx.eval(probs, us)
+            probs, us = probs.tolist(), us.tolist()
+            n = 0
+            while n < num_draft and us[n] <= probs[n]:
+                n += 1
+            correction = None
+            if n < num_draft:
+                correction = _residual_sample(target_lp[n], draft_lp[n])
+        # On full acceptance the target's own sample at the bonus position
+        # is a fresh draw from the target distribution, so reuse it. On
+        # rejection commit the residual-sampled correction instead.
+        return n, tokens[n] if correction is None else correction
 
     with mx.stream(generation_stream):
         draft_y = _prefill(draft_model, draft_cache, y)
@@ -602,7 +780,7 @@ def speculative_generate_step(
     try:
         while True:
             num_draft = min(max_tokens - ntoks, num_draft_tokens)
-            draft_tokens = _draft_generate(draft_y, num_draft)
+            draft_tokens, draft_logprobs = _draft_generate(draft_y, num_draft)
             if prev_tokens is not None:
                 prev_tokens = prev_tokens[: prev_tokens.size - y.size - num_draft + 1]
             y = mx.concatenate([y, draft_tokens])
@@ -610,24 +788,37 @@ def speculative_generate_step(
             mx.eval(tokens, draft_tokens)
             draft_tokens = draft_tokens.tolist()
             tokens = tokens.tolist()
-            n = 0
-            while n < num_draft:
-                tn, dtn, lpn = tokens[n], draft_tokens[n], logprobs[n]
-                if tn != dtn:
-                    break
-                n += 1
-                ntoks += 1
-                yield tn, lpn, True
-                if ntoks == max_tokens:
-                    break
+            if accept_rule == "exact":
+                n = 0
+                while n < num_draft:
+                    tn, dtn, lpn = tokens[n], draft_tokens[n], logprobs[n]
+                    if tn != dtn:
+                        break
+                    n += 1
+                    ntoks += 1
+                    yield tn, lpn, True
+                    if ntoks == max_tokens:
+                        break
+                last_token = tokens[n]
+            else:
+                n_accept, last_token = _verify(
+                    draft_tokens, draft_logprobs, tokens, logprobs
+                )
+                n = 0
+                while n < n_accept:
+                    n += 1
+                    ntoks += 1
+                    yield draft_tokens[n - 1], logprobs[n - 1], True
+                    if ntoks == max_tokens:
+                        break
             if ntoks < max_tokens:
                 ntoks += 1
-                yield tokens[n], logprobs[n], False
+                yield last_token, logprobs[n], False
 
             if ntoks == max_tokens:
                 break
 
-            y = mx.array([tokens[n]], mx.uint32)
+            y = mx.array([last_token], mx.uint32)
             draft_y = y
 
             # If we accepted all the draft tokens, include the last
@@ -691,6 +882,7 @@ def stream_generate(
 
     if draft_model is None:
         kwargs.pop("num_draft_tokens", None)
+        kwargs.pop("accept_rule", None)
         token_generator = generate_step(prompt, model, **kwargs)
         # from_draft always false for non-speculative generation
         token_generator = (
@@ -2181,6 +2373,7 @@ def main():
         quantized_kv_start=args.quantized_kv_start,
         draft_model=draft_model,
         num_draft_tokens=args.num_draft_tokens,
+        accept_rule=args.accept_rule,
     )
     if not args.verbose:
         print(response)

--- a/mlx_lm/sample_utils.py
+++ b/mlx_lm/sample_utils.py
@@ -1,4 +1,4 @@
-# Copyright © 2023-2024 Apple Inc.
+# Copyright © 2023-2026 Apple Inc.
 
 import math
 from functools import partial
@@ -44,7 +44,12 @@ def make_sampler(
             A sampler which takes log-probabilities and returns tokens.
     """
     if temp == 0:
-        return lambda x: mx.argmax(x, axis=-1)
+
+        def sampler(logprobs):
+            return mx.argmax(logprobs, axis=-1)
+
+        sampler.temp = 0.0
+        return sampler
 
     # Create sampler chain
     sampling_methods = []
@@ -66,6 +71,12 @@ def make_sampler(
         # Return the sampled token
         return categorical_sampling(logprobs, temp)
 
+    if not sampling_methods:
+        # Plain temperature sampling: expose the temperature so that
+        # consumers which need the sampled distribution (e.g. the
+        # ``accept_rule`` options of ``speculative_generate_step``) can
+        # recover it from the log-probabilities.
+        sampler.temp = temp
     return sampler
 
 

--- a/tests/test_accept_rules.py
+++ b/tests/test_accept_rules.py
@@ -1,0 +1,341 @@
+# Copyright © 2026 Apple Inc.
+
+"""Tests for the speculative decoding ``accept_rule`` options.
+
+Kernel tests drive the acceptance helpers directly with constructed
+distributions, where any bias in the committed-token distribution is
+unmistakable: the residual (rejection sampling) rule must commit tokens
+distributed exactly as the target while accepting drafts the sampled-token
+exact-match rule rejects, and block verification must preserve the target
+distribution while accepting at least as many tokens as the per-token rule.
+
+End-to-end tests use tiny random models: the default rule must be
+bit-identical to ``accept_rule="exact"``, greedy decoding must be identical
+across all rules, and the temperature > 0 committed marginals of every rule
+must match plain non-speculative sampling. Every trial is explicitly seeded
+so all statistics are deterministic; the bounds guard against math
+regressions, not sampling noise. Both the target and draft distributions of
+the tiny random models are near uniform, so the end-to-end chi-square is a
+consistency check — the kernel tests carry the exactness burden.
+"""
+
+import unittest
+from collections import Counter
+
+import mlx.core as mx
+
+from mlx_lm.generate import (
+    _acceptance_probs,
+    _block_verify,
+    _residual_sample,
+    _sampling_logprobs,
+    generate_step,
+    speculative_generate_step,
+)
+from mlx_lm.models import llama
+from mlx_lm.sample_utils import make_sampler
+
+
+def _lp(probs):
+    return mx.log(mx.array(probs, dtype=mx.float32))
+
+
+def _tv(counts, ref):
+    """Total variation between an empirical Counter and a reference pmf."""
+    total = sum(counts.values())
+    return 0.5 * sum(abs(counts.get(i, 0) / total - ref[i]) for i in range(len(ref)))
+
+
+# Constructed distributions: TV(P1, Q1) = 0.5, per-token acceptance
+# sum(min(p, q)) = 0.5 at position 1 and 0.55 at position 2.
+P1 = [0.5, 0.25, 0.125, 0.125]
+Q1 = [0.125, 0.125, 0.25, 0.5]
+P2 = [0.25, 0.25, 0.25, 0.25]
+Q2 = [0.7, 0.1, 0.1, 0.1]
+P3 = [0.5, 0.25, 0.125, 0.125]  # bonus row; any pmf works
+
+
+class TestAcceptRuleKernels(unittest.TestCase):
+    """Acceptance-rule helpers on constructed distributions — no model."""
+
+    def test_acceptance_probs_exact_values(self):
+        probs = _acceptance_probs(_lp([P1]), _lp([Q1]), [0])
+        self.assertAlmostEqual(probs[0].item(), 1.0, places=6)  # p > q
+        probs = _acceptance_probs(_lp([P1]), _lp([Q1]), [3])
+        self.assertAlmostEqual(probs[0].item(), 0.25, places=5)  # p / q
+        # p == q: the ratio is exactly 1 for every token, so the residual
+        # rule accepts every draft, while exact matching of two independent
+        # samples only accepts with probability sum(p^2).
+        probs = _acceptance_probs(_lp([P1] * 4), _lp([P1] * 4), [0, 1, 2, 3])
+        self.assertEqual(probs.tolist(), [1.0] * 4)
+
+    def test_exact_match_accepts_sum_p_squared_when_p_equals_q(self):
+        lp = _lp(P1)
+        n = 2000
+        hits = 0
+        for i in range(n):
+            mx.random.seed(50_000 + i)
+            d = mx.random.categorical(lp).item()
+            t = mx.random.categorical(lp).item()
+            hits += d == t
+        # sum(p^2) = 0.34375 for P1; residual accepts 1.0 (previous test)
+        self.assertLess(abs(hits / n - 0.34375), 0.04)
+
+    def test_subfloor_probabilities_accept_correctly(self):
+        # min(1, p/q) must be computed in log space: q=1e-35 and p=1e-34 are
+        # representable float32 probabilities and p/q = 10 means CERTAIN
+        # acceptance. A linear-space clamp such as max(q, 1e-30) would give
+        # p/floor = 1e-4 instead and reject nearly always, biasing the
+        # committed marginal.
+        tlp = mx.log(mx.array([0.4, 0.6, 1e-34, 1e-35], dtype=mx.float32))
+        dlp = mx.log(mx.array([0.5, 0.5, 1e-35, 1e-34], dtype=mx.float32))
+        probs = _acceptance_probs(tlp[None], dlp[None], [2])
+        self.assertEqual(probs[0].item(), 1.0)
+        # The sub-floor ratio must also be honored below 1: token 3 has
+        # p/q = 0.1 (clamped math would give ~1e-5, i.e. never accept).
+        probs = _acceptance_probs(tlp[None], dlp[None], [3])
+        self.assertAlmostEqual(probs[0].item(), 0.1, places=3)
+
+    def test_residual_rule_commits_target_distribution(self):
+        # Draft from q, accept with probability min(1, p/q), resample
+        # rejections from relu(p - q): the committed token must be
+        # distributed as p and the acceptance rate must sit at
+        # sum(min(p, q)) = 0.5.
+        lp1, lq1 = _lp(P1), _lp(Q1)
+        n = 4000
+        counts = Counter()
+        accepted = 0
+        for i in range(n):
+            mx.random.seed(10_000 + i)
+            d = mx.random.categorical(lq1).item()
+            prob = _acceptance_probs(lp1[None], lq1[None], [d])[0].item()
+            if mx.random.uniform().item() <= prob:
+                counts[d] += 1
+                accepted += 1
+            else:
+                counts[_residual_sample(lp1, lq1)] += 1
+        self.assertLess(_tv(counts, P1), 0.05)
+        self.assertGreater(_tv(counts, Q1), 0.4)  # power: not the draft dist
+        self.assertLess(abs(accepted / n - 0.5), 0.05)
+
+    def test_block_verify_preserves_target_and_beats_per_token(self):
+        # k=2 block: the first committed token must still be ~ p1, and the
+        # expected accepted length must be at least the per-token rule's
+        # (arXiv 2403.10444, Theorem 1; the cumulative-ratio rescue is worth
+        # ~+0.12 tokens per block on these distributions).
+        lp1, lq1, lq2 = _lp(P1), _lp(Q1), _lp(Q2)
+        target = mx.stack([lp1, _lp(P2), _lp(P3)])
+        drafts_lp = mx.stack([lq1, lq2])
+        n = 2500
+        counts = Counter()
+        block_total = token_total = 0
+        for i in range(n):
+            mx.random.seed(200_000 + i)
+            d1 = mx.random.categorical(lq1).item()
+            d2 = mx.random.categorical(lq2).item()
+            n_accept, correction = _block_verify(target, drafts_lp, [d1, d2])
+            counts[d1 if n_accept >= 1 else correction] += 1
+            block_total += n_accept
+            # Per-token residual rule on the SAME drafts, its own coins.
+            mx.random.seed(700_000 + i)
+            probs = _acceptance_probs(target[:2], drafts_lp, [d1, d2])
+            us = mx.random.uniform(shape=(2,))
+            if us[0].item() <= probs[0].item():
+                token_total += 1
+                if us[1].item() <= probs[1].item():
+                    token_total += 1
+        self.assertLess(_tv(counts, P1), 0.06)
+        self.assertGreater(_tv(counts, Q1), 0.35)
+        self.assertGreaterEqual(block_total / n, token_total / n + 0.05)
+
+    def test_block_verify_k1_matches_residual(self):
+        # Block size 1 degenerates to per-token rejection sampling:
+        # acceptance min(1, p/q) and residual relu(p - q), so the committed
+        # distribution is p and the acceptance rate is sum(min(p, q)) = 0.5.
+        lp1, lq1 = _lp(P1), _lp(Q1)
+        target = mx.stack([lp1, _lp(P2)])
+        n = 2000
+        counts = Counter()
+        accepted = 0
+        for i in range(n):
+            mx.random.seed(400_000 + i)
+            d1 = mx.random.categorical(lq1).item()
+            n_accept, correction = _block_verify(target, lq1[None], [d1])
+            counts[d1 if n_accept >= 1 else correction] += 1
+            accepted += n_accept
+        self.assertLess(_tv(counts, P1), 0.06)
+        self.assertLess(abs(accepted / n - 0.5), 0.06)
+
+    def test_sampling_logprobs_temperature(self):
+        lp = _lp(P1)
+        self.assertTrue(mx.allclose(_sampling_logprobs(lp, 1.0), lp))
+        scaled = _sampling_logprobs(lp, 0.5)
+        expected = 2.0 * lp - mx.logsumexp(2.0 * lp)
+        self.assertTrue(mx.allclose(scaled, expected))
+
+
+def _tiny_model(seed):
+    args = llama.ModelArgs(
+        model_type="llama",
+        hidden_size=64,
+        num_hidden_layers=2,
+        intermediate_size=128,
+        num_attention_heads=4,
+        num_key_value_heads=4,
+        rms_norm_eps=1e-5,
+        vocab_size=64,
+        tie_word_embeddings=True,
+    )
+    mx.random.seed(seed)
+    model = llama.Model(args)
+    mx.eval(model.parameters())
+    return model
+
+
+class TestAcceptRuleEndToEnd(unittest.TestCase):
+    """accept_rule through speculative_generate_step on tiny models."""
+
+    @classmethod
+    def setUpClass(cls):
+        cls.model = _tiny_model(0)
+        cls.draft_model = _tiny_model(1)
+        mx.random.seed(2)
+        cls.prompt = mx.random.randint(0, 64, (16,))
+
+    def _spec(self, seed, temp, max_tokens=12, **kwargs):
+        mx.random.seed(seed)
+        sampler = make_sampler(temp)
+        return [
+            (token, from_draft)
+            for token, _, from_draft in speculative_generate_step(
+                self.prompt,
+                self.model,
+                self.draft_model,
+                num_draft_tokens=2,
+                max_tokens=max_tokens,
+                sampler=sampler,
+                **kwargs,
+            )
+        ]
+
+    def test_default_is_exact(self):
+        # The default must be bit-identical to accept_rule="exact" for every
+        # temperature and seed: same tokens AND same draft/target labels.
+        for temp in (0.0, 0.7, 1.0):
+            for seed in range(3):
+                default = self._spec(seed, temp)
+                explicit = self._spec(seed, temp, accept_rule="exact")
+                self.assertEqual(default, explicit)
+
+    def test_greedy_identical_across_rules(self):
+        # At temperature 0 every rule reduces to exact matching, so the
+        # streams must be identical.
+        base = self._spec(5, 0.0)
+        for rule in ("exact", "residual", "block"):
+            self.assertEqual(self._spec(5, 0.0, accept_rule=rule), base)
+
+    def test_invalid_rule_raises(self):
+        gen = speculative_generate_step(
+            self.prompt,
+            self.model,
+            self.draft_model,
+            max_tokens=4,
+            accept_rule="bogus",
+        )
+        with self.assertRaises(ValueError):
+            next(gen)
+
+    def test_unsupported_sampler_raises(self):
+        # residual/block need the sampled distribution, which cannot be
+        # recovered from a filtering or custom sampler.
+        for sampler in (make_sampler(0.8, top_p=0.9), lambda x: mx.argmax(x, -1)):
+            for rule in ("residual", "block"):
+                gen = speculative_generate_step(
+                    self.prompt,
+                    self.model,
+                    self.draft_model,
+                    max_tokens=4,
+                    sampler=sampler,
+                    accept_rule=rule,
+                )
+                with self.assertRaises(ValueError):
+                    next(gen)
+
+    @staticmethod
+    def _binned_chi2(a, b, n_top=8):
+        # Two-sample chi-square over the reference arm's top-n_top tokens
+        # plus a pooled tail: sum (a_i - b_i)^2 / (a_i + b_i), df = n_top.
+        top = [t for t, _ in a.most_common(n_top)]
+
+        def cnt(c, tok):
+            if tok == "other":
+                return sum(v for k, v in c.items() if k not in top)
+            return c.get(tok, 0)
+
+        stat = 0.0
+        for tok in top + ["other"]:
+            x, y = cnt(a, tok), cnt(b, tok)
+            if x + y > 0:
+                stat += (x - y) ** 2 / (x + y)
+        return stat
+
+    def test_temp_marginals_match_plain_sampling(self):
+        # Per-position marginals over N seeded trials for each rule vs a
+        # plain non-speculative reference. Threshold 32 ~ chi2(df=8) 0.9999
+        # quantile; the observed values with these seeds sit well below it.
+        temp = 0.8
+        new_tokens = 4
+        n = 250
+        base_seed = {
+            "plain": 1000,
+            "exact": 20_000,
+            "residual": 40_000,
+            "block": 60_000,
+        }
+        arms = {}
+        accept_per_block = {}
+        for name in ("plain", "exact", "residual", "block"):
+            counts = [Counter() for _ in range(new_tokens)]
+            n_drafted = n_blocks = 0
+            for i in range(n):
+                seed = base_seed[name] + i
+                if name == "plain":
+                    mx.random.seed(seed)
+                    toks = [
+                        token
+                        for token, _ in generate_step(
+                            self.prompt,
+                            self.model,
+                            max_tokens=new_tokens,
+                            sampler=make_sampler(temp),
+                        )
+                    ]
+                else:
+                    stream = self._spec(
+                        seed, temp, max_tokens=new_tokens, accept_rule=name
+                    )
+                    toks = [t for t, _ in stream]
+                    n_drafted += sum(fd for _, fd in stream)
+                    n_blocks += sum(not fd for _, fd in stream)
+                for j, t in enumerate(toks):
+                    counts[j][t] += 1
+            arms[name] = counts
+            accept_per_block[name] = n_drafted / max(n_blocks, 1)
+        for name in ("exact", "residual", "block"):
+            for j in range(new_tokens):
+                stat = self._binned_chi2(arms["plain"][j], arms[name][j])
+                self.assertLess(stat, 32.0, f"arm={name} position={j} chi2={stat:.1f}")
+        # The point of the new rules: at temperature > 0 the residual rule
+        # accepts a large fraction of the drafts the sampled-token
+        # exact-match rule throws away, and block verification accepts at
+        # least as many.
+        self.assertGreater(
+            accept_per_block["residual"], accept_per_block["exact"] + 0.3
+        )
+        self.assertGreaterEqual(
+            accept_per_block["block"], accept_per_block["residual"] - 0.15
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Motivation

`speculative_generate_step` accepts a draft token only when it is bit-identical
to the token the target model sampled at that position. This is correct, but at
temperature > 0 it rejects many drafts that classic speculative sampling would
accept: two independent samples from nearly identical distributions rarely
collide (for `p == q` the exact-match acceptance rate is `sum(p^2)`, while
rejection sampling accepts with probability 1). The result is that speculative
decoding loses most of its speedup as soon as sampling is turned on.

This PR adds an opt-in `accept_rule` parameter with three settings:

- **`"exact"`** (default): today's behavior, unchanged — the default path is
  structurally identical to the current code, including RNG consumption.
- **`"residual"`**: standard speculative rejection sampling (Leviathan et al.,
  [arXiv 2211.17192](https://arxiv.org/abs/2211.17192); Chen et al.,
  [arXiv 2302.01318](https://arxiv.org/abs/2302.01318)) — accept a draft
  `x ~ q` with probability `min(1, p(x)/q(x))`; on rejection, resample from
  the normalized residual `relu(p - q)`.
- **`"block"`**: block verification (Sun et al.,
  [arXiv 2403.10444](https://arxiv.org/abs/2403.10444)) — verify the drafted
  block through cumulative likelihood ratios of its prefixes; a later position
  can rescue an earlier failure, so it accepts at least as many tokens in
  expectation as `"residual"` (their Theorem 1) with the same output
  distribution.

All three rules commit tokens distributed exactly as the target model's
sampling distribution; `"residual"` and `"block"` only raise the acceptance
rate. The acceptance ratio is computed in log space
(`exp(min(log p - log q, 0))`) rather than with a linear-space floor on `q`,
so tokens with representable but tiny probabilities are accepted at the
correct rate.

The parameter threads through `stream_generate`/`generate` (existing kwargs
plumbing) and the CLI (`--accept-rule`).

## Supported sampler configurations

The new rules need the distribution the tokens were *actually sampled from*.
`make_sampler` now records the temperature on the sampler it returns when no
filtering is active, and `speculative_generate_step` uses it to recover the
sampled distribution (`softmax(logprobs / temp)`) for both models:

- Supported: plain temperature samplers from `make_sampler` (any `temp`,
  including 0), with or without `logits_processors` (processors apply
  identically to both models' distributions, so the math is unaffected).
- Not supported: samplers with top-p / min-p / top-k / xtc filtering, or
  custom sampler callables — the sampled distribution cannot be recovered
  from an opaque sampler, so these raise a `ValueError` rather than silently
  biasing the output.
- Greedy (`temp == 0`, or no sampler): every rule coincides with exact
  matching, so the code takes the unchanged exact path.

## Validation

- **Default no-regression**: with `accept_rule` unset the code path is
  unchanged. Verified bit-for-bit against `main` on seeded tiny-model streams
  (temperatures 0 / 0.7 / 1.0, multiple seeds, with and without
  `logits_processors`): identical tokens, draft/target labels, and logprobs.
  `tests/test_accept_rules.py` additionally pins default ≡ `"exact"` and
  greedy-identical-across-rules.
- **Kernel exactness** (constructed p/q, no model): acceptance probabilities
  match `min(1, p/q)` exactly, including sub-floor probabilities (`p = 1e-34`,
  `q = 1e-35` accepts with probability 1; the reverse accepts at 0.1); for
  `p == q` the residual rule accepts everything while exact-match sits at
  `sum(p^2)`.
- **Committed-token distribution, verified by simulation**: seeded
  simulations check that the residual rule's committed marginal matches the
  target pmf (total variation < 0.05 against `p`, > 0.4 against `q`) with
  acceptance rate `sum(min(p, q))`; block verification at k=2 preserves the
  target marginal while accepting measurably more tokens than the per-token
  rule on the same drafts, and at k=1 reproduces the per-token rule's
  acceptance rate and marginal.
- **End-to-end distribution sanity**: with tiny random models at temp 0.8,
  per-position committed marginals of all three rules match plain
  non-speculative sampling under a seeded binned chi-square; on this fixture
  the residual rule accepts far more drafts per block than exact match, and
  block accepts at least as many as residual. (Both tiny-model distributions
  are near uniform, so this test is a consistency check; the kernel tests
  carry the exactness burden.)

All trials are explicitly seeded, so the statistical bounds are deterministic
guards against math regressions, not flaky sampling assertions.

`tests/test_generate.py` + `tests/test_accept_rules.py`: 38 tests, all pass
(26 baseline + 12 new; baseline unchanged).

## Caveats

- The default is unchanged; the new rules are opt-in.
- `"residual"` and `"block"` consume RNG differently from `"exact"` (uniform
  draws for acceptance tests and categorical draws for residual corrections),
  so seeded streams differ across rules at temperature > 0 — as expected,
  since the rules only guarantee the same distribution, not the same sample
  path.
- `"block"` does k extra scalar syncs per verification block for the
  cumulative thresholds; with typical `num_draft_tokens` (2–8) this is noise
  next to the model forward passes.
- The per-block verification cost of the new rules is otherwise the same as
  exact matching (no extra model evaluations; the draft's logprobs, already
  computed, are kept instead of discarded).
