### PR TITLE
Make Qwen3-Coder tool parsing tolerant of multiline code

### DIFF
--- a/mlx_lm/server.py
+++ b/mlx_lm/server.py
@@ -78,10 +78,10 @@ class ToolCallFormatter:
         for tool_text in tool_calls:
             try:
                 parsed = self._tool_parser(tool_text, self._tools)
-            except (ValueError, json.JSONDecodeError) as e:
+            except (SyntaxError, ValueError, json.JSONDecodeError) as e:
                 logging.warning(
-                    f"Failed to parse tool call ({type(e).__name__}: {e}) — "
-                    f"tool text was likely truncated mid-generation."
+                    f"Failed to parse tool call ({type(e).__name__}: {e}); "
+                    f"skipping malformed tool call."
                 )
                 continue
             if not isinstance(parsed, list):

--- a/mlx_lm/tool_parsers/qwen3_coder.py
+++ b/mlx_lm/tool_parsers/qwen3_coder.py
@@ -33,6 +33,47 @@ def _get_arguments_config(func_name: str, tools: Optional[Any]) -> dict:
     return {}
 
 
+def _normalize_backtick_strings(param_value: str) -> str:
+    """Convert Qwen's backtick-delimited strings to JSON strings."""
+    result = []
+    backtick_value = []
+    in_double_quote = False
+    in_backtick = False
+    escaped = False
+
+    for char in param_value:
+        if in_backtick:
+            if escaped:
+                if char != "`":
+                    backtick_value.append("\\")
+                backtick_value.append(char)
+                escaped = False
+            elif char == "\\":
+                escaped = True
+            elif char == "`":
+                result.append(json.dumps("".join(backtick_value)))
+                backtick_value = []
+                in_backtick = False
+            else:
+                backtick_value.append(char)
+        else:
+            result.append(char)
+            if escaped:
+                escaped = False
+            elif char == "\\" and in_double_quote:
+                escaped = True
+            elif char == '"':
+                in_double_quote = not in_double_quote
+            elif char == "`" and not in_double_quote:
+                result.pop()
+                in_backtick = True
+
+    if in_backtick:
+        raise ValueError("Unterminated backtick string")
+
+    return "".join(result)
+
+
 def _convert_param_value(param_value: str, param_name: str, param_config: dict) -> Any:
     """Convert parameter value based on its type in the schema."""
     if param_value.lower() == "null":
@@ -72,6 +113,7 @@ def _convert_param_value(param_value: str, param_name: str, param_config: dict) 
             or param_type.startswith("list")
         ):
             try:
+                param_value = _normalize_backtick_strings(param_value)
                 # Qwen sometimes emits literal control characters, such as
                 # newlines in source-code strings. Accept them while parsing
                 # model-generated JSON; valid JSON is unaffected.

--- a/mlx_lm/tool_parsers/qwen3_coder.py
+++ b/mlx_lm/tool_parsers/qwen3_coder.py
@@ -72,7 +72,10 @@ def _convert_param_value(param_value: str, param_name: str, param_config: dict) 
             or param_type.startswith("list")
         ):
             try:
-                return json.loads(param_value)
+                # Qwen sometimes emits literal control characters, such as
+                # newlines in source-code strings. Accept them while parsing
+                # model-generated JSON; valid JSON is unaffected.
+                return json.loads(param_value, strict=False)
             except json.JSONDecodeError:
                 return ast.literal_eval(param_value)
 

--- a/mlx_lm/tool_parsers/qwen3_coder.py
+++ b/mlx_lm/tool_parsers/qwen3_coder.py
@@ -113,13 +113,19 @@ def _convert_param_value(param_value: str, param_name: str, param_config: dict) 
             or param_type.startswith("list")
         ):
             try:
-                param_value = _normalize_backtick_strings(param_value)
                 # Qwen sometimes emits literal control characters, such as
                 # newlines in source-code strings. Accept them while parsing
                 # model-generated JSON; valid JSON is unaffected.
                 return json.loads(param_value, strict=False)
             except json.JSONDecodeError:
-                return ast.literal_eval(param_value)
+                try:
+                    return ast.literal_eval(param_value)
+                except (SyntaxError, ValueError):
+                    param_value = _normalize_backtick_strings(param_value)
+                    try:
+                        return json.loads(param_value, strict=False)
+                    except json.JSONDecodeError:
+                        return ast.literal_eval(param_value)
 
         return ast.literal_eval(param_value)
 

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -17,6 +17,7 @@ from mlx_lm.server import (
     Response,
     ResponseGenerator,
     SamplingArguments,
+    ToolCallFormatter,
     _make_sampler,
 )
 from mlx_lm.utils import load
@@ -196,6 +197,19 @@ class TestTextStateMachine(unittest.TestCase):
         self.assertEqual(text, "f[ARGS]{}")
         state, s = sm.discard(state)
         self.assertEqual(s, "tool")
+
+
+class TestToolCallFormatter(unittest.TestCase):
+    def test_syntax_error_is_skipped(self):
+        def parser(tool_text, tools):
+            raise SyntaxError("invalid tool arguments")
+
+        formatter = ToolCallFormatter(parser, [])
+
+        with self.assertLogs(level="WARNING") as logs:
+            self.assertEqual(formatter(["tool call"]), [])
+
+        self.assertIn("SyntaxError", logs.output[0])
 
 
 class TestServer(unittest.TestCase):

--- a/tests/test_tool_parsing.py
+++ b/tests/test_tool_parsing.py
@@ -197,6 +197,15 @@ class TestToolParsing(unittest.TestCase):
         self.assertEqual(tool_call["arguments"]["filters"], {"category": "books"})
         self.assertEqual(tool_call["arguments"]["tags"], ["fiction", "new"])
 
+        # literal backticks inside a Python-style string are content, not delimiters
+        test_case = (
+            "<function=search>"
+            "<parameter=tags>['use `code` here']</parameter>"
+            "</function>"
+        )
+        tool_call = qwen3_coder.parse_tool_call(test_case, tools)
+        self.assertEqual(tool_call["arguments"]["tags"], ["use `code` here"])
+
     def test_qwen3_coder_multiline_string_params(self):
         tools = [
             {

--- a/tests/test_tool_parsing.py
+++ b/tests/test_tool_parsing.py
@@ -214,9 +214,9 @@ class TestToolParsing(unittest.TestCase):
         ]
         test_case = (
             "<function=edit>"
-            "<parameter=edits>[{\"oldText\": \"const first = 1;\n"
-            "const second = 2;\", \"newText\": \"const first = 3;\n"
-            "const second = 4;\"}]</parameter>"
+            '<parameter=edits>[{"oldText": "const first = 1;\n'
+            'const second = 2;", "newText": "const first = 3;\n'
+            'const second = 4;"}]</parameter>'
             "</function>"
         )
 
@@ -230,6 +230,41 @@ class TestToolParsing(unittest.TestCase):
                     "newText": "const first = 3;\nconst second = 4;",
                 }
             ],
+        )
+
+    def test_qwen3_coder_backtick_string_params(self):
+        tools = [
+            {
+                "type": "function",
+                "function": {
+                    "name": "edit",
+                    "parameters": {
+                        "type": "object",
+                        "properties": {
+                            "edits": {"type": "array"},
+                        },
+                    },
+                },
+            }
+        ]
+        old_text = (
+            "import React, { useState, useRef, useEffect, useCallback } from "
+            "'react';\nconst title = \"Hello\";"
+        )
+        new_text = "import React from 'react';\nconst title = \"Goodbye\";"
+        test_case = (
+            '<function=edit><parameter=edits>[{"oldText": `'
+            + old_text
+            + '`, "newText": `'
+            + new_text
+            + "`}]</parameter></function>"
+        )
+
+        tool_call = qwen3_coder.parse_tool_call(test_case, tools)
+
+        self.assertEqual(
+            tool_call["arguments"]["edits"],
+            [{"oldText": old_text, "newText": new_text}],
         )
 
     def test_gemma4(self):

--- a/tests/test_tool_parsing.py
+++ b/tests/test_tool_parsing.py
@@ -197,6 +197,41 @@ class TestToolParsing(unittest.TestCase):
         self.assertEqual(tool_call["arguments"]["filters"], {"category": "books"})
         self.assertEqual(tool_call["arguments"]["tags"], ["fiction", "new"])
 
+    def test_qwen3_coder_multiline_string_params(self):
+        tools = [
+            {
+                "type": "function",
+                "function": {
+                    "name": "edit",
+                    "parameters": {
+                        "type": "object",
+                        "properties": {
+                            "edits": {"type": "array"},
+                        },
+                    },
+                },
+            }
+        ]
+        test_case = (
+            "<function=edit>"
+            "<parameter=edits>[{\"oldText\": \"const first = 1;\n"
+            "const second = 2;\", \"newText\": \"const first = 3;\n"
+            "const second = 4;\"}]</parameter>"
+            "</function>"
+        )
+
+        tool_call = qwen3_coder.parse_tool_call(test_case, tools)
+
+        self.assertEqual(
+            tool_call["arguments"]["edits"],
+            [
+                {
+                    "oldText": "const first = 1;\nconst second = 2;",
+                    "newText": "const first = 3;\nconst second = 4;",
+                }
+            ],
+        )
+
     def test_gemma4(self):
         # Nested object
         test_case = 'call:configure{settings:{enabled:true,name:<|"|>test<|"|>}}'


### PR DESCRIPTION
## Summary

Qwen3-Coder can emit source-code tool arguments in two non-standard forms:

- literal newlines inside JSON string values
- backtick-delimited multiline strings inside JSON-like arrays

The Qwen parser now normalizes backtick-delimited values before parsing and uses `json.loads(..., strict=False)` for model-generated JSON. Valid JSON behavior is unchanged.

The server formatter also catches `SyntaxError` from malformed tool arguments and reports that it skipped the malformed call, instead of allowing the request handler to crash with an uncaught exception.

## Testing

- `python -m unittest tests.test_tool_parsing` (7 passed)
- exact React-style backtick payload regression check
- direct `ToolCallFormatter` `SyntaxError` check
- Black check on changed Python files
- `git diff --check`

The full local suite has 3 unrelated errors because optional dependencies are not installed locally: `datasets`, `lm_eval`, and `requests`.

Related: #1627