### PR TITLE
fix(gemma3n): make attention work with the batch KV caches (#1699)

### DIFF
--- a/mlx_lm/models/gemma3n.py
+++ b/mlx_lm/models/gemma3n.py
@@ -127,15 +127,20 @@ class Gemma3nAttention(nn.Module):
         queries = queries.reshape(B, L, -1, self.head_dim)
         queries = self.q_norm(queries)
 
-        offset = 0
+        # Read the offset and rotate the queries before the cache is updated.
+        # The batch caches keep their offset in an mx.array that
+        # update_and_fetch mutates in place, so an offset read here would
+        # silently become the post-update value.
+        offset = cache.offset if cache is not None else 0
+        queries = queries.transpose(0, 2, 1, 3)
+        queries = self.rope(queries, offset=offset)
+
         if self.is_kv_shared_layer and cache is not None:
-            # For shared layers, retrieve KV from the designated cache layer
-            keys, values = cache.state
-            offset = cache.offset
+            # For shared layers, retrieve KV from the designated cache layer.
+            # The batch caches carry (keys, values, offset, left_padding).
+            keys, values = cache.state[:2]
 
         else:
-            if cache is not None:
-                offset = cache.offset
             keys = self.k_proj(x).reshape(B, L, -1, self.head_dim)
             keys = self.k_norm(keys)
             keys = keys.transpose(0, 2, 1, 3)
@@ -147,9 +152,6 @@ class Gemma3nAttention(nn.Module):
 
             if cache is not None:
                 keys, values = cache.update_and_fetch(keys, values)
-
-        queries = queries.transpose(0, 2, 1, 3)
-        queries = self.rope(queries, offset=offset)
 
         output = scaled_dot_product_attention(
             queries, keys, values, cache=cache, scale=self.scale, mask=mask

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -1527,6 +1527,64 @@ class TestModels(unittest.TestCase):
             model, args.model_type, args.vocab_size, args.num_hidden_layers
         )
 
+    def test_gemma3n_batch_caches_match_plain_caches(self):
+        """The batched generation path must agree with the plain caches.
+
+        The batch caches return a 4-tuple state and hold their offset in an
+        mx.array that ``update_and_fetch`` mutates in place, so gemma3n used to
+        crash on the shared layers and rotate the queries with a post-update
+        offset on the others.
+        """
+        from mlx_lm.models import gemma3n
+        from mlx_lm.models.cache import BatchKVCache, BatchRotatingKVCache
+
+        args = gemma3n.ModelArgs(
+            model_type="gemma3n",
+            text_config={
+                "model_type": "gemma3n",
+                "hidden_size": 128,
+                "num_hidden_layers": 4,
+                "intermediate_size": 128,
+                "num_attention_heads": 4,
+                "head_dim": 32,
+                "rms_norm_eps": 1e-5,
+                "vocab_size": 1000,
+                "num_key_value_heads": 2,
+                "num_kv_shared_layers": 2,
+                "vocab_size_per_layer_input": 1000,
+                "sliding_window": 8,
+                "max_position_embeddings": 1000,
+                "rope_local_base_freq": 1.0,
+                "rope_theta": 1000.0,
+                "final_logit_softcapping": 1.0,
+                "layer_types": [
+                    "sliding_attention",
+                    "full_attention",
+                    "sliding_attention",
+                    "full_attention",
+                ],
+                "activation_sparsity_pattern": [0.5, 0.5, 0.5, 0.5],
+                "hidden_size_per_layer_input": 256,
+                "altup_num_inputs": 4,
+                "altup_coef_clip": 1.0,
+                "altup_correct_scale": True,
+                "altup_active_idx": 0,
+                "laurel_rank": 8,
+            },
+        )
+        model = gemma3n.Model(args)
+        inputs = mx.array([[1, 2, 3, 4, 5, 6]])
+
+        def to_batch(c):
+            if isinstance(c, RotatingKVCache):
+                return BatchRotatingKVCache(c.max_size, [0])
+            return BatchKVCache([0])
+
+        plain = model(inputs, cache=make_prompt_cache(model))[:, -1, :]
+        batched = model(inputs, cache=[to_batch(c) for c in model.make_cache()])
+        batched = batched[:, -1, :]
+        self.assertTrue(mx.allclose(plain, batched, atol=1e-4, rtol=1e-4))
+
     def test_gemma4_text(self):
         from mlx_lm.models import gemma4_text
 


### PR DESCRIPTION
Fixes #1699.

Running a gemma3n text model through the batched generation path (`BatchKVCache` / `BatchRotatingKVCache`, i.e. `BatchGenerator` and anything built on it) fails in two independent ways.

### 1. Crash on the KV-shared layers

```python
keys, values = cache.state
```

`KVCache` / `RotatingKVCache` return `(keys, values)`, but `BatchKVCache.state` and `BatchRotatingKVCache.state` return `(keys, values, offset, left_padding)` (`mlx_lm/models/cache.py:995`, `:1229`), so the forward raises `ValueError: too many values to unpack (expected 2, got 4)`.

### 2. Wrong RoPE offset for the queries on every other layer

The offset was bound *before* the cache update and applied *after* it:

```python
if cache is not None:
    offset = cache.offset            # bound here
...
    keys, values = cache.update_and_fetch(keys, values)   # self.offset += S

queries = queries.transpose(0, 2, 1, 3)
queries = self.rope(queries, offset=offset)               # applied here
```

With the plain caches `offset` is a Python `int`, so this is harmless. The batch caches keep it in an `mx.array` (`cache.py:937`) that `update_and_fetch` mutates in place (`cache.py:961`, `:1256`), so the name bound earlier silently becomes the post-update value:

```python
a = mx.array([0]); b = a; a += 24; mx.eval(a)
print(b)   # array([24], dtype=int32)
```

Every query position is then shifted by the chunk length, and generation degenerates into repetition loops (`HierHierHier...` in the report) while the keys — rotated before the update — stay correct.

### Fix

Read the offset and rotate the queries up front, before anything can touch the cache, and unpack the shared-layer state tolerantly. Hoisting also removes the duplicate `offset = cache.offset` in the two branches, which always produced the same value.

This is the order every other model in the repo already uses — `gemma3_text.py`, for example, rotates both queries and keys off `cache.offset` and only then calls `update_and_fetch`. gemma3n was the outlier, and the ordering was only safe because the offset used to always be an `int`.

Nothing changes for the plain caches: the offset is an `int` there, so rotating the queries earlier gives the identical result. Confirmed by `tests/test_models.py::TestModels::test_gemma3n_text` and the rest of the gemma3n suite.

### Test

`test_gemma3n_batch_caches_match_plain_caches` runs the same prompt through the plain caches and through the batch caches and compares the final logits. On `main` it fails with the unpack `ValueError`; with the `[:2]` change alone it fails on the logits comparison; with both it passes.

### Note on #1702

[#1702](https://github.com/ml-explore/mlx-lm/pull/1702) (open, for #1674) restructures the same branch to make KV sharing work without a cache, which also removes the `cache.state` unpack. The two are independent — this PR does not depend on it and the fixes do not overlap in effect — but they touch adjacent lines, so whichever lands second will want a trivial rebase. Happy to fold this into #1702 instead if you'd rather have one change there.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
