### PR TITLE
Fix threadgroup memory race in fused KL and JS Metal kernels (fixes #1700)

### DIFF
--- a/mlx_lm/tuner/losses.py
+++ b/mlx_lm/tuner/losses.py
@@ -98,6 +98,8 @@ def _make_kl_forward_kernel():
         max_q = simd_max(max_q);
         max_p = simd_max(max_p);
 
+        threadgroup_barrier(mem_flags::mem_threadgroup);
+
         // Share the sum_exp across the threadgroup
         sum_exp_q *= metal::fast::exp(prev_max_q - max_q);
         sum_exp_p *= metal::fast::exp(prev_max_p - max_p);
@@ -117,7 +119,7 @@ def _make_kl_forward_kernel():
         lse_q_minus_p = max_q + metal::fast::log(sum_exp_q) - lse_p;
     }
 
-    threadgroup_barrier(mem_flags::mem_none);
+    threadgroup_barrier(mem_flags::mem_threadgroup);
 
     {
         float kl = 0;
@@ -157,7 +159,7 @@ def _make_kl_forward_kernel():
         if (simd_lane_id == 0) {
             shared[simd_group_id] = kl;
         }
-        threadgroup_barrier(mem_flags::mem_none);
+        threadgroup_barrier(mem_flags::mem_threadgroup);
         kl = shared[simd_lane_id];
         kl = simd_sum(kl);
 
@@ -267,6 +269,8 @@ def _make_kl_backward_kernel():
         max_q = simd_max(max_q);
         max_p = simd_max(max_p);
 
+        threadgroup_barrier(mem_flags::mem_threadgroup);
+
         // Share the sum_exp across the threadgroup
         sum_exp_q *= metal::fast::exp(prev_max_q - max_q);
         sum_exp_p *= metal::fast::exp(prev_max_p - max_p);
@@ -286,7 +290,7 @@ def _make_kl_backward_kernel():
         lse_q = max_q + metal::fast::log(sum_exp_q);
     }
 
-    threadgroup_barrier(mem_flags::mem_none);
+    threadgroup_barrier(mem_flags::mem_threadgroup);
 
     {
         float kl = 0;
@@ -477,6 +481,8 @@ def _make_js_forward_kernel():
         max_q = simd_max(max_q);
         max_p = simd_max(max_p);
 
+        threadgroup_barrier(mem_flags::mem_threadgroup);
+
         // Share the sum_exp across the threadgroup
         sum_exp_q *= metal::fast::exp(prev_max_q - max_q);
         sum_exp_p *= metal::fast::exp(prev_max_p - max_p);
@@ -496,7 +502,7 @@ def _make_js_forward_kernel():
         lse_q = max_q + metal::fast::log(sum_exp_q);
     }
 
-    threadgroup_barrier(mem_flags::mem_none);
+    threadgroup_barrier(mem_flags::mem_threadgroup);
 
     {
         float kl_p = 0;
@@ -664,6 +670,8 @@ def _make_js_backward_kernel():
         max_q = simd_max(max_q);
         max_p = simd_max(max_p);
 
+        threadgroup_barrier(mem_flags::mem_threadgroup);
+
         // Share the sum_exp across the threadgroup
         sum_exp_q *= metal::fast::exp(prev_max_q - max_q);
         sum_exp_p *= metal::fast::exp(prev_max_p - max_p);
@@ -683,7 +691,7 @@ def _make_js_backward_kernel():
         lse_q = max_q + metal::fast::log(sum_exp_q);
     }
 
-    threadgroup_barrier(mem_flags::mem_none);
+    threadgroup_barrier(mem_flags::mem_threadgroup);
 
     {
         float c = cotan[0];

--- a/mlx_lm/tuner/losses.py
+++ b/mlx_lm/tuner/losses.py
@@ -552,8 +552,12 @@ def _make_js_forward_kernel():
                 float logq_j = vals_q[j] - lse_q;
                 float p_j = metal::fast::exp(logp_j);
                 float q_j = metal::fast::exp(logq_j);
-                kl_p += p_j * (logtwo - metal::fast::log(1 + metal::fast::exp(logq_j - logp_j)));
-                kl_q += q_j * (logtwo - metal::fast::log(1 + metal::fast::exp(logp_j - logq_j)));
+                float d_qp = logq_j - logp_j;
+                float d_pq = logp_j - logq_j;
+                float sp_qp = (d_qp > 0) ? (d_qp + metal::fast::log(1 + metal::fast::exp(-d_qp))) : metal::fast::log(1 + metal::fast::exp(d_qp));
+                float sp_pq = (d_pq > 0) ? (d_pq + metal::fast::log(1 + metal::fast::exp(-d_pq))) : metal::fast::log(1 + metal::fast::exp(d_pq));
+                kl_p += p_j * (logtwo - sp_qp);
+                kl_q += q_j * (logtwo - sp_pq);
             }
 
             // Move to the next block
@@ -573,8 +577,12 @@ def _make_js_forward_kernel():
                     float logq_j = vals_q[j] - lse_q;
                     float p_j = metal::fast::exp(logp_j);
                     float q_j = metal::fast::exp(logq_j);
-                    kl_p += p_j * (logtwo - metal::fast::log(1 + metal::fast::exp(logq_j - logp_j)));
-                    kl_q += q_j * (logtwo - metal::fast::log(1 + metal::fast::exp(logp_j - logq_j)));
+                    float d_qp = logq_j - logp_j;
+                    float d_pq = logp_j - logq_j;
+                    float sp_qp = (d_qp > 0) ? (d_qp + metal::fast::log(1 + metal::fast::exp(-d_qp))) : metal::fast::log(1 + metal::fast::exp(d_qp));
+                    float sp_pq = (d_pq > 0) ? (d_pq + metal::fast::log(1 + metal::fast::exp(-d_pq))) : metal::fast::log(1 + metal::fast::exp(d_pq));
+                    kl_p += p_j * (logtwo - sp_qp);
+                    kl_q += q_j * (logtwo - sp_pq);
                 }
             }
         }
@@ -750,8 +758,10 @@ def _make_js_backward_kernel():
                 float logp_j = min(vals_p[j] - lse_p, 0.0f);
                 float logq_j = min(vals_q[j] - lse_q, 0.0f);
                 float q_j = metal::fast::exp(logq_j);
+                float d_pq = logp_j - logq_j;
+                float sp_pq = (d_pq > 0) ? (d_pq + metal::fast::log(1 + metal::fast::exp(-d_pq))) : metal::fast::log(1 + metal::fast::exp(d_pq));
                 out_q[offset + j] = static_cast<T>(
-                    c * 0.5 * q_j * (logtwo - metal::fast::log(1 + metal::fast::exp(logp_j - logq_j)) - kl_q)
+                    c * 0.5 * q_j * (logtwo - sp_pq - kl_q)
                 );
             }
 
@@ -771,8 +781,10 @@ def _make_js_backward_kernel():
                     float logp_j = min(vals_p[j] - lse_p, 0.0f);
                     float logq_j = min(vals_q[j] - lse_q, 0.0f);
                     float q_j = metal::fast::exp(logq_j);
+                    float d_pq = logp_j - logq_j;
+                    float sp_pq = (d_pq > 0) ? (d_pq + metal::fast::log(1 + metal::fast::exp(-d_pq))) : metal::fast::log(1 + metal::fast::exp(d_pq));
                     out_q[offset + j] = static_cast<T>(
-                        c * 0.5 * q_j * (logtwo - metal::fast::log(1 + metal::fast::exp(logp_j - logq_j)) - kl_q)
+                        c * 0.5 * q_j * (logtwo - sp_pq - kl_q)
                     );
                 }
             }

--- a/mlx_lm/tuner/losses.py
+++ b/mlx_lm/tuner/losses.py
@@ -51,8 +51,10 @@ def _make_kl_forward_kernel():
                 max_q = max(max_q, vals_q[j]);
                 max_p = max(max_p, vals_p[j]);
             }
-            sum_exp_q *= metal::fast::exp(prev_max_q - max_q);
-            sum_exp_p *= metal::fast::exp(prev_max_p - max_p);
+            float rq = prev_max_q - max_q;
+            float rp = prev_max_p - max_p;
+            sum_exp_q *= (rq < -80.0f) ? 0.0f : metal::fast::exp(rq);
+            sum_exp_p *= (rp < -80.0f) ? 0.0f : metal::fast::exp(rp);
             for (int j=0; j<M; j++) {
                 sum_exp_q += metal::fast::exp(vals_q[j] - max_q);
                 sum_exp_p += metal::fast::exp(vals_p[j] - max_p);
@@ -75,11 +77,15 @@ def _make_kl_forward_kernel():
                 max_q = max(max_q, vals_q[j]);
                 max_p = max(max_p, vals_p[j]);
             }
-            sum_exp_q *= metal::fast::exp(prev_max_q - max_q);
-            sum_exp_p *= metal::fast::exp(prev_max_p - max_p);
+            float rq = prev_max_q - max_q;
+            float rp = prev_max_p - max_p;
+            sum_exp_q *= (rq < -80.0f) ? 0.0f : metal::fast::exp(rq);
+            sum_exp_p *= (rp < -80.0f) ? 0.0f : metal::fast::exp(rp);
             for (int j=0; j<M; j++) {
-                sum_exp_q += metal::fast::exp(vals_q[j] - max_q);
-                sum_exp_p += metal::fast::exp(vals_p[j] - max_p);
+                if (offset + j < V) {
+                    sum_exp_q += metal::fast::exp(vals_q[j] - max_q);
+                    sum_exp_p += metal::fast::exp(vals_p[j] - max_p);
+                }
             }
         }
 
@@ -101,8 +107,10 @@ def _make_kl_forward_kernel():
         threadgroup_barrier(mem_flags::mem_threadgroup);
 
         // Share the sum_exp across the threadgroup
-        sum_exp_q *= metal::fast::exp(prev_max_q - max_q);
-        sum_exp_p *= metal::fast::exp(prev_max_p - max_p);
+        float rq = prev_max_q - max_q;
+        float rp = prev_max_p - max_p;
+        sum_exp_q *= (rq < -80.0f) ? 0.0f : metal::fast::exp(rq);
+        sum_exp_p *= (rp < -80.0f) ? 0.0f : metal::fast::exp(rp);
         sum_exp_q = simd_sum(sum_exp_q);
         sum_exp_p = simd_sum(sum_exp_p);
         if (simd_lane_id == 0) {
@@ -150,7 +158,9 @@ def _make_kl_forward_kernel():
             }
 
             for (int j=0; j<M; j++) {
-                kl += metal::fast::exp(vals_p[j] - lse_p) * (vals_p[j] - vals_q[j] + lse_q_minus_p);
+                if (offset + j < V) {
+                    kl += metal::fast::exp(vals_p[j] - lse_p) * (vals_p[j] - vals_q[j] + lse_q_minus_p);
+                }
             }
         }
 
@@ -222,8 +232,10 @@ def _make_kl_backward_kernel():
                 max_q = max(max_q, vals_q[j]);
                 max_p = max(max_p, vals_p[j]);
             }
-            sum_exp_q *= metal::fast::exp(prev_max_q - max_q);
-            sum_exp_p *= metal::fast::exp(prev_max_p - max_p);
+            float rq = prev_max_q - max_q;
+            float rp = prev_max_p - max_p;
+            sum_exp_q *= (rq < -80.0f) ? 0.0f : metal::fast::exp(rq);
+            sum_exp_p *= (rp < -80.0f) ? 0.0f : metal::fast::exp(rp);
             for (int j=0; j<M; j++) {
                 sum_exp_q += metal::fast::exp(vals_q[j] - max_q);
                 sum_exp_p += metal::fast::exp(vals_p[j] - max_p);
@@ -246,11 +258,15 @@ def _make_kl_backward_kernel():
                 max_q = max(max_q, vals_q[j]);
                 max_p = max(max_p, vals_p[j]);
             }
-            sum_exp_q *= metal::fast::exp(prev_max_q - max_q);
-            sum_exp_p *= metal::fast::exp(prev_max_p - max_p);
+            float rq = prev_max_q - max_q;
+            float rp = prev_max_p - max_p;
+            sum_exp_q *= (rq < -80.0f) ? 0.0f : metal::fast::exp(rq);
+            sum_exp_p *= (rp < -80.0f) ? 0.0f : metal::fast::exp(rp);
             for (int j=0; j<M; j++) {
-                sum_exp_q += metal::fast::exp(vals_q[j] - max_q);
-                sum_exp_p += metal::fast::exp(vals_p[j] - max_p);
+                if (offset + j < V) {
+                    sum_exp_q += metal::fast::exp(vals_q[j] - max_q);
+                    sum_exp_p += metal::fast::exp(vals_p[j] - max_p);
+                }
             }
         }
 
@@ -272,8 +288,10 @@ def _make_kl_backward_kernel():
         threadgroup_barrier(mem_flags::mem_threadgroup);
 
         // Share the sum_exp across the threadgroup
-        sum_exp_q *= metal::fast::exp(prev_max_q - max_q);
-        sum_exp_p *= metal::fast::exp(prev_max_p - max_p);
+        float rq = prev_max_q - max_q;
+        float rp = prev_max_p - max_p;
+        sum_exp_q *= (rq < -80.0f) ? 0.0f : metal::fast::exp(rq);
+        sum_exp_p *= (rp < -80.0f) ? 0.0f : metal::fast::exp(rp);
         sum_exp_q = simd_sum(sum_exp_q);
         sum_exp_p = simd_sum(sum_exp_p);
         if (simd_lane_id == 0) {
@@ -308,7 +326,8 @@ def _make_kl_backward_kernel():
 
             for (int j=0; j<M; j++) {
                 out[offset + j] = static_cast<T>(
-                    c * (metal::fast::exp(vals_q[j] - lse_q) - metal::fast::exp(vals_p[j] - lse_p)));
+                    c * (metal::fast::exp(min(vals_q[j] - lse_q, 0.0f))
+                       - metal::fast::exp(min(vals_p[j] - lse_p, 0.0f))));
             }
 
             // Move to the next block
@@ -325,7 +344,8 @@ def _make_kl_backward_kernel():
             for (int j=0; j<M; j++) {
                 if (offset + j < V) {
                     out[offset + j] = static_cast<T>(
-                        c * (metal::fast::exp(vals_q[j] - lse_q) - metal::fast::exp(vals_p[j] - lse_p)));
+                        c * (metal::fast::exp(min(vals_q[j] - lse_q, 0.0f))
+                           - metal::fast::exp(min(vals_p[j] - lse_p, 0.0f))));
                 }
             }
         }
@@ -434,8 +454,10 @@ def _make_js_forward_kernel():
                 max_q = max(max_q, vals_q[j]);
                 max_p = max(max_p, vals_p[j]);
             }
-            sum_exp_q *= metal::fast::exp(prev_max_q - max_q);
-            sum_exp_p *= metal::fast::exp(prev_max_p - max_p);
+            float rq = prev_max_q - max_q;
+            float rp = prev_max_p - max_p;
+            sum_exp_q *= (rq < -80.0f) ? 0.0f : metal::fast::exp(rq);
+            sum_exp_p *= (rp < -80.0f) ? 0.0f : metal::fast::exp(rp);
             for (int j=0; j<M; j++) {
                 sum_exp_q += metal::fast::exp(vals_q[j] - max_q);
                 sum_exp_p += metal::fast::exp(vals_p[j] - max_p);
@@ -458,11 +480,15 @@ def _make_js_forward_kernel():
                 max_q = max(max_q, vals_q[j]);
                 max_p = max(max_p, vals_p[j]);
             }
-            sum_exp_q *= metal::fast::exp(prev_max_q - max_q);
-            sum_exp_p *= metal::fast::exp(prev_max_p - max_p);
+            float rq = prev_max_q - max_q;
+            float rp = prev_max_p - max_p;
+            sum_exp_q *= (rq < -80.0f) ? 0.0f : metal::fast::exp(rq);
+            sum_exp_p *= (rp < -80.0f) ? 0.0f : metal::fast::exp(rp);
             for (int j=0; j<M; j++) {
-                sum_exp_q += metal::fast::exp(vals_q[j] - max_q);
-                sum_exp_p += metal::fast::exp(vals_p[j] - max_p);
+                if (offset + j < V) {
+                    sum_exp_q += metal::fast::exp(vals_q[j] - max_q);
+                    sum_exp_p += metal::fast::exp(vals_p[j] - max_p);
+                }
             }
         }
 
@@ -484,8 +510,10 @@ def _make_js_forward_kernel():
         threadgroup_barrier(mem_flags::mem_threadgroup);
 
         // Share the sum_exp across the threadgroup
-        sum_exp_q *= metal::fast::exp(prev_max_q - max_q);
-        sum_exp_p *= metal::fast::exp(prev_max_p - max_p);
+        float rq = prev_max_q - max_q;
+        float rp = prev_max_p - max_p;
+        sum_exp_q *= (rq < -80.0f) ? 0.0f : metal::fast::exp(rq);
+        sum_exp_p *= (rp < -80.0f) ? 0.0f : metal::fast::exp(rp);
         sum_exp_q = simd_sum(sum_exp_q);
         sum_exp_p = simd_sum(sum_exp_p);
         if (simd_lane_id == 0) {
@@ -540,12 +568,14 @@ def _make_js_forward_kernel():
             }
 
             for (int j=0; j<M; j++) {
-                float logp_j = vals_p[j] - lse_p;
-                float logq_j = vals_q[j] - lse_q;
-                float p_j = metal::fast::exp(logp_j);
-                float q_j = metal::fast::exp(logq_j);
-                kl_p += p_j * (logtwo - metal::fast::log(1 + metal::fast::exp(logq_j - logp_j)));
-                kl_q += q_j * (logtwo - metal::fast::log(1 + metal::fast::exp(logp_j - logq_j)));
+                if (offset + j < V) {
+                    float logp_j = vals_p[j] - lse_p;
+                    float logq_j = vals_q[j] - lse_q;
+                    float p_j = metal::fast::exp(logp_j);
+                    float q_j = metal::fast::exp(logq_j);
+                    kl_p += p_j * (logtwo - metal::fast::log(1 + metal::fast::exp(logq_j - logp_j)));
+                    kl_q += q_j * (logtwo - metal::fast::log(1 + metal::fast::exp(logp_j - logq_j)));
+                }
             }
         }
 
@@ -623,8 +653,10 @@ def _make_js_backward_kernel():
                 max_q = max(max_q, vals_q[j]);
                 max_p = max(max_p, vals_p[j]);
             }
-            sum_exp_q *= metal::fast::exp(prev_max_q - max_q);
-            sum_exp_p *= metal::fast::exp(prev_max_p - max_p);
+            float rq = prev_max_q - max_q;
+            float rp = prev_max_p - max_p;
+            sum_exp_q *= (rq < -80.0f) ? 0.0f : metal::fast::exp(rq);
+            sum_exp_p *= (rp < -80.0f) ? 0.0f : metal::fast::exp(rp);
             for (int j=0; j<M; j++) {
                 sum_exp_q += metal::fast::exp(vals_q[j] - max_q);
                 sum_exp_p += metal::fast::exp(vals_p[j] - max_p);
@@ -647,11 +679,15 @@ def _make_js_backward_kernel():
                 max_q = max(max_q, vals_q[j]);
                 max_p = max(max_p, vals_p[j]);
             }
-            sum_exp_q *= metal::fast::exp(prev_max_q - max_q);
-            sum_exp_p *= metal::fast::exp(prev_max_p - max_p);
+            float rq = prev_max_q - max_q;
+            float rp = prev_max_p - max_p;
+            sum_exp_q *= (rq < -80.0f) ? 0.0f : metal::fast::exp(rq);
+            sum_exp_p *= (rp < -80.0f) ? 0.0f : metal::fast::exp(rp);
             for (int j=0; j<M; j++) {
-                sum_exp_q += metal::fast::exp(vals_q[j] - max_q);
-                sum_exp_p += metal::fast::exp(vals_p[j] - max_p);
+                if (offset + j < V) {
+                    sum_exp_q += metal::fast::exp(vals_q[j] - max_q);
+                    sum_exp_p += metal::fast::exp(vals_p[j] - max_p);
+                }
             }
         }
 
@@ -673,8 +709,10 @@ def _make_js_backward_kernel():
         threadgroup_barrier(mem_flags::mem_threadgroup);
 
         // Share the sum_exp across the threadgroup
-        sum_exp_q *= metal::fast::exp(prev_max_q - max_q);
-        sum_exp_p *= metal::fast::exp(prev_max_p - max_p);
+        float rq = prev_max_q - max_q;
+        float rp = prev_max_p - max_p;
+        sum_exp_q *= (rq < -80.0f) ? 0.0f : metal::fast::exp(rq);
+        sum_exp_p *= (rp < -80.0f) ? 0.0f : metal::fast::exp(rp);
         sum_exp_q = simd_sum(sum_exp_q);
         sum_exp_p = simd_sum(sum_exp_p);
         if (simd_lane_id == 0) {
@@ -709,8 +747,8 @@ def _make_js_backward_kernel():
             }
 
             for (int j=0; j<M; j++) {
-                float logp_j = vals_p[j] - lse_p;
-                float logq_j = vals_q[j] - lse_q;
+                float logp_j = min(vals_p[j] - lse_p, 0.0f);
+                float logq_j = min(vals_q[j] - lse_q, 0.0f);
                 float q_j = metal::fast::exp(logq_j);
                 out_q[offset + j] = static_cast<T>(
                     c * 0.5 * q_j * (logtwo - metal::fast::log(1 + metal::fast::exp(logp_j - logq_j)) - kl_q)
@@ -730,8 +768,8 @@ def _make_js_backward_kernel():
 
             for (int j=0; j<M; j++) {
                 if (offset + j < V) {
-                    float logp_j = vals_p[j] - lse_p;
-                    float logq_j = vals_q[j] - lse_q;
+                    float logp_j = min(vals_p[j] - lse_p, 0.0f);
+                    float logq_j = min(vals_q[j] - lse_q, 0.0f);
                     float q_j = metal::fast::exp(logq_j);
                     out_q[offset + j] = static_cast<T>(
                         c * 0.5 * q_j * (logtwo - metal::fast::log(1 + metal::fast::exp(logp_j - logq_j)) - kl_q)

--- a/tests/test_losses.py
+++ b/tests/test_losses.py
@@ -74,7 +74,9 @@ class TestLosses(unittest.TestCase):
         with mx.stream(mx.cpu):
             expected = mx.vjp(kl_div_loss, [logits_q, logits_p], [cotan])[1][0]
 
-        runs = [mx.vjp(kl_div_loss, [logits_q, logits_p], [cotan])[1][0] for _ in range(5)]
+        runs = [
+            mx.vjp(kl_div_loss, [logits_q, logits_p], [cotan])[1][0] for _ in range(5)
+        ]
         mx.eval(runs, expected)
 
         for g in runs:
@@ -93,13 +95,47 @@ class TestLosses(unittest.TestCase):
         with mx.stream(mx.cpu):
             expected = mx.vjp(js_div_loss, [logits_q, logits_p], [cotan])[1][0]
 
-        runs = [mx.vjp(js_div_loss, [logits_q, logits_p], [cotan])[1][0] for _ in range(5)]
+        runs = [
+            mx.vjp(js_div_loss, [logits_q, logits_p], [cotan])[1][0] for _ in range(5)
+        ]
         mx.eval(runs, expected)
 
         for g in runs:
             self.assertTrue(mx.array_equal(g, runs[0]))
             self.assertTrue(mx.allclose(g, expected, rtol=1e-4, atol=1e-5))
             self.assertFalse(bool(mx.any(mx.abs(g) > 1e30)))
+
+    def test_js_div_loss_large_scale_softplus_finite(self):
+        # scale 20 produces log-ratios large enough that the naive
+        # log(1+exp(x)) softplus in the fused JS kernels overflowed to
+        # inf/NaN before the stable rewrite. Shape matched to a CI cell
+        # that stayed finite against the reference path after the fix
+        # (float32 scale=20 shape=(3,100): max abs grad diff 1.072e-6).
+        self.assertTrue(can_run_metal())
+        mx.random.seed(0)
+
+        logits_q = mx.random.normal((8, 100)) * 20.0
+        logits_p = mx.random.normal((8, 100)) * 20.0
+        cotan = mx.ones((8,))
+
+        with mx.stream(mx.cpu):
+            expected_y = js_div_loss(logits_q, logits_p)
+            expected_g = mx.vjp(js_div_loss, [logits_q, logits_p], [cotan])[1][0]
+
+        y = js_div_loss(logits_q, logits_p)
+        runs = [
+            mx.vjp(js_div_loss, [logits_q, logits_p], [cotan])[1][0] for _ in range(5)
+        ]
+        mx.eval(y, runs, expected_y, expected_g)
+
+        self.assertFalse(bool(mx.any(mx.isnan(y)) | mx.any(mx.isinf(y))))
+        self.assertTrue(mx.allclose(y, expected_y, rtol=1e-4, atol=1e-5))
+        for g in runs:
+            self.assertTrue(mx.array_equal(g, runs[0]))
+            self.assertFalse(
+                bool(mx.any(mx.isnan(g)) | mx.any(mx.isinf(g)) | (mx.abs(g) > 1e30))
+            )
+            self.assertTrue(mx.allclose(g, expected_g, rtol=1e-4, atol=1e-5))
 
 
 if __name__ == "__main__":

--- a/tests/test_losses.py
+++ b/tests/test_losses.py
@@ -63,6 +63,44 @@ class TestLosses(unittest.TestCase):
 
         self.assertTrue(mx.allclose(vjp_q, expected))
 
+    def test_kl_div_loss_vjp_large_vocab_deterministic(self):
+        self.assertTrue(can_run_metal())
+        mx.random.seed(0)
+
+        logits_q = mx.random.normal((64, 100003)) * 6.0
+        logits_p = mx.random.normal((64, 100003)) * 6.0
+        cotan = mx.ones((64,))
+
+        with mx.stream(mx.cpu):
+            expected = mx.vjp(kl_div_loss, [logits_q, logits_p], [cotan])[1][0]
+
+        runs = [mx.vjp(kl_div_loss, [logits_q, logits_p], [cotan])[1][0] for _ in range(5)]
+        mx.eval(runs, expected)
+
+        for g in runs:
+            self.assertTrue(mx.array_equal(g, runs[0]))
+            self.assertTrue(mx.allclose(g, expected, rtol=1e-4, atol=1e-5))
+            self.assertFalse(bool(mx.any(mx.abs(g) > 1e30)))
+
+    def test_js_div_loss_vjp_large_vocab_deterministic(self):
+        self.assertTrue(can_run_metal())
+        mx.random.seed(0)
+
+        logits_q = mx.random.normal((64, 100003)) * 6.0
+        logits_p = mx.random.normal((64, 100003)) * 6.0
+        cotan = mx.ones((64,))
+
+        with mx.stream(mx.cpu):
+            expected = mx.vjp(js_div_loss, [logits_q, logits_p], [cotan])[1][0]
+
+        runs = [mx.vjp(js_div_loss, [logits_q, logits_p], [cotan])[1][0] for _ in range(5)]
+        mx.eval(runs, expected)
+
+        for g in runs:
+            self.assertTrue(mx.array_equal(g, runs[0]))
+            self.assertTrue(mx.allclose(g, expected, rtol=1e-4, atol=1e-5))
+            self.assertFalse(bool(mx.any(mx.abs(g) > 1e30)))
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Problem

#1700 reports that during DWQ on models above roughly 1B parameters, the
backward pass of the fused Metal KL divergence kernel intermittently
saturates to -3.39e38 (about -FLT_MAX) and corrupts training on the first
step. The failure is nondeterministic and load dependent; forcing the
reference KL path avoids it entirely.

## Root cause

The four fused kernels in mlx_lm/tuner/losses.py reduce across simdgroups
through a single threadgroup buffer, first for the row max, then for the
sum of exponentials. After the barrier, every thread reads the maxes back
from `shared`, and lane 0 of each simdgroup then writes its partial sum
into the same slots. There is no barrier between those reads and writes.
Simdgroups make independent progress, so a fast group can overwrite a slot
before a slow group has read it. The affected thread folds a partial sum
into what it believes is a max, the row logsumexp collapses, and
exp(vals - lse) saturates in the gradient write. The forward pass shares
the hazard but reduces to a single scalar per row, which is why the
corruption surfaces in the backward first.

Two related issues in the same kernels are fixed alongside the race.
Several barriers separating accesses to `shared` used
mem_flags::mem_none, which orders execution but does not fence
threadgroup memory. And the tail block feeds a -1e30 sentinel into
metal::fast::exp, outside the documented input range of the fast math
functions; that did not appear to be the trigger here (the forward pass
performs the same out of range call on every row and computes correctly),
but those sites are now guarded as hardening in a separate commit that
can be dropped if preferred.

## Additional finding: deterministic JS softplus overflow

While validating the race fix on the diagnostic suite, a second, fully
deterministic bug showed up in the JS kernels only. They evaluated
log(1 + exp(logq - logp)) directly. At logit scale 20 the log-ratio
reaches several hundred, exp overflows to inf, and the reduction yields
-inf or NaN (including via 0 * inf when a probability underflows). That
matched the residual scale-20 saturation that remained after the barrier
fix alone: same on every retry of identical inputs, independent of
scheduling. The JS softplus sites now use the standard stable form
(mathematically identical for in-range inputs, finite where the naive
form overflowed). This is a separate commit from the race fix and from
the fast-math hardening; unlike the hardening, it intentionally changes
outputs exactly on the overflowing inputs.

## Changes

1. Add a threadgroup_barrier(mem_flags::mem_threadgroup) between the max
   read back and the sum exchange, in all four kernels.
2. Promote the mem_none barriers guarding `shared` to mem_threadgroup.
3. Hardening (separate commit): bounds guard on tail block accumulation,
   zero guard on the rescale factor below the f32 underflow range, and
   clamping of the exp arguments in the gradient writes to their
   mathematical range. Exact no ops for in range inputs.
4. Stable softplus in the JS kernels (separate commit): replaces the
   naive log(1+exp(x)) that overflowed at large log-ratios.
5. Regression tests: large non-block-aligned vocabulary determinism for
   KL and JS vjp, plus a JS scale-20 softplus case that asserts finite
   outputs and parity with the CPU reference path.

## Validation

Measured on a GitHub hosted macos-15 arm64 runner (virtualized Apple
M series, Metal available), mlx 0.32.0, mlx-lm 0.31.3.
Full logs are attached as CI artifacts on my fork.
Before: https://github.com/AxelNoun/mlx-lm/actions/runs/31542610875
After:  https://github.com/AxelNoun/mlx-lm/actions/runs/31547890243

Determinism, repeated backward on identical inputs, worst KL
configuration (float32, scale 6, shape (512, 151936)):
  before: 50/50 nondeterministic, 0 saturated
  after:  0/50 nondeterministic, 0 saturated

Pipelined stress (bf16, 8 concurrent backwards of shape (256, 151936)):
  before: 3/400 nondeterministic
  after:  0/400 nondeterministic

Parity with the reference path after the fix (max abs difference on the
gradient): float32 7.4e-6, bfloat16 2.0e-3 across vocabularies of 17,
4095, 4097, 100003 and 151936. Finite cells are small but nonzero, so
the fused Metal path is the one under test rather than a silent fallback
to the reference implementation.

No measurable performance regression on the same runner class for the
(512, 151936) bf16 backward; run to run variance on virtualized hosts
dominates any barrier cost on the once-per-row reduction path.

I do not have access to Apple hardware beyond CI runners, so I could
not run the DWQ recipe end to end. The reporter of #1700 offered to
test candidate patches on the M5 Max where the failure reproduces;
exact commands are posted in the issue. The new regression tests in
tests/test_losses.py will also exercise the fix on the project CI.