### PR TITLE
Absorb DeepSeek V2 kv_b_proj weights

### DIFF
--- a/mlx_lm/models/deepseek_v2.py
+++ b/mlx_lm/models/deepseek_v2.py
@@ -9,7 +9,13 @@ import mlx.nn as nn
 from mlx.nn.layers.distributed import shard_inplace, shard_linear, sum_gradients
 
 from .activations import swiglu
-from .base import BaseModelArgs, create_attention_mask, scaled_dot_product_attention
+from .base import (
+    BaseModelArgs,
+    create_attention_mask,
+    create_causal_mask,
+    scaled_dot_product_attention,
+)
+from .mla import MultiLinear
 from .pipeline import PipelineMixin
 from .switch_layers import SwitchGLU
 
@@ -162,11 +168,11 @@ class DeepseekV2Attention(nn.Module):
             bias=config.attention_bias,
         )
         self.kv_a_layernorm = nn.RMSNorm(self.kv_lora_rank, eps=1e-6)
-        self.kv_b_proj = nn.Linear(
-            self.kv_lora_rank,
-            self.num_heads
-            * (self.q_head_dim - self.qk_rope_head_dim + self.v_head_dim),
-            bias=False,
+        self.embed_q = MultiLinear(
+            self.qk_nope_head_dim, self.kv_lora_rank, self.num_heads
+        )
+        self.unembed_out = MultiLinear(
+            self.kv_lora_rank, self.v_head_dim, self.num_heads
         )
 
         self.o_proj = nn.Linear(
@@ -218,29 +224,39 @@ class DeepseekV2Attention(nn.Module):
         compressed_kv = self.kv_a_proj_with_mqa(x)
         compressed_kv, k_pe = mx.split(compressed_kv, [self.kv_lora_rank], axis=-1)
         k_pe = k_pe.reshape(B, L, 1, self.qk_rope_head_dim).transpose(0, 2, 1, 3)
-        kv = self.kv_b_proj(self.kv_a_layernorm(compressed_kv))
-        kv = kv.reshape(B, L, self.num_heads, -1).transpose(0, 2, 1, 3)
+        kv_latent = self.kv_a_layernorm(compressed_kv)
 
-        k_nope, values = mx.split(kv, [self.qk_nope_head_dim], axis=-1)
+        offset = cache.offset if cache is not None else 0
+        q_pe = self.rope(q_pe, offset)
+        k_pe = self.rope(k_pe, offset)
 
+        kv_latent = mx.expand_dims(kv_latent, axis=1)
         if cache is not None:
-            q_pe = self.rope(q_pe, cache.offset)
-            k_pe = self.rope(k_pe, cache.offset)
-            k_pe = mx.repeat(k_pe, self.num_heads, axis=1)
-            keys, values = cache.update_and_fetch(
-                mx.concatenate([k_nope, k_pe], axis=-1), values
-            )
-        else:
-            q_pe = self.rope(q_pe)
-            k_pe = self.rope(k_pe)
-            k_pe = mx.repeat(k_pe, self.num_heads, axis=1)
-            keys = mx.concatenate([k_nope, k_pe], axis=-1)
+            kv_latent, k_pe = cache.update_and_fetch(kv_latent, k_pe)
 
-        queries = mx.concatenate([q_nope, q_pe], axis=-1)
+        pe_scores = (q_pe * self.scale) @ k_pe.swapaxes(-1, -2)
+        if isinstance(mask, str) and mask == "causal":
+            mask = create_causal_mask(L, offset)
+        if mask is not None:
+            pe_scores = mx.where(
+                mask,
+                pe_scores,
+                mx.array(mx.finfo(pe_scores.dtype).min, pe_scores.dtype),
+            )
+
+        if L == 1:
+            q_nope = self.embed_q(q_nope)
+            keys = values = kv_latent
+        else:
+            keys = self.embed_q(kv_latent, transpose=False)
+            values = self.unembed_out(kv_latent)
 
         output = scaled_dot_product_attention(
-            queries, keys, values, cache=cache, scale=self.scale, mask=mask
+            q_nope, keys, values, cache=cache, scale=self.scale, mask=pe_scores
         )
+        if L == 1:
+            output = self.unembed_out(output)
+
         output = output.transpose(0, 2, 1, 3).reshape(B, L, -1)
         return self.o_proj(output)
 
@@ -438,6 +454,41 @@ class Model(nn.Module):
                             for e in range(self.args.n_routed_experts)
                         ]
                         weights[f"{prefix}.mlp.switch_mlp.{m}.{k}"] = mx.stack(to_join)
+            prefix = f"model.layers.{l}.self_attn"
+            if f"{prefix}.kv_b_proj.weight" in weights:
+                quantized = f"{prefix}.kv_b_proj.scales" in weights
+                v = weights.pop(f"{prefix}.kv_b_proj.weight")
+                head_dim = self.args.qk_nope_head_dim + self.args.v_head_dim
+
+                if quantized:
+                    dims = self.args.kv_lora_rank
+                    scales = weights.pop(f"{prefix}.kv_b_proj.scales")
+                    biases = weights.pop(f"{prefix}.kv_b_proj.biases")
+                    bits = (v.shape[-1] * 32) // dims
+                    group_size = dims // scales.shape[-1]
+                    num_heads = self.args.num_attention_heads
+                    qv = v.reshape(num_heads, head_dim, -1)
+                    qv_scales = scales.reshape(num_heads, head_dim, -1)
+                    qv_biases = biases.reshape(num_heads, head_dim, -1)
+                    v = mx.dequantize(
+                        v, scales, biases, bits=bits, group_size=group_size
+                    )
+                num_heads = self.args.num_attention_heads
+                v = v.reshape(num_heads, head_dim, -1)
+                wk = mx.contiguous(
+                    v[:, : self.args.qk_nope_head_dim, :].swapaxes(-1, -2)
+                )
+                wv = mx.contiguous(v[:, self.args.qk_nope_head_dim :, :])
+                if quantized:
+                    wv = mx.contiguous(qv[:, self.args.qk_nope_head_dim :, :])
+                    weights[f"{prefix}.unembed_out.scales"] = mx.contiguous(
+                        qv_scales[:, self.args.qk_nope_head_dim :, :]
+                    )
+                    weights[f"{prefix}.unembed_out.biases"] = mx.contiguous(
+                        qv_biases[:, self.args.qk_nope_head_dim :, :]
+                    )
+                weights[f"{prefix}.embed_q.weight"] = wk
+                weights[f"{prefix}.unembed_out.weight"] = wv
         return weights
 
     def shard(self, group: Optional[mx.distributed.Group] = None):
@@ -453,13 +504,20 @@ class Model(nn.Module):
                 layer.self_attn.q_b_proj = shard_linear(
                     layer.self_attn.q_b_proj, "all-to-sharded", group=group
                 )
-            layer.self_attn.kv_b_proj = shard_linear(
-                layer.self_attn.kv_b_proj, "all-to-sharded", group=group
-            )
+            layer.self_attn.num_heads //= N
+            num_heads = layer.self_attn.num_heads
+            sh = group.rank() * num_heads
+            eh = sh + num_heads
+
+            def shard_heads(w):
+                return w[sh:eh]
+
+            layer.self_attn.embed_q.apply(shard_heads)
+            layer.self_attn.unembed_out.apply(shard_heads)
+
             layer.self_attn.o_proj = shard_linear(
                 layer.self_attn.o_proj, "sharded-to-all", group=group
             )
-            layer.self_attn.num_heads //= N
 
             # Shard the MLP
             if isinstance(layer.mlp, DeepseekV2MLP):

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -1431,7 +1431,7 @@ class TestModels(unittest.TestCase):
             num_hidden_layers=4,
             num_attention_heads=4,
             num_key_value_heads=2,
-            kv_lora_rank=4,
+            kv_lora_rank=32,
             q_lora_rank=4,
             qk_rope_head_dim=32,
             v_head_dim=16,
@@ -1447,8 +1447,73 @@ class TestModels(unittest.TestCase):
             },
         )
         model = deepseek_v2.Model(args)
+        self.assertTrue(hasattr(model.layers[0].self_attn, "embed_q"))
+        self.assertTrue(hasattr(model.layers[0].self_attn, "unembed_out"))
+        self.assertFalse(hasattr(model.layers[0].self_attn, "kv_b_proj"))
         self.model_test_runner(
             model, args.model_type, args.vocab_size, args.num_hidden_layers
+        )
+
+        prefix = "model.layers.0.self_attn"
+        head_dim = args.qk_nope_head_dim + args.v_head_dim
+        kv_b_proj = mx.arange(
+            args.num_attention_heads * head_dim * args.kv_lora_rank,
+            dtype=mx.float32,
+        ).reshape(args.num_attention_heads * head_dim, args.kv_lora_rank)
+
+        weights = model.sanitize({f"{prefix}.kv_b_proj.weight": kv_b_proj})
+        kv_b_proj = kv_b_proj.reshape(
+            args.num_attention_heads, head_dim, args.kv_lora_rank
+        )
+        expected_embed_q = kv_b_proj[:, : args.qk_nope_head_dim, :].swapaxes(-1, -2)
+        expected_unembed_out = kv_b_proj[:, args.qk_nope_head_dim :, :]
+
+        self.assertTrue(
+            mx.array_equal(weights[f"{prefix}.embed_q.weight"], expected_embed_q)
+        )
+        self.assertTrue(
+            mx.array_equal(
+                weights[f"{prefix}.unembed_out.weight"], expected_unembed_out
+            )
+        )
+
+        q_weight, q_scales, *q_biases = mx.quantize(
+            kv_b_proj.reshape(args.num_attention_heads * head_dim, args.kv_lora_rank),
+            group_size=32,
+            bits=4,
+        )
+        q_biases = q_biases[0]
+        weights = model.sanitize(
+            {
+                f"{prefix}.kv_b_proj.weight": q_weight,
+                f"{prefix}.kv_b_proj.scales": q_scales,
+                f"{prefix}.kv_b_proj.biases": q_biases,
+            }
+        )
+        q_shape = (args.num_attention_heads, head_dim, -1)
+        self.assertNotIn(f"{prefix}.embed_q.scales", weights)
+        self.assertIn(f"{prefix}.unembed_out.scales", weights)
+        self.assertEqual(
+            weights[f"{prefix}.embed_q.weight"].shape,
+            (args.num_attention_heads, args.kv_lora_rank, args.qk_nope_head_dim),
+        )
+        self.assertTrue(
+            mx.array_equal(
+                weights[f"{prefix}.unembed_out.weight"],
+                q_weight.reshape(q_shape)[:, args.qk_nope_head_dim :, :],
+            )
+        )
+        self.assertTrue(
+            mx.array_equal(
+                weights[f"{prefix}.unembed_out.scales"],
+                q_scales.reshape(q_shape)[:, args.qk_nope_head_dim :, :],
+            )
+        )
+        self.assertTrue(
+            mx.array_equal(
+                weights[f"{prefix}.unembed_out.biases"],
+                q_biases.reshape(q_shape)[:, args.qk_nope_head_dim :, :],
+            )
         )
 
     def test_deepseek_v3(self):


### PR DESCRIPTION
## Summary

This moves DeepSeek-V2 MLA to the absorbed layout already used by DeepSeek-V3/GLM-style models: the attention module owns `embed_q` and `unembed_out`, and `sanitize()` converts checkpoint `kv_b_proj` weights into those tensors at load time.

The change keeps the same MLA math while letting decode operate over the latent KV state directly, matching the layout expected by downstream runtimes such as vllm-metal. This follows the maintainer guidance from vllm-metal PR #397: model-layout normalization should live in `mlx-lm` rather than inside the vllm-metal paged-attention backend.

## Details

- Replace `DeepseekV2Attention.kv_b_proj` with `MultiLinear` `embed_q` / `unembed_out`.
- Use the same decode/prefill split as DeepSeek-V3: latent attention for single-token decode, materialized K/V for multi-token prefill.
- Convert dense and quantized `kv_b_proj` checkpoint weights in `Model.sanitize()`.
- For quantized checkpoints, keep the transposed K-side `embed_q` dense after dequantization to avoid transpose/requantization error, while preserving the original packed V-side rows/scales/biases for `unembed_out`.
- Update sharding to shard the per-head absorbed projections.
- Extend the DeepSeek-V2 model test to verify normalized modules plus dense and quantized weight conversion.

## Validation

Dedicated Python 3.10 env with editable test install:

```
pip install -e ".[test]" pre-commit
```

Passing checks:

```
pre-commit run --files mlx_lm/models/deepseek_v2.py tests/test_models.py
# black Passed
# isort Passed

python -m unittest tests.test_models.TestModels.test_deepseek_v2 tests.test_models.TestModels.test_deepseek_v3
# Ran 2 tests: OK

python -m pytest tests/test_models.py::TestModels::test_deepseek_v2 tests/test_models.py::TestModels::test_deepseek_v3 -v --tb=short
# 2 passed

python -m compileall -q mlx_lm/models/deepseek_v2.py tests/test_models.py

git diff --check
```

Full-suite attempt, matching the CI setup as closely as possible locally:

```
curl -o test_data.zip -L https://github.com/ml-explore/mlx-lm/releases/download/test_data/test_data.zip
unzip test_data.zip
METAL_DEVICE_WRAPPER_TYPE=1 METAL_DEBUG_ERROR_MODE=0 HF_HOME="." python -m unittest discover tests/
# Ran 211 tests: FAILED (failures=9, skipped=1)
```

The same 9 failures reproduce on upstream `main` with the same local environment and test data, so they do not appear to be introduced by this PR. They are deterministic generation/SSM equality checks in `test_generate.py` and `test_models.py`; the DeepSeek-V2 and DeepSeek-V3 targeted tests pass.

Real model smoke with `mlx-community/DeepSeek-V2-Lite-Chat-4bit-mlx`:

```
has_embed_q True
has_unembed_out True
has_kv_b_proj False
'Paris.\nThe official language of France is French...'
```

Related vllm-metal context: https://github.com/vllm-project/vllm-metal/pull/397 and https://github.com/vllm-project/vllm-metal/issues/360
