### PR TITLE
fix(chat template): make --use-default-chat-template work again

### DIFF
--- a/mlx_lm/generate.py
+++ b/mlx_lm/generate.py
@@ -2112,6 +2112,9 @@ def main():
     for eos_token in args.extra_eos_token:
         tokenizer.add_eos_token(eos_token)
 
+    if args.use_default_chat_template:
+        tokenizer.use_default_chat_template()
+
     template_kwargs = {}
     if args.chat_template_config is not None:
         template_kwargs = json.loads(args.chat_template_config)

--- a/mlx_lm/server.py
+++ b/mlx_lm/server.py
@@ -336,8 +336,7 @@ class ModelProvider:
 
         # Use the default chat template if needed
         if self.cli_args.use_default_chat_template:
-            if tokenizer.chat_template is None:
-                tokenizer.chat_template = tokenizer.default_chat_template
+            tokenizer.use_default_chat_template()
 
         # Load the draft model for speculative decoding
         draft_model = None

--- a/mlx_lm/tokenizer_utils.py
+++ b/mlx_lm/tokenizer_utils.py
@@ -7,6 +7,18 @@ from typing import Any, Dict, List, Optional
 
 from transformers import AutoTokenizer, PreTrainedTokenizerFast
 
+# The ChatML template that ``PreTrainedTokenizerBase.default_chat_template``
+# returned before transformers removed it in v4.44. Used for models that ship
+# no chat template of their own.
+DEFAULT_CHAT_TEMPLATE = (
+    "{% for message in messages %}"
+    "{{ '<|im_start|>' + message['role'] + '\n' + message['content'] + '<|im_end|>' + '\n' }}"
+    "{% endfor %}"
+    "{% if add_generation_prompt %}"
+    "{{ '<|im_start|>assistant\n' }}"
+    "{% endif %}"
+)
+
 
 class StreamingDetokenizer:
     """The streaming detokenizer interface so that we can detokenize one token at a time.
@@ -341,6 +353,12 @@ class TokenizerWrapper:
 
         kwargs["return_dict"] = False
         return self._tokenizer.apply_chat_template(*args, tokenize=tokenize, **kwargs)
+
+    def use_default_chat_template(self):
+        """Install a default chat template if the model does not ship one."""
+        if self._tokenizer.chat_template is None:
+            self._tokenizer.chat_template = DEFAULT_CHAT_TEMPLATE
+            self.has_chat_template = True
 
     def add_eos_token(self, token: str):
         token_id = None


### PR DESCRIPTION
### The bug

`PreTrainedTokenizerBase.default_chat_template` was removed from transformers in
v4.44, but `setup.py` requires `transformers>=5.7.0`. The `--use-default-chat-template`
flag still depends on it, so today it is broken in two different ways:

**`mlx_lm.server`** raises at load time for any model whose `chat_template` is
`None` — which is the only case the flag exists for:

```
AttributeError: GPT2Tokenizer has no attribute default_chat_template
```

**`mlx_lm.generate`** declares the same flag but never reads
`args.use_default_chat_template` anywhere, so passing it is a silent no-op and the
prompt goes through `tokenizer.encode()` untemplated.

### The fix

Add `TokenizerWrapper.use_default_chat_template()`, which installs the ChatML
template that transformers used to hand back, and call it from both entry points.

It sets `has_chat_template` as well. Assigning `tokenizer.chat_template` alone is
not enough: `has_chat_template` is computed once in `TokenizerWrapper.__init__`, and
it is what both `generate.py` and `server.py` actually branch on when deciding
whether to apply a template — so the old code would not have templated anything
even if the attribute had still existed.

### Verification

`tokenizer_utils.py` has no `mlx` dependency, so it can be loaded by path and
exercised on non-Apple hardware. Against `gpt2` (ships no chat template), running
each checkout's own source for this flag:

**Before (`main` @ 254d153)**

```
before: chat_template=None has_chat_template=False

[server.py --use-default-chat-template]
  source: if tokenizer.chat_template is None: ; tokenizer.chat_template = tokenizer.default_chat_template
  -> AttributeError: GPT2Tokenizer has no attribute default_chat_template

[generate.py --use-default-chat-template]
  declared=True consumed=False

[apply_chat_template]
  has_chat_template is False -> generate.py falls back to the raw prompt
```

**After (this PR)**

```
before: chat_template=None has_chat_template=False

[server.py --use-default-chat-template]
  source: tokenizer.use_default_chat_template()
  -> ok, has_chat_template=True

[generate.py --use-default-chat-template]
  declared=True consumed=True

[apply_chat_template]
  rendered: '<|im_start|>user\nhi<|im_end|>\n<|im_start|>assistant\n'
```

Environment: transformers 5.15.0. `black==25.1.0` and `isort==6.0.0` (the pinned
pre-commit versions) report the three touched files unchanged.

### Note

If you would rather drop the feature than carry a ChatML constant, removing the
flag from both parsers is a smaller change and I am happy to switch this PR over —
the current state (crash in one entry point, silent no-op in the other) seems worth
fixing either way.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
