### PR TITLE
feat(generate): expose --repetition-penalty in the CLI (#1669)

### DIFF
--- a/mlx_lm/generate.py
+++ b/mlx_lm/generate.py
@@ -29,7 +29,7 @@ from .models.cache import (
     TokenBuffer,
     load_prompt_cache,
 )
-from .sample_utils import make_sampler
+from .sample_utils import make_logits_processors, make_sampler
 from .tokenizer_utils import TokenizerWrapper
 from .utils import does_model_support_input_embeddings, load
 
@@ -42,6 +42,8 @@ DEFAULT_TOP_K = 0
 DEFAULT_XTC_PROBABILITY = 0.0
 DEFAULT_XTC_THRESHOLD = 0.0
 DEFAULT_MIN_TOKENS_TO_KEEP = 1
+DEFAULT_REPETITION_PENALTY = None
+DEFAULT_REPETITION_CONTEXT_SIZE = 20
 DEFAULT_SEED = None
 DEFAULT_MODEL = "mlx-community/Llama-3.2-3B-Instruct-4bit"
 DEFAULT_QUANTIZED_KV_START = 5000
@@ -132,6 +134,19 @@ def setup_arg_parser():
         type=int,
         default=DEFAULT_MIN_TOKENS_TO_KEEP,
         help="Minimum tokens to keep for min-p sampling.",
+    )
+    parser.add_argument(
+        "--repetition-penalty",
+        type=float,
+        default=DEFAULT_REPETITION_PENALTY,
+        help="Penalty for repeating tokens (>1 discourages repetition). "
+        "Off by default.",
+    )
+    parser.add_argument(
+        "--repetition-context-size",
+        type=int,
+        default=DEFAULT_REPETITION_CONTEXT_SIZE,
+        help="Number of recent tokens the repetition penalty considers.",
     )
     parser.add_argument(
         "--seed",
@@ -2167,6 +2182,10 @@ def main():
         xtc_threshold=args.xtc_threshold,
         xtc_special_tokens=tokenizer.encode("\n") + list(tokenizer.eos_token_ids),
     )
+    logits_processors = make_logits_processors(
+        repetition_penalty=args.repetition_penalty,
+        repetition_context_size=args.repetition_context_size,
+    )
     response = generate(
         model,
         tokenizer,
@@ -2174,6 +2193,7 @@ def main():
         max_tokens=args.max_tokens,
         verbose=args.verbose,
         sampler=sampler,
+        logits_processors=logits_processors,
         max_kv_size=args.max_kv_size,
         prompt_cache=prompt_cache if using_cache else None,
         kv_bits=args.kv_bits,


### PR DESCRIPTION
### What

`mlx_lm.generate`'s CLI builds a sampler and passes **no** logits processors, so the
repetition penalty — which lives in `make_logits_processors` — is unreachable from the
command line. Meanwhile `mlx_lm.server` already exposes it (`_make_logits_processors`
→ `make_logits_processors(..., repetition_penalty, repetition_context_size, ...)`).
So a `generate` user who hits a repetition loop has no CLI knob to fix it, and `--help`
gives no hint that the capability exists.

This adds `--repetition-penalty` and `--repetition-context-size` to `mlx_lm.generate`
and threads them into `generate()` via `make_logits_processors`, mirroring the server.

### Behavior is unchanged by default

Both flags default to *off* (`repetition_penalty=None`). `make_logits_processors`
already skips any penalty that is `None` or `0`, so with no flags the processor list is
empty and generation is byte-for-byte identical to today. The knob only does something
when a user opts in (e.g. `--repetition-penalty 1.2`).

I intentionally did **not** change the *default* penalty value — the linked issue also
asks whether a non-zero default would be desirable, but that's a behavior change and a
separate decision. This PR is just the missing plumbing so the existing feature is
reachable from `generate`, matching `server`.

### Verification

mlx isn't available off Apple silicon, so I exercised the argument parser directly
(stubbing the mlx imports) against `main` and this branch:

- **`main`**: `--repetition-penalty` / `--repetition-context-size` — not present.
- **this branch**: both present; `--repetition-penalty 1.3 --repetition-context-size 40`
  parses to `1.3 / 40`; with no flags the defaults are `None / 20` → empty processor list.

Scope: `mlx_lm/generate.py` only, +19 −1.

Fixes #1669. Thanks @arjunneema09 for the report and for pinpointing that the gap is the
missing CLI surface rather than a docs nit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
