### PR TITLE
Give a helpful error when a model has only .bin weights

### DIFF
--- a/mlx_lm/utils.py
+++ b/mlx_lm/utils.py
@@ -335,6 +335,17 @@ def load_model(
     weight_files = glob.glob(str(model_path / "model*.safetensors"))
 
     if not weight_files and strict:
+        bin_files = glob.glob(str(model_path / "*.bin")) + glob.glob(
+            str(model_path / "*.pt")
+        )
+        if bin_files:
+            raise FileNotFoundError(
+                f"No safetensors found in {model_path}, but PyTorch weight "
+                f"files ({', '.join(Path(f).name for f in bin_files)}) are "
+                "present. mlx-lm can only load models in the safetensors "
+                "format. Convert the weights first, e.g. with "
+                "https://huggingface.co/spaces/safetensors/convert"
+            )
         raise FileNotFoundError(f"No safetensors found in {model_path}")
 
     weights = {}

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -41,6 +41,17 @@ class TestUtils(unittest.TestCase):
         p2 = model_lazy.layers[0].mlp.up_proj.weight
         self.assertTrue(mx.allclose(p1, p2))
 
+    def test_load_model_bin_weights_error(self):
+        with tempfile.TemporaryDirectory() as d:
+            d = Path(d)
+            (d / "pytorch_model.bin").write_bytes(b"")
+            with open(d / "config.json", "w") as f:
+                json.dump({"model_type": "llama"}, f)
+            with self.assertRaises(FileNotFoundError) as cm:
+                utils.load_model(d)
+            self.assertIn("safetensors", str(cm.exception))
+            self.assertIn("pytorch_model.bin", str(cm.exception))
+
     def test_make_shards(self):
         from mlx_lm.models import llama
 


### PR DESCRIPTION
`load_model` raised a bare `FileNotFoundError: No safetensors found` when a repo ships only PyTorch .bin/.pt weights, with no hint about the cause or fix.

I hit this converting a real model whose repo only had .bin weights. This detects that case and raises a message naming the .bin/.pt files found and pointing to the safetensors converter, the same conversion the CONTRIBUTING "Adding New Models" section already directs people to.

Kept it message-only rather than auto-loading .bin, to avoid pulling torch into the load path. The genuine "no weights at all" case is unchanged.

Added `test_load_model_bin_weights_error`; `tests/test_utils.py` passes.