### PR TITLE
Fix empty shard for oversized first weight

### DIFF
--- a/mlx_lm/utils.py
+++ b/mlx_lm/utils.py
@@ -653,7 +653,7 @@ def make_shards(weights: dict, max_file_size_gb: int = MAX_FILE_SIZE_GB) -> list
     shards = []
     shard, shard_size = {}, 0
     for k, v in weights.items():
-        if shard_size + v.nbytes > max_file_size_bytes:
+        if shard and shard_size + v.nbytes > max_file_size_bytes:
             shards.append(shard)
             shard, shard_size = {}, 0
         shard[k] = v

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -5,6 +5,7 @@ import os
 import tempfile
 import unittest
 from pathlib import Path
+from types import SimpleNamespace
 
 import mlx.core as mx
 import mlx.nn as nn
@@ -58,6 +59,15 @@ class TestUtils(unittest.TestCase):
         gb = sum(p.nbytes for _, p in weights) // 2**30
         shards = utils.make_shards(dict(weights), 1)
         self.assertTrue(gb <= len(shards) <= gb + 1)
+
+    def test_make_shards_does_not_prepend_empty_shard_for_oversized_weight(self):
+        oversized_weight = SimpleNamespace(nbytes=(1 << 30) + 1)
+        weights = {"model.embed_tokens.weight": oversized_weight}
+
+        shards = utils.make_shards(weights, max_file_size_gb=1)
+
+        self.assertEqual(shards, [weights])
+        self.assertTrue(all(shards))
 
     def test_quantize(self):
         from mlx_lm.models import llama


### PR DESCRIPTION
## Summary

Fixes #1720.

`make_shards()` flushed the current shard whenever the next weight would cross the size limit, even when no weight had been added yet. If the first tensor itself exceeded the limit, the function returned an empty shard followed by the real oversized shard.

`save_model()` then silently wrote that empty mapping as part 1 and placed the only real weight in part 2, producing a misleading, unreferenced shard in the model artifact.

The flush now requires the current shard to be non-empty. Oversized tensors still remain intact in an oversized shard, since this helper cannot split a tensor, and normal shard boundaries are unchanged.

## Validation

- red-to-green regression using an oversized first weight without allocating a multi-GiB tensor
- existing and new `make_shards` tests: 2 passed
- Black and isort repository hooks on both changed files
- Python compile check and `git diff --check`
- verified `mx.save_safetensors()` silently writes an empty mapping (41-byte file), confirming the artifact path
- exact open/closed issue and PR duplicate search; branch synchronized with `main`

AI assistance was used to identify the boundary condition, design the allocation-free regression, and review the diff; every changed line and test result was manually verified.