### PR TITLE
Add transactional native Qwen MTP batching and sparse admission

### DIFF
--- a/mlx_lm/generate.py
+++ b/mlx_lm/generate.py
@@ -18,7 +18,9 @@ from typing import (
     Callable,
     ContextManager,
     Dict,
+    FrozenSet,
     Generator,
+    Iterable,
     List,
     Optional,
     Sequence,
@@ -592,8 +594,8 @@ class _NativeMTPSamplingState:
 
     The single-request generator deliberately keeps this object private: its
     public call signature and draw order are part of the existing B=1
-    behaviour.  The batched native-MTP path uses the same operations with a
-    fixed set of per-row slots, rather than sharing a mutable global key.
+    behaviour.  The batched native-MTP path keeps an equivalent UID-local
+    retained key, rather than sharing a mutable global key across rows.
     """
 
     def __init__(
@@ -660,14 +662,16 @@ class _NativeMTPSamplingState:
             logprobs = logprobs / self.config.temperature
         return (logprobs - mx.logsumexp(logprobs, axis=-1, keepdims=True)).squeeze(0)
 
-    def sample(self, logprobs):
+    def sample(self, logprobs, *, rng_key=None):
         if self.config.stochastic:
-            return mx.random.categorical(logprobs, key=self.next_rng_key())
+            return mx.random.categorical(
+                logprobs, key=self.next_rng_key() if rng_key is None else rng_key
+            )
         if self.sampler is None:
             return mx.argmax(logprobs, axis=-1)
         return self.sampler(logprobs)
 
-    def residual_sample(self, target_logprobs, draft_logprobs):
+    def residual_sample(self, target_logprobs, draft_logprobs, *, rng_key=None):
         target_probs = mx.exp(target_logprobs)
         draft_probs = mx.exp(draft_logprobs)
         residual = mx.maximum(target_probs - draft_probs, 0)
@@ -677,7 +681,7 @@ class _NativeMTPSamplingState:
             mx.log(residual / normalizer),
             target_logprobs,
         )
-        return self.sample(residual_logprobs), residual_logprobs
+        return self.sample(residual_logprobs, rng_key=rng_key), residual_logprobs
 
 
 @dataclass(frozen=True)
@@ -987,21 +991,54 @@ class _NativeMTPCohortCache:
             zip(before, after, expected)
         ):
             # KV metadata is (_idx, offsets, left_padding); Arrays metadata is
-            # (None, left_padding, lengths). Both Arrays metadata values must
-            # remain exact across a native-MTP decode transaction.
+            # (None, left_padding, lengths).  Each ArraysCache vector is
+            # independently optional: an absent vector is an advance no-op;
+            # a present vector must retain its cohort width and exact delta.
             before_index, before_primary, *before_rest = before_layer
             after_index, after_primary, *after_rest = after_layer
             if before_index is None:
-                if before_primary != after_primary or tuple(before_rest) != tuple(
-                    after_rest
-                ):
+                if len(before_rest) != 1 or len(after_rest) != 1:
                     raise RuntimeError(
                         f"native_mtp_cohort_{name}_arrays_metadata_changed: layer={layer}"
                     )
-                if expected_layer:
-                    raise RuntimeError(
-                        f"native_mtp_cohort_{name}_array_delta_unsupported: layer={layer}"
-                    )
+                before_lengths, after_lengths = before_rest[0], after_rest[0]
+                if not expected_layer:
+                    if tuple(before_primary) != tuple(after_primary) or tuple(
+                        before_lengths
+                    ) != tuple(after_lengths):
+                        raise RuntimeError(
+                            f"native_mtp_cohort_{name}_arrays_metadata_changed: layer={layer}"
+                        )
+                    continue
+                expected_delta = tuple(-value for value in expected_layer)
+                for before_vector, after_vector in (
+                    (before_primary, after_primary),
+                    (before_lengths, after_lengths),
+                ):
+                    if not before_vector:
+                        if after_vector:
+                            raise RuntimeError(
+                                f"native_mtp_cohort_{name}_arrays_metadata_changed: layer={layer}"
+                            )
+                        continue
+                    if (
+                        not after_vector
+                        or len(before_vector) != len(expected_layer)
+                        or len(after_vector) != len(expected_layer)
+                    ):
+                        raise RuntimeError(
+                            f"native_mtp_cohort_{name}_arrays_metadata_changed: layer={layer}"
+                        )
+                    if (
+                        tuple(
+                            current - prior
+                            for prior, current in zip(before_vector, after_vector)
+                        )
+                        != expected_delta
+                    ):
+                        raise RuntimeError(
+                            f"native_mtp_cohort_{name}_array_delta_unsupported: layer={layer}"
+                        )
                 continue
             if tuple(after_rest) != tuple(before_rest):
                 raise RuntimeError(
@@ -1374,6 +1411,1081 @@ class _NativeMTPCohortCache:
         self._checkpoint = None
         self._transaction_sealed = False
         self._poisoned_reason = reason
+
+
+class _NativeMTPPhase(str, Enum):
+    """Public, linear phases of a native-MTP batch epoch.
+
+    This is intentionally a lifecycle API, not a second batch generator.  The
+    ordinary ``BatchGenerator`` owns its existing scheduling contract.  Native
+    MTP has a stricter transaction: a caller can advance only through the
+    phase handles returned by :class:`NativeMTPBatchGenerator`.
+    """
+
+    INITIAL = "initial"
+    READY = "ready"
+    DECISION = "decision"
+    ACCEPTED = "accepted"
+    BONUS = "bonus"
+    REJECTED = "rejected"
+    CLOSED = "closed"
+
+
+@dataclass(frozen=True)
+class NativeMTPRowSpec:
+    """Immutable admission contract for one native-MTP row.
+
+    ``seed`` is deliberately row-owned.  Batch split, reorder, and deferred
+    ready-join code must preserve this UID-to-seed binding rather than derive
+    random state from a cohort index.
+    """
+
+    uid: int
+    prompt: Tuple[int, ...]
+    max_tokens: int
+    seed: Optional[int] = None
+    eos_token_ids: FrozenSet[int] = frozenset()
+    sampling_config: NativeMTPSamplingConfig = NativeMTPSamplingConfig()
+
+    def __post_init__(self):
+        if isinstance(self.uid, bool) or not isinstance(self.uid, int):
+            raise TypeError("native_mtp_row_uid_invalid")
+        if not isinstance(self.prompt, tuple) or not self.prompt:
+            raise ValueError("native_mtp_row_prompt_required")
+        if any(
+            isinstance(token, bool) or not isinstance(token, int) or token < 0
+            for token in self.prompt
+        ):
+            raise ValueError("native_mtp_row_prompt_token_invalid")
+        if (
+            isinstance(self.max_tokens, bool)
+            or not isinstance(self.max_tokens, int)
+            or self.max_tokens < 0
+        ):
+            raise ValueError("native_mtp_row_max_tokens_invalid")
+        if self.seed is not None and (
+            isinstance(self.seed, bool)
+            or not isinstance(self.seed, int)
+            or self.seed < 0
+        ):
+            raise ValueError("native_mtp_row_seed_invalid")
+        if not isinstance(self.eos_token_ids, frozenset) or any(
+            isinstance(token, bool) or not isinstance(token, int) or token < 0
+            for token in self.eos_token_ids
+        ):
+            raise ValueError("native_mtp_row_eos_invalid")
+        if not isinstance(self.sampling_config, NativeMTPSamplingConfig):
+            raise TypeError("native_mtp_row_sampling_config_invalid")
+
+
+@dataclass(frozen=True)
+class NativeMTPEmission:
+    """One immutable token result at one public MTP emission boundary."""
+
+    uid: int
+    token: int
+    logprobs: mx.array
+    from_draft: bool
+    finish_reason: Optional[str] = None
+
+    def __post_init__(self):
+        if isinstance(self.uid, bool) or not isinstance(self.uid, int):
+            raise TypeError("native_mtp_emission_uid_invalid")
+        if (
+            isinstance(self.token, bool)
+            or not isinstance(self.token, int)
+            or self.token < 0
+        ):
+            raise ValueError("native_mtp_emission_token_invalid")
+        if not isinstance(self.logprobs, mx.array) or self.logprobs.ndim != 1:
+            raise TypeError("native_mtp_emission_logprobs_invalid")
+        if not isinstance(self.from_draft, bool):
+            raise TypeError("native_mtp_emission_draft_flag_invalid")
+        if self.finish_reason not in (None, "eos", "length", "cancelled"):
+            raise ValueError("native_mtp_emission_finish_reason_invalid")
+
+
+@dataclass(frozen=True)
+class _NativeMTPTelemetryEvent:
+    """Append-only public audit event; payload is never mutated in place."""
+
+    phase: _NativeMTPPhase
+    uids: Tuple[int, ...]
+    event: str
+
+
+@dataclass(frozen=True)
+class NativeMTPAdmission:
+    """Validated native-MTP cohort admission.
+
+    Admission is intentionally fail-closed.  Prefix reuse, media, external
+    drafters, sparse receipts, opaque processors, rotating caches and
+    quantized caches have different rollback/position contracts and must be
+    handled by later, separately qualified integrations.
+    """
+
+    model: nn.Module
+    rows: Tuple[NativeMTPRowSpec, ...]
+    cohort: _NativeMTPCohortCache
+
+    @classmethod
+    def create(
+        cls,
+        model: nn.Module,
+        rows: Sequence[NativeMTPRowSpec],
+        request_caches: Sequence[cache.NativeMTPRequestCache],
+        *,
+        prefix_cache=None,
+        media=None,
+        external_draft=None,
+        sparse_bootstrap=None,
+        logits_processors=None,
+        kv_bits=None,
+        max_kv_size=None,
+    ) -> "NativeMTPAdmission":
+        rows = tuple(rows)
+        request_caches = tuple(request_caches)
+        if not rows or len(rows) != len(request_caches):
+            raise ValueError("native_mtp_batch_rows_and_caches_required")
+        if any(not isinstance(row, NativeMTPRowSpec) for row in rows):
+            raise TypeError("native_mtp_batch_row_spec_required")
+        if len({row.uid for row in rows}) != len(rows):
+            raise ValueError("native_mtp_batch_uid_collision")
+        if prefix_cache is not None:
+            raise ValueError("native_mtp_batch_prefix_reuse_unsupported")
+        if media is not None:
+            raise ValueError("native_mtp_batch_media_unsupported")
+        if external_draft is not None:
+            raise ValueError("native_mtp_batch_external_draft_unsupported")
+        if sparse_bootstrap is not None:
+            raise ValueError("native_mtp_batch_sparse_bootstrap_unsupported")
+        if logits_processors:
+            raise ValueError("native_mtp_batch_logits_processors_unsupported")
+        if kv_bits is not None:
+            raise ValueError("native_mtp_batch_quantized_cache_unsupported")
+        if max_kv_size is not None:
+            raise ValueError("native_mtp_batch_rotating_cache_unsupported")
+        capability = getattr(model, "mtp_capability", None)
+        if capability is None or not capability.supported:
+            raise RuntimeError(
+                "native_mtp_model_capability_missing"
+                if capability is None
+                else capability.reason
+            )
+        return cls(
+            model,
+            rows,
+            _NativeMTPCohortCache(
+                model, request_caches, uids=tuple(row.uid for row in rows)
+            ),
+        )
+
+
+class _NativeMTPEpoch:
+    """Move-only base for public phase handles."""
+
+    def __init__(self, generator, phase, active_uids):
+        self._generator = generator
+        self._phase = phase
+        self._active_uids = tuple(active_uids)
+        self._moved = False
+
+    @property
+    def phase(self) -> str:
+        return self._phase
+
+    @property
+    def active_uids(self) -> Tuple[int, ...]:
+        return self._active_uids
+
+    def _consume(self):
+        if self._moved or self._generator._epoch is not self:
+            raise RuntimeError("native_mtp_epoch_moved")
+        self._moved = True
+
+    def cancel(self) -> None:
+        self._consume()
+        self._generator._close("cancelled")
+
+
+class NativeMTPInitialEpoch(_NativeMTPEpoch):
+    def resume(self) -> "NativeMTPReadyEpoch":
+        return self._generator._resume_initial(self)
+
+
+class NativeMTPReadyEpoch(_NativeMTPEpoch):
+    def decide(self) -> "NativeMTPDecisionEpoch":
+        return self._generator._decide(self)
+
+
+class NativeMTPDecisionEpoch(_NativeMTPEpoch):
+    def accept(self) -> "NativeMTPAcceptedEpoch":
+        return self._generator._accept(self)
+
+    def reject(self) -> "NativeMTPRejectedEpoch":
+        return self._generator._reject(self)
+
+    def resolve(self):
+        return self._generator._resolve_mixed(self)
+
+
+class NativeMTPAcceptedEpoch(_NativeMTPEpoch):
+    def bonus(self) -> "NativeMTPBonusEpoch":
+        return self._generator._bonus(self)
+
+
+class NativeMTPBonusEpoch(_NativeMTPEpoch):
+    def catch_up(self) -> "NativeMTPReadyEpoch":
+        return self._generator._catch_up(self)
+
+
+class NativeMTPRejectedEpoch(_NativeMTPEpoch):
+    def redraft(self) -> "NativeMTPReadyEpoch":
+        return self._generator._redraft(self)
+
+
+class NativeMTPMixedContinuation:
+    """Opaque branch owner after one mixed decision emission boundary."""
+
+    def __init__(self, generator, accepted_uids, rejected_uids):
+        self._generator = generator
+        self._accepted_uids = accepted_uids
+        self._rejected_uids = rejected_uids
+        self._moved = False
+
+    def resume_after_resolution(self):
+        if self._moved:
+            raise RuntimeError("native_mtp_epoch_moved")
+        self._moved = True
+        try:
+            return self._generator._mixed_after_resolution(self)
+        except BaseException:
+            self._generator._poison_all("native_mtp_batch_mixed_resolution_failed")
+            raise
+
+    def cancel(self) -> None:
+        if self._moved:
+            raise RuntimeError("native_mtp_epoch_moved")
+        self._moved = True
+        self._generator._poison_all("native_mtp_batch_cancelled")
+
+
+class NativeMTPMixedBonusContinuation:
+    """Opaque accepted-bonus owner awaiting catch-up and Ready join."""
+
+    def __init__(self, generator):
+        self._generator = generator
+        self._moved = False
+
+    def resume_after_bonus(self):
+        if self._moved:
+            raise RuntimeError("native_mtp_epoch_moved")
+        self._moved = True
+        try:
+            return self._generator._mixed_after_bonus(self)
+        except BaseException:
+            self._generator._poison_all("native_mtp_batch_mixed_bonus_failed")
+            raise
+
+    def cancel(self) -> None:
+        if self._moved:
+            raise RuntimeError("native_mtp_epoch_moved")
+        self._moved = True
+        self._generator._poison_all("native_mtp_batch_cancelled")
+
+
+class NativeMTPBatchGenerator:
+    """Typed public lifecycle for a committed native-MTP cohort cache.
+
+    The numeric model calls remain private implementation detail.  This class
+    owns the externally observable epoch ordering, one-token emission rule,
+    terminal filtering, and immutable telemetry needed to make those calls
+    safe to batch.  It deliberately does not wire into ``BatchGenerator``.
+    """
+
+    def __init__(self, admission: NativeMTPAdmission):
+        if not isinstance(admission, NativeMTPAdmission):
+            raise TypeError("native_mtp_batch_admission_required")
+        self._admission = admission
+        self._cohort = admission.cohort
+        self._rows = {row.uid: row for row in admission.rows}
+        self._generated = {row.uid: 0 for row in admission.rows}
+        self._active = tuple(row.uid for row in admission.rows)
+        self._epoch = None
+        self._closed = False
+        self._events = ()
+        self._sampling = {
+            row.uid: _NativeMTPSamplingState(
+                row.sampling_config,
+                seed=row.seed if row.seed is not None else row.sampling_config.seed,
+            )
+            for row in admission.rows
+        }
+        self._history = {
+            row.uid: mx.array(row.prompt, dtype=mx.uint32) for row in admission.rows
+        }
+        self._head = {}
+        self._hidden = {}
+        self._draft = {}
+        self._draft_logprobs = {}
+        self._rng_key = {
+            row.uid: mx.random.key(
+                row.seed if row.seed is not None else (row.sampling_config.seed or 0)
+            )
+            for row in admission.rows
+        }
+        self._last_failed_owners = ()
+
+    @property
+    def telemetry(self) -> tuple:
+        return self._events
+
+    @property
+    def closed(self) -> bool:
+        return self._closed
+
+    def _initial(self, emissions: Iterable[NativeMTPEmission]) -> NativeMTPInitialEpoch:
+        active = self._record_emissions(
+            _NativeMTPPhase.INITIAL, emissions, expected=self._active
+        )
+        return self._replace(
+            NativeMTPInitialEpoch(self, _NativeMTPPhase.INITIAL, active),
+            "initial_emission",
+        )
+
+    def prefill(self, *, prefill_step_size: int = 512):
+        """Run isolated merged, variable-length shifted prefill and emit heads.
+
+        Rows are temporarily partitioned only when their remaining prompt work
+        differs.  Every target/MTP call still receives a merged cache owner;
+        the resulting temporary owner is joined back without host row-cache
+        extraction.  This is the required safe path for unequal prompt sizes.
+        """
+
+        if self._epoch is not None or self._closed:
+            raise RuntimeError("native_mtp_batch_initial_already_started")
+        if (
+            isinstance(prefill_step_size, bool)
+            or not isinstance(prefill_step_size, int)
+            or prefill_step_size < 1
+        ):
+            raise ValueError("native_mtp_batch_prefill_step_size_invalid")
+        positions = {uid: 0 for uid in self._active}
+        while True:
+            pending = tuple(
+                uid
+                for uid in self._active
+                if positions[uid] < len(self._rows[uid].prompt) - 1
+            )
+            if not pending:
+                break
+            # A chunk cohort contains only equal remaining work.  Unequal rows
+            # are partitioned on-device, processed as a real B×N call, then
+            # rejoined before the next size class.
+            by_count = {}
+            for uid in pending:
+                count = min(
+                    prefill_step_size, len(self._rows[uid].prompt) - 1 - positions[uid]
+                )
+                by_count.setdefault(count, []).append(uid)
+            for count, uids in by_count.items():
+                uids = tuple(uids)
+                remaining = self._move_to_front(uids)
+                selected = self._cohort
+                try:
+                    tokens = tuple(
+                        self._rows[uid].prompt[positions[uid] : positions[uid] + count]
+                        for uid in uids
+                    )
+                    successors = tuple(
+                        self._rows[uid].prompt[
+                            positions[uid] + 1 : positions[uid] + count + 1
+                        ]
+                        for uid in uids
+                    )
+                    _, hidden = self._target_forward(
+                        tokens, phase=GenerationForwardPhase.PREFILL
+                    )
+                    self._mtp_forward(hidden, successors)
+                    for uid in uids:
+                        positions[uid] += count
+                except BaseException:
+                    self._poison_all(
+                        "native_mtp_batch_prefill_failed", selected, remaining
+                    )
+                    raise
+                else:
+                    try:
+                        self._cohort = selected
+                        self._restore_from_front(remaining)
+                    except BaseException:
+                        self._poison_all(
+                            "native_mtp_batch_prefill_join_failed", selected, remaining
+                        )
+                        raise
+        final_uids = tuple(self._active)
+        remaining = self._move_to_front(final_uids)
+        selected = self._cohort
+        try:
+            tokens = tuple(self._rows[uid].prompt[-1] for uid in final_uids)
+            logits, hidden = self._target_forward(
+                tokens, phase=GenerationForwardPhase.PREFILL
+            )
+            emissions = []
+            for index, uid in enumerate(final_uids):
+                state = self._sampling[uid]
+                reported = state.reported_logprobs(
+                    logits[index, -1, :], self._history[uid]
+                )
+                sampled = state.sample(
+                    state.sampling_distribution(reported),
+                    rng_key=(
+                        self._next_rng_key(uid) if state.config.stochastic else None
+                    ),
+                ).reshape(-1)
+                mx.eval(sampled, reported)
+                token = sampled.item()
+                self._head[uid] = sampled
+                self._hidden[uid] = hidden[index : index + 1, -1:, :]
+                emissions.append(self._make_emission(uid, token, reported, False))
+        except BaseException:
+            self._poison_all("native_mtp_batch_prefill_failed", selected, remaining)
+            raise
+        else:
+            try:
+                self._cohort = selected
+                self._restore_from_front(remaining)
+            except BaseException:
+                self._poison_all(
+                    "native_mtp_batch_prefill_join_failed", selected, remaining
+                )
+                raise
+        return tuple(emissions), self._initial(emissions)
+
+    def _move_to_front(self, uids):
+        """Return a selected move-only owner while keeping the selected UIDs first."""
+
+        uids = tuple(uids)
+        if not uids:
+            return None
+        indices = tuple(self._cohort.uids.index(uid) for uid in uids)
+        remaining = self._cohort
+        self._cohort = remaining.split(indices)
+        return remaining
+
+    def _restore_from_front(self, remaining):
+        if remaining is None:
+            return
+        self._cohort.join(remaining)
+
+    def _poison_all(self, reason, *extra_owners):
+        """Close every owned cohort after an irreversible lifecycle failure."""
+
+        owners = {id(self._cohort): self._cohort}
+        for name in ("_mixed_accepted_owner", "_mixed_rejected_owner"):
+            owner = getattr(self, name, None)
+            if owner is not None:
+                owners[id(owner)] = owner
+        for owner in extra_owners:
+            if owner is not None:
+                owners[id(owner)] = owner
+        for owner in owners.values():
+            owner.poison(reason)
+        self._last_failed_owners = tuple(owners.values())
+        self._closed = True
+        self._active = ()
+        self._epoch = None
+
+    @staticmethod
+    def _delta(entries, advance):
+        return tuple(
+            (
+                (advance,) * entry.batch_size
+                if isinstance(entry, ArraysCache)
+                else (advance,) * entry.offset.size
+            )
+            for entry in entries
+        )
+
+    def _seal_delta(self, *, backbone, mtp):
+        self._cohort.seal_after_mutation(
+            _NativeMTPCohortMutationDelta(
+                backbone=self._delta(self._cohort.backbone, backbone),
+                mtp=self._delta(self._cohort.mtp, mtp),
+            )
+        )
+
+    def _target_forward(self, tokens, *, phase):
+        try:
+            self._cohort.bind_before_mutation()
+            inputs = mx.array(tokens, dtype=mx.uint32)
+            if inputs.ndim == 1:
+                inputs = inputs[:, None]
+            result = self._admission.model(
+                inputs, cache=self._cohort.backbone, return_hidden=True
+            )
+            if not isinstance(result, tuple) or len(result) != 2:
+                raise RuntimeError("native_mtp_batch_target_hidden_missing")
+            self._seal_delta(backbone=inputs.shape[1], mtp=0)
+            return result
+        except BaseException:
+            self._poison_all("native_mtp_batch_target_failed")
+            raise
+
+    def _mtp_forward(self, hidden, tokens):
+        try:
+            self._cohort.bind_before_mutation()
+            inputs = mx.array(tokens, dtype=mx.uint32)
+            if inputs.ndim == 1:
+                inputs = inputs[:, None]
+            result = self._admission.model.mtp_forward(hidden, inputs, self._cohort.mtp)
+            self._seal_delta(backbone=0, mtp=inputs.shape[1])
+            return result
+        except BaseException:
+            self._poison_all("native_mtp_batch_mtp_failed")
+            raise
+
+    def _make_emission(self, uid, token, logprobs, from_draft):
+        row = self._rows[uid]
+        total = self._generated[uid] + 1
+        reason = (
+            "eos"
+            if token in row.eos_token_ids
+            else ("length" if total >= row.max_tokens else None)
+        )
+        return NativeMTPEmission(uid, token, logprobs, from_draft, reason)
+
+    def _next_rng_key(self, uid):
+        """Consume one B=1-compatible stochastic draw for one stable UID."""
+
+        retained, draw = mx.random.split(self._rng_key[uid])
+        self._rng_key[uid] = retained
+        return draw
+
+    def _replace(self, epoch, event):
+        self._epoch = epoch
+        self._events = self._events + (
+            _NativeMTPTelemetryEvent(epoch.phase, epoch.active_uids, event),
+        )
+        return epoch
+
+    def _record_emissions(self, phase, emissions, *, expected):
+        emissions = tuple(emissions)
+        if len(emissions) != len(expected):
+            raise ValueError("native_mtp_batch_emission_boundary_incomplete")
+        if any(not isinstance(item, NativeMTPEmission) for item in emissions):
+            raise TypeError("native_mtp_batch_emission_required")
+        if {item.uid for item in emissions} != set(expected):
+            raise ValueError("native_mtp_batch_emission_uid_mismatch")
+        next_active = []
+        for emission in emissions:
+            row = self._rows[emission.uid]
+            self._generated[emission.uid] += 1
+            terminal = (
+                emission.finish_reason is not None
+                or self._generated[emission.uid] >= row.max_tokens
+            )
+            if not terminal:
+                next_active.append(emission.uid)
+        self._events = self._events + (
+            _NativeMTPTelemetryEvent(phase, tuple(expected), "emission"),
+        )
+        self._active = tuple(next_active)
+        return self._active
+
+    @staticmethod
+    def _filter_owner_uids(owner, uids):
+        if owner is None:
+            return None
+        if not uids:
+            owner.poison("native_mtp_batch_terminal_rows_removed")
+            return None
+        indices = tuple(owner.uids.index(uid) for uid in uids)
+        owner.filter(indices)
+        return owner
+
+    def _prune_mixed_terminal_owners(self, emissions, accepted_uids, rejected_uids):
+        """Drop terminal branch rows before a later branch forward or join."""
+
+        emission_by_uid = {emission.uid: emission for emission in emissions}
+        self._mixed_accepted_uids = tuple(
+            uid for uid in accepted_uids if emission_by_uid[uid].finish_reason is None
+        )
+        self._mixed_rejected_uids = tuple(
+            uid for uid in rejected_uids if emission_by_uid[uid].finish_reason is None
+        )
+        self._mixed_accepted_owner = self._filter_owner_uids(
+            self._mixed_accepted_owner, self._mixed_accepted_uids
+        )
+        self._mixed_rejected_owner = self._filter_owner_uids(
+            self._mixed_rejected_owner, self._mixed_rejected_uids
+        )
+
+    def _resume_initial(self, epoch):
+        epoch._consume()
+        drafts = tuple(epoch.active_uids)
+        if drafts:
+            logits = self._mtp_forward(
+                mx.concatenate([self._hidden[uid] for uid in drafts], axis=0),
+                tuple(self._head[uid].item() for uid in drafts),
+            )[:, -1, :]
+            for index, uid in enumerate(drafts):
+                state = self._sampling[uid]
+                self._history[uid] = mx.concatenate(
+                    [self._history[uid], self._head[uid]]
+                )
+                reported = state.reported_logprobs(logits[index], self._history[uid])
+                draft_logprobs = state.sampling_distribution(reported)
+                draft = state.sample(
+                    draft_logprobs,
+                    rng_key=(
+                        self._next_rng_key(uid) if state.config.stochastic else None
+                    ),
+                ).reshape(-1)
+                mx.eval(draft, reported)
+                self._draft[uid] = draft
+                self._draft_logprobs[uid] = draft_logprobs
+        return self._replace(
+            NativeMTPReadyEpoch(self, _NativeMTPPhase.READY, drafts),
+            "initial_head_plus_one_draft",
+        )
+
+    def _decide(self, epoch):
+        epoch._consume()
+        try:
+            self._cohort.checkpoint()
+            inputs = mx.stack(
+                [
+                    mx.concatenate([self._head[uid], self._draft[uid]])
+                    for uid in epoch.active_uids
+                ],
+                axis=0,
+            )
+            self._cohort.bind_before_mutation()
+            verify_logits, verify_hidden = self._admission.model(
+                inputs, cache=self._cohort.backbone, return_hidden=True
+            )
+            self._seal_delta(backbone=2, mtp=0)
+            (
+                self._verify_hidden,
+                self._verify_logits,
+                self._verify_logprobs,
+                self._replacement,
+            ) = ({}, {}, {}, {})
+            accepted_values = []
+            for index, uid in enumerate(epoch.active_uids):
+                state = self._sampling[uid]
+                reported = state.reported_logprobs(
+                    verify_logits[index, 0, :], self._history[uid]
+                )
+                sampled = state.sampling_distribution(reported)
+                if state.config.stochastic:
+                    draft_id = self._draft[uid].item()
+                    probability = mx.minimum(
+                        mx.exp(sampled[draft_id] - self._draft_logprobs[uid][draft_id]),
+                        1.0,
+                    )
+                    accepted_value = (
+                        mx.random.uniform(key=self._next_rng_key(uid)) < probability
+                    )
+                    mx.eval(accepted_value)
+                    is_accepted = bool(accepted_value.item())
+                    replacement = self._draft[uid]
+                    if not is_accepted:
+                        replacement, _ = state.residual_sample(
+                            sampled,
+                            self._draft_logprobs[uid],
+                            rng_key=self._next_rng_key(uid),
+                        )
+                        replacement = replacement.reshape(-1)
+                else:
+                    replacement = state.sample(sampled).reshape(-1)
+                    is_accepted = replacement.item() == self._draft[uid].item()
+                mx.eval(replacement, reported)
+                self._verify_hidden[uid] = verify_hidden[index : index + 1]
+                self._verify_logits[uid] = verify_logits[index : index + 1, 1:2, :]
+                self._verify_logprobs[uid] = reported
+                self._replacement[uid] = replacement
+                if is_accepted:
+                    accepted_values.append(uid)
+            accepted = tuple(accepted_values)
+        except BaseException:
+            self._poison_all("native_mtp_batch_decision_failed")
+            raise
+        rejected = tuple(uid for uid in epoch.active_uids if uid not in set(accepted))
+        result = NativeMTPDecisionEpoch(
+            self, _NativeMTPPhase.DECISION, epoch.active_uids
+        )
+        result.accepted_uids = accepted
+        result.rejected_uids = rejected
+        return self._replace(result, "target_plus_two_checkpoint_decision")
+
+    def _accept(self, epoch):
+        epoch._consume()
+        try:
+            if epoch.rejected_uids:
+                raise RuntimeError(
+                    "native_mtp_batch_mixed_decision_requires_branch_resolution"
+                )
+            self._cohort.commit()
+            emissions = tuple(
+                self._make_emission(
+                    uid, self._draft[uid].item(), self._verify_logprobs[uid], True
+                )
+                for uid in epoch.accepted_uids
+            )
+        except BaseException:
+            self._poison_all("native_mtp_batch_accept_failed")
+            raise
+        active = self._record_emissions(
+            _NativeMTPPhase.ACCEPTED, emissions, expected=epoch.accepted_uids
+        )
+        result = NativeMTPAcceptedEpoch(self, _NativeMTPPhase.ACCEPTED, active)
+        result._deferred_rejected = epoch.rejected_uids
+        return self._replace(result, "accepted_draft_emission")
+
+    def _resolve_mixed(self, epoch):
+        """Split only after rollback; branch owners never share recurrent state."""
+
+        epoch._consume()
+        accepted_owner = rejected_owner = None
+        original_owner = self._cohort
+        try:
+            self._cohort.rollback()
+            accepted_indices = tuple(
+                self._cohort.uids.index(uid) for uid in epoch.accepted_uids
+            )
+            if accepted_indices:
+                accepted_owner = self._cohort.split(accepted_indices)
+                rejected_owner = self._cohort
+            else:
+                accepted_owner, rejected_owner = None, self._cohort
+            self._mixed_accepted_owner = accepted_owner
+            self._mixed_rejected_owner = rejected_owner
+            self._mixed_accepted_uids = epoch.accepted_uids
+            self._mixed_rejected_uids = epoch.rejected_uids
+            emissions = []
+            # Rerun the verified target call on the accepted owner, then commit its
+            # all-or-nothing recurrent state before its draft token is observable.
+            if accepted_owner is not None:
+                self._cohort = accepted_owner
+                self._cohort.checkpoint()
+                inputs = mx.stack(
+                    [
+                        mx.concatenate([self._head[uid], self._draft[uid]])
+                        for uid in epoch.accepted_uids
+                    ],
+                    axis=0,
+                )
+                verify_logits, verify_hidden = self._admission.model(
+                    inputs, cache=self._cohort.backbone, return_hidden=True
+                )
+                self._seal_delta(backbone=2, mtp=0)
+                self._cohort.commit()
+                for index, uid in enumerate(epoch.accepted_uids):
+                    self._verify_hidden[uid] = verify_hidden[index : index + 1]
+                    self._verify_logits[uid] = verify_logits[index : index + 1, 1:2, :]
+                    emissions.append(
+                        self._make_emission(
+                            uid,
+                            self._draft[uid].item(),
+                            self._verify_logprobs[uid],
+                            True,
+                        )
+                    )
+            for uid in epoch.rejected_uids:
+                emissions.append(
+                    self._make_emission(
+                        uid,
+                        self._replacement[uid].item(),
+                        self._verify_logprobs[uid],
+                        False,
+                    )
+                )
+            # This is the required exactly-one-token/UID resolution boundary.
+            self._record_emissions(
+                _NativeMTPPhase.DECISION, emissions, expected=epoch.active_uids
+            )
+            self._prune_mixed_terminal_owners(
+                emissions, epoch.accepted_uids, epoch.rejected_uids
+            )
+            self._events = self._events + (
+                _NativeMTPTelemetryEvent(
+                    _NativeMTPPhase.DECISION,
+                    epoch.active_uids,
+                    "mixed_resolution_emission",
+                ),
+            )
+            return tuple(emissions), NativeMTPMixedContinuation(
+                self, self._mixed_accepted_uids, self._mixed_rejected_uids
+            )
+        except BaseException:
+            self._poison_all(
+                "native_mtp_batch_mixed_resolve_failed",
+                original_owner,
+                accepted_owner,
+                rejected_owner,
+            )
+            raise
+
+    def _mixed_after_resolution(self, continuation):
+        """Replay rejected head, redraft it, and emit accepted bonus only."""
+
+        rejected_ready = ()
+        if self._mixed_rejected_uids:
+            self._cohort = self._mixed_rejected_owner
+            _, replay_hidden = self._target_forward(
+                tuple(self._head[uid].item() for uid in self._mixed_rejected_uids),
+                phase=GenerationForwardPhase.DECODE,
+            )
+            self._replay_hidden = {}
+            for index, uid in enumerate(self._mixed_rejected_uids):
+                self._replay_hidden[uid] = replay_hidden[index : index + 1, -1:, :]
+            logits = self._mtp_forward(
+                mx.concatenate(
+                    [self._replay_hidden[uid] for uid in self._mixed_rejected_uids],
+                    axis=0,
+                ),
+                tuple(
+                    self._replacement[uid].item() for uid in self._mixed_rejected_uids
+                ),
+            )[:, -1, :]
+            rejected_ready = self._mixed_rejected_uids
+            for index, uid in enumerate(rejected_ready):
+                state = self._sampling[uid]
+                self._head[uid] = self._replacement[uid]
+                self._history[uid] = mx.concatenate(
+                    [self._history[uid], self._head[uid]]
+                )
+                reported = state.reported_logprobs(logits[index], self._history[uid])
+                draft_logprobs = state.sampling_distribution(reported)
+                self._draft[uid] = state.sample(
+                    draft_logprobs,
+                    rng_key=(
+                        self._next_rng_key(uid) if state.config.stochastic else None
+                    ),
+                ).reshape(-1)
+                self._draft_logprobs[uid] = draft_logprobs
+        emissions = []
+        accepted_bonus = ()
+        if self._mixed_accepted_owner is not None:
+            self._cohort = self._mixed_accepted_owner
+            for uid in self._mixed_accepted_uids:
+                state = self._sampling[uid]
+                history = mx.concatenate([self._history[uid], self._draft[uid]])
+                reported = state.reported_logprobs(
+                    self._verify_logits[uid].squeeze((0, 1)), history
+                )
+                token = state.sample(
+                    state.sampling_distribution(reported),
+                    rng_key=(
+                        self._next_rng_key(uid) if state.config.stochastic else None
+                    ),
+                ).reshape(-1)
+                mx.eval(token, reported)
+                self._history[uid] = mx.concatenate([history, token])
+                self._head[uid] = token
+                emission = self._make_emission(uid, token.item(), reported, False)
+                emissions.append(emission)
+                if emission.finish_reason is None:
+                    accepted_bonus += (uid,)
+        # Bonus is an emission boundary: terminal accepted rows must not be
+        # caught up or rejoined with the rejected Ready owner.
+        self._mixed_accepted_uids = accepted_bonus
+        self._mixed_accepted_owner = self._filter_owner_uids(
+            self._mixed_accepted_owner, accepted_bonus
+        )
+        self._events = self._events + (
+            _NativeMTPTelemetryEvent(
+                _NativeMTPPhase.BONUS, accepted_bonus, "mixed_accepted_bonus_emission"
+            ),
+        )
+        self._mixed_rejected_ready = rejected_ready
+        self._mixed_accepted_ready = accepted_bonus
+        return tuple(emissions), NativeMTPMixedBonusContinuation(self)
+
+    def _mixed_after_bonus(self, continuation):
+        """Catch up accepted MTP state, then join compatible Ready owners."""
+
+        if self._mixed_accepted_owner is not None and self._mixed_accepted_ready:
+            self._cohort = self._mixed_accepted_owner
+            uids = self._mixed_accepted_ready
+            hidden = mx.concatenate([self._verify_hidden[uid] for uid in uids], axis=0)
+            tokens = mx.array(
+                [(self._draft[uid].item(), self._head[uid].item()) for uid in uids],
+                dtype=mx.uint32,
+            )
+            self._cohort.bind_before_mutation()
+            logits = self._admission.model.mtp_forward(
+                hidden, tokens, self._cohort.mtp
+            )[:, -1, :]
+            self._seal_delta(backbone=0, mtp=2)
+            for index, uid in enumerate(uids):
+                state = self._sampling[uid]
+                reported = state.reported_logprobs(logits[index], self._history[uid])
+                draft_logprobs = state.sampling_distribution(reported)
+                self._draft[uid] = state.sample(
+                    draft_logprobs,
+                    rng_key=(
+                        self._next_rng_key(uid) if state.config.stochastic else None
+                    ),
+                ).reshape(-1)
+                self._draft_logprobs[uid] = draft_logprobs
+        owners = [
+            owner
+            for owner in (self._mixed_accepted_owner, self._mixed_rejected_owner)
+            if owner is not None
+        ]
+        if not owners:
+            self._close("cancelled")
+            raise RuntimeError("native_mtp_batch_mixed_owner_missing")
+        ready_owner = owners[0]
+        for owner in owners[1:]:
+            ready_owner.join(owner)
+        self._cohort = ready_owner
+        ready_uids = tuple(self._mixed_accepted_ready + self._mixed_rejected_ready)
+        if tuple(ready_owner.uids) != ready_uids:
+            self._poison_all("native_mtp_batch_mixed_ready_uid_mismatch", *owners)
+            raise RuntimeError("native_mtp_batch_mixed_ready_uid_mismatch")
+        self._active = ready_uids
+        return self._replace(
+            NativeMTPReadyEpoch(self, _NativeMTPPhase.READY, ready_uids),
+            "mixed_ready_join",
+        )
+
+    def _bonus(self, epoch):
+        epoch._consume()
+        emissions = []
+        for uid in epoch.active_uids:
+            state = self._sampling[uid]
+            history = mx.concatenate([self._history[uid], self._draft[uid]])
+            reported = state.reported_logprobs(
+                self._verify_logits[uid].squeeze((0, 1)), history
+            )
+            token = state.sample(
+                state.sampling_distribution(reported),
+                rng_key=self._next_rng_key(uid) if state.config.stochastic else None,
+            ).reshape(-1)
+            mx.eval(token, reported)
+            self._history[uid] = mx.concatenate([history, token])
+            self._head[uid] = token
+            emissions.append(self._make_emission(uid, token.item(), reported, False))
+        active = self._record_emissions(
+            _NativeMTPPhase.BONUS, emissions, expected=epoch.active_uids
+        )
+        result = NativeMTPBonusEpoch(self, _NativeMTPPhase.BONUS, active)
+        result._deferred_rejected = epoch._deferred_rejected
+        return self._replace(result, "bonus_emission")
+
+    def _catch_up(self, epoch):
+        epoch._consume()
+        drafts = tuple(epoch.active_uids)
+        if drafts:
+            hidden = mx.concatenate(
+                [self._verify_hidden[uid] for uid in drafts], axis=0
+            )
+            tokens = mx.array(
+                [(self._draft[uid].item(), self._head[uid].item()) for uid in drafts],
+                dtype=mx.uint32,
+            )
+            self._cohort.bind_before_mutation()
+            logits = self._admission.model.mtp_forward(
+                hidden, tokens, self._cohort.mtp
+            )[:, -1, :]
+            self._seal_delta(backbone=0, mtp=2)
+            for index, uid in enumerate(drafts):
+                state = self._sampling[uid]
+                reported = state.reported_logprobs(logits[index], self._history[uid])
+                draft_logprobs = state.sampling_distribution(reported)
+                draft = state.sample(
+                    draft_logprobs,
+                    rng_key=(
+                        self._next_rng_key(uid) if state.config.stochastic else None
+                    ),
+                ).reshape(-1)
+                mx.eval(draft, reported)
+                self._draft[uid] = draft
+                self._draft_logprobs[uid] = draft_logprobs
+        return self._replace(
+            NativeMTPReadyEpoch(self, _NativeMTPPhase.READY, drafts),
+            "head_catch_up_plus_two",
+        )
+
+    def _reject(self, epoch):
+        epoch._consume()
+        try:
+            if epoch.accepted_uids:
+                raise RuntimeError(
+                    "native_mtp_batch_mixed_decision_requires_branch_resolution"
+                )
+            self._cohort.rollback()
+            _, replay_hidden = self._target_forward(
+                tuple(self._head[uid].item() for uid in epoch.rejected_uids),
+                phase=GenerationForwardPhase.DECODE,
+            )
+            self._replay_hidden = {}
+            emissions = []
+            for index, uid in enumerate(epoch.rejected_uids):
+                self._replay_hidden[uid] = replay_hidden[index : index + 1, -1:, :]
+                emissions.append(
+                    self._make_emission(
+                        uid,
+                        self._replacement[uid].item(),
+                        self._verify_logprobs[uid],
+                        False,
+                    )
+                )
+        except BaseException:
+            self._poison_all("native_mtp_batch_reject_failed")
+            raise
+        active = self._record_emissions(
+            _NativeMTPPhase.REJECTED, emissions, expected=epoch.rejected_uids
+        )
+        return self._replace(
+            NativeMTPRejectedEpoch(self, _NativeMTPPhase.REJECTED, active),
+            "rollback_replay_replacement_emission",
+        )
+
+    def _redraft(self, epoch):
+        epoch._consume()
+        drafts = tuple(epoch.active_uids)
+        if drafts:
+            logits = self._mtp_forward(
+                mx.concatenate([self._replay_hidden[uid] for uid in drafts], axis=0),
+                tuple(self._replacement[uid].item() for uid in drafts),
+            )[:, -1, :]
+            for index, uid in enumerate(drafts):
+                state = self._sampling[uid]
+                self._head[uid] = self._replacement[uid]
+                self._history[uid] = mx.concatenate(
+                    [self._history[uid], self._head[uid]]
+                )
+                reported = state.reported_logprobs(logits[index], self._history[uid])
+                draft_logprobs = state.sampling_distribution(reported)
+                draft = state.sample(
+                    draft_logprobs,
+                    rng_key=(
+                        self._next_rng_key(uid) if state.config.stochastic else None
+                    ),
+                ).reshape(-1)
+                mx.eval(draft, reported)
+                self._draft[uid] = draft
+                self._draft_logprobs[uid] = draft_logprobs
+        return self._replace(
+            NativeMTPReadyEpoch(self, _NativeMTPPhase.READY, drafts),
+            "head_redraft_plus_one",
+        )
+
+    def _close(self, reason):
+        if self._closed:
+            return
+        self._cohort.poison("native_mtp_batch_" + reason)
+        self._closed = True
+        self._epoch = None
+        self._active = ()
+        self._events = self._events + (
+            _NativeMTPTelemetryEvent(_NativeMTPPhase.CLOSED, (), reason),
+        )
 
 
 def _validate_receipt_against_record(receipt, record):

--- a/mlx_lm/generate.py
+++ b/mlx_lm/generate.py
@@ -9,8 +9,19 @@ import sys
 import time
 from collections import deque
 from dataclasses import dataclass
+from enum import Enum
 from functools import partial
-from typing import Any, Callable, Generator, List, Optional, Sequence, Tuple, Union
+from typing import (
+    Any,
+    Callable,
+    ContextManager,
+    Generator,
+    List,
+    Optional,
+    Sequence,
+    Tuple,
+    Union,
+)
 
 import mlx.core as mx
 import mlx.nn as nn
@@ -45,6 +56,40 @@ DEFAULT_MIN_TOKENS_TO_KEEP = 1
 DEFAULT_SEED = None
 DEFAULT_MODEL = "mlx-community/Llama-3.2-3B-Instruct-4bit"
 DEFAULT_QUANTIZED_KV_START = 5000
+
+
+class GenerationForwardPhase(str, Enum):
+    """A stable description of a model forward within generation.
+
+    ``DRAFT`` and ``VERIFY`` are used by external speculative decoding.  The
+    enum deliberately describes generation mechanics rather than a particular
+    model architecture so callers can use the same callback with ordinary and
+    speculative generation.
+    """
+
+    PREFILL = "prefill"
+    DECODE = "decode"
+    DRAFT = "draft"
+    VERIFY = "verify"
+
+
+@dataclass(frozen=True)
+class GenerationForward:
+    """Immutable metadata for one Python model-call graph construction.
+
+    The callback scope deliberately covers graph construction only.  MLX
+    realization may remain asynchronously pipelined after the scope exits.
+    ``input_tokens`` has the exact batched shape passed to the model.
+    """
+
+    model: nn.Module
+    input_tokens: mx.array
+    cache: Any
+    phase: GenerationForwardPhase
+    input_embeddings: Optional[mx.array] = None
+
+
+GenerationForwardContext = Callable[[GenerationForward], ContextManager[None]]
 
 
 def str2bool(string):
@@ -295,6 +340,23 @@ def maybe_quantize_kv_cache(prompt_cache, quantized_kv_start, kv_group_size, kv_
             prompt_cache[e] = c.to_quantized(group_size=kv_group_size, bits=kv_bits)
 
 
+def _prompt_cache_has_tokens(prompt_cache: Any) -> bool:
+    """Return whether a supplied prompt cache already represents a prefix.
+
+    ``offset`` is the public occupancy contract of the standard KV cache
+    families.  A few cache implementations expose only ``empty()``; use that
+    as a conservative fallback without asking callers to identify cache types.
+    """
+    for entry in prompt_cache:
+        offset = getattr(entry, "offset", None)
+        if isinstance(offset, int) and offset > 0:
+            return True
+        is_empty = getattr(entry, "empty", None)
+        if callable(is_empty) and not is_empty():
+            return True
+    return False
+
+
 def generate_step(
     prompt: mx.array,
     model: nn.Module,
@@ -310,6 +372,7 @@ def generate_step(
     quantized_kv_start: int = 0,
     prompt_progress_callback: Optional[Callable[[int, int], None]] = None,
     input_embeddings: Optional[mx.array] = None,
+    model_forward_context: Optional[GenerationForwardContext] = None,
 ) -> Generator[Tuple[mx.array, mx.array], None, None]:
     """
     A generator producing token ids based on the given prompt from the model.
@@ -338,6 +401,9 @@ def generate_step(
            prompt tokens processed so far and the total number of prompt tokens.
         input_embeddings (mx.array, optional): Input embeddings to use instead of or in
           conjunction with prompt tokens. Default: ``None``.
+        model_forward_context (Callable[[GenerationForward], ContextManager], optional):
+          A request-local context factory invoked around each Python model call.
+          The scope covers MLX graph construction, not deferred realization.
 
     Yields:
         Tuple[mx.array, mx.array]: One token and a vector of log probabilities.
@@ -358,6 +424,14 @@ def generate_step(
 
     tokens = None
 
+    # The final prompt token is a semantic prefill for a fresh cache, but a
+    # decode when the caller supplies an already-populated continuation cache.
+    has_cached_prefix = (
+        model_forward_context is not None
+        and prompt_cache is not None
+        and _prompt_cache_has_tokens(prompt_cache)
+    )
+
     # Create the KV cache for generation
     if prompt_cache is None:
         prompt_cache = cache.make_prompt_cache(
@@ -376,15 +450,39 @@ def generate_step(
 
     sampler = sampler or (lambda x: mx.argmax(x, axis=-1))
 
-    def _model_call(input_tokens: mx.array, input_embeddings: Optional[mx.array]):
-        if input_embeddings is not None:
-            return model(
-                input_tokens, cache=prompt_cache, input_embeddings=input_embeddings
-            )
-        else:
+    def _model_call(
+        input_tokens: mx.array,
+        input_embeddings: Optional[mx.array],
+        phase: GenerationForwardPhase,
+    ):
+        # Preserve the ordinary generation path when no caller needs forward
+        # metadata: no context-manager or metadata allocation occurs here.
+        if model_forward_context is None:
+            if input_embeddings is not None:
+                return model(
+                    input_tokens, cache=prompt_cache, input_embeddings=input_embeddings
+                )
             return model(input_tokens, cache=prompt_cache)
 
-    def _step(input_tokens: mx.array, input_embeddings: Optional[mx.array] = None):
+        forward = GenerationForward(
+            model=model,
+            input_tokens=input_tokens,
+            cache=prompt_cache,
+            phase=phase,
+            input_embeddings=input_embeddings,
+        )
+        with model_forward_context(forward):
+            if input_embeddings is not None:
+                return model(
+                    input_tokens, cache=prompt_cache, input_embeddings=input_embeddings
+                )
+            return model(input_tokens, cache=prompt_cache)
+
+    def _step(
+        input_tokens: mx.array,
+        input_embeddings: Optional[mx.array] = None,
+        phase: GenerationForwardPhase = GenerationForwardPhase.DECODE,
+    ):
         nonlocal tokens
 
         with mx.stream(generation_stream):
@@ -393,6 +491,7 @@ def generate_step(
                 input_embeddings=(
                     input_embeddings[None] if input_embeddings is not None else None
                 ),
+                phase=phase,
             )
 
             logits = logits[:, -1, :]
@@ -428,6 +527,7 @@ def generate_step(
                     if input_embeddings is not None
                     else None
                 ),
+                phase=GenerationForwardPhase.PREFILL,
             )
             quantize_cache_fn(prompt_cache)
             mx.eval([c.state for c in prompt_cache])
@@ -441,7 +541,15 @@ def generate_step(
             )
             mx.clear_cache()
 
-        y, logprobs = _step(input_tokens=prompt, input_embeddings=input_embeddings)
+        y, logprobs = _step(
+            input_tokens=prompt,
+            input_embeddings=input_embeddings,
+            phase=(
+                GenerationForwardPhase.DECODE
+                if has_cached_prefix
+                else GenerationForwardPhase.PREFILL
+            ),
+        )
 
     mx.async_eval(y, logprobs)
     n = 0
@@ -475,6 +583,7 @@ def speculative_generate_step(
     kv_bits: Optional[int] = None,
     kv_group_size: int = 64,
     quantized_kv_start: int = 0,
+    model_forward_context: Optional[GenerationForwardContext] = None,
 ) -> Generator[Tuple[mx.array, mx.array, bool], None, None]:
     """
     A generator producing token ids based on the given prompt from the model.
@@ -500,6 +609,9 @@ def speculative_generate_step(
         kv_group_size (int): Group size for KV cache quantization. Default: ``64``.
         quantized_kv_start (int): Step to begin using a quantized KV cache.
            when ``kv_bits`` is non-None. Default: ``0``.
+        model_forward_context (Callable[[GenerationForward], ContextManager], optional):
+          A request-local context factory invoked around each Python model call.
+          The scope covers MLX graph construction, not deferred realization.
 
     Yields:
         Tuple[mx.array, mx.array, bool]: One token, a vector of log probabilities,
@@ -541,9 +653,23 @@ def speculative_generate_step(
         y = sampler(logprobs)
         return y, logprobs
 
-    def _step(model, cache, y, n_predict=1):
+    def _model_call(model, cache, input_tokens, phase):
+        # Keep the no-callback path direct: this is the hot path for ordinary
+        # speculative decoding and does not allocate a context or metadata.
+        if model_forward_context is None:
+            return model(input_tokens, cache=cache)
+        forward = GenerationForward(
+            model=model,
+            input_tokens=input_tokens,
+            cache=cache,
+            phase=phase,
+        )
+        with model_forward_context(forward):
+            return model(input_tokens, cache=cache)
+
+    def _step(model, cache, y, n_predict=1, phase=GenerationForwardPhase.VERIFY):
         with mx.stream(generation_stream):
-            logits = model(y[None], cache=cache)
+            logits = _model_call(model, cache, y[None], phase)
             logits = logits[:, -n_predict:, :]
 
             quantize_cache_fn(cache)
@@ -570,7 +696,12 @@ def speculative_generate_step(
     def _prefill(model, cache, y):
         while y.size > 1:
             n_to_process = min(prefill_step_size, y.size - 1)
-            model(y[:n_to_process][None], cache=cache)
+            _model_call(
+                model,
+                cache,
+                y[:n_to_process][None],
+                GenerationForwardPhase.PREFILL,
+            )
             quantize_cache_fn(cache)
             mx.eval([c.state for c in cache])
             y = y[n_to_process:]
@@ -586,7 +717,12 @@ def speculative_generate_step(
             return mx.array([], mx.uint32)
         ys = []
         for _ in range(num_draft):
-            y, _ = _step(draft_model, draft_cache, y)
+            y, _ = _step(
+                draft_model,
+                draft_cache,
+                y,
+                phase=GenerationForwardPhase.DRAFT,
+            )
             mx.async_eval(y)
             ys.append(y)
         return mx.concatenate(ys)
@@ -599,6 +735,7 @@ def speculative_generate_step(
     # Set these so the finally block doesn't raise
     num_draft = 0
     n = 0
+    first_target_round = True
     try:
         while True:
             num_draft = min(max_tokens - ntoks, num_draft_tokens)
@@ -606,7 +743,22 @@ def speculative_generate_step(
             if prev_tokens is not None:
                 prev_tokens = prev_tokens[: prev_tokens.size - y.size - num_draft + 1]
             y = mx.concatenate([y, draft_tokens])
-            tokens, logprobs = _step(model, model_cache, y, num_draft + 1)
+            tokens, logprobs = _step(
+                model,
+                model_cache,
+                y,
+                num_draft + 1,
+                phase=(
+                    GenerationForwardPhase.VERIFY
+                    if num_draft
+                    else (
+                        GenerationForwardPhase.PREFILL
+                        if first_target_round
+                        else GenerationForwardPhase.DECODE
+                    )
+                ),
+            )
+            first_target_round = False
             mx.eval(tokens, draft_tokens)
             draft_tokens = draft_tokens.tolist()
             tokens = tokens.tolist()
@@ -651,6 +803,7 @@ def stream_generate(
     prompt: Union[str, mx.array, List[int]],
     max_tokens: int = 256,
     draft_model: Optional[nn.Module] = None,
+    model_forward_context: Optional[GenerationForwardContext] = None,
     **kwargs,
 ) -> Generator[GenerationResponse, None, None]:
     """
@@ -666,6 +819,9 @@ def stream_generate(
         draft_model (Optional[nn.Module]): An optional draft model. If provided
           then speculative decoding is used. The draft model must use the same
           tokenizer as the main model. Default: ``None``.
+        model_forward_context (Callable[[GenerationForward], ContextManager], optional):
+          A request-local context factory forwarded to the selected generation
+          implementation. The scope covers Python model-call graph construction.
         kwargs: The remaining options get passed to :func:`generate_step`.
           See :func:`generate_step` for more details.
 
@@ -688,6 +844,8 @@ def stream_generate(
     detokenizer = tokenizer.detokenizer
 
     kwargs["max_tokens"] = max_tokens
+    if model_forward_context is not None:
+        kwargs["model_forward_context"] = model_forward_context
 
     if draft_model is None:
         kwargs.pop("num_draft_tokens", None)

--- a/mlx_lm/generate.py
+++ b/mlx_lm/generate.py
@@ -7,11 +7,12 @@ import functools
 import json
 import math
 import sys
+import threading
 import time
+import weakref
 from collections import deque
 from dataclasses import dataclass
 from enum import Enum
-from functools import partial
 from typing import (
     Any,
     Callable,
@@ -94,6 +95,242 @@ class GenerationForward:
     logical_position_ack: Optional["GenerationForwardPositionAck"] = None
 
 
+@dataclass(frozen=True)
+class NativeMTPCapabilityFingerprint:
+    """Stable value identity for a model's native-MTP capability snapshot."""
+
+    type_module: str
+    type_name: str
+    supported: bool
+    reason: str
+    num_layers: Optional[int]
+
+    @classmethod
+    def from_model(cls, model: nn.Module) -> "NativeMTPCapabilityFingerprint":
+        capability = getattr(model, "mtp_capability", None)
+        if capability is None:
+            raise RuntimeError("native_mtp_model_capability_missing")
+        capability_type = type(capability)
+        return cls(
+            capability_type.__module__,
+            capability_type.__qualname__,
+            capability.supported,
+            capability.reason,
+            getattr(capability, "num_layers", None),
+        )
+
+
+_GENERATION_FORWARD_RECEIPT_ISSUER = object()
+_GENERATION_FORWARD_RECEIPT_LOCK = threading.Lock()
+
+
+class _GenerationForwardReceiptToken:
+    __slots__ = ("__weakref__",)
+
+
+_GENERATION_FORWARD_RECEIPTS = weakref.WeakKeyDictionary()
+
+
+def _array_identity_evidence(value):
+    if value is None:
+        return None
+    if isinstance(value, (list, tuple)):
+        return type(value), tuple(_array_identity_evidence(item) for item in value)
+    return id(value), tuple(value.shape), value.dtype
+
+
+def _cache_state_identity_evidence(entries):
+    evidence = []
+    for entry in entries:
+        if isinstance(entry, ArraysCache):
+            state = tuple(_array_identity_evidence(value) for value in entry.cache)
+            evidence.append(
+                (
+                    type(entry),
+                    state,
+                    _array_identity_evidence(entry.left_padding),
+                    _array_identity_evidence(entry.lengths),
+                )
+            )
+        else:
+            evidence.append(
+                (
+                    type(entry),
+                    entry.offset,
+                    _array_identity_evidence(entry.keys),
+                    _array_identity_evidence(entry.values),
+                )
+            )
+    return tuple(evidence)
+
+
+def _uint64_hash_constant(value):
+    """Construct exact uint64 bits without MLX's unsigned Python-int cast."""
+
+    value &= (1 << 64) - 1
+    if value >= 1 << 63:
+        value -= 1 << 64
+    return mx.array(value, dtype=mx.int64).view(mx.uint64)
+
+
+def _active_array_payload_hash(array):
+    """Hash exact payload bits to two words; this is not cryptographic."""
+
+    payload = array.view(mx.uint8)
+    if payload.ndim == 0:
+        payload = payload.reshape(1)
+    words = payload.astype(mx.uint64)
+    position = _uint64_hash_constant(0)
+    position_constant = 0x517CC1B727220A95
+    position_step = 0x6C8E9CF570932BD5
+    mask = (1 << 64) - 1
+    for axis, size in enumerate(payload.shape):
+        coordinate_shape = [1] * payload.ndim
+        coordinate_shape[axis] = size
+        coordinates = mx.arange(size, dtype=mx.uint64).reshape(coordinate_shape)
+        axis_constant = _uint64_hash_constant(
+            (position_constant + axis * position_step) & mask
+        )
+        position = position + coordinates * axis_constant
+
+    initial = mx.bitwise_xor(
+        words + _uint64_hash_constant(0x243F6A8885A308D3),
+        position + _uint64_hash_constant(0x13198A2E03707344),
+    )
+    mixed = initial * _uint64_hash_constant(0x9E3779B185EBCA87)
+    mixed = mx.bitwise_xor(mixed, mx.right_shift(mixed, 29))
+    mixed = mixed * _uint64_hash_constant(0xC2B2AE3D27D4EB4F)
+    second = mx.bitwise_xor(
+        mixed,
+        position * _uint64_hash_constant(0x165667B19E3779F9)
+        + _uint64_hash_constant(0x85EBCA77C2B2AE63),
+    )
+    lanes = mx.stack((mixed, second), axis=-1)
+    return mx.sum(lanes, axis=tuple(range(payload.ndim)))
+
+
+def _array_content_digest(value):
+    """Return compact dtype-preserving hashes for a nested array payload."""
+
+    flattened = []
+
+    def append_arrays(item):
+        if item is None:
+            return
+        if isinstance(item, (list, tuple)):
+            for child in item:
+                append_arrays(child)
+            return
+        flattened.append(item)
+
+    append_arrays(value)
+    parts = [_active_array_payload_hash(array) for array in flattened]
+    if not parts:
+        return mx.zeros((0,), dtype=mx.uint64)
+    return mx.concatenate(parts)
+
+
+def _cache_content_digest(entries):
+    active = []
+    for entry in entries:
+        if isinstance(entry, ArraysCache):
+            active.extend(entry.cache)
+            active.extend((entry.left_padding, entry.lengths))
+            continue
+
+        def active_prefix(value):
+            if value is None:
+                return None
+            if isinstance(value, (list, tuple)):
+                return type(value)(active_prefix(item) for item in value)
+            return value[..., : entry.offset, :]
+
+        active.extend((active_prefix(entry.keys), active_prefix(entry.values)))
+    return _array_content_digest(active)
+
+
+@dataclass(frozen=True)
+class _GenerationForwardCanonicalRecord:
+    receipt_id: int
+    model_id: int
+    cache: List[Any]
+    cache_container_id: int
+    cache_entry_ids: Tuple[int, ...]
+    cache_state_evidence: tuple
+    cache_content_digest: Optional[mx.array]
+    capability: NativeMTPCapabilityFingerprint
+    phase: GenerationForwardPhase
+    logical_positions: Tuple[int, ...]
+    token_ids: Tuple[int, ...]
+    immediate_successor_token_ids: Tuple[int, ...]
+    logits: mx.array
+    logits_evidence: tuple
+    canonical_final_logits: Optional[mx.array]
+    hidden_rows: mx.array
+    hidden_evidence: tuple
+    canonical_hidden_rows: mx.array
+
+
+@dataclass
+class _GenerationForwardAuthority:
+    record: _GenerationForwardCanonicalRecord
+    reservation: Optional[Any] = None
+
+
+@dataclass(frozen=True, init=False)
+class GenerationForwardPositionReceipt:
+    """Unforgeable immutable evidence from one acknowledged target call."""
+
+    model_id: int
+    cache_container_id: int
+    cache_entry_ids: Tuple[int, ...]
+    capability: NativeMTPCapabilityFingerprint
+    phase: GenerationForwardPhase
+    logical_positions: Tuple[int, ...]
+    token_ids: Tuple[int, ...]
+    immediate_successor_token_ids: Tuple[int, ...]
+    logits: mx.array
+    hidden_rows: mx.array
+    _issuer_seal: Any
+    _record_token: Any
+
+    def __init__(
+        self,
+        *,
+        _issuer,
+        model_id,
+        cache_container_id,
+        cache_entry_ids,
+        capability,
+        phase,
+        logical_positions,
+        token_ids,
+        immediate_successor_token_ids,
+        logits,
+        hidden_rows,
+        record_token,
+    ):
+        if _issuer is not _GENERATION_FORWARD_RECEIPT_ISSUER:
+            raise TypeError(
+                "generation forward receipts are issued by an acknowledged call"
+            )
+        for name, value in (
+            ("model_id", model_id),
+            ("cache_container_id", cache_container_id),
+            ("cache_entry_ids", cache_entry_ids),
+            ("capability", capability),
+            ("phase", phase),
+            ("logical_positions", logical_positions),
+            ("token_ids", token_ids),
+            ("immediate_successor_token_ids", immediate_successor_token_ids),
+            ("logits", logits),
+            ("hidden_rows", hidden_rows),
+            ("_issuer_seal", _issuer),
+            ("_record_token", record_token),
+        ):
+            object.__setattr__(self, name, value)
+
+
 class GenerationForwardPositionAck:
     """One-shot proof that a context consumer used exact logical positions.
 
@@ -104,11 +341,32 @@ class GenerationForwardPositionAck:
     rejected.
     """
 
-    def __init__(self, logical_positions: Tuple[int, ...]):
+    def __init__(
+        self,
+        logical_positions: Tuple[int, ...],
+        *,
+        model: Optional[nn.Module] = None,
+        cache: Optional[Any] = None,
+        token_ids: Optional[Tuple[int, ...]] = None,
+        immediate_successor_token_ids: Tuple[int, ...] = (),
+        phase: Optional[GenerationForwardPhase] = None,
+        _receipt_issuer=None,
+    ):
         self._logical_positions = logical_positions
+        self._model = model
+        self._cache = cache
+        self._token_ids = token_ids
+        self._immediate_successor_token_ids = immediate_successor_token_ids
+        self._phase = phase
+        self._receipt_issuer = _receipt_issuer
         self._active = False
         self._acknowledged = False
         self._finished = False
+        self._receipt = None
+
+    @property
+    def receipt(self) -> Optional[GenerationForwardPositionReceipt]:
+        return self._receipt
 
     def acknowledge(self, logical_positions: Tuple[int, ...]) -> None:
         if not self._active or self._finished:
@@ -134,8 +392,147 @@ class GenerationForwardPositionAck:
         self._active = False
         self._finished = True
 
+    def _issue_receipt(self, result) -> GenerationForwardPositionReceipt:
+        if not self._finished or not self._acknowledged or self._receipt is not None:
+            raise RuntimeError("generation_logical_position_receipt_not_ready")
+        if self._receipt_issuer is not _GENERATION_FORWARD_RECEIPT_ISSUER:
+            raise RuntimeError("generation_logical_position_receipt_untrusted")
+        if (
+            self._model is None
+            or not isinstance(self._cache, list)
+            or self._token_ids is None
+            or self._phase is None
+        ):
+            raise RuntimeError("generation_logical_position_receipt_unbound")
+        if not isinstance(result, tuple) or len(result) != 2:
+            raise RuntimeError("generation_logical_position_receipt_missing_hidden")
+        logits, hidden_rows = result
+        canonical_hidden_rows = hidden_rows + mx.zeros(
+            hidden_rows.shape, dtype=hidden_rows.dtype
+        )
+        canonical_final_logits = None
+        cache_content_digest = None
+        if len(self._immediate_successor_token_ids) == len(self._logical_positions) - 1:
+            final_logits = logits[:, -1:, :]
+            canonical_final_logits = final_logits + mx.zeros(
+                final_logits.shape, dtype=final_logits.dtype
+            )
+            cache_content_digest = _cache_content_digest(self._cache)
+        canonical_values = [canonical_hidden_rows]
+        if canonical_final_logits is not None:
+            canonical_values.append(canonical_final_logits)
+            canonical_values.append(cache_content_digest)
+        mx.eval(canonical_values)
+        record_token = _GenerationForwardReceiptToken()
+        self._receipt = GenerationForwardPositionReceipt(
+            _issuer=_GENERATION_FORWARD_RECEIPT_ISSUER,
+            model_id=id(self._model),
+            cache_container_id=id(self._cache),
+            cache_entry_ids=tuple(id(entry) for entry in self._cache),
+            capability=NativeMTPCapabilityFingerprint.from_model(self._model),
+            phase=self._phase,
+            logical_positions=self._logical_positions,
+            token_ids=self._token_ids,
+            immediate_successor_token_ids=self._immediate_successor_token_ids,
+            logits=logits,
+            hidden_rows=hidden_rows,
+            record_token=record_token,
+        )
+        record = _GenerationForwardCanonicalRecord(
+            receipt_id=id(self._receipt),
+            model_id=id(self._model),
+            cache=self._cache,
+            cache_container_id=id(self._cache),
+            cache_entry_ids=tuple(id(entry) for entry in self._cache),
+            cache_state_evidence=_cache_state_identity_evidence(self._cache),
+            cache_content_digest=cache_content_digest,
+            capability=NativeMTPCapabilityFingerprint.from_model(self._model),
+            phase=self._phase,
+            logical_positions=self._logical_positions,
+            token_ids=self._token_ids,
+            immediate_successor_token_ids=self._immediate_successor_token_ids,
+            logits=logits,
+            logits_evidence=_array_identity_evidence(logits),
+            canonical_final_logits=canonical_final_logits,
+            hidden_rows=hidden_rows,
+            hidden_evidence=_array_identity_evidence(hidden_rows),
+            canonical_hidden_rows=canonical_hidden_rows,
+        )
+        with _GENERATION_FORWARD_RECEIPT_LOCK:
+            _GENERATION_FORWARD_RECEIPTS[record_token] = _GenerationForwardAuthority(
+                record
+            )
+        return self._receipt
+
 
 GenerationForwardContext = Callable[[GenerationForward], ContextManager[None]]
+
+
+def attested_target_forward(
+    model: nn.Module,
+    token_ids: Tuple[int, ...],
+    target_cache: List[Any],
+    *,
+    phase: GenerationForwardPhase,
+    logical_positions: Tuple[int, ...],
+    immediate_successor_token_ids: Tuple[int, ...],
+    model_forward_context: GenerationForwardContext,
+) -> Tuple[Tuple[mx.array, mx.array], GenerationForwardPositionReceipt]:
+    """Run and attest one exact hidden-returning target forward.
+
+    This is the only public receipt producer.  It owns the entire call rather
+    than accepting caller-provided outputs, so a receipt can only be issued
+    after the model itself returned hidden rows under an acknowledged position
+    context and those lazy outputs realized successfully.
+    """
+
+    if not isinstance(target_cache, list):
+        raise TypeError("attested target cache must be a caller-owned list")
+    if not isinstance(token_ids, tuple) or not token_ids:
+        raise ValueError("attested target forward requires non-empty host tokens")
+    if any(
+        isinstance(token_id, bool) or not isinstance(token_id, int) or token_id < 0
+        for token_id in token_ids
+    ):
+        raise ValueError("attested target token IDs must be non-negative integers")
+    if not isinstance(logical_positions, tuple) or len(logical_positions) != len(
+        token_ids
+    ):
+        raise ValueError("attested target positions must match input tokens")
+    if not isinstance(immediate_successor_token_ids, tuple) or len(
+        immediate_successor_token_ids
+    ) not in (len(logical_positions), len(logical_positions) - 1):
+        raise ValueError("attested target successor count is invalid")
+    input_tokens = mx.array(token_ids, dtype=mx.uint32)
+    ack = GenerationForwardPositionAck(
+        logical_positions,
+        model=model,
+        cache=target_cache,
+        token_ids=token_ids,
+        immediate_successor_token_ids=immediate_successor_token_ids,
+        phase=phase,
+        _receipt_issuer=_GENERATION_FORWARD_RECEIPT_ISSUER,
+    )
+    forward = GenerationForward(
+        model=model,
+        input_tokens=input_tokens[None],
+        cache=target_cache,
+        phase=phase,
+        logical_positions=logical_positions,
+        logical_position_ack=ack,
+    )
+    with model_forward_context(forward):
+        ack._activate()
+        try:
+            result = model(input_tokens[None], cache=target_cache, return_hidden=True)
+            ack._require_acknowledged()
+            if not isinstance(result, tuple) or len(result) != 2:
+                raise RuntimeError("attested target forward did not return hidden rows")
+            mx.eval(result)
+        finally:
+            ack._finish()
+    receipt = ack._issue_receipt(result)
+    return result, receipt
 
 
 @dataclass(frozen=True)
@@ -184,6 +581,318 @@ class NativeMTPSamplingConfig:
     @property
     def stochastic(self) -> bool:
         return self.temperature > 0
+
+
+def _validate_receipt_against_record(receipt, record):
+    if (
+        not isinstance(receipt, GenerationForwardPositionReceipt)
+        or getattr(receipt, "_issuer_seal", None)
+        is not _GENERATION_FORWARD_RECEIPT_ISSUER
+        or id(receipt) != record.receipt_id
+        or receipt.model_id != record.model_id
+        or receipt.cache_container_id != record.cache_container_id
+        or receipt.cache_entry_ids != record.cache_entry_ids
+        or receipt.capability != record.capability
+        or receipt.phase is not record.phase
+        or receipt.logical_positions != record.logical_positions
+        or receipt.token_ids != record.token_ids
+        or receipt.immediate_successor_token_ids != record.immediate_successor_token_ids
+        or receipt.logits is not record.logits
+        or receipt.hidden_rows is not record.hidden_rows
+        or _array_identity_evidence(receipt.logits) != record.logits_evidence
+        or _array_identity_evidence(receipt.hidden_rows) != record.hidden_evidence
+    ):
+        raise RuntimeError("native_mtp_sparse_receipt_canonical_mismatch")
+
+
+def _sparse_attestation_host_decision(decision):
+    mx.eval(decision)
+    return bool(decision.item())
+
+
+def _verify_sparse_canonical_content(records):
+    """Realize all mutable evidence checks with one aggregate host decision."""
+
+    checks = [
+        mx.array_equal(record.hidden_rows, record.canonical_hidden_rows)
+        for record in records
+    ]
+    final = records[-1]
+    checks.extend(
+        (
+            mx.array_equal(final.logits[:, -1:, :], final.canonical_final_logits),
+            mx.array_equal(
+                _cache_content_digest(final.cache), final.cache_content_digest
+            ),
+        )
+    )
+    decision = mx.all(mx.stack(checks))
+    if not _sparse_attestation_host_decision(decision):
+        raise RuntimeError("native_mtp_sparse_evidence_content_mismatch")
+
+
+@dataclass(frozen=True)
+class _NativeMTPSparseClaim:
+    records: Tuple[_GenerationForwardCanonicalRecord, ...]
+    selected_logical_positions: Tuple[int, ...]
+    selected_token_ids: Tuple[int, ...]
+    immediate_successor_token_ids: Tuple[int, ...]
+    target_cache: List[Any]
+    next_logical_position: int
+
+    @property
+    def final_target_hidden(self):
+        return self.records[-1].canonical_hidden_rows[:, -1:, :]
+
+    @property
+    def final_target_logits(self):
+        return self.records[-1].canonical_final_logits
+
+
+@dataclass(frozen=True)
+class NativeMTPSparseBootstrap:
+    """Attested sparse target state from which native MTP may start.
+
+    The receipts retain the exact target outputs.  The explicit host tuples
+    make the caller contract inspectable, but never act as a second authority:
+    validation requires them to equal the ordered receipt contents exactly.
+    """
+
+    receipts: Tuple[GenerationForwardPositionReceipt, ...]
+    selected_logical_positions: Tuple[int, ...]
+    selected_token_ids: Tuple[int, ...]
+    immediate_successor_token_ids: Tuple[int, ...]
+    target_cache: List[Any]
+    next_logical_position: int
+
+    @property
+    def final_target_hidden(self) -> mx.array:
+        return self.receipts[-1].hidden_rows[:, -1:, :]
+
+    @property
+    def final_target_logits(self) -> mx.array:
+        return self.receipts[-1].logits
+
+    def _canonical_records_locked(self, reservation=None):
+        records = []
+        tokens = []
+        authorities = []
+        for receipt in self.receipts:
+            record_token = getattr(receipt, "_record_token", None)
+            if not isinstance(record_token, _GenerationForwardReceiptToken):
+                raise RuntimeError("native_mtp_sparse_receipt_canonical_mismatch")
+            authority = _GENERATION_FORWARD_RECEIPTS.get(record_token)
+            if authority is None or authority.reservation is not None:
+                raise RuntimeError("native_mtp_sparse_bootstrap_already_claimed")
+            record = authority.record
+            _validate_receipt_against_record(receipt, record)
+            records.append(record)
+            tokens.append(record_token)
+            authorities.append(authority)
+        if len(tokens) != len(set(tokens)):
+            raise RuntimeError("native_mtp_sparse_receipt_reused")
+        if reservation is not None:
+            for authority in authorities:
+                authority.reservation = reservation
+        return tuple(records), tuple(tokens)
+
+    def _validate_records(self, model: nn.Module, canonical_records) -> None:
+        """Validate provenance, values, topology-facing shapes, and cursor."""
+
+        if not isinstance(self.receipts, tuple) or not self.receipts:
+            raise ValueError("native_mtp_sparse_receipts_required")
+        if not isinstance(self.target_cache, list) or not self.target_cache:
+            raise TypeError("native_mtp_sparse_target_cache_must_be_list")
+        for name, values in (
+            ("positions", self.selected_logical_positions),
+            ("tokens", self.selected_token_ids),
+            ("successors", self.immediate_successor_token_ids),
+        ):
+            if not isinstance(values, tuple):
+                raise TypeError(f"native MTP sparse {name} must be a host tuple")
+
+        positions = self.selected_logical_positions
+        token_ids = self.selected_token_ids
+        successors = self.immediate_successor_token_ids
+        if not positions or len(token_ids) != len(positions):
+            raise ValueError("native_mtp_sparse_selected_length_mismatch")
+        if len(successors) != len(positions) - 1:
+            raise ValueError("native_mtp_sparse_successor_length_mismatch")
+
+        previous = -1
+        for position in positions:
+            if (
+                isinstance(position, bool)
+                or not isinstance(position, int)
+                or position <= previous
+            ):
+                raise ValueError("native_mtp_sparse_positions_not_strict")
+            previous = position
+        if (
+            isinstance(self.next_logical_position, bool)
+            or not isinstance(self.next_logical_position, int)
+            or self.next_logical_position != positions[-1] + 1
+        ):
+            raise ValueError("native_mtp_sparse_cursor_mismatch")
+
+        vocab_size = getattr(model, "vocab_size", None)
+        if vocab_size is None:
+            vocab_size = getattr(getattr(model, "args", None), "vocab_size", None)
+        for token_id in (*token_ids, *successors):
+            if (
+                isinstance(token_id, bool)
+                or not isinstance(token_id, int)
+                or token_id < 0
+                or (vocab_size is not None and token_id >= vocab_size)
+            ):
+                raise ValueError("native_mtp_sparse_token_id_invalid")
+
+        capability = NativeMTPCapabilityFingerprint.from_model(model)
+        expected_cache_id = id(self.target_cache)
+        expected_entry_ids = tuple(id(entry) for entry in self.target_cache)
+        model_args = getattr(model, "args", None)
+        if getattr(model_args, "hidden_size", None) is None:
+            model_args = getattr(getattr(model, "language_model", None), "args", None)
+        expected_hidden_width = getattr(model_args, "hidden_size", None)
+        if canonical_records[-1].canonical_final_logits is None:
+            raise RuntimeError("native_mtp_sparse_final_logits_evidence_missing")
+        if canonical_records[-1].cache_content_digest is None:
+            raise RuntimeError("native_mtp_sparse_final_cache_evidence_missing")
+        if any(
+            record.canonical_final_logits is not None
+            for record in canonical_records[:-1]
+        ):
+            raise RuntimeError("native_mtp_sparse_final_logits_evidence_order_mismatch")
+        receipt_positions = []
+        receipt_tokens = []
+        receipt_successors = []
+        hidden_width = None
+        floating_dtypes = (mx.float16, mx.float32, mx.bfloat16)
+        for index, (receipt, record) in enumerate(
+            zip(self.receipts, canonical_records)
+        ):
+            if not isinstance(receipt, GenerationForwardPositionReceipt):
+                raise TypeError("native_mtp_sparse_receipt_invalid")
+            if (
+                getattr(receipt, "_issuer_seal", None)
+                is not _GENERATION_FORWARD_RECEIPT_ISSUER
+            ):
+                raise TypeError("native_mtp_sparse_receipt_not_issued")
+            if receipt.phase is not GenerationForwardPhase.PREFILL:
+                raise ValueError("native_mtp_sparse_receipt_phase_mismatch")
+            if (
+                receipt.model_id != id(model)
+                or receipt.cache_container_id != expected_cache_id
+                or receipt.cache_entry_ids != expected_entry_ids
+                or receipt.capability != capability
+            ):
+                raise RuntimeError("native_mtp_sparse_receipt_provenance_mismatch")
+            if record.cache is not self.target_cache:
+                raise RuntimeError("native_mtp_sparse_target_cache_identity_mismatch")
+            if not receipt.logical_positions or len(receipt.token_ids) != len(
+                receipt.logical_positions
+            ):
+                raise ValueError("native_mtp_sparse_receipt_length_mismatch")
+            expected_successors = len(receipt.token_ids)
+            if index == len(self.receipts) - 1:
+                expected_successors -= 1
+            if len(receipt.immediate_successor_token_ids) != expected_successors:
+                raise ValueError("native_mtp_sparse_receipt_successor_mismatch")
+
+            hidden = receipt.hidden_rows
+            logits = receipt.logits
+            chunk_size = len(receipt.token_ids)
+            if (
+                not isinstance(hidden, mx.array)
+                or hidden.ndim != 3
+                or hidden.shape[0] != 1
+                or hidden.shape[1] != chunk_size
+                or hidden.dtype not in floating_dtypes
+            ):
+                raise ValueError("native_mtp_sparse_hidden_shape_or_dtype_mismatch")
+            if hidden_width is None:
+                hidden_width = hidden.shape[2]
+            elif hidden.shape[2] != hidden_width:
+                raise ValueError("native_mtp_sparse_hidden_width_mismatch")
+            if (
+                expected_hidden_width is not None
+                and hidden.shape[2] != expected_hidden_width
+            ):
+                raise ValueError("native_mtp_sparse_hidden_model_width_mismatch")
+            if (
+                not isinstance(logits, mx.array)
+                or logits.ndim != 3
+                or logits.shape[0] != 1
+                or logits.shape[1] != chunk_size
+                or logits.dtype not in floating_dtypes
+                or (vocab_size is not None and logits.shape[2] != vocab_size)
+            ):
+                raise ValueError("native_mtp_sparse_logits_shape_or_dtype_mismatch")
+
+            receipt_positions.extend(receipt.logical_positions)
+            receipt_tokens.extend(receipt.token_ids)
+            receipt_successors.extend(receipt.immediate_successor_token_ids)
+
+        if tuple(receipt_positions) != positions:
+            raise ValueError("native_mtp_sparse_receipt_positions_mismatch")
+        if tuple(receipt_tokens) != token_ids:
+            raise ValueError("native_mtp_sparse_receipt_tokens_mismatch")
+        if tuple(receipt_successors) != successors:
+            raise ValueError("native_mtp_sparse_receipt_successors_mismatch")
+        if (
+            _cache_state_identity_evidence(self.target_cache)
+            != canonical_records[-1].cache_state_evidence
+        ):
+            raise RuntimeError("native_mtp_sparse_target_cache_state_mismatch")
+
+    def validate(self, model: nn.Module) -> None:
+        """Validate currently issued authority without consuming it."""
+
+        if not isinstance(self.receipts, tuple) or not self.receipts:
+            raise ValueError("native_mtp_sparse_receipts_required")
+        with _GENERATION_FORWARD_RECEIPT_LOCK:
+            records, _ = self._canonical_records_locked()
+        self._validate_records(model, records)
+        _verify_sparse_canonical_content(records)
+
+    def claim(self, model: nn.Module) -> _NativeMTPSparseClaim:
+        """Reserve, verify off-lock, and permanently consume receipt authority."""
+
+        if not isinstance(self.receipts, tuple) or not self.receipts:
+            raise ValueError("native_mtp_sparse_receipts_required")
+        reservation = object()
+        with _GENERATION_FORWARD_RECEIPT_LOCK:
+            records, record_tokens = self._canonical_records_locked(reservation)
+        try:
+            self._validate_records(model, records)
+            _verify_sparse_canonical_content(records)
+        finally:
+            with _GENERATION_FORWARD_RECEIPT_LOCK:
+                for record_token in record_tokens:
+                    authority = _GENERATION_FORWARD_RECEIPTS.get(record_token)
+                    if authority is not None and authority.reservation is reservation:
+                        del _GENERATION_FORWARD_RECEIPTS[record_token]
+
+        positions = tuple(
+            position for record in records for position in record.logical_positions
+        )
+        token_ids = tuple(
+            token_id for record in records for token_id in record.token_ids
+        )
+        successors = tuple(
+            token_id
+            for record in records
+            for token_id in record.immediate_successor_token_ids
+        )
+        final = records[-1]
+        return _NativeMTPSparseClaim(
+            records=records,
+            selected_logical_positions=positions,
+            selected_token_ids=token_ids,
+            immediate_successor_token_ids=successors,
+            target_cache=final.cache,
+            next_logical_position=positions[-1] + 1,
+        )
 
 
 def str2bool(string):
@@ -895,7 +1604,7 @@ def speculative_generate_step(
 
 
 def mtp_generate_step(
-    prompt: mx.array,
+    prompt: Optional[mx.array],
     model: nn.Module,
     *,
     max_tokens: int = 256,
@@ -911,6 +1620,7 @@ def mtp_generate_step(
     eos_token_ids: Optional[Sequence[int]] = None,
     telemetry: Optional[Dict[str, Any]] = None,
     prompt_logical_positions: Optional[Sequence[int]] = None,
+    sparse_bootstrap: Optional[NativeMTPSparseBootstrap] = None,
 ) -> Generator[Tuple[int, mx.array, bool], None, None]:
     """Stream native-Qwen MTP with request-local transactional cache state.
 
@@ -939,10 +1649,24 @@ def mtp_generate_step(
         if telemetry is not None:
             telemetry["mtp_bypass_reason"] = reason
         raise RuntimeError(reason)
-    if prompt.ndim != 1 or prompt.size == 0:
-        raise ValueError("native MTP requires one non-empty unbatched prompt")
+    if sparse_bootstrap is None:
+        if prompt is None or prompt.ndim != 1 or prompt.size == 0:
+            raise ValueError("native MTP requires one non-empty unbatched prompt")
+    else:
+        if prompt is not None:
+            raise ValueError("native_mtp_sparse_bootstrap_owns_selected_tokens")
+        if prompt_logical_positions is not None:
+            raise ValueError("native_mtp_sparse_bootstrap_owns_logical_positions")
+        if model_forward_context is None:
+            raise ValueError("native_mtp_sparse_bootstrap_requires_position_context")
     if max_tokens < 0:
         raise ValueError("native MTP requires a finite non-negative max_tokens")
+    if (
+        isinstance(prefill_step_size, bool)
+        or not isinstance(prefill_step_size, int)
+        or prefill_step_size < 1
+    ):
+        raise ValueError("native MTP prefill_step_size must be a positive integer")
     sampling_config = sampling_config or NativeMTPSamplingConfig()
     model_vocab_size = getattr(model, "vocab_size", None)
     if model_vocab_size is None:
@@ -993,19 +1717,12 @@ def mtp_generate_step(
                 )
             previous_position = position
 
-    request = model.make_mtp_request_cache()
-    if telemetry is not None:
-        telemetry.update(
-            mtp_drafts=0,
-            mtp_accepted=0,
-            mtp_bypass_reason=None,
-        )
-    eos_token_ids = frozenset(eos_token_ids or ())
-    rng_key = mx.random.key(
-        sampling_config.seed
-        if sampling_config.seed is not None
-        else (time.time_ns() & ((1 << 63) - 1))
+    logical_positions_active = (
+        logical_prompt is not None or sparse_bootstrap is not None
     )
+
+    request = None
+    sparse_claim = None
 
     def _next_rng_key():
         nonlocal rng_key
@@ -1065,7 +1782,12 @@ def mtp_generate_step(
         return (logprobs - mx.logsumexp(logprobs, axis=-1, keepdims=True)).squeeze(0)
 
     def _target_call(
-        input_tokens, phase, *, return_hidden=False, logical_positions=None
+        input_tokens,
+        phase,
+        *,
+        return_hidden=False,
+        logical_positions=None,
+        immediate_successor_token_ids=(),
     ):
         batched = input_tokens[None]
         if model_forward_context is None:
@@ -1094,9 +1816,9 @@ def mtp_generate_step(
                     batched, cache=request.backbone, return_hidden=return_hidden
                 )
                 position_ack._require_acknowledged()
-                return result
             finally:
                 position_ack._finish()
+        return result
 
     def _mtp_call(hidden, next_tokens, *, logical_positions=None):
         next_ids = next_tokens.reshape(1, -1)
@@ -1178,94 +1900,169 @@ def mtp_generate_step(
     finish_reason = "generator_closed"
     generated = 0
     try:
+        if sparse_bootstrap is None:
+            request = model.make_mtp_request_cache()
+        else:
+            sparse_claim = sparse_bootstrap.claim(model)
+            request = cache.NativeMTPRequestCache.adopt_sparse_target(
+                model,
+                target_cache=sparse_claim.target_cache,
+                target_tokens=len(sparse_claim.selected_token_ids),
+                next_logical_position=sparse_claim.next_logical_position,
+            )
+        if telemetry is not None:
+            telemetry.update(
+                mtp_drafts=0,
+                mtp_accepted=0,
+                mtp_bypass_reason=None,
+            )
+        eos_token_ids = frozenset(eos_token_ids or ())
+        rng_key = mx.random.key(
+            sampling_config.seed
+            if sampling_config.seed is not None
+            else (time.time_ns() & ((1 << 63) - 1))
+        )
         if max_tokens == 0:
             finish_reason = "length"
             return
 
-        # Shifted hidden/token pairs prefill the MTP head to the same physical
-        # and logical position as the target before decode begins.
-        remaining = prompt.astype(mx.uint32)
-        prompt_position_index = 0 if logical_prompt is not None else None
-        with mx.stream(generation_stream):
-            while remaining.size > 1:
-                count = min(prefill_step_size, remaining.size - 1)
-                forward_positions = (
-                    logical_prompt[
-                        prompt_position_index : prompt_position_index + count
-                    ]
+        if sparse_bootstrap is None:
+            # Shifted hidden/token pairs prefill the MTP head to the same
+            # physical and logical position as the target before decode.
+            remaining = prompt.astype(mx.uint32)
+            prompt_position_index = 0 if logical_prompt is not None else None
+            with mx.stream(generation_stream):
+                while remaining.size > 1:
+                    count = min(prefill_step_size, remaining.size - 1)
+                    forward_positions = (
+                        logical_prompt[
+                            prompt_position_index : prompt_position_index + count
+                        ]
+                        if logical_prompt is not None
+                        else None
+                    )
+                    _, hidden = _target_call(
+                        remaining[:count],
+                        GenerationForwardPhase.PREFILL,
+                        return_hidden=True,
+                        logical_positions=forward_positions,
+                        immediate_successor_token_ids=remaining[1 : count + 1].tolist(),
+                    )
+                    _mtp_call(
+                        hidden,
+                        remaining[1 : count + 1],
+                        logical_positions=forward_positions,
+                    )
+                    _quantize()
+                    mx.eval(
+                        [entry.state for entry in request.backbone],
+                        [entry.state for entry in request.mtp],
+                    )
+                    if forward_positions is None:
+                        request.retain(
+                            backbone_tokens=request.state.backbone_tokens + count,
+                            mtp_tokens=request.state.mtp_tokens + count,
+                        )
+                    else:
+                        request.retain_logical_position(
+                            backbone_tokens=request.state.backbone_tokens + count,
+                            mtp_tokens=request.state.mtp_tokens + count,
+                            next_logical_position=forward_positions[-1] + 1,
+                        )
+                    _assert_target_mtp_alignment()
+                    remaining = remaining[count:]
+                    if logical_prompt is not None:
+                        prompt_position_index += count
+                    mx.clear_cache()
+
+                final_prompt_positions = (
+                    (logical_prompt[prompt_position_index],)
                     if logical_prompt is not None
                     else None
                 )
-                _, hidden = _target_call(
-                    remaining[:count],
+                initial_logits, initial_hidden = _target_call(
+                    remaining,
                     GenerationForwardPhase.PREFILL,
                     return_hidden=True,
-                    logical_positions=forward_positions,
-                )
-                _mtp_call(
-                    hidden,
-                    remaining[1 : count + 1],
-                    logical_positions=forward_positions,
+                    logical_positions=final_prompt_positions,
                 )
                 _quantize()
-                mx.eval(
-                    [entry.state for entry in request.backbone],
-                    [entry.state for entry in request.mtp],
-                )
-                if forward_positions is None:
+                if final_prompt_positions is None:
                     request.retain(
-                        backbone_tokens=request.state.backbone_tokens + count,
-                        mtp_tokens=request.state.mtp_tokens + count,
+                        backbone_tokens=request.state.backbone_tokens + 1,
+                        mtp_tokens=request.state.mtp_tokens,
                     )
                 else:
                     request.retain_logical_position(
-                        backbone_tokens=request.state.backbone_tokens + count,
-                        mtp_tokens=request.state.mtp_tokens + count,
-                        next_logical_position=forward_positions[-1] + 1,
+                        backbone_tokens=request.state.backbone_tokens + 1,
+                        mtp_tokens=request.state.mtp_tokens,
+                        next_logical_position=final_prompt_positions[0] + 1,
                     )
-                _assert_target_mtp_alignment()
-                remaining = remaining[count:]
-                if logical_prompt is not None:
-                    prompt_position_index += count
-                mx.clear_cache()
-
-            final_prompt_positions = (
-                (logical_prompt[prompt_position_index],)
-                if logical_prompt is not None
-                else None
-            )
-            initial_logits, initial_hidden = _target_call(
-                remaining,
-                GenerationForwardPhase.PREFILL,
-                return_hidden=True,
-                logical_positions=final_prompt_positions,
-            )
-            _quantize()
-            if final_prompt_positions is None:
-                request.retain(
-                    backbone_tokens=request.state.backbone_tokens + 1,
-                    mtp_tokens=request.state.mtp_tokens,
+                # Match generate_step: processors see only the final step.
+                history = remaining.astype(mx.uint32)
+                current_logprobs = _reported_logprobs(
+                    initial_logits[:, -1, :].squeeze(0), history
                 )
-            else:
-                request.retain_logical_position(
-                    backbone_tokens=request.state.backbone_tokens + 1,
-                    mtp_tokens=request.state.mtp_tokens,
-                    next_logical_position=final_prompt_positions[0] + 1,
+                current_sampling_logprobs = _sampling_distribution(current_logprobs)
+                current_token = _sample(current_sampling_logprobs).reshape(-1)
+            current_hidden = initial_hidden[:, -1:, :]
+        else:
+            selected_count = len(sparse_claim.selected_token_ids)
+            final_prompt_positions = (sparse_claim.selected_logical_positions[-1],)
+            with mx.stream(generation_stream):
+                for record in sparse_claim.records:
+                    pair_count = len(record.immediate_successor_token_ids)
+                    pair_start = 0
+                    while pair_start < pair_count:
+                        pair_end = min(pair_start + prefill_step_size, pair_count)
+                        _mtp_call(
+                            record.canonical_hidden_rows[:, pair_start:pair_end, :],
+                            mx.array(
+                                record.immediate_successor_token_ids[
+                                    pair_start:pair_end
+                                ],
+                                dtype=mx.uint32,
+                            ),
+                            logical_positions=record.logical_positions[
+                                pair_start:pair_end
+                            ],
+                        )
+                        _quantize()
+                        mx.eval([entry.state for entry in request.mtp])
+                        pair_start = pair_end
+                        mx.clear_cache()
+                mx.eval(
+                    tuple(
+                        record.canonical_hidden_rows for record in sparse_claim.records
+                    ),
+                    sparse_claim.final_target_logits,
+                    [entry.state for entry in request.backbone],
+                    [entry.state for entry in request.mtp],
                 )
-            # Match generate_step: processors see only the input tokens passed
-            # to its final prefill/decode step, not chunks consumed by _step.
-            history = remaining.astype(mx.uint32)
-            current_logprobs = _reported_logprobs(
-                initial_logits[:, -1, :].squeeze(0), history
-            )
-            current_sampling_logprobs = _sampling_distribution(current_logprobs)
-            current_token = _sample(current_sampling_logprobs).reshape(-1)
+                history = mx.array(
+                    [sparse_claim.selected_token_ids[-1]], dtype=mx.uint32
+                )
+                current_logprobs = _reported_logprobs(
+                    sparse_claim.final_target_logits[:, -1, :].squeeze(0),
+                    history,
+                )
+                current_sampling_logprobs = _sampling_distribution(current_logprobs)
+                current_token = _sample(current_sampling_logprobs).reshape(-1)
+            current_hidden = sparse_claim.final_target_hidden
         mx.eval(current_token, current_logprobs)
-        current_hidden = initial_hidden[:, -1:, :]
+        if sparse_bootstrap is not None:
+            request.seal_verified(
+                backbone_tokens=selected_count,
+                mtp_tokens=selected_count - 1,
+            )
+            request.commit(
+                backbone_tokens=selected_count,
+                mtp_tokens=selected_count - 1,
+            )
         history = mx.concatenate([history, current_token])
 
         generated = 1
-        if logical_prompt is not None:
+        if logical_positions_active:
             request.advance_logical_position()
         current_id = current_token.item()
         terminal = current_id in eos_token_ids or generated >= max_tokens
@@ -1291,7 +2088,7 @@ def mtp_generate_step(
                     request.state.next_logical_position - 1,
                     request.state.next_logical_position,
                 )
-                if logical_prompt is not None
+                if logical_positions_active
                 else None
             )
             with mx.stream(generation_stream):
@@ -1343,7 +2140,7 @@ def mtp_generate_step(
                 if telemetry is not None:
                     telemetry["mtp_accepted"] += 1
                 generated += 1
-                if logical_prompt is not None:
+                if logical_positions_active:
                     request.advance_logical_position()
                 draft_id = draft_token.item()
                 draft_terminal = draft_id in eos_token_ids or generated >= max_tokens
@@ -1365,7 +2162,7 @@ def mtp_generate_step(
                 mx.eval(bonus_token, bonus_logprobs)
                 next_history = mx.concatenate([bonus_history, bonus_token])
                 generated += 1
-                if logical_prompt is not None:
+                if logical_positions_active:
                     request.advance_logical_position()
                 bonus_id = bonus_token.item()
                 bonus_terminal = bonus_id in eos_token_ids or generated >= max_tokens
@@ -1402,7 +2199,7 @@ def mtp_generate_step(
             request.reject_partial(accepted_backbone_tokens=1, accepted_mtp_tokens=0)
             replay_positions = (
                 (request.state.next_logical_position - 1,)
-                if logical_prompt is not None
+                if logical_positions_active
                 else None
             )
             with mx.stream(generation_stream):
@@ -1419,7 +2216,7 @@ def mtp_generate_step(
                 )
             next_history = mx.concatenate([history, replacement_token])
             generated += 1
-            if logical_prompt is not None:
+            if logical_positions_active:
                 request.advance_logical_position()
             replacement_id = replacement_token.item()
             replacement_terminal = (
@@ -1451,7 +2248,7 @@ def mtp_generate_step(
         finish_reason = "cancelled"
         raise
     finally:
-        if not request.closed:
+        if request is not None and not request.closed:
             request.finish(finish_reason)
 
 

--- a/mlx_lm/generate.py
+++ b/mlx_lm/generate.py
@@ -587,6 +587,795 @@ class NativeMTPSamplingConfig:
         return self.temperature > 0
 
 
+class _NativeMTPSamplingState:
+    """Replay-safe sampling and RNG state for one native-MTP row.
+
+    The single-request generator deliberately keeps this object private: its
+    public call signature and draw order are part of the existing B=1
+    behaviour.  The batched native-MTP path uses the same operations with a
+    fixed set of per-row slots, rather than sharing a mutable global key.
+    """
+
+    def __init__(
+        self,
+        config: NativeMTPSamplingConfig,
+        *,
+        sampler: Optional[Callable[[mx.array], mx.array]] = None,
+        logits_processors: Optional[
+            List[Callable[[mx.array, mx.array], mx.array]]
+        ] = None,
+        seed: Optional[int] = None,
+    ):
+        self.config = config
+        self.sampler = sampler
+        self.logits_processors = logits_processors or []
+        self._rng_key = mx.random.key(
+            seed if seed is not None else (time.time_ns() & ((1 << 63) - 1))
+        )
+
+    def next_rng_key(self):
+        keys = mx.random.split(self._rng_key)
+        self._rng_key = keys[0]
+        return keys[1]
+
+    def reported_logprobs(self, logits, tokens):
+        if logits.ndim == 1:
+            logits = logits[None]
+        for processor in self.logits_processors:
+            logits = processor(tokens, logits)
+        return (logits - mx.logsumexp(logits, axis=-1, keepdims=True)).squeeze(0)
+
+    def sampling_distribution(self, reported_logprobs):
+        logprobs = reported_logprobs[None]
+        if self.config.top_p < 1:
+            logprobs = apply_top_p(logprobs, self.config.top_p)
+        if self.config.min_p > 0:
+            keep = self.config.min_tokens_to_keep
+            vocab_size = logprobs.shape[-1]
+            if keep > vocab_size:
+                raise ValueError(
+                    "native MTP min_tokens_to_keep cannot exceed vocabulary size"
+                )
+            if keep < vocab_size:
+                # apply_min_p's multi-token branch passes a Python bool to
+                # put_along_axis, which newer MLX releases reject. Preserve
+                # the standard filter exactly by restoring requested top rows.
+                unfiltered = logprobs
+                logprobs = apply_min_p(logprobs, self.config.min_p)
+                if keep > 1:
+                    top_indices = mx.argpartition(unfiltered, kth=-keep, axis=-1)[
+                        ..., -keep:
+                    ]
+                    top_values = mx.take_along_axis(unfiltered, top_indices, axis=-1)
+                    logprobs = mx.put_along_axis(
+                        logprobs, top_indices, top_values, axis=-1
+                    )
+        if self.config.top_k > 0:
+            if self.config.top_k >= logprobs.shape[-1]:
+                raise ValueError(
+                    "native MTP top_k must be smaller than vocabulary size"
+                )
+            logprobs = apply_top_k(logprobs, self.config.top_k)
+        if self.config.stochastic:
+            logprobs = logprobs / self.config.temperature
+        return (logprobs - mx.logsumexp(logprobs, axis=-1, keepdims=True)).squeeze(0)
+
+    def sample(self, logprobs):
+        if self.config.stochastic:
+            return mx.random.categorical(logprobs, key=self.next_rng_key())
+        if self.sampler is None:
+            return mx.argmax(logprobs, axis=-1)
+        return self.sampler(logprobs)
+
+    def residual_sample(self, target_logprobs, draft_logprobs):
+        target_probs = mx.exp(target_logprobs)
+        draft_probs = mx.exp(draft_logprobs)
+        residual = mx.maximum(target_probs - draft_probs, 0)
+        normalizer = mx.sum(residual)
+        residual_logprobs = mx.where(
+            normalizer > 0,
+            mx.log(residual / normalizer),
+            target_logprobs,
+        )
+        return self.sample(residual_logprobs), residual_logprobs
+
+
+@dataclass(frozen=True)
+class _NativeMTPCohortBinding:
+    """Exact cache identities bound before a cohort forward may mutate them."""
+
+    model_id: int
+    backbone_container_id: int
+    mtp_container_id: int
+    uids: Tuple[int, ...]
+    backbone_layout: Tuple[tuple, ...]
+    mtp_layout: Tuple[tuple, ...]
+    backbone_metadata: Tuple[tuple, ...]
+    mtp_metadata: Tuple[tuple, ...]
+
+
+@dataclass(frozen=True)
+class _NativeMTPCohortCacheCheckpoint:
+    """Recurrent-value / KV-offset transaction state for one cohort round."""
+
+    backbone: Tuple[tuple, ...]
+    mtp: Tuple[tuple, ...]
+
+
+@dataclass(frozen=True)
+class _NativeMTPCohortMutationDelta:
+    """Caller-declared physical cache advance for one verified cohort forward."""
+
+    backbone: Tuple[Tuple[int, ...], ...]
+    mtp: Tuple[Tuple[int, ...], ...]
+
+
+class _NativeMTPCohortCache:
+    """Private move-only cache owner for a homogeneous native-MTP cohort.
+
+    Rows enter as separately owned B=1 native-MTP requests, then become one
+    merged cohort cache.  The caller must bind immediately before each model
+    forward, so replacing a cache container or entry cannot silently redirect a
+    transaction.  KV rollback records only offsets and cache references; only
+    small recurrent ``ArraysCache`` values are copied at the transaction
+    boundary.  Rotating and quantized layouts are deliberately refused.
+    """
+
+    _MAX_RECURRENT_STATE_ELEMENTS = 65536
+
+    def __init__(
+        self,
+        model: nn.Module,
+        rows: Sequence[cache.NativeMTPRequestCache],
+        *,
+        uids: Optional[Sequence[int]] = None,
+    ):
+        if not rows:
+            raise ValueError("native_mtp_cohort_requires_rows")
+        if any(not isinstance(row, cache.NativeMTPRequestCache) for row in rows):
+            raise TypeError("native_mtp_cohort_requires_native_request_caches")
+        if any(row.model is not model for row in rows):
+            raise ValueError("native_mtp_cohort_model_mismatch")
+        if any(row.closed for row in rows):
+            raise RuntimeError("native_mtp_cohort_row_closed")
+        if any(row.checkpoint_active for row in rows):
+            raise RuntimeError("native_mtp_cohort_row_transaction_active")
+        for row in rows:
+            row.assert_aligned(
+                backbone_tokens=row.state.backbone_tokens,
+                mtp_tokens=row.state.mtp_tokens,
+            )
+
+        if uids is None:
+            uids = tuple(range(len(rows)))
+        if len(uids) != len(rows) or len(set(uids)) != len(uids):
+            raise ValueError("native_mtp_cohort_uids_invalid")
+
+        # Build every destination entry before consuming any source owner.  A
+        # source request becomes closed only after the full merged cohort is
+        # valid, which makes failed construction atomically non-consuming.
+        backbone = self._merge_entries([row.backbone for row in rows])
+        mtp = self._merge_entries([row.mtp for row in rows])
+        self.model = model
+        self._poisoned_reason = None
+        self._checkpoint = None
+        self._transaction_sealed = False
+        self._size = len(rows)
+        self.uids = tuple(uids)
+        self.backbone = backbone
+        self.mtp = mtp
+        self._binding = self._make_binding()
+        try:
+            for row in rows:
+                row.finish("generator_closed")
+        except BaseException:
+            for row in rows:
+                row._checkpoint = None
+                row._replay_required = None
+                row._closed = True
+            self.poison("native_mtp_cohort_source_consume_failed")
+            raise
+
+    @staticmethod
+    def _reject_entry(entry):
+        if isinstance(entry, (QuantizedKVCache, RotatingKVCache, BatchRotatingKVCache)):
+            raise RuntimeError("native_mtp_cohort_cache_layout_unsupported")
+        if not isinstance(entry, (KVCache, BatchKVCache, ArraysCache)):
+            raise TypeError("native_mtp_cohort_cache_type_unsupported")
+
+    @classmethod
+    def _merge_entries(cls, rows):
+        width = len(rows[0])
+        if width == 0 or any(len(row) != width for row in rows):
+            raise ValueError("native_mtp_cohort_cache_topology_mismatch")
+        merged = []
+        for index in range(width):
+            entries = [row[index] for row in rows]
+            for entry in entries:
+                cls._reject_entry(entry)
+            entry_type = type(entries[0])
+            if any(type(entry) is not entry_type for entry in entries):
+                raise TypeError("native_mtp_cohort_cache_type_mismatch")
+            schema = cls._entry_schema(entries[0])
+            if any(cls._entry_schema(entry) != schema for entry in entries[1:]):
+                raise TypeError("native_mtp_cohort_cache_storage_schema_mismatch")
+            merged.append(entry_type.merge(entries))
+        return merged
+
+    @property
+    def size(self):
+        return self._size
+
+    @property
+    def poisoned(self):
+        return self._poisoned_reason is not None
+
+    @staticmethod
+    def _array_layout(value):
+        if value is None:
+            return None
+        return id(value), tuple(value.shape), value.dtype
+
+    @classmethod
+    def _entry_schema(cls, entry):
+        """Stable topology/storage schema; excludes mutable sequence capacity."""
+
+        cls._reject_entry(entry)
+        if isinstance(entry, ArraysCache):
+            batch_size = entry.batch_size
+            if any(
+                value is not None
+                and math.prod(value.shape[1:]) > cls._MAX_RECURRENT_STATE_ELEMENTS
+                for value in entry.cache
+            ):
+                raise RuntimeError("native_mtp_cohort_recurrent_state_too_large")
+            slots = []
+            for value in entry.cache:
+                if value is None:
+                    slots.append(None)
+                    continue
+                if value.ndim < 1 or value.shape[0] != batch_size:
+                    raise RuntimeError(
+                        "native_mtp_cohort_recurrent_batch_size_mismatch"
+                    )
+                slots.append(
+                    (value.ndim, value.shape[0], tuple(value.shape[1:]), value.dtype)
+                )
+            return (
+                type(entry),
+                batch_size,
+                tuple(slots),
+            )
+
+        def kv_schema(value):
+            if value is None:
+                return None
+            return (
+                value.ndim,
+                value.shape[0],
+                value.shape[1],
+                value.shape[3],
+                value.dtype,
+            )
+
+        if entry.keys is None and isinstance(entry, BatchKVCache):
+            if entry.offset.size != entry.left_padding.size:
+                raise RuntimeError("native_mtp_cohort_batch_metadata_width_mismatch")
+            batch_size = entry.offset.size
+        else:
+            batch_size = entry.keys.shape[0] if entry.keys is not None else 1
+
+        return (
+            type(entry),
+            batch_size,
+            kv_schema(entry.keys),
+            kv_schema(entry.values),
+        )
+
+    @classmethod
+    def _entry_layout(cls, entry):
+        """Stable entry ownership plus schema; mutable backing storage is excluded."""
+
+        return id(entry), cls._entry_schema(entry)
+
+    @staticmethod
+    def _metadata_spec(entry):
+        if isinstance(entry, ArraysCache):
+            return (entry.left_padding, entry.lengths)
+        if not isinstance(entry, BatchKVCache):
+            return (mx.array([entry.offset]), None)
+        return (entry.offset, entry.left_padding)
+
+    @classmethod
+    def _host_metadata(cls, entries):
+        """Read mutable cache metadata through exactly one aggregate decision."""
+
+        arrays = []
+        widths = []
+        for entry in entries:
+            entry_widths = []
+            for value in cls._metadata_spec(entry):
+                width = 0 if value is None else value.size
+                entry_widths.append(width)
+                if value is not None:
+                    arrays.append(value.reshape(-1).astype(mx.int64))
+            widths.append(tuple(entry_widths))
+        flattened = mx.concatenate(arrays) if arrays else mx.array([], dtype=mx.int64)
+        mx.eval(flattened)
+        values = tuple(flattened.tolist())
+        cursor = 0
+        metadata = []
+        for entry_widths in widths:
+            entry_values = []
+            for width in entry_widths:
+                entry_values.append(values[cursor : cursor + width])
+                cursor += width
+            entry = entries[len(metadata)]
+            if isinstance(entry, ArraysCache):
+                metadata.append((None, *entry_values))
+            else:
+                metadata.append((entry._idx, *entry_values))
+        return tuple(metadata)
+
+    def _make_binding(self):
+        entries = self.backbone + self.mtp
+        metadata = self._host_metadata(entries)
+        split = len(self.backbone)
+        return _NativeMTPCohortBinding(
+            model_id=id(self.model),
+            backbone_container_id=id(self.backbone),
+            mtp_container_id=id(self.mtp),
+            uids=self.uids,
+            backbone_layout=tuple(self._entry_layout(entry) for entry in self.backbone),
+            mtp_layout=tuple(self._entry_layout(entry) for entry in self.mtp),
+            backbone_metadata=metadata[:split],
+            mtp_metadata=metadata[split:],
+        )
+
+    def _binding_topology_matches(self):
+        """Check ownership identity before reading mutable cache internals.
+
+        In particular, a same-type replacement can be deliberately incomplete
+        (for example, a fresh ``KVCache`` in place of a merged
+        ``BatchKVCache``).  Its identity mismatch is enough to reject it; do
+        not walk its metadata just to discover that its representation is not
+        a valid cohort entry.
+        """
+
+        binding = self._binding
+        if (
+            id(self.model) != binding.model_id
+            or id(self.backbone) != binding.backbone_container_id
+            or id(self.mtp) != binding.mtp_container_id
+            or self.uids != binding.uids
+        ):
+            return False
+
+        def entries_match(entries, layouts):
+            return len(entries) == len(layouts) and all(
+                id(entry) == entry_id and type(entry) is schema[0]
+                for entry, (entry_id, schema) in zip(entries, layouts)
+            )
+
+        return entries_match(self.backbone, binding.backbone_layout) and entries_match(
+            self.mtp, binding.mtp_layout
+        )
+
+    def bind_before_mutation(self):
+        """Assert that the exact cache identities survive until the forward."""
+
+        if self.poisoned:
+            raise RuntimeError(self._poisoned_reason)
+        if not self._binding_topology_matches():
+            self.poison("native_mtp_cohort_cache_binding_changed")
+            raise RuntimeError("native_mtp_cohort_cache_binding_changed")
+        try:
+            actual = self._make_binding()
+        except BaseException as exc:
+            self.poison("native_mtp_cohort_cache_binding_changed")
+            raise RuntimeError("native_mtp_cohort_cache_binding_changed") from exc
+        if actual != self._binding:
+            self.poison("native_mtp_cohort_cache_binding_changed")
+            raise RuntimeError("native_mtp_cohort_cache_binding_changed")
+        return self.backbone, self.mtp
+
+    @staticmethod
+    def _validate_delta(name, before, after, expected):
+        if len(before) != len(after) or len(before) != len(expected):
+            raise ValueError(f"native_mtp_cohort_{name}_delta_topology_mismatch")
+        for layer, (before_layer, after_layer, expected_layer) in enumerate(
+            zip(before, after, expected)
+        ):
+            # KV metadata is (_idx, offsets, left_padding); Arrays metadata is
+            # (None, left_padding, lengths). Both Arrays metadata values must
+            # remain exact across a native-MTP decode transaction.
+            before_index, before_primary, *before_rest = before_layer
+            after_index, after_primary, *after_rest = after_layer
+            if before_index is None:
+                if before_primary != after_primary or tuple(before_rest) != tuple(
+                    after_rest
+                ):
+                    raise RuntimeError(
+                        f"native_mtp_cohort_{name}_arrays_metadata_changed: layer={layer}"
+                    )
+                if expected_layer:
+                    raise RuntimeError(
+                        f"native_mtp_cohort_{name}_array_delta_unsupported: layer={layer}"
+                    )
+                continue
+            if tuple(after_rest) != tuple(before_rest):
+                raise RuntimeError(
+                    f"native_mtp_cohort_{name}_metadata_changed: layer={layer}"
+                )
+            actual_delta = tuple(
+                current - prior for prior, current in zip(before_primary, after_primary)
+            )
+            if (
+                len(before_primary) != len(after_primary)
+                or tuple(expected_layer) != actual_delta
+                or after_index - before_index
+                != (actual_delta[0] if actual_delta else 0)
+                or len(set(actual_delta)) > 1
+            ):
+                raise RuntimeError(
+                    f"native_mtp_cohort_{name}_delta_mismatch: layer={layer}"
+                )
+
+    @classmethod
+    def _schema_transition_allowed(cls, before, after):
+        """Allow only one-way first-population transitions for one owner."""
+
+        before_entry_id, before_schema = before
+        after_entry_id, after_schema = after
+        if (
+            before_entry_id != after_entry_id
+            or len(before_schema) < 2
+            or len(after_schema) < 2
+        ):
+            return False
+
+        before_type, before_batch = before_schema[:2]
+        after_type, after_batch = after_schema[:2]
+        if before_type is not after_type or before_batch != after_batch:
+            return False
+
+        def valid_dimension(value):
+            return isinstance(value, int) and not isinstance(value, bool) and value > 0
+
+        def valid_kv_schema(schema):
+            return (
+                isinstance(schema, tuple)
+                and len(schema) == 5
+                and schema[0] == 4
+                and schema[1] == before_batch
+                and valid_dimension(schema[2])
+                and valid_dimension(schema[3])
+                and schema[4] is not None
+            )
+
+        if before_type in (KVCache, BatchKVCache):
+            if len(before_schema) != 4 or len(after_schema) != 4:
+                return False
+            before_keys, before_values = before_schema[2:]
+            after_keys, after_values = after_schema[2:]
+            return (
+                before_keys is None
+                and before_values is None
+                and valid_kv_schema(after_keys)
+                and valid_kv_schema(after_values)
+            )
+
+        if before_type is ArraysCache:
+            if len(before_schema) != 3 or len(after_schema) != 3:
+                return False
+            before_slots, after_slots = before_schema[2], after_schema[2]
+            if len(before_slots) != len(after_slots):
+                return False
+
+            def valid_array_schema(schema):
+                return (
+                    isinstance(schema, tuple)
+                    and len(schema) == 4
+                    and valid_dimension(schema[0])
+                    and schema[1] == before_batch
+                    and isinstance(schema[2], tuple)
+                    and len(schema[2]) == schema[0] - 1
+                    and all(
+                        isinstance(dimension, int)
+                        and not isinstance(dimension, bool)
+                        and dimension >= 0
+                        for dimension in schema[2]
+                    )
+                    and schema[3] is not None
+                )
+
+            return any(
+                before_slot is None and after_slot is not None
+                for before_slot, after_slot in zip(before_slots, after_slots)
+            ) and all(
+                before_slot == after_slot
+                or (before_slot is None and valid_array_schema(after_slot))
+                for before_slot, after_slot in zip(before_slots, after_slots)
+            )
+
+        return False
+
+    def seal_after_mutation(self, expected: _NativeMTPCohortMutationDelta):
+        """Record the exact post-forward layout before a later forward.
+
+        Call immediately after the cohort's known model forward.  Subsequent
+        ``bind_before_mutation`` calls reject any topology, row ordering,
+        metadata, offset, or backing-array change made outside that boundary.
+        """
+
+        if self.poisoned:
+            raise RuntimeError(self._poisoned_reason)
+        if not isinstance(expected, _NativeMTPCohortMutationDelta):
+            raise TypeError("native_mtp_cohort_expected_delta_required")
+        before = self._binding
+        try:
+            after = self._make_binding()
+        except BaseException as exc:
+            self.poison("native_mtp_cohort_unexpected_layout_change")
+            raise RuntimeError("native_mtp_cohort_unexpected_layout_change") from exc
+        if (
+            before.model_id != after.model_id
+            or before.backbone_container_id != after.backbone_container_id
+            or before.mtp_container_id != after.mtp_container_id
+            or before.uids != after.uids
+            or len(before.backbone_layout) != len(after.backbone_layout)
+            or len(before.mtp_layout) != len(after.mtp_layout)
+            or any(
+                previous != current
+                and not self._schema_transition_allowed(previous, current)
+                for previous, current in zip(
+                    before.backbone_layout, after.backbone_layout
+                )
+            )
+            or any(
+                previous != current
+                and not self._schema_transition_allowed(previous, current)
+                for previous, current in zip(before.mtp_layout, after.mtp_layout)
+            )
+        ):
+            self.poison("native_mtp_cohort_unexpected_layout_change")
+            raise RuntimeError("native_mtp_cohort_unexpected_layout_change")
+        try:
+            self._validate_delta(
+                "backbone",
+                before.backbone_metadata,
+                after.backbone_metadata,
+                expected.backbone,
+            )
+            self._validate_delta(
+                "mtp", before.mtp_metadata, after.mtp_metadata, expected.mtp
+            )
+        except BaseException:
+            self.poison("native_mtp_cohort_unexpected_metadata_change")
+            raise
+        self._binding = after
+        self._transaction_sealed = True
+
+    @staticmethod
+    def _copy_recurrent(value):
+        """Copy a bounded recurrent value without retaining its write target."""
+
+        if value is None:
+            return None
+        return value + mx.zeros(value.shape, dtype=value.dtype)
+
+    @staticmethod
+    def _snapshot_entry(entry):
+        if isinstance(entry, ArraysCache):
+            return (
+                entry,
+                tuple(
+                    _NativeMTPCohortCache._copy_recurrent(value)
+                    for value in entry.cache
+                ),
+                _NativeMTPCohortCache._copy_recurrent(entry.left_padding),
+                _NativeMTPCohortCache._copy_recurrent(entry.lengths),
+            )
+        if not isinstance(entry, BatchKVCache):
+            raise TypeError("native_mtp_cohort_cache_type_unsupported")
+        return (entry, entry._idx, entry.offset, entry.left_padding)
+
+    @staticmethod
+    def _restore_entry(snapshot):
+        entry = snapshot[0]
+        if isinstance(entry, ArraysCache):
+            _, values, left_padding, lengths = snapshot
+            entry.cache = list(values)
+            entry.left_padding = left_padding
+            entry.lengths = lengths
+            return
+        _, previous_idx, previous_offset, previous_left_padding = snapshot
+        trim = entry._idx - previous_idx
+        if trim < 0 or (trim and entry.trim(trim) != trim):
+            raise RuntimeError("native_mtp_cohort_cache_rollback_inexact")
+        entry.offset = previous_offset
+        entry.left_padding = previous_left_padding
+
+    def checkpoint(self):
+        if self.poisoned:
+            raise RuntimeError(self._poisoned_reason)
+        if self._checkpoint is not None:
+            raise RuntimeError("native_mtp_cohort_checkpoint_already_active")
+        self.bind_before_mutation()
+        self._checkpoint = _NativeMTPCohortCacheCheckpoint(
+            backbone=tuple(self._snapshot_entry(entry) for entry in self.backbone),
+            mtp=tuple(self._snapshot_entry(entry) for entry in self.mtp),
+        )
+        self._transaction_sealed = False
+        return self._checkpoint
+
+    def commit(self):
+        if self._checkpoint is None:
+            raise RuntimeError("native_mtp_cohort_checkpoint_missing")
+        if not self._transaction_sealed:
+            raise RuntimeError("native_mtp_cohort_mutation_not_sealed")
+        self._checkpoint = None
+        self._transaction_sealed = False
+
+    def rollback(self):
+        if self._checkpoint is None:
+            raise RuntimeError("native_mtp_cohort_checkpoint_missing")
+        checkpoint, self._checkpoint = self._checkpoint, None
+        self._transaction_sealed = False
+        try:
+            for snapshot in checkpoint.backbone:
+                self._restore_entry(snapshot)
+            for snapshot in checkpoint.mtp:
+                self._restore_entry(snapshot)
+            self._binding = self._make_binding()
+        except BaseException:
+            self.poison("native_mtp_cohort_rollback_failed")
+            raise
+
+    def filter(self, keep: Sequence[int]):
+        if self._checkpoint is not None:
+            raise RuntimeError("native_mtp_cohort_filter_during_transaction")
+        if len(set(keep)) != len(keep) or any(
+            index < 0 or index >= self.size for index in keep
+        ):
+            raise ValueError("native_mtp_cohort_filter_indices_invalid")
+        self.bind_before_mutation()
+        try:
+            partition = self._partition(keep)
+        except BaseException:
+            self.poison("native_mtp_cohort_filter_failed")
+            raise
+        self.backbone, self.mtp, self.uids = partition
+        self._size = len(keep)
+        self._binding = self._make_binding()
+
+    def split(self, keep: Sequence[int]):
+        """Move selected rows into a new owner; neither owner shares a cache."""
+
+        if self._checkpoint is not None:
+            raise RuntimeError("native_mtp_cohort_split_during_transaction")
+        keep = tuple(keep)
+        if len(set(keep)) != len(keep) or any(
+            index < 0 or index >= self.size for index in keep
+        ):
+            raise ValueError("native_mtp_cohort_split_indices_invalid")
+        self.bind_before_mutation()
+        try:
+            selected = self._from_partition(keep)
+            remaining = tuple(
+                index for index in range(self.size) if index not in set(keep)
+            )
+            remaining_partition = self._partition(remaining)
+        except BaseException:
+            self.poison("native_mtp_cohort_split_failed")
+            raise
+        self.backbone, self.mtp, self.uids = remaining_partition
+        self._size = len(remaining)
+        self._binding = self._make_binding()
+        return selected
+
+    @staticmethod
+    def _gather_batch_rows(value, indices):
+        """Select row indices on-device while preserving every trailing axis."""
+
+        if value is None:
+            return None
+        return mx.take(value, indices, axis=0)
+
+    @staticmethod
+    def _partition_entry(entry, indices):
+        """Device-side whole-cohort partition; never extract host rows."""
+
+        indices = mx.array(indices, dtype=mx.int32)
+        clone = copy.copy(entry)
+        if isinstance(entry, ArraysCache):
+            clone.cache = [
+                _NativeMTPCohortCache._gather_batch_rows(value, indices)
+                for value in entry.cache
+            ]
+            clone.left_padding = _NativeMTPCohortCache._gather_batch_rows(
+                entry.left_padding, indices
+            )
+            clone.lengths = _NativeMTPCohortCache._gather_batch_rows(
+                entry.lengths, indices
+            )
+            return clone
+        clone.keys = _NativeMTPCohortCache._gather_batch_rows(entry.keys, indices)
+        clone.values = _NativeMTPCohortCache._gather_batch_rows(entry.values, indices)
+        clone.offset = _NativeMTPCohortCache._gather_batch_rows(entry.offset, indices)
+        clone.left_padding = _NativeMTPCohortCache._gather_batch_rows(
+            entry.left_padding, indices
+        )
+        clone._right_padding = None
+        return clone
+
+    def _partition(self, indices):
+        if not indices:
+            return [], [], ()
+        return (
+            [self._partition_entry(entry, indices) for entry in self.backbone],
+            [self._partition_entry(entry, indices) for entry in self.mtp],
+            tuple(self.uids[index] for index in indices),
+        )
+
+    @classmethod
+    def _from_merged(cls, model, backbone, mtp, uids):
+        owner = object.__new__(cls)
+        owner.model = model
+        owner._poisoned_reason = None
+        owner._checkpoint = None
+        owner._transaction_sealed = False
+        owner._size = len(uids)
+        owner.uids = tuple(uids)
+        owner.backbone = backbone
+        owner.mtp = mtp
+        owner._binding = owner._make_binding()
+        return owner
+
+    def _from_partition(self, indices):
+        return self._from_merged(self.model, *self._partition(indices))
+
+    def join(self, other):
+        if not isinstance(other, type(self)) or other.model is not self.model:
+            raise ValueError("native_mtp_cohort_join_model_mismatch")
+        if self._checkpoint is not None or other._checkpoint is not None:
+            raise RuntimeError("native_mtp_cohort_join_during_transaction")
+        self.bind_before_mutation()
+        other.bind_before_mutation()
+        if self.size == 0:
+            self.backbone, self.mtp, self.uids = other.backbone, other.mtp, other.uids
+            self._size = other.size
+            self._binding = self._make_binding()
+            other.poison("native_mtp_cohort_moved")
+            return
+        if other.size == 0:
+            other.poison("native_mtp_cohort_moved")
+            return
+        try:
+            staged_backbone = [copy.copy(entry) for entry in self.backbone]
+            staged_mtp = [copy.copy(entry) for entry in self.mtp]
+            for own, incoming in zip(
+                staged_backbone + staged_mtp, other.backbone + other.mtp
+            ):
+                own.extend(incoming)
+            staged_uids = self.uids + other.uids
+            if len(set(staged_uids)) != len(staged_uids):
+                raise ValueError("native_mtp_cohort_join_uid_collision")
+        except BaseException:
+            self.poison("native_mtp_cohort_join_failed")
+            other.poison("native_mtp_cohort_join_failed")
+            raise
+        self.backbone, self.mtp, self.uids = staged_backbone, staged_mtp, staged_uids
+        self._size += other.size
+        self._binding = self._make_binding()
+        other.poison("native_mtp_cohort_moved")
+
+    def poison(self, reason):
+        self._checkpoint = None
+        self._transaction_sealed = False
+        self._poisoned_reason = reason
+
+
 def _validate_receipt_against_record(receipt, record):
     if (
         not isinstance(receipt, GenerationForwardPositionReceipt)
@@ -802,9 +1591,7 @@ class NativeMTPSparseBootstrap:
                 return None
             previous_position = position
         if any(
-            isinstance(token_id, bool)
-            or not isinstance(token_id, int)
-            or token_id < 0
+            isinstance(token_id, bool) or not isinstance(token_id, int) or token_id < 0
             for token_id in (*token_ids, *successors)
         ):
             return None
@@ -1930,63 +2717,6 @@ def mtp_generate_step(
     request = None
     sparse_claim = None
 
-    def _next_rng_key():
-        nonlocal rng_key
-        keys = mx.random.split(rng_key)
-        rng_key = keys[0]
-        return keys[1]
-
-    def _sample(logprobs):
-        if sampling_config.stochastic:
-            return mx.random.categorical(logprobs, key=_next_rng_key())
-        if sampler is None:
-            return mx.argmax(logprobs, axis=-1)
-        return sampler(logprobs)
-
-    def _reported_logprobs(logits, tokens):
-        if logits.ndim == 1:
-            logits = logits[None]
-        if logits_processors:
-            for processor in logits_processors:
-                logits = processor(tokens, logits)
-        return (logits - mx.logsumexp(logits, axis=-1, keepdims=True)).squeeze(0)
-
-    def _sampling_distribution(reported_logprobs):
-        logprobs = reported_logprobs[None]
-        if sampling_config.top_p < 1:
-            logprobs = apply_top_p(logprobs, sampling_config.top_p)
-        if sampling_config.min_p > 0:
-            keep = sampling_config.min_tokens_to_keep
-            vocab_size = logprobs.shape[-1]
-            if keep > vocab_size:
-                raise ValueError(
-                    "native MTP min_tokens_to_keep cannot exceed vocabulary size"
-                )
-            if keep < vocab_size:
-                # apply_min_p's multi-token branch passes a Python bool to
-                # put_along_axis, which newer MLX releases reject.  Preserve
-                # the standard filter exactly by restoring the requested top
-                # tokens with array-valued replacements.
-                unfiltered = logprobs
-                logprobs = apply_min_p(logprobs, sampling_config.min_p)
-                if keep > 1:
-                    top_indices = mx.argpartition(unfiltered, kth=-keep, axis=-1)[
-                        ..., -keep:
-                    ]
-                    top_values = mx.take_along_axis(unfiltered, top_indices, axis=-1)
-                    logprobs = mx.put_along_axis(
-                        logprobs, top_indices, top_values, axis=-1
-                    )
-        if sampling_config.top_k > 0:
-            if sampling_config.top_k >= logprobs.shape[-1]:
-                raise ValueError(
-                    "native MTP top_k must be smaller than vocabulary size"
-                )
-            logprobs = apply_top_k(logprobs, sampling_config.top_k)
-        if sampling_config.stochastic:
-            logprobs = logprobs / sampling_config.temperature
-        return (logprobs - mx.logsumexp(logprobs, axis=-1, keepdims=True)).squeeze(0)
-
     def _target_call(
         input_tokens,
         phase,
@@ -2081,27 +2811,17 @@ def mtp_generate_step(
                 mtp_tokens=request.state.mtp_tokens + next_tokens.size,
             )
             _assert_target_mtp_alignment()
-            draft_reported_logprobs = _reported_logprobs(
+            draft_reported_logprobs = sampling_state.reported_logprobs(
                 logits.squeeze(0), token_history
             )
-            draft_logprobs = _sampling_distribution(draft_reported_logprobs)
-            draft_token = _sample(draft_logprobs)
+            draft_logprobs = sampling_state.sampling_distribution(
+                draft_reported_logprobs
+            )
+            draft_token = sampling_state.sample(draft_logprobs)
         mx.eval(draft_token, draft_logprobs)
         if telemetry is not None:
             telemetry["mtp_drafts"] += 1
         return draft_token.reshape(-1), draft_logprobs
-
-    def _residual_sample(target_logprobs, draft_logprobs):
-        target_probs = mx.exp(target_logprobs)
-        draft_probs = mx.exp(draft_logprobs)
-        residual = mx.maximum(target_probs - draft_probs, 0)
-        normalizer = mx.sum(residual)
-        residual_logprobs = mx.where(
-            normalizer > 0,
-            mx.log(residual / normalizer),
-            target_logprobs,
-        )
-        return _sample(residual_logprobs), residual_logprobs
 
     finish_reason = "generator_closed"
     generated = 0
@@ -2123,10 +2843,11 @@ def mtp_generate_step(
                 mtp_bypass_reason=None,
             )
         eos_token_ids = frozenset(eos_token_ids or ())
-        rng_key = mx.random.key(
-            sampling_config.seed
-            if sampling_config.seed is not None
-            else (time.time_ns() & ((1 << 63) - 1))
+        sampling_state = _NativeMTPSamplingState(
+            sampling_config,
+            sampler=sampler,
+            logits_processors=logits_processors,
+            seed=sampling_config.seed,
         )
         if max_tokens == 0:
             finish_reason = "length"
@@ -2206,11 +2927,15 @@ def mtp_generate_step(
                     )
                 # Match generate_step: processors see only the final step.
                 history = remaining.astype(mx.uint32)
-                current_logprobs = _reported_logprobs(
+                current_logprobs = sampling_state.reported_logprobs(
                     initial_logits[:, -1, :].squeeze(0), history
                 )
-                current_sampling_logprobs = _sampling_distribution(current_logprobs)
-                current_token = _sample(current_sampling_logprobs).reshape(-1)
+                current_sampling_logprobs = sampling_state.sampling_distribution(
+                    current_logprobs
+                )
+                current_token = sampling_state.sample(
+                    current_sampling_logprobs
+                ).reshape(-1)
             current_hidden = initial_hidden[:, -1:, :]
         else:
             selected_count = len(sparse_claim.selected_token_ids)
@@ -2238,9 +2963,7 @@ def mtp_generate_step(
                         pair_start = pair_end
                         mx.clear_cache()
                 mx.eval(
-                    tuple(
-                        record.hidden_rows for record in sparse_claim.records
-                    ),
+                    tuple(record.hidden_rows for record in sparse_claim.records),
                     sparse_claim.final_target_logits,
                     [entry.state for entry in request.backbone],
                     [entry.state for entry in request.mtp],
@@ -2248,12 +2971,16 @@ def mtp_generate_step(
                 history = mx.array(
                     [sparse_claim.selected_token_ids[-1]], dtype=mx.uint32
                 )
-                current_logprobs = _reported_logprobs(
+                current_logprobs = sampling_state.reported_logprobs(
                     sparse_claim.final_target_logits[:, -1, :].squeeze(0),
                     history,
                 )
-                current_sampling_logprobs = _sampling_distribution(current_logprobs)
-                current_token = _sample(current_sampling_logprobs).reshape(-1)
+                current_sampling_logprobs = sampling_state.sampling_distribution(
+                    current_logprobs
+                )
+                current_token = sampling_state.sample(
+                    current_sampling_logprobs
+                ).reshape(-1)
             current_hidden = sparse_claim.final_target_hidden
         mx.eval(current_token, current_logprobs)
         if sparse_bootstrap is not None:
@@ -2309,10 +3036,12 @@ def mtp_generate_step(
                     backbone_tokens=request.state.backbone_tokens + 2,
                     mtp_tokens=request.state.mtp_tokens,
                 )
-                verify_logprobs = _reported_logprobs(
+                verify_logprobs = sampling_state.reported_logprobs(
                     verify_logits[:, 0, :].squeeze(0), history
                 )
-                verify_sampling_logprobs = _sampling_distribution(verify_logprobs)
+                verify_sampling_logprobs = sampling_state.sampling_distribution(
+                    verify_logprobs
+                )
 
             if sampling_config.stochastic:
                 draft_id = draft_token.item()
@@ -2322,18 +3051,24 @@ def mtp_generate_step(
                     ),
                     1.0,
                 )
-                accepted = mx.random.uniform(key=_next_rng_key()) < acceptance
+                accepted = (
+                    mx.random.uniform(key=sampling_state.next_rng_key()) < acceptance
+                )
                 mx.eval(accepted)
                 accepted = bool(accepted.item())
                 replacement_token = replacement_logprobs = None
                 if not accepted:
-                    replacement_token, replacement_logprobs = _residual_sample(
-                        verify_sampling_logprobs, draft_logprobs
+                    replacement_token, replacement_logprobs = (
+                        sampling_state.residual_sample(
+                            verify_sampling_logprobs, draft_logprobs
+                        )
                     )
                     replacement_token = replacement_token.reshape(-1)
                     mx.eval(replacement_token, replacement_logprobs)
             else:
-                replacement_token = _sample(verify_sampling_logprobs).reshape(-1)
+                replacement_token = sampling_state.sample(
+                    verify_sampling_logprobs
+                ).reshape(-1)
                 mx.eval(replacement_token)
                 accepted = replacement_token.item() == draft_token.item()
                 replacement_logprobs = verify_sampling_logprobs
@@ -2360,11 +3095,13 @@ def mtp_generate_step(
                 # Bonus processing begins only after the accepted draft has
                 # crossed its yield/resume boundary.
                 bonus_history = mx.concatenate([history, draft_token])
-                bonus_logprobs = _reported_logprobs(
+                bonus_logprobs = sampling_state.reported_logprobs(
                     verify_logits[:, 1, :].squeeze(0), bonus_history
                 )
-                bonus_sampling_logprobs = _sampling_distribution(bonus_logprobs)
-                bonus_token = _sample(bonus_sampling_logprobs).reshape(-1)
+                bonus_sampling_logprobs = sampling_state.sampling_distribution(
+                    bonus_logprobs
+                )
+                bonus_token = sampling_state.sample(bonus_sampling_logprobs).reshape(-1)
                 mx.eval(bonus_token, bonus_logprobs)
                 next_history = mx.concatenate([bonus_history, bonus_token])
                 generated += 1
@@ -2545,7 +3282,9 @@ def stream_generate(
             prompt = tokenizer.encode(prompt, add_special_tokens=add_special_tokens)
         prompt = mx.array(prompt)
 
-    prompt_tokens = prompt.size if sparse_prompt_tokens is None else sparse_prompt_tokens
+    prompt_tokens = (
+        prompt.size if sparse_prompt_tokens is None else sparse_prompt_tokens
+    )
 
     detokenizer = tokenizer.detokenizer
 

--- a/mlx_lm/generate.py
+++ b/mlx_lm/generate.py
@@ -649,6 +649,35 @@ class _NativeMTPSparseClaim:
         return self.records[-1].canonical_final_logits
 
 
+def abandon_native_mtp_sparse_receipts(
+    receipts: Sequence[GenerationForwardPositionReceipt],
+) -> None:
+    """Consume issued, unreserved sparse receipts without touching model state.
+
+    This is the narrow owner for a partial ordered receipt set when a later
+    attested target chunk fails before a complete bootstrap can be formed.
+    It is deliberately best-effort for malformed caller containers: only a
+    live canonical receipt can remove its own direct weak-registry authority.
+    A claim reservation always wins over abandonment and remains responsible
+    for its existing finally-path cleanup.
+    """
+
+    if not isinstance(receipts, (list, tuple)):
+        return
+    with _GENERATION_FORWARD_RECEIPT_LOCK:
+        for receipt in receipts:
+            record_token = getattr(receipt, "_record_token", None)
+            if not isinstance(record_token, _GenerationForwardReceiptToken):
+                continue
+            authority = _GENERATION_FORWARD_RECEIPTS.get(record_token)
+            if (
+                authority is not None
+                and authority.reservation is None
+                and authority.record.receipt_id == id(receipt)
+            ):
+                del _GENERATION_FORWARD_RECEIPTS[record_token]
+
+
 @dataclass(frozen=True)
 class NativeMTPSparseBootstrap:
     """Attested sparse target state from which native MTP may start.
@@ -672,6 +701,17 @@ class NativeMTPSparseBootstrap:
     @property
     def final_target_logits(self) -> mx.array:
         return self.receipts[-1].logits
+
+    def close(self) -> None:
+        """Abandon this bootstrap's still-unclaimed receipt authority.
+
+        Closing is idempotent and does not sample, construct an MTP request,
+        or mutate the attested target cache. A claim that already reserved the
+        same receipts remains its sole owner and consumes them in its own
+        finally path.
+        """
+
+        abandon_native_mtp_sparse_receipts(self.receipts)
 
     def _canonical_records_locked(self, reservation=None):
         records = []

--- a/mlx_lm/generate.py
+++ b/mlx_lm/generate.py
@@ -1619,10 +1619,14 @@ class NativeMTPReadyEpoch(_NativeMTPEpoch):
 
 
 class NativeMTPDecisionEpoch(_NativeMTPEpoch):
-    def accept(self) -> "NativeMTPAcceptedEpoch":
+    def accept(
+        self,
+    ) -> Tuple[Tuple[NativeMTPEmission, ...], "NativeMTPAcceptedEpoch"]:
         return self._generator._accept(self)
 
-    def reject(self) -> "NativeMTPRejectedEpoch":
+    def reject(
+        self,
+    ) -> Tuple[Tuple[NativeMTPEmission, ...], "NativeMTPRejectedEpoch"]:
         return self._generator._reject(self)
 
     def resolve(self):
@@ -2142,7 +2146,7 @@ class NativeMTPBatchGenerator:
         )
         result = NativeMTPAcceptedEpoch(self, _NativeMTPPhase.ACCEPTED, active)
         result._deferred_rejected = epoch.rejected_uids
-        return self._replace(result, "accepted_draft_emission")
+        return emissions, self._replace(result, "accepted_draft_emission")
 
     def _resolve_mixed(self, epoch):
         """Split only after rollback; branch owners never share recurrent state."""
@@ -2441,7 +2445,7 @@ class NativeMTPBatchGenerator:
         active = self._record_emissions(
             _NativeMTPPhase.REJECTED, emissions, expected=epoch.rejected_uids
         )
-        return self._replace(
+        return emissions, self._replace(
             NativeMTPRejectedEpoch(self, _NativeMTPPhase.REJECTED, active),
             "rollback_replay_replacement_emission",
         )

--- a/mlx_lm/generate.py
+++ b/mlx_lm/generate.py
@@ -79,6 +79,58 @@ class GenerationForwardPhase(str, Enum):
     MTP_DRAFT = "mtp_draft"
 
 
+LogicalPositionVector = Tuple[int, ...]
+LogicalPositionMatrix = Tuple[LogicalPositionVector, ...]
+GenerationLogicalPositions = Union[LogicalPositionVector, LogicalPositionMatrix]
+
+
+def _logical_position_shape(
+    logical_positions: GenerationLogicalPositions,
+) -> Tuple[int, int]:
+    """Validate immutable host positions and return their exact ``(B, S)``.
+
+    A legacy vector is deliberately only valid for a single row.  Batched
+    callers must supply one explicit immutable row per input batch entry, so a
+    shared row can never be silently broadcast over another request.
+    """
+
+    if not isinstance(logical_positions, tuple) or not logical_positions:
+        raise ValueError("generation_logical_positions_required")
+    first = logical_positions[0]
+    if isinstance(first, tuple):
+        rows = logical_positions
+        if not rows or any(not isinstance(row, tuple) or not row for row in rows):
+            raise ValueError("generation_logical_position_matrix_ragged")
+        sequence_length = len(rows[0])
+        if any(len(row) != sequence_length for row in rows):
+            raise ValueError("generation_logical_position_matrix_ragged")
+        values = (position for row in rows for position in row)
+        shape = (len(rows), sequence_length)
+    else:
+        values = iter(logical_positions)
+        shape = (1, len(logical_positions))
+    if any(
+        isinstance(position, bool) or not isinstance(position, int) or position < 0
+        for position in values
+    ):
+        raise ValueError("generation_logical_position_value_invalid")
+    return shape
+
+
+def _validate_logical_positions_for_input(
+    logical_positions: GenerationLogicalPositions, input_shape: Tuple[int, ...]
+) -> None:
+    if len(input_shape) != 2:
+        raise ValueError("generation_logical_position_input_rank_invalid")
+    if input_shape[0] > 1 and not isinstance(logical_positions[0], tuple):
+        raise ValueError("generation_logical_position_batch_requires_matrix")
+    if input_shape[0] == 1 and isinstance(logical_positions[0], tuple):
+        raise ValueError("generation_logical_position_single_row_requires_vector")
+    position_shape = _logical_position_shape(logical_positions)
+    if position_shape != input_shape:
+        raise ValueError("generation_logical_position_input_shape_mismatch")
+
+
 @dataclass(frozen=True)
 class GenerationForward:
     """Immutable metadata for one Python model-call graph construction.
@@ -93,8 +145,22 @@ class GenerationForward:
     cache: Any
     phase: GenerationForwardPhase
     input_embeddings: Optional[mx.array] = None
-    logical_positions: Optional[Tuple[int, ...]] = None
+    logical_positions: Optional[GenerationLogicalPositions] = None
     logical_position_ack: Optional["GenerationForwardPositionAck"] = None
+
+    def __post_init__(self):
+        if self.logical_positions is not None:
+            _validate_logical_positions_for_input(
+                self.logical_positions, tuple(self.input_tokens.shape)
+            )
+            if self.logical_position_ack is not None and (
+                self.logical_position_ack._logical_positions != self.logical_positions
+                or self.logical_position_ack._position_shape
+                != tuple(self.input_tokens.shape)
+            ):
+                raise ValueError("generation_logical_position_ack_binding_mismatch")
+        elif self.logical_position_ack is not None:
+            raise ValueError("generation_logical_position_ack_requires_positions")
 
 
 @dataclass(frozen=True)
@@ -345,7 +411,7 @@ class GenerationForwardPositionAck:
 
     def __init__(
         self,
-        logical_positions: Tuple[int, ...],
+        logical_positions: GenerationLogicalPositions,
         *,
         model: Optional[nn.Module] = None,
         cache: Optional[Any] = None,
@@ -354,12 +420,18 @@ class GenerationForwardPositionAck:
         phase: Optional[GenerationForwardPhase] = None,
         _receipt_issuer=None,
     ):
+        self._position_shape = _logical_position_shape(logical_positions)
         self._logical_positions = logical_positions
         self._model = model
         self._cache = cache
         self._token_ids = token_ids
         self._immediate_successor_token_ids = immediate_successor_token_ids
         self._phase = phase
+        self._capability = (
+            NativeMTPCapabilityFingerprint.from_model(model)
+            if model is not None and getattr(model, "mtp_capability", None) is not None
+            else None
+        )
         self._receipt_issuer = _receipt_issuer
         self._active = False
         self._acknowledged = False
@@ -370,7 +442,7 @@ class GenerationForwardPositionAck:
     def receipt(self) -> Optional[GenerationForwardPositionReceipt]:
         return self._receipt
 
-    def acknowledge(self, logical_positions: Tuple[int, ...]) -> None:
+    def acknowledge(self, logical_positions: GenerationLogicalPositions) -> None:
         if not self._active or self._finished:
             raise RuntimeError("generation_logical_position_ack_outside_forward")
         if self._acknowledged:
@@ -380,6 +452,21 @@ class GenerationForwardPositionAck:
         ):
             raise RuntimeError("generation_logical_position_ack_mismatch")
         self._acknowledged = True
+
+    def _assert_consumer_binding(self, *, model, cache, phase, input_shape) -> None:
+        """Reject a context consumed by a different model-call graph."""
+
+        if (
+            self._model is not model
+            or self._cache is not cache
+            or self._phase is not phase
+            or tuple(input_shape) != self._position_shape
+        ):
+            raise RuntimeError("generation_logical_position_consumer_mismatch")
+        if self._capability is not None and (
+            NativeMTPCapabilityFingerprint.from_model(model) != self._capability
+        ):
+            raise RuntimeError("generation_logical_position_capability_mismatch")
 
     def _activate(self) -> None:
         if self._active or self._finished:
@@ -472,6 +559,32 @@ class GenerationForwardPositionAck:
 
 
 GenerationForwardContext = Callable[[GenerationForward], ContextManager[None]]
+
+
+def _native_mtp_position_context(
+    model: nn.Module,
+    external_context: Optional[GenerationForwardContext],
+) -> GenerationForwardContext:
+    """Choose the one authoritative position consumer for native MTP.
+
+    Qwen publishes a model-owned context hook.  It is selected automatically
+    so callers cannot accidentally request sparse logical positions without
+    applying them inside the model.  Older third-party native-MTP models may
+    still provide the existing external callback, but a Qwen hook and a
+    different external callback would create ambiguous dual consumers and is
+    rejected before any cache is constructed.
+    """
+
+    canonical_context = getattr(model, "generation_forward_context", None)
+    if canonical_context is not None and not callable(canonical_context):
+        raise TypeError("native_mtp_model_position_context_invalid")
+    if canonical_context is not None:
+        if external_context is not None and external_context is not canonical_context:
+            raise ValueError("native_mtp_position_context_ambiguous")
+        return canonical_context
+    if external_context is None:
+        raise ValueError("native_mtp_position_context_missing")
+    return external_context
 
 
 def attested_target_forward(
@@ -3742,8 +3855,9 @@ def mtp_generate_step(
     uses an explicit per-request MLX key.  Opaque filters and stateful logits
     processors fail before cache construction because they cannot be replayed
     exactly after a rejected recurrent verification.  Optional sparse prompt
-    coordinates are immutable host metadata only: every forward must be
-    acknowledged by the request-local context consumer that applies them.
+    coordinates are immutable host metadata only: Qwen selects its canonical
+    in-model context automatically and every forward must acknowledge exact
+    consumption before its request cache can be retained.
     """
 
     if prompt_cache is not None:
@@ -3766,8 +3880,6 @@ def mtp_generate_step(
             raise ValueError("native_mtp_sparse_bootstrap_owns_selected_tokens")
         if prompt_logical_positions is not None:
             raise ValueError("native_mtp_sparse_bootstrap_owns_logical_positions")
-        if model_forward_context is None:
-            raise ValueError("native_mtp_sparse_bootstrap_requires_position_context")
     if max_tokens < 0:
         raise ValueError("native MTP requires a finite non-negative max_tokens")
     if (
@@ -3799,8 +3911,6 @@ def mtp_generate_step(
 
     logical_prompt = None
     if prompt_logical_positions is not None:
-        if model_forward_context is None:
-            raise ValueError("native_mtp_logical_positions_require_forward_context")
         if isinstance(prompt_logical_positions, mx.array) or not isinstance(
             prompt_logical_positions, Sequence
         ):
@@ -3829,6 +3939,11 @@ def mtp_generate_step(
     logical_positions_active = (
         logical_prompt is not None or sparse_bootstrap is not None
     )
+    position_forward_context = (
+        _native_mtp_position_context(model, model_forward_context)
+        if logical_positions_active
+        else None
+    )
 
     request = None
     sparse_claim = None
@@ -3842,10 +3957,20 @@ def mtp_generate_step(
         immediate_successor_token_ids=(),
     ):
         batched = input_tokens[None]
-        if model_forward_context is None:
+        forward_context = (
+            position_forward_context
+            if logical_positions is not None
+            else model_forward_context
+        )
+        if forward_context is None:
             return model(batched, cache=request.backbone, return_hidden=return_hidden)
         position_ack = (
-            GenerationForwardPositionAck(logical_positions)
+            GenerationForwardPositionAck(
+                logical_positions,
+                model=model,
+                cache=request.backbone,
+                phase=phase,
+            )
             if logical_positions is not None
             else None
         )
@@ -3857,7 +3982,7 @@ def mtp_generate_step(
             logical_positions=logical_positions,
             logical_position_ack=position_ack,
         )
-        with model_forward_context(forward):
+        with forward_context(forward):
             if position_ack is None:
                 return model(
                     batched, cache=request.backbone, return_hidden=return_hidden
@@ -3874,10 +3999,20 @@ def mtp_generate_step(
 
     def _mtp_call(hidden, next_tokens, *, logical_positions=None):
         next_ids = next_tokens.reshape(1, -1)
-        if model_forward_context is None:
+        forward_context = (
+            position_forward_context
+            if logical_positions is not None
+            else model_forward_context
+        )
+        if forward_context is None:
             return model.mtp_forward(hidden, next_ids, request.mtp)
         position_ack = (
-            GenerationForwardPositionAck(logical_positions)
+            GenerationForwardPositionAck(
+                logical_positions,
+                model=model,
+                cache=request.mtp,
+                phase=GenerationForwardPhase.MTP_DRAFT,
+            )
             if logical_positions is not None
             else None
         )
@@ -3889,7 +4024,7 @@ def mtp_generate_step(
             logical_positions=logical_positions,
             logical_position_ack=position_ack,
         )
-        with model_forward_context(forward):
+        with forward_context(forward):
             if position_ack is None:
                 return model.mtp_forward(hidden, next_ids, request.mtp)
             position_ack._activate()
@@ -4365,8 +4500,6 @@ def stream_generate(
             raise ValueError("native_mtp_sparse_bootstrap_external_draft_unsupported")
         if prompt is not None:
             raise ValueError("native_mtp_sparse_bootstrap_owns_selected_tokens")
-        if model_forward_context is None:
-            raise ValueError("native_mtp_sparse_bootstrap_requires_position_context")
         if kwargs.get("prompt_logical_positions") is not None:
             raise ValueError("native_mtp_sparse_bootstrap_owns_logical_positions")
         if kwargs.get("prompt_cache") is not None:

--- a/mlx_lm/generate.py
+++ b/mlx_lm/generate.py
@@ -2255,12 +2255,13 @@ def mtp_generate_step(
 def stream_generate(
     model: nn.Module,
     tokenizer: Union[PreTrainedTokenizer, TokenizerWrapper],
-    prompt: Union[str, mx.array, List[int]],
+    prompt: Optional[Union[str, mx.array, List[int]]],
     max_tokens: int = 256,
     draft_model: Optional[nn.Module] = None,
     mtp: bool = False,
     mtp_sampling_config: Optional[NativeMTPSamplingConfig] = None,
     model_forward_context: Optional[GenerationForwardContext] = None,
+    sparse_bootstrap: Optional[NativeMTPSparseBootstrap] = None,
     **kwargs,
 ) -> Generator[GenerationResponse, None, None]:
     """
@@ -2269,8 +2270,9 @@ def stream_generate(
     Args:
         model (nn.Module): The model to use for generation.
         tokenizer (PreTrainedTokenizer): The tokenizer.
-        prompt (Union[str, mx.array, List[int]]): The input prompt string or
-          integer tokens.
+        prompt (Union[str, mx.array, List[int]], optional): The input prompt
+          string or integer tokens. ``None`` is only valid with native MTP and
+          an attested ``sparse_bootstrap`` that owns the selected prompt state.
         max_tokens (int): The maximum number of tokens to generate.
           Default: ``256``.
         draft_model (Optional[nn.Module]): An optional draft model. If provided
@@ -2283,6 +2285,10 @@ def stream_generate(
         model_forward_context (Callable[[GenerationForward], ContextManager], optional):
           A request-local context factory forwarded to the selected generation
           implementation. The scope covers Python model-call graph construction.
+        sparse_bootstrap (NativeMTPSparseBootstrap, optional): Attested sparse
+          target state for native MTP. It owns the prompt tokens and logical
+          positions, and cannot be combined with ``prompt`` or an external
+          draft model.
         kwargs: The remaining options get passed to :func:`generate_step`.
           See :func:`generate_step` for more details.
 
@@ -2290,10 +2296,41 @@ def stream_generate(
         GenerationResponse: An instance containing the generated text segment and
             associated metadata. See :class:`GenerationResponse` for details.
     """
+    sparse_prompt_tokens = None
+    if sparse_bootstrap is not None:
+        if not isinstance(sparse_bootstrap, NativeMTPSparseBootstrap):
+            raise TypeError("native_mtp_sparse_bootstrap_invalid")
+        if not mtp:
+            raise ValueError("native_mtp_sparse_bootstrap_requires_mtp")
+        if draft_model is not None:
+            raise ValueError("native_mtp_sparse_bootstrap_external_draft_unsupported")
+        if prompt is not None:
+            raise ValueError("native_mtp_sparse_bootstrap_owns_selected_tokens")
+        if model_forward_context is None:
+            raise ValueError("native_mtp_sparse_bootstrap_requires_position_context")
+        if kwargs.get("prompt_logical_positions") is not None:
+            raise ValueError("native_mtp_sparse_bootstrap_owns_logical_positions")
+        if kwargs.get("prompt_cache") is not None:
+            raise ValueError("native_mtp_prefix_reuse_unsupported")
+        capability = getattr(model, "mtp_capability", None)
+        if capability is None or not capability.supported:
+            reason = (
+                "native_mtp_model_capability_missing"
+                if capability is None
+                else capability.reason
+            )
+            raise RuntimeError(reason)
+        # Sparse prefill completed before this public stream starts. The next
+        # logical position is immutable host metadata and preserves original
+        # prompt-token usage without forcing device realization.
+        sparse_prompt_tokens = sparse_bootstrap.next_logical_position
+    elif prompt is None:
+        raise ValueError("stream_generate requires a prompt")
+
     if not isinstance(tokenizer, TokenizerWrapper):
         tokenizer = TokenizerWrapper(tokenizer)
 
-    if not isinstance(prompt, mx.array):
+    if sparse_bootstrap is None and not isinstance(prompt, mx.array):
         if isinstance(prompt, str):
             # Try to infer if special tokens are needed
             add_special_tokens = tokenizer.bos_token is None or not prompt.startswith(
@@ -2301,6 +2338,8 @@ def stream_generate(
             )
             prompt = tokenizer.encode(prompt, add_special_tokens=add_special_tokens)
         prompt = mx.array(prompt)
+
+    prompt_tokens = prompt.size if sparse_prompt_tokens is None else sparse_prompt_tokens
 
     detokenizer = tokenizer.detokenizer
 
@@ -2319,12 +2358,17 @@ def stream_generate(
             kwargs.pop("max_kv_size", None)
             kwargs.pop("prompt_progress_callback", None)
             kwargs.pop("num_draft_tokens", None)
+            native_mtp_kwargs = {
+                "sampling_config": mtp_sampling_config,
+                "eos_token_ids": tokenizer.eos_token_ids,
+                "telemetry": mtp_telemetry,
+            }
+            if sparse_bootstrap is not None:
+                native_mtp_kwargs["sparse_bootstrap"] = sparse_bootstrap
             token_generator = mtp_generate_step(
                 prompt,
                 model,
-                sampling_config=mtp_sampling_config,
-                eos_token_ids=tokenizer.eos_token_ids,
-                telemetry=mtp_telemetry,
+                **native_mtp_kwargs,
                 **kwargs,
             )
         else:
@@ -2364,7 +2408,11 @@ def stream_generate(
             for n, (token, logprobs, from_draft) in enumerate(token_generator):
                 if n == 0:
                     prompt_time = time.perf_counter() - tic
-                    prompt_tps = prompt.size / prompt_time
+                    prompt_tps = (
+                        0.0
+                        if sparse_bootstrap is not None
+                        else prompt_tokens / prompt_time
+                    )
                     tic = time.perf_counter()
                 if token in tokenizer.eos_token_ids:
                     break
@@ -2378,7 +2426,7 @@ def stream_generate(
                     token=token,
                     logprobs=logprobs,
                     from_draft=from_draft,
-                    prompt_tokens=prompt.size,
+                    prompt_tokens=prompt_tokens,
                     prompt_tps=prompt_tps,
                     generation_tokens=n + 1,
                     generation_tps=(n + 1) / (time.perf_counter() - tic),
@@ -2399,7 +2447,7 @@ def stream_generate(
             token=token,
             logprobs=logprobs,
             from_draft=from_draft,
-            prompt_tokens=prompt.size,
+            prompt_tokens=prompt_tokens,
             prompt_tps=prompt_tps,
             generation_tokens=n + 1,
             generation_tps=(n + 1) / (time.perf_counter() - tic),

--- a/mlx_lm/generate.py
+++ b/mlx_lm/generate.py
@@ -90,6 +90,49 @@ class GenerationForward:
     cache: Any
     phase: GenerationForwardPhase
     input_embeddings: Optional[mx.array] = None
+    logical_positions: Optional[Tuple[int, ...]] = None
+    logical_position_ack: Optional["GenerationForwardPositionAck"] = None
+
+
+class GenerationForwardPositionAck:
+    """One-shot proof that a context consumer used exact logical positions.
+
+    The generation wrapper activates the acknowledgement only for the model
+    call itself.  A request-local position hook must acknowledge the immutable
+    host positions while that call is in progress; acknowledging on context
+    entry/exit, acknowledging twice, or acknowledging different positions is
+    rejected.
+    """
+
+    def __init__(self, logical_positions: Tuple[int, ...]):
+        self._logical_positions = logical_positions
+        self._active = False
+        self._acknowledged = False
+        self._finished = False
+
+    def acknowledge(self, logical_positions: Tuple[int, ...]) -> None:
+        if not self._active or self._finished:
+            raise RuntimeError("generation_logical_position_ack_outside_forward")
+        if self._acknowledged:
+            raise RuntimeError("generation_logical_position_ack_reused")
+        if not isinstance(logical_positions, tuple) or (
+            logical_positions != self._logical_positions
+        ):
+            raise RuntimeError("generation_logical_position_ack_mismatch")
+        self._acknowledged = True
+
+    def _activate(self) -> None:
+        if self._active or self._finished:
+            raise RuntimeError("generation_logical_position_ack_reused")
+        self._active = True
+
+    def _require_acknowledged(self) -> None:
+        if not self._active or not self._acknowledged:
+            raise RuntimeError("generation_logical_positions_not_acknowledged")
+
+    def _finish(self) -> None:
+        self._active = False
+        self._finished = True
 
 
 GenerationForwardContext = Callable[[GenerationForward], ContextManager[None]]
@@ -867,6 +910,7 @@ def mtp_generate_step(
     sampling_config: Optional[NativeMTPSamplingConfig] = None,
     eos_token_ids: Optional[Sequence[int]] = None,
     telemetry: Optional[Dict[str, Any]] = None,
+    prompt_logical_positions: Optional[Sequence[int]] = None,
 ) -> Generator[Tuple[int, mx.array, bool], None, None]:
     """Stream native-Qwen MTP with request-local transactional cache state.
 
@@ -878,7 +922,9 @@ def mtp_generate_step(
     Stochastic sampling is described by :class:`NativeMTPSamplingConfig` and
     uses an explicit per-request MLX key.  Opaque filters and stateful logits
     processors fail before cache construction because they cannot be replayed
-    exactly after a rejected recurrent verification.
+    exactly after a rejected recurrent verification.  Optional sparse prompt
+    coordinates are immutable host metadata only: every forward must be
+    acknowledged by the request-local context consumer that applies them.
     """
 
     if prompt_cache is not None:
@@ -917,6 +963,35 @@ def mtp_generate_step(
         for processor in logits_processors
     ):
         raise ValueError("native_mtp_non_replay_safe_logits_processor")
+
+    logical_prompt = None
+    if prompt_logical_positions is not None:
+        if model_forward_context is None:
+            raise ValueError("native_mtp_logical_positions_require_forward_context")
+        if isinstance(prompt_logical_positions, mx.array) or not isinstance(
+            prompt_logical_positions, Sequence
+        ):
+            raise TypeError(
+                "native MTP prompt logical positions must be a host sequence"
+            )
+        logical_prompt = tuple(prompt_logical_positions)
+        if len(logical_prompt) != prompt.size:
+            raise ValueError("native MTP prompt logical positions must match prompt")
+        previous_position = -1
+        for position in logical_prompt:
+            if (
+                isinstance(position, bool)
+                or not isinstance(position, int)
+                or position < 0
+            ):
+                raise ValueError(
+                    "native MTP prompt logical positions must be non-negative integers"
+                )
+            if position <= previous_position:
+                raise ValueError(
+                    "native MTP prompt logical positions must be strictly increasing"
+                )
+            previous_position = position
 
     request = model.make_mtp_request_cache()
     if telemetry is not None:
@@ -989,31 +1064,67 @@ def mtp_generate_step(
             logprobs = logprobs / sampling_config.temperature
         return (logprobs - mx.logsumexp(logprobs, axis=-1, keepdims=True)).squeeze(0)
 
-    def _target_call(input_tokens, phase, *, return_hidden=False):
+    def _target_call(
+        input_tokens, phase, *, return_hidden=False, logical_positions=None
+    ):
         batched = input_tokens[None]
         if model_forward_context is None:
             return model(batched, cache=request.backbone, return_hidden=return_hidden)
+        position_ack = (
+            GenerationForwardPositionAck(logical_positions)
+            if logical_positions is not None
+            else None
+        )
         forward = GenerationForward(
             model=model,
             input_tokens=batched,
             cache=request.backbone,
             phase=phase,
+            logical_positions=logical_positions,
+            logical_position_ack=position_ack,
         )
         with model_forward_context(forward):
-            return model(batched, cache=request.backbone, return_hidden=return_hidden)
+            if position_ack is None:
+                return model(
+                    batched, cache=request.backbone, return_hidden=return_hidden
+                )
+            position_ack._activate()
+            try:
+                result = model(
+                    batched, cache=request.backbone, return_hidden=return_hidden
+                )
+                position_ack._require_acknowledged()
+                return result
+            finally:
+                position_ack._finish()
 
-    def _mtp_call(hidden, next_tokens):
+    def _mtp_call(hidden, next_tokens, *, logical_positions=None):
         next_ids = next_tokens.reshape(1, -1)
         if model_forward_context is None:
             return model.mtp_forward(hidden, next_ids, request.mtp)
+        position_ack = (
+            GenerationForwardPositionAck(logical_positions)
+            if logical_positions is not None
+            else None
+        )
         forward = GenerationForward(
             model=model,
             input_tokens=next_ids,
             cache=request.mtp,
             phase=GenerationForwardPhase.MTP_DRAFT,
+            logical_positions=logical_positions,
+            logical_position_ack=position_ack,
         )
         with model_forward_context(forward):
-            return model.mtp_forward(hidden, next_ids, request.mtp)
+            if position_ack is None:
+                return model.mtp_forward(hidden, next_ids, request.mtp)
+            position_ack._activate()
+            try:
+                result = model.mtp_forward(hidden, next_ids, request.mtp)
+                position_ack._require_acknowledged()
+                return result
+            finally:
+                position_ack._finish()
 
     def _quantize():
         request.quantize(
@@ -1031,9 +1142,11 @@ def mtp_generate_step(
             mtp_tokens=state.mtp_tokens,
         )
 
-    def _draft(hidden, next_tokens, token_history):
+    def _draft(hidden, next_tokens, token_history, logical_positions=None):
         with mx.stream(generation_stream):
-            logits = _mtp_call(hidden, next_tokens)[:, -1, :]
+            logits = _mtp_call(
+                hidden, next_tokens, logical_positions=logical_positions
+            )[:, -1, :]
             _quantize()
             request.retain(
                 backbone_tokens=request.state.backbone_tokens,
@@ -1072,36 +1185,73 @@ def mtp_generate_step(
         # Shifted hidden/token pairs prefill the MTP head to the same physical
         # and logical position as the target before decode begins.
         remaining = prompt.astype(mx.uint32)
+        prompt_position_index = 0 if logical_prompt is not None else None
         with mx.stream(generation_stream):
             while remaining.size > 1:
                 count = min(prefill_step_size, remaining.size - 1)
+                forward_positions = (
+                    logical_prompt[
+                        prompt_position_index : prompt_position_index + count
+                    ]
+                    if logical_prompt is not None
+                    else None
+                )
                 _, hidden = _target_call(
                     remaining[:count],
                     GenerationForwardPhase.PREFILL,
                     return_hidden=True,
+                    logical_positions=forward_positions,
                 )
-                _mtp_call(hidden, remaining[1 : count + 1])
+                _mtp_call(
+                    hidden,
+                    remaining[1 : count + 1],
+                    logical_positions=forward_positions,
+                )
                 _quantize()
                 mx.eval(
                     [entry.state for entry in request.backbone],
                     [entry.state for entry in request.mtp],
                 )
-                request.retain(
-                    backbone_tokens=request.state.backbone_tokens + count,
-                    mtp_tokens=request.state.mtp_tokens + count,
-                )
+                if forward_positions is None:
+                    request.retain(
+                        backbone_tokens=request.state.backbone_tokens + count,
+                        mtp_tokens=request.state.mtp_tokens + count,
+                    )
+                else:
+                    request.retain_logical_position(
+                        backbone_tokens=request.state.backbone_tokens + count,
+                        mtp_tokens=request.state.mtp_tokens + count,
+                        next_logical_position=forward_positions[-1] + 1,
+                    )
                 _assert_target_mtp_alignment()
                 remaining = remaining[count:]
+                if logical_prompt is not None:
+                    prompt_position_index += count
                 mx.clear_cache()
 
+            final_prompt_positions = (
+                (logical_prompt[prompt_position_index],)
+                if logical_prompt is not None
+                else None
+            )
             initial_logits, initial_hidden = _target_call(
-                remaining, GenerationForwardPhase.PREFILL, return_hidden=True
+                remaining,
+                GenerationForwardPhase.PREFILL,
+                return_hidden=True,
+                logical_positions=final_prompt_positions,
             )
             _quantize()
-            request.retain(
-                backbone_tokens=request.state.backbone_tokens + 1,
-                mtp_tokens=request.state.mtp_tokens,
-            )
+            if final_prompt_positions is None:
+                request.retain(
+                    backbone_tokens=request.state.backbone_tokens + 1,
+                    mtp_tokens=request.state.mtp_tokens,
+                )
+            else:
+                request.retain_logical_position(
+                    backbone_tokens=request.state.backbone_tokens + 1,
+                    mtp_tokens=request.state.mtp_tokens,
+                    next_logical_position=final_prompt_positions[0] + 1,
+                )
             # Match generate_step: processors see only the input tokens passed
             # to its final prefill/decode step, not chunks consumed by _step.
             history = remaining.astype(mx.uint32)
@@ -1115,6 +1265,8 @@ def mtp_generate_step(
         history = mx.concatenate([history, current_token])
 
         generated = 1
+        if logical_prompt is not None:
+            request.advance_logical_position()
         current_id = current_token.item()
         terminal = current_id in eos_token_ids or generated >= max_tokens
         if terminal:
@@ -1123,17 +1275,31 @@ def mtp_generate_step(
         yield current_id, current_logprobs, False
         if terminal:
             return
-        draft_token, draft_logprobs = _draft(current_hidden, current_token, history)
+        draft_token, draft_logprobs = _draft(
+            current_hidden,
+            current_token,
+            history,
+            logical_positions=final_prompt_positions,
+        )
 
         while True:
 
             request.checkpoint()
             verify_inputs = mx.concatenate([current_token, draft_token])
+            verify_positions = (
+                (
+                    request.state.next_logical_position - 1,
+                    request.state.next_logical_position,
+                )
+                if logical_prompt is not None
+                else None
+            )
             with mx.stream(generation_stream):
                 verify_logits, verify_hidden = _target_call(
                     verify_inputs,
                     GenerationForwardPhase.VERIFY,
                     return_hidden=True,
+                    logical_positions=verify_positions,
                 )
                 _quantize()
                 request.seal_verified(
@@ -1177,6 +1343,8 @@ def mtp_generate_step(
                 if telemetry is not None:
                     telemetry["mtp_accepted"] += 1
                 generated += 1
+                if logical_prompt is not None:
+                    request.advance_logical_position()
                 draft_id = draft_token.item()
                 draft_terminal = draft_id in eos_token_ids or generated >= max_tokens
                 if draft_terminal:
@@ -1197,6 +1365,8 @@ def mtp_generate_step(
                 mx.eval(bonus_token, bonus_logprobs)
                 next_history = mx.concatenate([bonus_history, bonus_token])
                 generated += 1
+                if logical_prompt is not None:
+                    request.advance_logical_position()
                 bonus_id = bonus_token.item()
                 bonus_terminal = bonus_id in eos_token_ids or generated >= max_tokens
                 if bonus_terminal:
@@ -1213,7 +1383,10 @@ def mtp_generate_step(
                 )
                 mtp_tokens = mx.concatenate([draft_token, bonus_token])
                 next_draft, next_draft_logprobs = _draft(
-                    mtp_hidden, mtp_tokens, next_history
+                    mtp_hidden,
+                    mtp_tokens,
+                    next_history,
+                    logical_positions=verify_positions,
                 )
                 history = next_history
                 current_token = bonus_token
@@ -1227,11 +1400,17 @@ def mtp_generate_step(
             # recurrent state cannot retain a prefix of that forward.  Restore
             # then replay exactly that token before drafting from the residual.
             request.reject_partial(accepted_backbone_tokens=1, accepted_mtp_tokens=0)
+            replay_positions = (
+                (request.state.next_logical_position - 1,)
+                if logical_prompt is not None
+                else None
+            )
             with mx.stream(generation_stream):
                 _, replay_hidden = _target_call(
                     current_token,
                     GenerationForwardPhase.DECODE,
                     return_hidden=True,
+                    logical_positions=replay_positions,
                 )
                 _quantize()
                 request.replay_retained(
@@ -1240,6 +1419,8 @@ def mtp_generate_step(
                 )
             next_history = mx.concatenate([history, replacement_token])
             generated += 1
+            if logical_prompt is not None:
+                request.advance_logical_position()
             replacement_id = replacement_token.item()
             replacement_terminal = (
                 replacement_id in eos_token_ids or generated >= max_tokens
@@ -1252,7 +1433,10 @@ def mtp_generate_step(
                 return
 
             next_draft, next_draft_logprobs = _draft(
-                replay_hidden[:, -1:, :], replacement_token, next_history
+                replay_hidden[:, -1:, :],
+                replacement_token,
+                next_history,
+                logical_positions=replay_positions,
             )
             history = next_history
             current_token = replacement_token

--- a/mlx_lm/generate.py
+++ b/mlx_lm/generate.py
@@ -263,12 +263,12 @@ class _GenerationForwardCanonicalRecord:
     logical_positions: Tuple[int, ...]
     token_ids: Tuple[int, ...]
     immediate_successor_token_ids: Tuple[int, ...]
-    logits: mx.array
-    logits_evidence: tuple
-    canonical_final_logits: Optional[mx.array]
+    logits: Optional[mx.array]
+    logits_evidence: Optional[tuple]
+    logits_content_digest: Optional[mx.array]
     hidden_rows: mx.array
     hidden_evidence: tuple
-    canonical_hidden_rows: mx.array
+    hidden_content_digest: mx.array
 
 
 @dataclass
@@ -289,7 +289,7 @@ class GenerationForwardPositionReceipt:
     logical_positions: Tuple[int, ...]
     token_ids: Tuple[int, ...]
     immediate_successor_token_ids: Tuple[int, ...]
-    logits: mx.array
+    logits: Optional[mx.array]
     hidden_rows: mx.array
     _issuer_seal: Any
     _record_token: Any
@@ -407,20 +407,24 @@ class GenerationForwardPositionAck:
         if not isinstance(result, tuple) or len(result) != 2:
             raise RuntimeError("generation_logical_position_receipt_missing_hidden")
         logits, hidden_rows = result
-        canonical_hidden_rows = hidden_rows + mx.zeros(
+        retained_hidden_rows = hidden_rows + mx.zeros(
             hidden_rows.shape, dtype=hidden_rows.dtype
         )
-        canonical_final_logits = None
+        hidden_content_digest = _array_content_digest(retained_hidden_rows)
+        retained_final_logits = None
+        logits_content_digest = None
         cache_content_digest = None
         if len(self._immediate_successor_token_ids) == len(self._logical_positions) - 1:
             final_logits = logits[:, -1:, :]
-            canonical_final_logits = final_logits + mx.zeros(
+            retained_final_logits = final_logits + mx.zeros(
                 final_logits.shape, dtype=final_logits.dtype
             )
+            logits_content_digest = _array_content_digest(retained_final_logits)
             cache_content_digest = _cache_content_digest(self._cache)
-        canonical_values = [canonical_hidden_rows]
-        if canonical_final_logits is not None:
-            canonical_values.append(canonical_final_logits)
+        canonical_values = [retained_hidden_rows, hidden_content_digest]
+        if retained_final_logits is not None:
+            canonical_values.append(retained_final_logits)
+            canonical_values.append(logits_content_digest)
             canonical_values.append(cache_content_digest)
         mx.eval(canonical_values)
         record_token = _GenerationForwardReceiptToken()
@@ -434,8 +438,8 @@ class GenerationForwardPositionAck:
             logical_positions=self._logical_positions,
             token_ids=self._token_ids,
             immediate_successor_token_ids=self._immediate_successor_token_ids,
-            logits=logits,
-            hidden_rows=hidden_rows,
+            logits=retained_final_logits,
+            hidden_rows=retained_hidden_rows,
             record_token=record_token,
         )
         record = _GenerationForwardCanonicalRecord(
@@ -451,12 +455,12 @@ class GenerationForwardPositionAck:
             logical_positions=self._logical_positions,
             token_ids=self._token_ids,
             immediate_successor_token_ids=self._immediate_successor_token_ids,
-            logits=logits,
-            logits_evidence=_array_identity_evidence(logits),
-            canonical_final_logits=canonical_final_logits,
-            hidden_rows=hidden_rows,
-            hidden_evidence=_array_identity_evidence(hidden_rows),
-            canonical_hidden_rows=canonical_hidden_rows,
+            logits=retained_final_logits,
+            logits_evidence=_array_identity_evidence(retained_final_logits),
+            logits_content_digest=logits_content_digest,
+            hidden_rows=retained_hidden_rows,
+            hidden_evidence=_array_identity_evidence(retained_hidden_rows),
+            hidden_content_digest=hidden_content_digest,
         )
         with _GENERATION_FORWARD_RECEIPT_LOCK:
             _GENERATION_FORWARD_RECEIPTS[record_token] = _GenerationForwardAuthority(
@@ -614,13 +618,17 @@ def _verify_sparse_canonical_content(records):
     """Realize all mutable evidence checks with one aggregate host decision."""
 
     checks = [
-        mx.array_equal(record.hidden_rows, record.canonical_hidden_rows)
+        mx.array_equal(
+            _array_content_digest(record.hidden_rows), record.hidden_content_digest
+        )
         for record in records
     ]
     final = records[-1]
     checks.extend(
         (
-            mx.array_equal(final.logits[:, -1:, :], final.canonical_final_logits),
+            mx.array_equal(
+                _array_content_digest(final.logits), final.logits_content_digest
+            ),
             mx.array_equal(
                 _cache_content_digest(final.cache), final.cache_content_digest
             ),
@@ -642,11 +650,11 @@ class _NativeMTPSparseClaim:
 
     @property
     def final_target_hidden(self):
-        return self.records[-1].canonical_hidden_rows[:, -1:, :]
+        return self.records[-1].hidden_rows[:, -1:, :]
 
     @property
     def final_target_logits(self):
-        return self.records[-1].canonical_final_logits
+        return self.records[-1].logits
 
 
 def abandon_native_mtp_sparse_receipts(
@@ -712,6 +720,154 @@ class NativeMTPSparseBootstrap:
         """
 
         abandon_native_mtp_sparse_receipts(self.receipts)
+
+    def _abandonable_authority_locked(self):
+        """Return this exact unreserved authority set using host metadata only."""
+
+        if not isinstance(self.receipts, tuple) or not self.receipts:
+            return None
+        if not isinstance(self.target_cache, list) or not self.target_cache:
+            return None
+        if not all(
+            isinstance(values, tuple)
+            for values in (
+                self.selected_logical_positions,
+                self.selected_token_ids,
+                self.immediate_successor_token_ids,
+            )
+        ):
+            return None
+        if isinstance(self.next_logical_position, bool) or not isinstance(
+            self.next_logical_position, int
+        ):
+            return None
+
+        records = []
+        record_tokens = []
+        for receipt in self.receipts:
+            record_token = getattr(receipt, "_record_token", None)
+            if not isinstance(record_token, _GenerationForwardReceiptToken):
+                return None
+            authority = _GENERATION_FORWARD_RECEIPTS.get(record_token)
+            if authority is None or authority.reservation is not None:
+                return None
+            try:
+                _validate_receipt_against_record(receipt, authority.record)
+            except Exception:
+                return None
+            records.append(authority.record)
+            record_tokens.append(record_token)
+        if len(record_tokens) != len(set(record_tokens)):
+            return None
+
+        final = records[-1]
+        try:
+            current_entry_ids = tuple(id(entry) for entry in self.target_cache)
+            current_cache_state = _cache_state_identity_evidence(self.target_cache)
+        except Exception:
+            return None
+        if (
+            id(self.target_cache) != final.cache_container_id
+            or current_entry_ids != final.cache_entry_ids
+            or current_cache_state != final.cache_state_evidence
+        ):
+            return None
+
+        positions = tuple(
+            position for record in records for position in record.logical_positions
+        )
+        token_ids = tuple(
+            token_id for record in records for token_id in record.token_ids
+        )
+        successors = tuple(
+            token_id
+            for record in records
+            for token_id in record.immediate_successor_token_ids
+        )
+        if (
+            positions != self.selected_logical_positions
+            or token_ids != self.selected_token_ids
+            or successors != self.immediate_successor_token_ids
+            or not positions
+            or self.next_logical_position != positions[-1] + 1
+        ):
+            return None
+        previous_position = -1
+        for position in positions:
+            if (
+                isinstance(position, bool)
+                or not isinstance(position, int)
+                or position <= previous_position
+            ):
+                return None
+            previous_position = position
+        if any(
+            isinstance(token_id, bool)
+            or not isinstance(token_id, int)
+            or token_id < 0
+            for token_id in (*token_ids, *successors)
+        ):
+            return None
+
+        for index, record in enumerate(records):
+            is_final = index == len(records) - 1
+            expected_successors = len(record.token_ids) - int(is_final)
+            if (
+                record.cache is not self.target_cache
+                or record.phase is not GenerationForwardPhase.PREFILL
+                or len(record.logical_positions) != len(record.token_ids)
+                or len(record.immediate_successor_token_ids) != expected_successors
+                or (record.logits is None) is is_final
+                or (record.logits_content_digest is None) is is_final
+                or (record.cache_content_digest is None) is is_final
+            ):
+                return None
+            if is_final and (
+                record.logits.ndim != 3
+                or record.logits.shape[0] != 1
+                or record.logits.shape[1] != 1
+            ):
+                return None
+        return tuple(records), tuple(record_tokens)
+
+    def try_abandon_unclaimed(self) -> bool:
+        """Atomically consume valid unclaimed authority for safe dense replay.
+
+        Canonical payload hashes are verified off-lock. The final locked pass
+        rechecks every exact receipt and reservation before deleting all keys;
+        a concurrent claim therefore either owns the complete set or loses to
+        this abandonment, never a partial mixture.
+        """
+
+        try:
+            with _GENERATION_FORWARD_RECEIPT_LOCK:
+                snapshot = self._abandonable_authority_locked()
+        except Exception:
+            return False
+        if snapshot is None:
+            return False
+        records, _ = snapshot
+        try:
+            _verify_sparse_canonical_content(records)
+        except Exception:
+            return False
+
+        try:
+            with _GENERATION_FORWARD_RECEIPT_LOCK:
+                current = self._abandonable_authority_locked()
+                if current is None:
+                    return False
+                current_records, record_tokens = current
+                if any(
+                    current_record is not snapshot_record
+                    for current_record, snapshot_record in zip(current_records, records)
+                ):
+                    return False
+                for record_token in record_tokens:
+                    del _GENERATION_FORWARD_RECEIPTS[record_token]
+        except Exception:
+            return False
+        return True
 
     def _canonical_records_locked(self, reservation=None):
         records = []
@@ -794,12 +950,16 @@ class NativeMTPSparseBootstrap:
         if getattr(model_args, "hidden_size", None) is None:
             model_args = getattr(getattr(model, "language_model", None), "args", None)
         expected_hidden_width = getattr(model_args, "hidden_size", None)
-        if canonical_records[-1].canonical_final_logits is None:
+        if canonical_records[-1].logits is None:
             raise RuntimeError("native_mtp_sparse_final_logits_evidence_missing")
+        if canonical_records[-1].logits_content_digest is None:
+            raise RuntimeError("native_mtp_sparse_final_logits_digest_missing")
         if canonical_records[-1].cache_content_digest is None:
             raise RuntimeError("native_mtp_sparse_final_cache_evidence_missing")
         if any(
-            record.canonical_final_logits is not None
+            record.logits is not None
+            or record.logits_content_digest is not None
+            or record.cache_content_digest is not None
             for record in canonical_records[:-1]
         ):
             raise RuntimeError("native_mtp_sparse_final_logits_evidence_order_mismatch")
@@ -859,15 +1019,21 @@ class NativeMTPSparseBootstrap:
                 and hidden.shape[2] != expected_hidden_width
             ):
                 raise ValueError("native_mtp_sparse_hidden_model_width_mismatch")
-            if (
-                not isinstance(logits, mx.array)
-                or logits.ndim != 3
-                or logits.shape[0] != 1
-                or logits.shape[1] != chunk_size
-                or logits.dtype not in floating_dtypes
-                or (vocab_size is not None and logits.shape[2] != vocab_size)
-            ):
-                raise ValueError("native_mtp_sparse_logits_shape_or_dtype_mismatch")
+            is_final = index == len(self.receipts) - 1
+            if is_final:
+                if (
+                    not isinstance(logits, mx.array)
+                    or logits.ndim != 3
+                    or logits.shape[0] != 1
+                    or logits.shape[1] != 1
+                    or logits.dtype not in floating_dtypes
+                    or (vocab_size is not None and logits.shape[2] != vocab_size)
+                ):
+                    raise ValueError(
+                        "native_mtp_sparse_final_logits_shape_or_dtype_mismatch"
+                    )
+            elif logits is not None:
+                raise ValueError("native_mtp_sparse_nonfinal_logits_retained")
 
             receipt_positions.extend(receipt.logical_positions)
             receipt_tokens.extend(receipt.token_ids)
@@ -2056,7 +2222,7 @@ def mtp_generate_step(
                     while pair_start < pair_count:
                         pair_end = min(pair_start + prefill_step_size, pair_count)
                         _mtp_call(
-                            record.canonical_hidden_rows[:, pair_start:pair_end, :],
+                            record.hidden_rows[:, pair_start:pair_end, :],
                             mx.array(
                                 record.immediate_successor_token_ids[
                                     pair_start:pair_end
@@ -2073,7 +2239,7 @@ def mtp_generate_step(
                         mx.clear_cache()
                 mx.eval(
                     tuple(
-                        record.canonical_hidden_rows for record in sparse_claim.records
+                        record.hidden_rows for record in sparse_claim.records
                     ),
                     sparse_claim.final_target_logits,
                     [entry.state for entry in request.backbone],

--- a/mlx_lm/generate.py
+++ b/mlx_lm/generate.py
@@ -5,6 +5,7 @@ import contextlib
 import copy
 import functools
 import json
+import math
 import sys
 import time
 from collections import deque
@@ -15,6 +16,7 @@ from typing import (
     Any,
     Callable,
     ContextManager,
+    Dict,
     Generator,
     List,
     Optional,
@@ -40,7 +42,7 @@ from .models.cache import (
     TokenBuffer,
     load_prompt_cache,
 )
-from .sample_utils import make_sampler
+from .sample_utils import apply_min_p, apply_top_k, apply_top_p, make_sampler
 from .tokenizer_utils import TokenizerWrapper
 from .utils import does_model_support_input_embeddings, load
 
@@ -71,6 +73,7 @@ class GenerationForwardPhase(str, Enum):
     DECODE = "decode"
     DRAFT = "draft"
     VERIFY = "verify"
+    MTP_DRAFT = "mtp_draft"
 
 
 @dataclass(frozen=True)
@@ -90,6 +93,54 @@ class GenerationForward:
 
 
 GenerationForwardContext = Callable[[GenerationForward], ContextManager[None]]
+
+
+@dataclass(frozen=True)
+class NativeMTPSamplingConfig:
+    """Replay-safe sampling contract for native MTP speculation."""
+
+    temperature: float = 0.0
+    top_p: float = 1.0
+    top_k: int = 0
+    min_p: float = 0.0
+    min_tokens_to_keep: int = 1
+    seed: Optional[int] = None
+
+    def __post_init__(self):
+        for name in ("temperature", "top_p", "min_p"):
+            value = getattr(self, name)
+            if (
+                isinstance(value, bool)
+                or not isinstance(value, (int, float))
+                or not math.isfinite(value)
+            ):
+                raise ValueError(f"native MTP {name} must be a finite number")
+        if isinstance(self.top_k, bool) or not isinstance(self.top_k, int):
+            raise ValueError("native MTP top_k must be an integer")
+        if isinstance(self.min_tokens_to_keep, bool) or not isinstance(
+            self.min_tokens_to_keep, int
+        ):
+            raise ValueError("native MTP min_tokens_to_keep must be an integer")
+        if self.seed is not None and (
+            isinstance(self.seed, bool) or not isinstance(self.seed, int)
+        ):
+            raise ValueError("native MTP seed must be an integer or None")
+        if self.temperature < 0:
+            raise ValueError("native MTP temperature must be non-negative")
+        if not 0 < self.top_p <= 1:
+            raise ValueError("native MTP top_p must be in (0, 1]")
+        if self.top_k < 0:
+            raise ValueError("native MTP top_k must be non-negative")
+        if not 0 <= self.min_p <= 1:
+            raise ValueError("native MTP min_p must be in [0, 1]")
+        if self.min_tokens_to_keep < 1:
+            raise ValueError("native MTP min_tokens_to_keep must be positive")
+        if self.seed is not None and self.seed < 0:
+            raise ValueError("native MTP seed must be non-negative")
+
+    @property
+    def stochastic(self) -> bool:
+        return self.temperature > 0
 
 
 def str2bool(string):
@@ -330,6 +381,9 @@ class GenerationResponse:
     generation_tps: float
     peak_memory: float
     finish_reason: Optional[str] = None
+    mtp_drafts: int = 0
+    mtp_accepted: int = 0
+    mtp_bypass_reason: Optional[str] = None
 
 
 def maybe_quantize_kv_cache(prompt_cache, quantized_kv_start, kv_group_size, kv_bits):
@@ -797,12 +851,434 @@ def speculative_generate_step(
         _rewind_cache(num_draft, n)
 
 
+def mtp_generate_step(
+    prompt: mx.array,
+    model: nn.Module,
+    *,
+    max_tokens: int = 256,
+    sampler: Optional[Callable[[mx.array], mx.array]] = None,
+    logits_processors: Optional[List[Callable[[mx.array, mx.array], mx.array]]] = None,
+    prompt_cache: Optional[Any] = None,
+    prefill_step_size: int = 512,
+    kv_bits: Optional[int] = None,
+    kv_group_size: int = 64,
+    quantized_kv_start: int = 0,
+    model_forward_context: Optional[GenerationForwardContext] = None,
+    sampling_config: Optional[NativeMTPSamplingConfig] = None,
+    eos_token_ids: Optional[Sequence[int]] = None,
+    telemetry: Optional[Dict[str, Any]] = None,
+) -> Generator[Tuple[int, mx.array, bool], None, None]:
+    """Stream native-Qwen MTP with request-local transactional cache state.
+
+    This implementation intentionally supports a single sequence and no
+    prefix cache.  A full verification commits atomically.  A rejected draft
+    rolls the full transaction back and replays the already-emitted token
+    before continuing, which is required for the Qwen recurrent layers.
+
+    Stochastic sampling is described by :class:`NativeMTPSamplingConfig` and
+    uses an explicit per-request MLX key.  Opaque filters and stateful logits
+    processors fail before cache construction because they cannot be replayed
+    exactly after a rejected recurrent verification.
+    """
+
+    if prompt_cache is not None:
+        raise ValueError("native_mtp_prefix_reuse_unsupported")
+    capability = getattr(model, "mtp_capability", None)
+    if capability is None or not capability.supported:
+        reason = (
+            "native_mtp_model_capability_missing"
+            if capability is None
+            else capability.reason
+        )
+        if telemetry is not None:
+            telemetry["mtp_bypass_reason"] = reason
+        raise RuntimeError(reason)
+    if prompt.ndim != 1 or prompt.size == 0:
+        raise ValueError("native MTP requires one non-empty unbatched prompt")
+    if max_tokens < 0:
+        raise ValueError("native MTP requires a finite non-negative max_tokens")
+    sampling_config = sampling_config or NativeMTPSamplingConfig()
+    model_vocab_size = getattr(model, "vocab_size", None)
+    if model_vocab_size is None:
+        model_vocab_size = getattr(getattr(model, "args", None), "vocab_size", None)
+    if (
+        sampling_config.top_k > 0
+        and model_vocab_size is not None
+        and sampling_config.top_k >= model_vocab_size
+    ):
+        raise ValueError("native MTP top_k must be smaller than vocabulary size")
+    if sampler is not None and (
+        sampling_config.stochastic
+        or not getattr(sampler, "native_mtp_deterministic", False)
+    ):
+        raise ValueError("native_mtp_opaque_sampler_unsupported")
+    if logits_processors and any(
+        not getattr(processor, "native_mtp_replay_safe", False)
+        for processor in logits_processors
+    ):
+        raise ValueError("native_mtp_non_replay_safe_logits_processor")
+
+    request = model.make_mtp_request_cache()
+    if telemetry is not None:
+        telemetry.update(
+            mtp_drafts=0,
+            mtp_accepted=0,
+            mtp_bypass_reason=None,
+        )
+    eos_token_ids = frozenset(eos_token_ids or ())
+    rng_key = mx.random.key(
+        sampling_config.seed
+        if sampling_config.seed is not None
+        else (time.time_ns() & ((1 << 63) - 1))
+    )
+
+    def _next_rng_key():
+        nonlocal rng_key
+        keys = mx.random.split(rng_key)
+        rng_key = keys[0]
+        return keys[1]
+
+    def _sample(logprobs):
+        if sampling_config.stochastic:
+            return mx.random.categorical(logprobs, key=_next_rng_key())
+        if sampler is None:
+            return mx.argmax(logprobs, axis=-1)
+        return sampler(logprobs)
+
+    def _reported_logprobs(logits, tokens):
+        if logits.ndim == 1:
+            logits = logits[None]
+        if logits_processors:
+            for processor in logits_processors:
+                logits = processor(tokens, logits)
+        return (logits - mx.logsumexp(logits, axis=-1, keepdims=True)).squeeze(0)
+
+    def _sampling_distribution(reported_logprobs):
+        logprobs = reported_logprobs[None]
+        if sampling_config.top_p < 1:
+            logprobs = apply_top_p(logprobs, sampling_config.top_p)
+        if sampling_config.min_p > 0:
+            keep = sampling_config.min_tokens_to_keep
+            vocab_size = logprobs.shape[-1]
+            if keep > vocab_size:
+                raise ValueError(
+                    "native MTP min_tokens_to_keep cannot exceed vocabulary size"
+                )
+            if keep < vocab_size:
+                # apply_min_p's multi-token branch passes a Python bool to
+                # put_along_axis, which newer MLX releases reject.  Preserve
+                # the standard filter exactly by restoring the requested top
+                # tokens with array-valued replacements.
+                unfiltered = logprobs
+                logprobs = apply_min_p(logprobs, sampling_config.min_p)
+                if keep > 1:
+                    top_indices = mx.argpartition(unfiltered, kth=-keep, axis=-1)[
+                        ..., -keep:
+                    ]
+                    top_values = mx.take_along_axis(unfiltered, top_indices, axis=-1)
+                    logprobs = mx.put_along_axis(
+                        logprobs, top_indices, top_values, axis=-1
+                    )
+        if sampling_config.top_k > 0:
+            if sampling_config.top_k >= logprobs.shape[-1]:
+                raise ValueError(
+                    "native MTP top_k must be smaller than vocabulary size"
+                )
+            logprobs = apply_top_k(logprobs, sampling_config.top_k)
+        if sampling_config.stochastic:
+            logprobs = logprobs / sampling_config.temperature
+        return (logprobs - mx.logsumexp(logprobs, axis=-1, keepdims=True)).squeeze(0)
+
+    def _target_call(input_tokens, phase, *, return_hidden=False):
+        batched = input_tokens[None]
+        if model_forward_context is None:
+            return model(batched, cache=request.backbone, return_hidden=return_hidden)
+        forward = GenerationForward(
+            model=model,
+            input_tokens=batched,
+            cache=request.backbone,
+            phase=phase,
+        )
+        with model_forward_context(forward):
+            return model(batched, cache=request.backbone, return_hidden=return_hidden)
+
+    def _mtp_call(hidden, next_tokens):
+        next_ids = next_tokens.reshape(1, -1)
+        if model_forward_context is None:
+            return model.mtp_forward(hidden, next_ids, request.mtp)
+        forward = GenerationForward(
+            model=model,
+            input_tokens=next_ids,
+            cache=request.mtp,
+            phase=GenerationForwardPhase.MTP_DRAFT,
+        )
+        with model_forward_context(forward):
+            return model.mtp_forward(hidden, next_ids, request.mtp)
+
+    def _quantize():
+        request.quantize(
+            kv_bits=kv_bits,
+            kv_group_size=kv_group_size,
+            start=quantized_kv_start,
+        )
+
+    def _assert_target_mtp_alignment():
+        state = request.state
+        if state.backbone_tokens != state.mtp_tokens:
+            raise RuntimeError("native_mtp_target_head_alignment_mismatch")
+        request.assert_aligned(
+            backbone_tokens=state.backbone_tokens,
+            mtp_tokens=state.mtp_tokens,
+        )
+
+    def _draft(hidden, next_tokens, token_history):
+        with mx.stream(generation_stream):
+            logits = _mtp_call(hidden, next_tokens)[:, -1, :]
+            _quantize()
+            request.retain(
+                backbone_tokens=request.state.backbone_tokens,
+                mtp_tokens=request.state.mtp_tokens + next_tokens.size,
+            )
+            _assert_target_mtp_alignment()
+            draft_reported_logprobs = _reported_logprobs(
+                logits.squeeze(0), token_history
+            )
+            draft_logprobs = _sampling_distribution(draft_reported_logprobs)
+            draft_token = _sample(draft_logprobs)
+        mx.eval(draft_token, draft_logprobs)
+        if telemetry is not None:
+            telemetry["mtp_drafts"] += 1
+        return draft_token.reshape(-1), draft_logprobs
+
+    def _residual_sample(target_logprobs, draft_logprobs):
+        target_probs = mx.exp(target_logprobs)
+        draft_probs = mx.exp(draft_logprobs)
+        residual = mx.maximum(target_probs - draft_probs, 0)
+        normalizer = mx.sum(residual)
+        residual_logprobs = mx.where(
+            normalizer > 0,
+            mx.log(residual / normalizer),
+            target_logprobs,
+        )
+        return _sample(residual_logprobs), residual_logprobs
+
+    finish_reason = "generator_closed"
+    generated = 0
+    try:
+        if max_tokens == 0:
+            finish_reason = "length"
+            return
+
+        # Shifted hidden/token pairs prefill the MTP head to the same physical
+        # and logical position as the target before decode begins.
+        remaining = prompt.astype(mx.uint32)
+        with mx.stream(generation_stream):
+            while remaining.size > 1:
+                count = min(prefill_step_size, remaining.size - 1)
+                _, hidden = _target_call(
+                    remaining[:count],
+                    GenerationForwardPhase.PREFILL,
+                    return_hidden=True,
+                )
+                _mtp_call(hidden, remaining[1 : count + 1])
+                _quantize()
+                mx.eval(
+                    [entry.state for entry in request.backbone],
+                    [entry.state for entry in request.mtp],
+                )
+                request.retain(
+                    backbone_tokens=request.state.backbone_tokens + count,
+                    mtp_tokens=request.state.mtp_tokens + count,
+                )
+                _assert_target_mtp_alignment()
+                remaining = remaining[count:]
+                mx.clear_cache()
+
+            initial_logits, initial_hidden = _target_call(
+                remaining, GenerationForwardPhase.PREFILL, return_hidden=True
+            )
+            _quantize()
+            request.retain(
+                backbone_tokens=request.state.backbone_tokens + 1,
+                mtp_tokens=request.state.mtp_tokens,
+            )
+            # Match generate_step: processors see only the input tokens passed
+            # to its final prefill/decode step, not chunks consumed by _step.
+            history = remaining.astype(mx.uint32)
+            current_logprobs = _reported_logprobs(
+                initial_logits[:, -1, :].squeeze(0), history
+            )
+            current_sampling_logprobs = _sampling_distribution(current_logprobs)
+            current_token = _sample(current_sampling_logprobs).reshape(-1)
+        mx.eval(current_token, current_logprobs)
+        current_hidden = initial_hidden[:, -1:, :]
+        history = mx.concatenate([history, current_token])
+
+        generated = 1
+        current_id = current_token.item()
+        terminal = current_id in eos_token_ids or generated >= max_tokens
+        if terminal:
+            finish_reason = "eos" if current_id in eos_token_ids else "length"
+            request.finish(finish_reason)
+        yield current_id, current_logprobs, False
+        if terminal:
+            return
+        draft_token, draft_logprobs = _draft(current_hidden, current_token, history)
+
+        while True:
+
+            request.checkpoint()
+            verify_inputs = mx.concatenate([current_token, draft_token])
+            with mx.stream(generation_stream):
+                verify_logits, verify_hidden = _target_call(
+                    verify_inputs,
+                    GenerationForwardPhase.VERIFY,
+                    return_hidden=True,
+                )
+                _quantize()
+                request.seal_verified(
+                    backbone_tokens=request.state.backbone_tokens + 2,
+                    mtp_tokens=request.state.mtp_tokens,
+                )
+                verify_logprobs = _reported_logprobs(
+                    verify_logits[:, 0, :].squeeze(0), history
+                )
+                verify_sampling_logprobs = _sampling_distribution(verify_logprobs)
+
+            if sampling_config.stochastic:
+                draft_id = draft_token.item()
+                acceptance = mx.minimum(
+                    mx.exp(
+                        verify_sampling_logprobs[draft_id] - draft_logprobs[draft_id]
+                    ),
+                    1.0,
+                )
+                accepted = mx.random.uniform(key=_next_rng_key()) < acceptance
+                mx.eval(accepted)
+                accepted = bool(accepted.item())
+                replacement_token = replacement_logprobs = None
+                if not accepted:
+                    replacement_token, replacement_logprobs = _residual_sample(
+                        verify_sampling_logprobs, draft_logprobs
+                    )
+                    replacement_token = replacement_token.reshape(-1)
+                    mx.eval(replacement_token, replacement_logprobs)
+            else:
+                replacement_token = _sample(verify_sampling_logprobs).reshape(-1)
+                mx.eval(replacement_token)
+                accepted = replacement_token.item() == draft_token.item()
+                replacement_logprobs = verify_sampling_logprobs
+
+            if accepted:
+                request.commit(
+                    backbone_tokens=request.state.backbone_tokens + 2,
+                    mtp_tokens=request.state.mtp_tokens,
+                )
+                if telemetry is not None:
+                    telemetry["mtp_accepted"] += 1
+                generated += 1
+                draft_id = draft_token.item()
+                draft_terminal = draft_id in eos_token_ids or generated >= max_tokens
+                if draft_terminal:
+                    finish_reason = "eos" if draft_id in eos_token_ids else "length"
+                    request.finish(finish_reason)
+                yield draft_id, verify_logprobs, True
+                if draft_terminal:
+                    return
+
+                # Bonus processing begins only after the accepted draft has
+                # crossed its yield/resume boundary.
+                bonus_history = mx.concatenate([history, draft_token])
+                bonus_logprobs = _reported_logprobs(
+                    verify_logits[:, 1, :].squeeze(0), bonus_history
+                )
+                bonus_sampling_logprobs = _sampling_distribution(bonus_logprobs)
+                bonus_token = _sample(bonus_sampling_logprobs).reshape(-1)
+                mx.eval(bonus_token, bonus_logprobs)
+                next_history = mx.concatenate([bonus_history, bonus_token])
+                generated += 1
+                bonus_id = bonus_token.item()
+                bonus_terminal = bonus_id in eos_token_ids or generated >= max_tokens
+                if bonus_terminal:
+                    finish_reason = "eos" if bonus_id in eos_token_ids else "length"
+                    request.finish(finish_reason)
+                yield bonus_id, bonus_logprobs, False
+                if bonus_terminal:
+                    return
+
+                # Catch the MTP state up and create the next draft only after
+                # the bonus token has crossed its yield/resume boundary.
+                mtp_hidden = mx.concatenate(
+                    [verify_hidden[:, 0:1, :], verify_hidden[:, 1:2, :]], axis=1
+                )
+                mtp_tokens = mx.concatenate([draft_token, bonus_token])
+                next_draft, next_draft_logprobs = _draft(
+                    mtp_hidden, mtp_tokens, next_history
+                )
+                history = next_history
+                current_token = bonus_token
+                current_logprobs = bonus_logprobs
+                current_hidden = verify_hidden[:, 1:2, :]
+                draft_token = next_draft
+                draft_logprobs = next_draft_logprobs
+                continue
+
+            # The prior output token was physically included by verify but
+            # recurrent state cannot retain a prefix of that forward.  Restore
+            # then replay exactly that token before drafting from the residual.
+            request.reject_partial(accepted_backbone_tokens=1, accepted_mtp_tokens=0)
+            with mx.stream(generation_stream):
+                _, replay_hidden = _target_call(
+                    current_token,
+                    GenerationForwardPhase.DECODE,
+                    return_hidden=True,
+                )
+                _quantize()
+                request.replay_retained(
+                    backbone_tokens=request.state.backbone_tokens + 1,
+                    mtp_tokens=request.state.mtp_tokens,
+                )
+            next_history = mx.concatenate([history, replacement_token])
+            generated += 1
+            replacement_id = replacement_token.item()
+            replacement_terminal = (
+                replacement_id in eos_token_ids or generated >= max_tokens
+            )
+            if replacement_terminal:
+                finish_reason = "eos" if replacement_id in eos_token_ids else "length"
+                request.finish(finish_reason)
+            yield replacement_id, verify_logprobs, False
+            if replacement_terminal:
+                return
+
+            next_draft, next_draft_logprobs = _draft(
+                replay_hidden[:, -1:, :], replacement_token, next_history
+            )
+            history = next_history
+            current_token = replacement_token
+            current_logprobs = verify_logprobs
+            current_hidden = replay_hidden[:, -1:, :]
+            draft_token = next_draft
+            draft_logprobs = next_draft_logprobs
+    except GeneratorExit:
+        finish_reason = "generator_closed"
+        raise
+    except BaseException:
+        finish_reason = "cancelled"
+        raise
+    finally:
+        if not request.closed:
+            request.finish(finish_reason)
+
+
 def stream_generate(
     model: nn.Module,
     tokenizer: Union[PreTrainedTokenizer, TokenizerWrapper],
     prompt: Union[str, mx.array, List[int]],
     max_tokens: int = 256,
     draft_model: Optional[nn.Module] = None,
+    mtp: bool = False,
+    mtp_sampling_config: Optional[NativeMTPSamplingConfig] = None,
     model_forward_context: Optional[GenerationForwardContext] = None,
     **kwargs,
 ) -> Generator[GenerationResponse, None, None]:
@@ -819,6 +1295,10 @@ def stream_generate(
         draft_model (Optional[nn.Module]): An optional draft model. If provided
           then speculative decoding is used. The draft model must use the same
           tokenizer as the main model. Default: ``None``.
+        mtp (bool): Request native model-owned MTP.  This is text-only,
+          B=1, and does not support prefix cache reuse.
+        mtp_sampling_config (NativeMTPSamplingConfig, optional): Immutable,
+          request-local native MTP sampling and filtering policy.
         model_forward_context (Callable[[GenerationForward], ContextManager], optional):
           A request-local context factory forwarded to the selected generation
           implementation. The scope covers Python model-call graph construction.
@@ -847,7 +1327,37 @@ def stream_generate(
     if model_forward_context is not None:
         kwargs["model_forward_context"] = model_forward_context
 
-    if draft_model is None:
+    mtp_telemetry = {
+        "mtp_drafts": 0,
+        "mtp_accepted": 0,
+        "mtp_bypass_reason": None,
+    }
+    if draft_model is None and mtp:
+        capability = getattr(model, "mtp_capability", None)
+        if capability is not None and capability.supported:
+            kwargs.pop("max_kv_size", None)
+            kwargs.pop("prompt_progress_callback", None)
+            kwargs.pop("num_draft_tokens", None)
+            token_generator = mtp_generate_step(
+                prompt,
+                model,
+                sampling_config=mtp_sampling_config,
+                eos_token_ids=tokenizer.eos_token_ids,
+                telemetry=mtp_telemetry,
+                **kwargs,
+            )
+        else:
+            mtp_telemetry["mtp_bypass_reason"] = (
+                "native_mtp_model_capability_missing"
+                if capability is None
+                else capability.reason
+            )
+            kwargs.pop("num_draft_tokens", None)
+            token_generator = generate_step(prompt, model, **kwargs)
+            token_generator = (
+                (token, logprobs, False) for token, logprobs in token_generator
+            )
+    elif draft_model is None:
         kwargs.pop("num_draft_tokens", None)
         token_generator = generate_step(prompt, model, **kwargs)
         # from_draft always false for non-speculative generation
@@ -855,6 +1365,8 @@ def stream_generate(
             (token, logprobs, False) for token, logprobs in token_generator
         )
     else:
+        if mtp:
+            mtp_telemetry["mtp_bypass_reason"] = "native_mtp_external_draft_unsupported"
         kwargs.pop("max_kv_size", None)
         kwargs.pop("prompt_progress_callback", None)
         token_generator = speculative_generate_step(
@@ -862,30 +1374,43 @@ def stream_generate(
         )
     with wired_limit(model, [generation_stream]):
         tic = time.perf_counter()
-        for n, (token, logprobs, from_draft) in enumerate(token_generator):
-            if n == 0:
-                prompt_time = time.perf_counter() - tic
-                prompt_tps = prompt.size / prompt_time
-                tic = time.perf_counter()
-            if token in tokenizer.eos_token_ids:
-                break
+        token = 0
+        logprobs = mx.array([])
+        from_draft = False
+        prompt_tps = 0.0
+        n = -1
+        try:
+            for n, (token, logprobs, from_draft) in enumerate(token_generator):
+                if n == 0:
+                    prompt_time = time.perf_counter() - tic
+                    prompt_tps = prompt.size / prompt_time
+                    tic = time.perf_counter()
+                if token in tokenizer.eos_token_ids:
+                    break
 
-            detokenizer.add_token(token)
-            if (n + 1) == max_tokens:
-                break
+                detokenizer.add_token(token)
+                if (n + 1) == max_tokens:
+                    break
 
-            yield GenerationResponse(
-                text=detokenizer.last_segment,
-                token=token,
-                logprobs=logprobs,
-                from_draft=from_draft,
-                prompt_tokens=prompt.size,
-                prompt_tps=prompt_tps,
-                generation_tokens=n + 1,
-                generation_tps=(n + 1) / (time.perf_counter() - tic),
-                peak_memory=mx.get_peak_memory() / 1e9,
-                finish_reason=None,
-            )
+                yield GenerationResponse(
+                    text=detokenizer.last_segment,
+                    token=token,
+                    logprobs=logprobs,
+                    from_draft=from_draft,
+                    prompt_tokens=prompt.size,
+                    prompt_tps=prompt_tps,
+                    generation_tokens=n + 1,
+                    generation_tps=(n + 1) / (time.perf_counter() - tic),
+                    peak_memory=mx.get_peak_memory() / 1e9,
+                    finish_reason=None,
+                    mtp_drafts=mtp_telemetry["mtp_drafts"],
+                    mtp_accepted=mtp_telemetry["mtp_accepted"],
+                    mtp_bypass_reason=mtp_telemetry["mtp_bypass_reason"],
+                )
+        finally:
+            close = getattr(token_generator, "close", None)
+            if close is not None:
+                close()
 
         detokenizer.finalize()
         yield GenerationResponse(
@@ -899,6 +1424,9 @@ def stream_generate(
             generation_tps=(n + 1) / (time.perf_counter() - tic),
             peak_memory=mx.get_peak_memory() / 1e9,
             finish_reason="stop" if token in tokenizer.eos_token_ids else "length",
+            mtp_drafts=mtp_telemetry["mtp_drafts"],
+            mtp_accepted=mtp_telemetry["mtp_accepted"],
+            mtp_bypass_reason=mtp_telemetry["mtp_bypass_reason"],
         )
 
 

--- a/mlx_lm/generate.py
+++ b/mlx_lm/generate.py
@@ -1640,6 +1640,12 @@ class NativeMTPAdmission:
     model: nn.Module
     rows: Tuple[NativeMTPRowSpec, ...]
     cohort: _NativeMTPCohortCache
+    # Sparse admission is deliberately represented by the already-claimed
+    # canonical records, never by caller-provided duplicate values.  Keeping
+    # this private also prevents a later caller from reusing a bootstrap after
+    # its receipt authority was consumed.
+    _sparse_claims: Optional[Tuple["_NativeMTPSparseClaim", ...]] = None
+    _position_context: Optional[GenerationForwardContext] = None
 
     @classmethod
     def create(
@@ -1692,6 +1698,142 @@ class NativeMTPAdmission:
                 model, request_caches, uids=tuple(row.uid for row in rows)
             ),
         )
+
+    @classmethod
+    def create_from_sparse_bootstraps(
+        cls,
+        model: nn.Module,
+        rows: Sequence[NativeMTPRowSpec],
+        bootstraps: Sequence["NativeMTPSparseBootstrap"],
+    ) -> "NativeMTPAdmission":
+        """Atomically adopt B=1 sparse target receipts into one cohort.
+
+        Every bootstrap is claimed before any MTP cache is made observable.
+        Its target cache remains the attested cache; only the retained hidden
+        rows and their original immediate successors initialize the fresh MTP
+        cache.  Destination cohort construction happens last, after every
+        source request has reached the exact ``target=N, mtp=N-1`` state.
+        """
+
+        rows = tuple(rows)
+        bootstraps = tuple(bootstraps)
+        if not rows or len(rows) != len(bootstraps):
+            raise ValueError("native_mtp_sparse_batch_rows_and_bootstraps_required")
+        if any(not isinstance(row, NativeMTPRowSpec) for row in rows):
+            raise TypeError("native_mtp_batch_row_spec_required")
+        if any(not isinstance(item, NativeMTPSparseBootstrap) for item in bootstraps):
+            raise TypeError("native_mtp_sparse_bootstrap_invalid")
+        if len({row.uid for row in rows}) != len(rows):
+            raise ValueError("native_mtp_batch_uid_collision")
+        # Reject an incoherent caller contract before reserving or consuming a
+        # single receipt.  This is admission validation, not a partial batch
+        # failure, so the caller may correct the row metadata and retry its
+        # still-live sparse evidence.
+        for row, bootstrap in zip(rows, bootstraps):
+            if row.prompt != bootstrap.selected_token_ids:
+                raise ValueError("native_mtp_sparse_row_prompt_mismatch")
+        capability = getattr(model, "mtp_capability", None)
+        if capability is None or not capability.supported:
+            raise RuntimeError(
+                "native_mtp_model_capability_missing"
+                if capability is None
+                else capability.reason
+            )
+
+        # Establish the only valid model-owned consumer before consuming
+        # receipts.  This fails without touching receipt authority.
+        position_context = _native_mtp_position_context(model, None)
+        claims = []
+        requests = []
+        cohort = None
+        try:
+            for bootstrap in bootstraps:
+                claim = bootstrap.claim(model)
+                claims.append(claim)
+                request = cache.NativeMTPRequestCache.adopt_sparse_target(
+                    model,
+                    target_cache=claim.target_cache,
+                    target_tokens=len(claim.selected_token_ids),
+                    next_logical_position=claim.next_logical_position,
+                )
+                requests.append(request)
+                cls._initialize_sparse_mtp_request(
+                    model, request, claim, position_context
+                )
+            cohort = _NativeMTPCohortCache(
+                model, requests, uids=tuple(row.uid for row in rows)
+            )
+            return cls(
+                model,
+                rows,
+                cohort,
+                _sparse_claims=tuple(claims),
+                _position_context=position_context,
+            )
+        except BaseException:
+            # ``claim`` consumes receipt authority even if validation fails;
+            # close every not-yet-claimed bootstrap as well so a failed batch
+            # can never be retried as an accidental partial cohort.
+            for bootstrap in bootstraps:
+                bootstrap.close()
+            for request in requests:
+                if not request.closed:
+                    request.finish("cancelled")
+            if cohort is not None:
+                cohort.poison("native_mtp_sparse_batch_admission_failed")
+            raise
+
+    @staticmethod
+    def _initialize_sparse_mtp_request(model, request, claim, position_context):
+        """Populate one fresh MTP cache from attested hidden/successor pairs."""
+
+        try:
+            for record in claim.records:
+                if not record.immediate_successor_token_ids:
+                    continue
+                positions = record.logical_positions[
+                    : len(record.immediate_successor_token_ids)
+                ]
+                tokens = mx.array(
+                    record.immediate_successor_token_ids, dtype=mx.uint32
+                )[None]
+                ack = GenerationForwardPositionAck(
+                    positions,
+                    model=model,
+                    cache=request.mtp,
+                    phase=GenerationForwardPhase.MTP_DRAFT,
+                )
+                forward = GenerationForward(
+                    model=model,
+                    input_tokens=tokens,
+                    cache=request.mtp,
+                    phase=GenerationForwardPhase.MTP_DRAFT,
+                    logical_positions=positions,
+                    logical_position_ack=ack,
+                )
+                with position_context(forward):
+                    ack._activate()
+                    try:
+                        model.mtp_forward(
+                            record.hidden_rows[:, : len(positions), :],
+                            tokens,
+                            request.mtp,
+                        )
+                        ack._require_acknowledged()
+                    finally:
+                        ack._finish()
+            request.seal_verified(
+                backbone_tokens=len(claim.selected_token_ids),
+                mtp_tokens=len(claim.immediate_successor_token_ids),
+            )
+            request.commit(
+                backbone_tokens=len(claim.selected_token_ids),
+                mtp_tokens=len(claim.immediate_successor_token_ids),
+            )
+        except BaseException:
+            if not request.closed:
+                request.finish("cancelled")
+            raise
 
 
 class _NativeMTPEpoch:
@@ -1852,6 +1994,43 @@ class NativeMTPBatchGenerator:
             for row in admission.rows
         }
         self._last_failed_owners = ()
+        self._sparse_claims = admission._sparse_claims
+        self._position_context = admission._position_context
+        self._logical_cursor = (
+            {
+                row.uid: claim.next_logical_position
+                for row, claim in zip(admission.rows, self._sparse_claims)
+            }
+            if self._sparse_claims is not None
+            else None
+        )
+        self._initial_mtp_positions = (
+            {
+                row.uid: claim.selected_logical_positions[-1]
+                for row, claim in zip(admission.rows, self._sparse_claims)
+            }
+            if self._sparse_claims is not None
+            else None
+        )
+        if self._sparse_claims is not None:
+            # Canonical B=1 sparse generation deliberately begins processor
+            # history at the final retained target anchor, not the caller's
+            # original selected-token sequence.  The latter would alter
+            # stateful/replay-safe processors and make a batched sparse row
+            # diverge before its first emitted head.
+            self._history = {
+                row.uid: mx.array([claim.selected_token_ids[-1]], dtype=mx.uint32)
+                for row, claim in zip(admission.rows, self._sparse_claims)
+            }
+
+    def start_sparse(self):
+        """Start a sparse admission from its retained final target evidence."""
+
+        if self._sparse_claims is None:
+            raise RuntimeError("native_mtp_sparse_batch_admission_required")
+        if self._epoch is not None or self._closed:
+            raise RuntimeError("native_mtp_batch_initial_already_started")
+        return self._sparse_initial()
 
     @property
     def telemetry(self) -> tuple:
@@ -1881,6 +2060,8 @@ class NativeMTPBatchGenerator:
 
         if self._epoch is not None or self._closed:
             raise RuntimeError("native_mtp_batch_initial_already_started")
+        if self._sparse_claims is not None:
+            raise RuntimeError("native_mtp_sparse_batch_requires_start_sparse")
         if (
             isinstance(prefill_step_size, bool)
             or not isinstance(prefill_step_size, int)
@@ -1979,6 +2160,34 @@ class NativeMTPBatchGenerator:
                 raise
         return tuple(emissions), self._initial(emissions)
 
+    def _sparse_initial(self):
+        """Turn retained final sparse logits into the Initial epoch only."""
+
+        emissions = []
+        try:
+            for row, claim in zip(self._admission.rows, self._sparse_claims):
+                uid = row.uid
+                state = self._sampling[uid]
+                reported = state.reported_logprobs(
+                    claim.final_target_logits[0, -1, :], self._history[uid]
+                )
+                sampled = state.sample(
+                    state.sampling_distribution(reported),
+                    rng_key=(
+                        self._next_rng_key(uid) if state.config.stochastic else None
+                    ),
+                ).reshape(-1)
+                mx.eval(sampled, reported)
+                self._head[uid] = sampled
+                self._hidden[uid] = claim.final_target_hidden
+                emissions.append(
+                    self._make_emission(uid, sampled.item(), reported, False)
+                )
+        except BaseException:
+            self._poison_all("native_mtp_sparse_initial_failed")
+            raise
+        return tuple(emissions), self._initial(emissions)
+
     def _move_to_front(self, uids):
         """Return a selected move-only owner while keeping the selected UIDs first."""
 
@@ -2032,15 +2241,13 @@ class NativeMTPBatchGenerator:
             )
         )
 
-    def _target_forward(self, tokens, *, phase):
+    def _target_forward(self, tokens, *, phase, logical_positions=None):
         try:
             self._cohort.bind_before_mutation()
             inputs = mx.array(tokens, dtype=mx.uint32)
             if inputs.ndim == 1:
                 inputs = inputs[:, None]
-            result = self._admission.model(
-                inputs, cache=self._cohort.backbone, return_hidden=True
-            )
+            result = self._positioned_target_call(inputs, phase, logical_positions)
             if not isinstance(result, tuple) or len(result) != 2:
                 raise RuntimeError("native_mtp_batch_target_hidden_missing")
             self._seal_delta(backbone=inputs.shape[1], mtp=0)
@@ -2049,18 +2256,103 @@ class NativeMTPBatchGenerator:
             self._poison_all("native_mtp_batch_target_failed")
             raise
 
-    def _mtp_forward(self, hidden, tokens):
+    def _mtp_forward(self, hidden, tokens, *, logical_positions=None):
         try:
             self._cohort.bind_before_mutation()
             inputs = mx.array(tokens, dtype=mx.uint32)
             if inputs.ndim == 1:
                 inputs = inputs[:, None]
-            result = self._admission.model.mtp_forward(hidden, inputs, self._cohort.mtp)
+            result = self._positioned_mtp_call(hidden, inputs, logical_positions)
             self._seal_delta(backbone=0, mtp=inputs.shape[1])
             return result
         except BaseException:
             self._poison_all("native_mtp_batch_mtp_failed")
             raise
+
+    def _positioned_target_call(self, inputs, phase, logical_positions):
+        if logical_positions is None:
+            return self._admission.model(
+                inputs, cache=self._cohort.backbone, return_hidden=True
+            )
+        if self._position_context is None:
+            raise RuntimeError("native_mtp_sparse_position_context_missing")
+        ack = GenerationForwardPositionAck(
+            logical_positions,
+            model=self._admission.model,
+            cache=self._cohort.backbone,
+            phase=phase,
+        )
+        forward = GenerationForward(
+            model=self._admission.model,
+            input_tokens=inputs,
+            cache=self._cohort.backbone,
+            phase=phase,
+            logical_positions=logical_positions,
+            logical_position_ack=ack,
+        )
+        with self._position_context(forward):
+            ack._activate()
+            try:
+                result = self._admission.model(
+                    inputs, cache=self._cohort.backbone, return_hidden=True
+                )
+                ack._require_acknowledged()
+                return result
+            finally:
+                ack._finish()
+
+    def _positioned_mtp_call(self, hidden, inputs, logical_positions):
+        if logical_positions is None:
+            return self._admission.model.mtp_forward(hidden, inputs, self._cohort.mtp)
+        if self._position_context is None:
+            raise RuntimeError("native_mtp_sparse_position_context_missing")
+        ack = GenerationForwardPositionAck(
+            logical_positions,
+            model=self._admission.model,
+            cache=self._cohort.mtp,
+            phase=GenerationForwardPhase.MTP_DRAFT,
+        )
+        forward = GenerationForward(
+            model=self._admission.model,
+            input_tokens=inputs,
+            cache=self._cohort.mtp,
+            phase=GenerationForwardPhase.MTP_DRAFT,
+            logical_positions=logical_positions,
+            logical_position_ack=ack,
+        )
+        with self._position_context(forward):
+            ack._activate()
+            try:
+                result = self._admission.model.mtp_forward(
+                    hidden, inputs, self._cohort.mtp
+                )
+                ack._require_acknowledged()
+                return result
+            finally:
+                ack._finish()
+
+    @staticmethod
+    def _position_argument(rows):
+        """Keep B=1 on the canonical vector contract, B>1 on matrices."""
+
+        return rows[0] if len(rows) == 1 else tuple(rows)
+
+    def _position_rows(self, uids, width, *, start_delta):
+        if self._logical_cursor is None:
+            return None
+        return tuple(
+            tuple(
+                self._logical_cursor[uid] + start_delta + index
+                for index in range(width)
+            )
+            for uid in uids
+        )
+
+    def _positions(self, uids, width, *, start_delta):
+        """Return exact B=1 vectors or explicit B>1 position matrices."""
+
+        rows = self._position_rows(uids, width, start_delta=start_delta)
+        return None if rows is None else self._position_argument(rows)
 
     def _make_emission(self, uid, token, logprobs, from_draft):
         row = self._rows[uid]
@@ -2098,6 +2390,8 @@ class NativeMTPBatchGenerator:
         for emission in emissions:
             row = self._rows[emission.uid]
             self._generated[emission.uid] += 1
+            if self._logical_cursor is not None:
+                self._logical_cursor[emission.uid] += 1
             terminal = (
                 emission.finish_reason is not None
                 or self._generated[emission.uid] >= row.max_tokens
@@ -2145,6 +2439,13 @@ class NativeMTPBatchGenerator:
             logits = self._mtp_forward(
                 mx.concatenate([self._hidden[uid] for uid in drafts], axis=0),
                 tuple(self._head[uid].item() for uid in drafts),
+                logical_positions=(
+                    self._position_argument(
+                        tuple((self._initial_mtp_positions[uid],) for uid in drafts)
+                    )
+                    if self._initial_mtp_positions is not None
+                    else None
+                ),
             )[:, -1, :]
             for index, uid in enumerate(drafts):
                 state = self._sampling[uid]
@@ -2171,6 +2472,17 @@ class NativeMTPBatchGenerator:
         epoch._consume()
         try:
             self._cohort.checkpoint()
+            verify_rows = self._position_rows(epoch.active_uids, 2, start_delta=-1)
+            self._verify_positions = (
+                self._position_argument(verify_rows)
+                if verify_rows is not None
+                else None
+            )
+            self._verify_position_by_uid = (
+                dict(zip(epoch.active_uids, verify_rows))
+                if verify_rows is not None
+                else None
+            )
             inputs = mx.stack(
                 [
                     mx.concatenate([self._head[uid], self._draft[uid]])
@@ -2178,11 +2490,11 @@ class NativeMTPBatchGenerator:
                 ],
                 axis=0,
             )
-            self._cohort.bind_before_mutation()
-            verify_logits, verify_hidden = self._admission.model(
-                inputs, cache=self._cohort.backbone, return_hidden=True
+            verify_logits, verify_hidden = self._target_forward(
+                inputs,
+                phase=GenerationForwardPhase.VERIFY,
+                logical_positions=self._verify_positions,
             )
-            self._seal_delta(backbone=2, mtp=0)
             (
                 self._verify_hidden,
                 self._verify_logits,
@@ -2294,10 +2606,21 @@ class NativeMTPBatchGenerator:
                     ],
                     axis=0,
                 )
-                verify_logits, verify_hidden = self._admission.model(
-                    inputs, cache=self._cohort.backbone, return_hidden=True
+                accepted_positions = (
+                    self._position_argument(
+                        tuple(
+                            self._verify_position_by_uid[uid]
+                            for uid in epoch.accepted_uids
+                        )
+                    )
+                    if self._verify_position_by_uid is not None
+                    else None
                 )
-                self._seal_delta(backbone=2, mtp=0)
+                verify_logits, verify_hidden = self._target_forward(
+                    inputs,
+                    phase=GenerationForwardPhase.VERIFY,
+                    logical_positions=accepted_positions,
+                )
                 self._cohort.commit()
                 for index, uid in enumerate(epoch.accepted_uids):
                     self._verify_hidden[uid] = verify_hidden[index : index + 1]
@@ -2351,9 +2674,27 @@ class NativeMTPBatchGenerator:
         rejected_ready = ()
         if self._mixed_rejected_uids:
             self._cohort = self._mixed_rejected_owner
+            self._replay_position_by_uid = (
+                {
+                    uid: self._logical_cursor[uid] - 2
+                    for uid in self._mixed_rejected_uids
+                }
+                if self._logical_cursor is not None
+                else None
+            )
             _, replay_hidden = self._target_forward(
                 tuple(self._head[uid].item() for uid in self._mixed_rejected_uids),
                 phase=GenerationForwardPhase.DECODE,
+                logical_positions=(
+                    self._position_argument(
+                        tuple(
+                            (self._replay_position_by_uid[uid],)
+                            for uid in self._mixed_rejected_uids
+                        )
+                    )
+                    if self._replay_position_by_uid is not None
+                    else None
+                ),
             )
             self._replay_hidden = {}
             for index, uid in enumerate(self._mixed_rejected_uids):
@@ -2365,6 +2706,16 @@ class NativeMTPBatchGenerator:
                 ),
                 tuple(
                     self._replacement[uid].item() for uid in self._mixed_rejected_uids
+                ),
+                logical_positions=(
+                    self._position_argument(
+                        tuple(
+                            (self._replay_position_by_uid[uid],)
+                            for uid in self._mixed_rejected_uids
+                        )
+                    )
+                    if self._replay_position_by_uid is not None
+                    else None
                 ),
             )[:, -1, :]
             rejected_ready = self._mixed_rejected_uids
@@ -2384,7 +2735,6 @@ class NativeMTPBatchGenerator:
                 ).reshape(-1)
                 self._draft_logprobs[uid] = draft_logprobs
         emissions = []
-        accepted_bonus = ()
         if self._mixed_accepted_owner is not None:
             self._cohort = self._mixed_accepted_owner
             for uid in self._mixed_accepted_uids:
@@ -2404,18 +2754,19 @@ class NativeMTPBatchGenerator:
                 self._head[uid] = token
                 emission = self._make_emission(uid, token.item(), reported, False)
                 emissions.append(emission)
-                if emission.finish_reason is None:
-                    accepted_bonus += (uid,)
-        # Bonus is an emission boundary: terminal accepted rows must not be
-        # caught up or rejoined with the rejected Ready owner.
+        # This is a real public emission boundary.  Record it exactly once
+        # before terminal pruning so generated counts, finish semantics and
+        # sparse logical cursors remain B=1-equivalent.
+        accepted_bonus = self._record_emissions(
+            _NativeMTPPhase.BONUS,
+            emissions,
+            expected=self._mixed_accepted_uids,
+        )
+        # Terminal accepted rows must not be caught up or rejoined with the
+        # rejected Ready owner.
         self._mixed_accepted_uids = accepted_bonus
         self._mixed_accepted_owner = self._filter_owner_uids(
             self._mixed_accepted_owner, accepted_bonus
-        )
-        self._events = self._events + (
-            _NativeMTPTelemetryEvent(
-                _NativeMTPPhase.BONUS, accepted_bonus, "mixed_accepted_bonus_emission"
-            ),
         )
         self._mixed_rejected_ready = rejected_ready
         self._mixed_accepted_ready = accepted_bonus
@@ -2433,9 +2784,16 @@ class NativeMTPBatchGenerator:
                 dtype=mx.uint32,
             )
             self._cohort.bind_before_mutation()
-            logits = self._admission.model.mtp_forward(
-                hidden, tokens, self._cohort.mtp
-            )[:, -1, :]
+            accepted_positions = (
+                self._position_argument(
+                    tuple(self._verify_position_by_uid[uid] for uid in uids)
+                )
+                if self._verify_position_by_uid is not None
+                else None
+            )
+            logits = self._positioned_mtp_call(hidden, tokens, accepted_positions)[
+                :, -1, :
+            ]
             self._seal_delta(backbone=0, mtp=2)
             for index, uid in enumerate(uids):
                 state = self._sampling[uid]
@@ -2506,8 +2864,16 @@ class NativeMTPBatchGenerator:
                 dtype=mx.uint32,
             )
             self._cohort.bind_before_mutation()
-            logits = self._admission.model.mtp_forward(
-                hidden, tokens, self._cohort.mtp
+            logits = self._positioned_mtp_call(
+                hidden,
+                tokens,
+                (
+                    self._position_argument(
+                        tuple(self._verify_position_by_uid[uid] for uid in drafts)
+                    )
+                    if getattr(self, "_verify_position_by_uid", None) is not None
+                    else None
+                ),
             )[:, -1, :]
             self._seal_delta(backbone=0, mtp=2)
             for index, uid in enumerate(drafts):
@@ -2536,9 +2902,24 @@ class NativeMTPBatchGenerator:
                     "native_mtp_batch_mixed_decision_requires_branch_resolution"
                 )
             self._cohort.rollback()
+            self._replay_position_by_uid = (
+                {uid: self._logical_cursor[uid] - 1 for uid in epoch.rejected_uids}
+                if self._logical_cursor is not None
+                else None
+            )
             _, replay_hidden = self._target_forward(
                 tuple(self._head[uid].item() for uid in epoch.rejected_uids),
                 phase=GenerationForwardPhase.DECODE,
+                logical_positions=(
+                    self._position_argument(
+                        tuple(
+                            (self._replay_position_by_uid[uid],)
+                            for uid in epoch.rejected_uids
+                        )
+                    )
+                    if self._replay_position_by_uid is not None
+                    else None
+                ),
             )
             self._replay_hidden = {}
             emissions = []
@@ -2570,6 +2951,13 @@ class NativeMTPBatchGenerator:
             logits = self._mtp_forward(
                 mx.concatenate([self._replay_hidden[uid] for uid in drafts], axis=0),
                 tuple(self._replacement[uid].item() for uid in drafts),
+                logical_positions=(
+                    self._position_argument(
+                        tuple((self._replay_position_by_uid[uid],) for uid in drafts)
+                    )
+                    if getattr(self, "_replay_position_by_uid", None) is not None
+                    else None
+                ),
             )[:, -1, :]
             for index, uid in enumerate(drafts):
                 state = self._sampling[uid]

--- a/mlx_lm/models/cache.py
+++ b/mlx_lm/models/cache.py
@@ -956,6 +956,49 @@ class NativeMTPRequestCache:
             raise RuntimeError(capability.reason)
         return cls(model, model.make_cache(), model.make_mtp_cache())
 
+    @classmethod
+    def adopt_sparse_target(
+        cls,
+        model: Any,
+        *,
+        target_cache: List[Any],
+        target_tokens: int,
+        next_logical_position: int,
+    ):
+        """Adopt an attested target cache and checkpoint before MTP writes.
+
+        Receipt validation belongs to the generation layer that owns the
+        evidence objects.  This cache-owned boundary independently validates
+        the exact target topology/physical occupancy, creates a fresh MTP
+        cache, initializes the shared cursor, and opens the rollback boundary
+        before returning control to any MTP forward.
+        """
+
+        if isinstance(target_tokens, bool) or not isinstance(target_tokens, int):
+            raise TypeError("native MTP sparse target token count must be an integer")
+        if target_tokens < 1:
+            raise ValueError("native MTP sparse target cache must be non-empty")
+        if (
+            isinstance(next_logical_position, bool)
+            or not isinstance(next_logical_position, int)
+            or next_logical_position < 1
+        ):
+            raise ValueError("native MTP sparse logical cursor is invalid")
+        request = None
+        try:
+            request = cls(model, target_cache, model.make_mtp_cache())
+            request.retain_logical_position(
+                backbone_tokens=target_tokens,
+                mtp_tokens=0,
+                next_logical_position=next_logical_position,
+            )
+            request.checkpoint()
+            return request
+        except BaseException:
+            if request is not None and not request.closed:
+                request.finish("cancelled")
+            raise
+
     def assert_aligned(self, *, backbone_tokens: int, mtp_tokens: int) -> None:
         """Assert exact logical/cache alignment before output may be emitted."""
 

--- a/mlx_lm/models/cache.py
+++ b/mlx_lm/models/cache.py
@@ -806,10 +806,11 @@ def _mtp_copy_array(value):
 class NativeMTPRequestCache:
     """B=1 transactional cache owner for native Qwen MTP.
 
-    This is intentionally an unused engine-neutral foundation.  No generation
-    lifecycle consumes it yet, so it cannot certify native MTP by itself.  A
-    future generation loop must record every retained backbone/MTP token
-    through :meth:`commit`, and use a checkpoint around each proposed draft.
+    This engine-neutral owner is consumed by ``mtp_generate_step``, which
+    records retained backbone/MTP tokens and owns every checkpoint, verified
+    seal, commit, partial rollback/replay, and terminal finish boundary.
+    Server and continuous-batching integrations still require separate
+    qualification evidence.
     Cache replacement caused by KV quantization is performed through these
     caller-owned containers, so a rollback restores the exact pre-draft entry
     object when necessary.

--- a/mlx_lm/models/cache.py
+++ b/mlx_lm/models/cache.py
@@ -728,6 +728,485 @@ class ArraysCache(_BaseCache):
         return sum(c.nbytes for c in self.cache if c is not None)
 
 
+@dataclass(frozen=True)
+class NativeMTPCacheIdentity:
+    """Identity of the caller-owned cache containers for one native MTP request.
+
+    Native MTP has two independent state machines: the backbone cache and the
+    MTP-head cache.  The container identities, rather than a concatenated list
+    layout, are the public ownership boundary.  This deliberately makes a
+    legacy ``backbone + mtp`` cache impossible to pass by accident.
+    """
+
+    model_id: int
+    backbone_container_id: int
+    mtp_container_id: int
+
+
+@dataclass(frozen=True)
+class NativeMTPCacheState:
+    """Logical positions attached to a request-local native MTP cache."""
+
+    identity: NativeMTPCacheIdentity
+    backbone_tokens: int
+    mtp_tokens: int
+
+
+@dataclass(frozen=True)
+class _NativeMTPEntryCheckpoint:
+    """Rollback state for one cache entry.
+
+    Attention cache writes append after ``offset``; retaining the prior offset
+    is therefore enough to discard an unaccepted suffix without copying the
+    potentially very large KV tensors.  ArraysCache is recurrent state and has
+    no logical offset, so its small state vectors are copied at the transaction
+    boundary.
+    """
+
+    index: int
+    cache: Any
+    offset: Optional[int]
+    array_state: Optional[tuple]
+    left_padding: Optional[mx.array]
+    lengths: Optional[mx.array]
+
+
+@dataclass(frozen=True)
+class NativeMTPCacheCheckpoint:
+    state: NativeMTPCacheState
+    backbone: tuple[_NativeMTPEntryCheckpoint, ...]
+    mtp: tuple[_NativeMTPEntryCheckpoint, ...]
+
+
+@dataclass(frozen=True)
+class NativeMTPReplayRequired:
+    """The only legal result of retaining a strict prefix of a verified draft.
+
+    Recurrent backbone state cannot be trimmed to retain a prefix of a
+    multi-token verification forward.  The caller must restore the checkpoint
+    and replay every accepted token through the ordinary single-token path.
+    """
+
+    state: NativeMTPCacheState
+    replay_to_backbone_tokens: int
+    replay_to_mtp_tokens: int
+
+
+def _mtp_copy_array(value):
+    """Make a value snapshot without retaining a mutable MLX backing buffer."""
+
+    if value is None:
+        return None
+    # ``mx.array`` may preserve an existing array object.  Adding zero makes a
+    # distinct lazy graph value and is evaluated only with the caller's normal
+    # generation graph; ArraysCache state is intentionally small.
+    return value + mx.zeros(value.shape, dtype=value.dtype)
+
+
+class NativeMTPRequestCache:
+    """B=1 transactional cache owner for native Qwen MTP.
+
+    This is intentionally an unused engine-neutral foundation.  No generation
+    lifecycle consumes it yet, so it cannot certify native MTP by itself.  A
+    future generation loop must record every retained backbone/MTP token
+    through :meth:`commit`, and use a checkpoint around each proposed draft.
+    Cache replacement caused by KV quantization is performed through these
+    caller-owned containers, so a rollback restores the exact pre-draft entry
+    object when necessary.
+
+    Prefix reuse is deliberately not supported: a generic prompt cache cannot
+    prove that its MTP-head position and recurrent state are aligned with the
+    backbone.  It must remain disabled until that separate proof exists.
+    """
+
+    def __init__(self, model: Any, backbone: List[Any], mtp: List[Any]):
+        if not isinstance(backbone, list) or not isinstance(mtp, list):
+            raise TypeError("native MTP caches must be caller-owned lists")
+        if not backbone or not mtp:
+            raise ValueError("native MTP requires non-empty backbone and MTP caches")
+        if backbone is mtp:
+            raise ValueError("native MTP backbone and MTP caches must be distinct")
+
+        self.model = model
+        self.backbone = backbone
+        self.mtp = mtp
+        self.identity = NativeMTPCacheIdentity(id(model), id(backbone), id(mtp))
+        self._backbone_entry_ids = tuple(id(entry) for entry in backbone)
+        self._mtp_entry_ids = tuple(id(entry) for entry in mtp)
+        self._state = NativeMTPCacheState(self.identity, 0, 0)
+        self._checkpoint: Optional[NativeMTPCacheCheckpoint] = None
+        self._sealed: Optional[NativeMTPCacheState] = None
+        self._replay_required: Optional[NativeMTPReplayRequired] = None
+        self._closed = False
+        self._validate_layout()
+
+    @property
+    def state(self) -> NativeMTPCacheState:
+        return self._state
+
+    @property
+    def checkpoint_active(self) -> bool:
+        return self._checkpoint is not None
+
+    @property
+    def closed(self) -> bool:
+        return self._closed
+
+    @property
+    def replay_required(self) -> Optional[NativeMTPReplayRequired]:
+        return self._replay_required
+
+    def _validate_layout(self) -> None:
+        """Fail closed for unsupported batch, pipeline, and cache topologies."""
+
+        capability = getattr(self.model, "mtp_capability", None)
+        if capability is None:
+            raise RuntimeError("native_mtp_model_capability_missing")
+        if not capability.supported:
+            raise RuntimeError(capability.reason)
+        text_model = getattr(self.model, "model", None)
+        if text_model is None:
+            text_model = getattr(
+                getattr(self.model, "language_model", None), "model", None
+            )
+        if getattr(text_model, "pipeline_size", 1) != 1:
+            raise RuntimeError("native_mtp_pipeline_parallelism_unsupported")
+
+        expected_backbone = getattr(self.model, "layers", None)
+        mtp_module = getattr(self.model, "mtp", None)
+        expected_mtp = getattr(mtp_module, "layers", None)
+        if expected_backbone is None or expected_mtp is None:
+            raise RuntimeError("native_mtp_cache_topology_unavailable")
+        if len(self.backbone) != len(expected_backbone):
+            raise ValueError("native_mtp_backbone_cache_topology_mismatch")
+        if len(self.mtp) != len(expected_mtp):
+            raise ValueError("native_mtp_head_cache_topology_mismatch")
+        entry_ids = tuple(id(entry) for entry in self.backbone + self.mtp)
+        if len(entry_ids) != len(set(entry_ids)):
+            raise ValueError("native_mtp_cache_entries_must_be_unique")
+
+        for index, (layer, entry) in enumerate(zip(expected_backbone, self.backbone)):
+            expected_type = (
+                ArraysCache if layer.is_linear else (KVCache, QuantizedKVCache)
+            )
+            if not isinstance(entry, expected_type):
+                raise TypeError(
+                    f"native_mtp_backbone_cache_type_mismatch: entry={index}"
+                )
+            self._validate_batch_size(entry)
+        for index, entry in enumerate(self.mtp):
+            if not isinstance(entry, (KVCache, QuantizedKVCache)):
+                raise TypeError(f"native_mtp_head_cache_type_mismatch: entry={index}")
+            self._validate_batch_size(entry)
+
+    @staticmethod
+    def _validate_batch_size(entry: Any) -> None:
+        if isinstance(entry, ArraysCache):
+            if entry.batch_size != 1:
+                raise RuntimeError("native_mtp_batch_size_unsupported")
+            return
+        keys = entry.keys
+        if isinstance(entry, QuantizedKVCache) and keys is not None:
+            keys = keys[0]
+        if keys is not None and keys.shape[0] != 1:
+            raise RuntimeError("native_mtp_batch_size_unsupported")
+
+    def _assert_owned(self) -> None:
+        if self.identity != NativeMTPCacheIdentity(
+            id(self.model), id(self.backbone), id(self.mtp)
+        ):
+            raise RuntimeError("native_mtp_cache_container_identity_changed")
+        if tuple(id(entry) for entry in self.backbone) != self._backbone_entry_ids:
+            raise RuntimeError("native_mtp_backbone_cache_entry_replaced_externally")
+        if tuple(id(entry) for entry in self.mtp) != self._mtp_entry_ids:
+            raise RuntimeError("native_mtp_head_cache_entry_replaced_externally")
+
+    @staticmethod
+    def _entry_checkpoint(index: int, entry: Any) -> _NativeMTPEntryCheckpoint:
+        if isinstance(entry, ArraysCache):
+            return _NativeMTPEntryCheckpoint(
+                index=index,
+                cache=entry,
+                offset=None,
+                array_state=tuple(_mtp_copy_array(value) for value in entry.cache),
+                left_padding=_mtp_copy_array(entry.left_padding),
+                lengths=_mtp_copy_array(entry.lengths),
+            )
+        return _NativeMTPEntryCheckpoint(
+            index=index,
+            cache=entry,
+            offset=entry.offset,
+            array_state=None,
+            left_padding=None,
+            lengths=None,
+        )
+
+    @classmethod
+    def create(cls, model: Any, *, prompt_cache: Optional[Any] = None):
+        """Create fresh aligned target/MTP caches, refusing prefix reuse."""
+
+        if prompt_cache is not None:
+            raise ValueError("native_mtp_prefix_reuse_unsupported")
+        capability = getattr(model, "mtp_capability", None)
+        if capability is None:
+            raise RuntimeError("native_mtp_model_capability_missing")
+        if not capability.supported:
+            raise RuntimeError(capability.reason)
+        return cls(model, model.make_cache(), model.make_mtp_cache())
+
+    def assert_aligned(self, *, backbone_tokens: int, mtp_tokens: int) -> None:
+        """Assert exact logical/cache alignment before output may be emitted."""
+
+        self._assert_owned()
+        self._validate_layout()
+        if backbone_tokens < 0 or mtp_tokens < 0:
+            raise ValueError("native MTP logical positions must be non-negative")
+        for name, entries, expected in (
+            ("backbone", self.backbone, backbone_tokens),
+            ("mtp", self.mtp, mtp_tokens),
+        ):
+            for index, entry in enumerate(entries):
+                if isinstance(entry, ArraysCache):
+                    continue
+                if entry.offset != expected:
+                    raise RuntimeError(
+                        f"native_mtp_{name}_cache_position_mismatch: entry={index} "
+                        f"cache={entry.offset} logical={expected}"
+                    )
+
+    def checkpoint(self) -> NativeMTPCacheCheckpoint:
+        """Start a reversible draft transaction at the current aligned state."""
+
+        if self._closed:
+            raise RuntimeError("native_mtp_cache_closed")
+        if self._replay_required is not None:
+            raise RuntimeError("native_mtp_cache_replay_required")
+        if self._checkpoint is not None:
+            raise RuntimeError("native_mtp_cache_checkpoint_already_active")
+        self.assert_aligned(
+            backbone_tokens=self._state.backbone_tokens,
+            mtp_tokens=self._state.mtp_tokens,
+        )
+        self._checkpoint = NativeMTPCacheCheckpoint(
+            state=self._state,
+            backbone=tuple(
+                self._entry_checkpoint(index, entry)
+                for index, entry in enumerate(self.backbone)
+            ),
+            mtp=tuple(
+                self._entry_checkpoint(index, entry)
+                for index, entry in enumerate(self.mtp)
+            ),
+        )
+        return self._checkpoint
+
+    def seal_verified(
+        self, *, backbone_tokens: int, mtp_tokens: int
+    ) -> NativeMTPCacheState:
+        """Seal a full verified forward before it may be committed.
+
+        A sealed state is an all-or-nothing boundary.  It prevents a caller
+        from using attention-cache trimming to retain only part of a verification
+        forward while incorrectly keeping the final recurrent state.
+        """
+
+        if self._checkpoint is None:
+            raise RuntimeError("native_mtp_cache_checkpoint_missing")
+        if self._sealed is not None:
+            raise RuntimeError("native_mtp_cache_verification_already_sealed")
+        previous = self._checkpoint.state
+        if (
+            backbone_tokens < previous.backbone_tokens
+            or mtp_tokens < previous.mtp_tokens
+        ):
+            raise ValueError("native MTP sealed positions cannot move backwards")
+        self.assert_aligned(backbone_tokens=backbone_tokens, mtp_tokens=mtp_tokens)
+        self._sealed = NativeMTPCacheState(self.identity, backbone_tokens, mtp_tokens)
+        return self._sealed
+
+    @staticmethod
+    def _restore_entries(entries, checkpoints) -> None:
+        for snapshot in checkpoints:
+            entry = snapshot.cache
+            entries[snapshot.index] = entry
+            if snapshot.array_state is not None:
+                entry.cache = list(snapshot.array_state)
+                entry.left_padding = snapshot.left_padding
+                entry.lengths = snapshot.lengths
+                continue
+            if entry.offset < snapshot.offset:
+                raise RuntimeError("native_mtp_cache_advanced_backwards")
+            trim = entry.offset - snapshot.offset
+            if trim:
+                removed = entry.trim(trim)
+                if removed != trim or entry.offset != snapshot.offset:
+                    raise RuntimeError("native_mtp_cache_rollback_inexact")
+
+    def rollback(self) -> NativeMTPCacheState:
+        """Discard the active draft suffix and restore its exact checkpoint."""
+
+        if self._checkpoint is None:
+            raise RuntimeError("native_mtp_cache_checkpoint_missing")
+        checkpoint = self._checkpoint
+        self._restore_entries(self.backbone, checkpoint.backbone)
+        self._restore_entries(self.mtp, checkpoint.mtp)
+        self._backbone_entry_ids = tuple(id(entry) for entry in self.backbone)
+        self._mtp_entry_ids = tuple(id(entry) for entry in self.mtp)
+        self._state = checkpoint.state
+        self._checkpoint = None
+        self._sealed = None
+        self.assert_aligned(
+            backbone_tokens=self._state.backbone_tokens,
+            mtp_tokens=self._state.mtp_tokens,
+        )
+        return self._state
+
+    def commit(self, *, backbone_tokens: int, mtp_tokens: int) -> NativeMTPCacheState:
+        """Commit only the exact full state previously sealed by verification."""
+
+        if self._closed:
+            raise RuntimeError("native_mtp_cache_closed")
+        if self._checkpoint is None:
+            raise RuntimeError("native_mtp_cache_checkpoint_missing")
+        if self._sealed is None:
+            raise RuntimeError("native_mtp_cache_verification_not_sealed")
+        if (backbone_tokens, mtp_tokens) != (
+            self._sealed.backbone_tokens,
+            self._sealed.mtp_tokens,
+        ):
+            raise RuntimeError("native_mtp_partial_commit_requires_replay")
+        self.assert_aligned(backbone_tokens=backbone_tokens, mtp_tokens=mtp_tokens)
+        self._state = self._sealed
+        self._checkpoint = None
+        self._sealed = None
+        return self._state
+
+    def reject_partial(
+        self, *, accepted_backbone_tokens: int, accepted_mtp_tokens: int
+    ) -> NativeMTPReplayRequired:
+        """Rollback a strict verified prefix and require sequential replay."""
+
+        if self._checkpoint is None or self._sealed is None:
+            raise RuntimeError("native_mtp_cache_verification_not_sealed")
+        start = self._checkpoint.state
+        backbone_delta = self._sealed.backbone_tokens - start.backbone_tokens
+        mtp_delta = self._sealed.mtp_tokens - start.mtp_tokens
+        if not (
+            0 <= accepted_backbone_tokens <= backbone_delta
+            and 0 <= accepted_mtp_tokens <= mtp_delta
+        ):
+            raise ValueError("native MTP partial acceptance exceeds verified tokens")
+        if (
+            accepted_backbone_tokens == backbone_delta
+            and accepted_mtp_tokens == mtp_delta
+        ):
+            raise ValueError("full verified acceptance must use native MTP commit")
+        replay = NativeMTPReplayRequired(
+            state=start,
+            replay_to_backbone_tokens=start.backbone_tokens + accepted_backbone_tokens,
+            replay_to_mtp_tokens=start.mtp_tokens + accepted_mtp_tokens,
+        )
+        self.rollback()
+        self._replay_required = replay
+        return replay
+
+    def retain(self, *, backbone_tokens: int, mtp_tokens: int) -> NativeMTPCacheState:
+        """Record a non-speculative retained token boundary."""
+
+        if self._replay_required is not None:
+            raise RuntimeError("native_mtp_cache_replay_required")
+        if self._checkpoint is not None:
+            raise RuntimeError("native_mtp_cache_verification_not_sealed")
+        if (
+            backbone_tokens < self._state.backbone_tokens
+            or mtp_tokens < self._state.mtp_tokens
+        ):
+            raise ValueError("native MTP retained positions cannot move backwards")
+        self.assert_aligned(backbone_tokens=backbone_tokens, mtp_tokens=mtp_tokens)
+        self._state = NativeMTPCacheState(self.identity, backbone_tokens, mtp_tokens)
+        return self._state
+
+    def replay_retained(
+        self, *, backbone_tokens: int, mtp_tokens: int
+    ) -> NativeMTPCacheState:
+        """Record exactly one sequential replay step after partial rejection."""
+
+        replay = self._replay_required
+        if replay is None:
+            raise RuntimeError("native_mtp_cache_replay_not_required")
+        if not (
+            self._state.backbone_tokens
+            <= backbone_tokens
+            <= replay.replay_to_backbone_tokens
+            and self._state.mtp_tokens <= mtp_tokens <= replay.replay_to_mtp_tokens
+        ):
+            raise ValueError(
+                "native MTP replay position is outside the accepted prefix"
+            )
+        if (
+            backbone_tokens - self._state.backbone_tokens not in (0, 1)
+            or mtp_tokens - self._state.mtp_tokens not in (0, 1)
+            or (backbone_tokens, mtp_tokens)
+            == (self._state.backbone_tokens, self._state.mtp_tokens)
+        ):
+            raise ValueError("native MTP replay must advance one retained token step")
+        self.assert_aligned(backbone_tokens=backbone_tokens, mtp_tokens=mtp_tokens)
+        self._state = NativeMTPCacheState(self.identity, backbone_tokens, mtp_tokens)
+        if (backbone_tokens, mtp_tokens) == (
+            replay.replay_to_backbone_tokens,
+            replay.replay_to_mtp_tokens,
+        ):
+            self._replay_required = None
+        return self._state
+
+    def quantize(
+        self, *, kv_bits: Optional[int], kv_group_size: int = 64, start: int = 0
+    ):
+        """Quantize eligible caches in place through the caller-owned lists."""
+
+        if kv_bits is None:
+            return 0
+        if self._closed:
+            raise RuntimeError("native_mtp_cache_closed")
+        self._assert_owned()
+        staged_backbone = list(self.backbone)
+        staged_mtp = list(self.mtp)
+        staged_values = []
+        converted = 0
+        for entries in (staged_backbone, staged_mtp):
+            for index, entry in enumerate(entries):
+                if not isinstance(entry, KVCache) or entry.offset < start:
+                    continue
+                staged = entry.to_quantized(group_size=kv_group_size, bits=kv_bits)
+                entries[index] = staged
+                staged_values.extend((staged.keys, staged.values))
+                converted += 1
+        try:
+            mx.eval(staged_values)
+        except Exception as error:
+            raise RuntimeError("native_mtp_cache_quantization_failed") from error
+        for index, entry in enumerate(staged_backbone):
+            self.backbone[index] = entry
+        for index, entry in enumerate(staged_mtp):
+            self.mtp[index] = entry
+        self._backbone_entry_ids = tuple(id(entry) for entry in self.backbone)
+        self._mtp_entry_ids = tuple(id(entry) for entry in self.mtp)
+        return converted
+
+    def finish(self, reason: str) -> NativeMTPCacheState:
+        """Close safely for EOS, length, cancellation, or generator shutdown."""
+
+        if reason not in {"eos", "length", "cancelled", "generator_closed"}:
+            raise ValueError(f"unsupported native MTP finish reason: {reason}")
+        if self._closed:
+            return self._state
+        if self._checkpoint is not None:
+            self.rollback()
+        self._replay_required = None
+        self._closed = True
+        return self._state
+
+
 class ChunkedKVCache(_BaseCache):
     step = 256
 

--- a/mlx_lm/models/cache.py
+++ b/mlx_lm/models/cache.py
@@ -745,11 +745,12 @@ class NativeMTPCacheIdentity:
 
 @dataclass(frozen=True)
 class NativeMTPCacheState:
-    """Logical positions attached to a request-local native MTP cache."""
+    """Physical occupancies and the shared request-local logical cursor."""
 
     identity: NativeMTPCacheIdentity
     backbone_tokens: int
     mtp_tokens: int
+    next_logical_position: Optional[int] = None
 
 
 @dataclass(frozen=True)
@@ -1022,7 +1023,12 @@ class NativeMTPRequestCache:
         ):
             raise ValueError("native MTP sealed positions cannot move backwards")
         self.assert_aligned(backbone_tokens=backbone_tokens, mtp_tokens=mtp_tokens)
-        self._sealed = NativeMTPCacheState(self.identity, backbone_tokens, mtp_tokens)
+        self._sealed = NativeMTPCacheState(
+            self.identity,
+            backbone_tokens,
+            mtp_tokens,
+            previous.next_logical_position,
+        )
         return self._sealed
 
     @staticmethod
@@ -1124,7 +1130,62 @@ class NativeMTPRequestCache:
         ):
             raise ValueError("native MTP retained positions cannot move backwards")
         self.assert_aligned(backbone_tokens=backbone_tokens, mtp_tokens=mtp_tokens)
-        self._state = NativeMTPCacheState(self.identity, backbone_tokens, mtp_tokens)
+        self._state = NativeMTPCacheState(
+            self.identity,
+            backbone_tokens,
+            mtp_tokens,
+            self._state.next_logical_position,
+        )
+        return self._state
+
+    def retain_logical_position(
+        self, *, backbone_tokens: int, mtp_tokens: int, next_logical_position: int
+    ) -> NativeMTPCacheState:
+        """Record physical retention plus an independently advancing cursor.
+
+        Sparse prompt positions may contain gaps, so prompt retention can move
+        the cursor forward by more than one.  Generated tokens use
+        :meth:`advance_logical_position`, whose contract is exactly one step.
+        """
+
+        current = self._state.next_logical_position
+        if (
+            isinstance(next_logical_position, bool)
+            or not isinstance(next_logical_position, int)
+            or next_logical_position < 0
+            or (current is not None and next_logical_position < current)
+        ):
+            raise ValueError("native MTP logical cursor cannot move backwards")
+        state = self.retain(
+            backbone_tokens=backbone_tokens,
+            mtp_tokens=mtp_tokens,
+        )
+        self._state = NativeMTPCacheState(
+            self.identity,
+            state.backbone_tokens,
+            state.mtp_tokens,
+            next_logical_position,
+        )
+        return self._state
+
+    def advance_logical_position(self) -> NativeMTPCacheState:
+        """Advance the shared generated-token cursor exactly once."""
+
+        if self._closed:
+            raise RuntimeError("native_mtp_cache_closed")
+        if self._replay_required is not None:
+            raise RuntimeError("native_mtp_cache_replay_required")
+        if self._checkpoint is not None:
+            raise RuntimeError("native_mtp_cache_checkpoint_active")
+        state = self._state
+        if state.next_logical_position is None:
+            raise RuntimeError("native_mtp_logical_cursor_uninitialized")
+        self._state = NativeMTPCacheState(
+            self.identity,
+            state.backbone_tokens,
+            state.mtp_tokens,
+            state.next_logical_position + 1,
+        )
         return self._state
 
     def replay_retained(
@@ -1152,7 +1213,12 @@ class NativeMTPRequestCache:
         ):
             raise ValueError("native MTP replay must advance one retained token step")
         self.assert_aligned(backbone_tokens=backbone_tokens, mtp_tokens=mtp_tokens)
-        self._state = NativeMTPCacheState(self.identity, backbone_tokens, mtp_tokens)
+        self._state = NativeMTPCacheState(
+            self.identity,
+            backbone_tokens,
+            mtp_tokens,
+            self._state.next_logical_position,
+        )
         if (backbone_tokens, mtp_tokens) == (
             replay.replay_to_backbone_tokens,
             replay.replay_to_mtp_tokens,

--- a/mlx_lm/models/generation_context.py
+++ b/mlx_lm/models/generation_context.py
@@ -1,0 +1,70 @@
+# Copyright © 2026 Apple Inc.
+"""Request-local logical-position context for batched generation forwards.
+
+The generation package deliberately owns the public forward metadata while
+models own the mechanics of consuming it.  Keeping the context in this small
+module avoids a generate-to-model import cycle and makes the binding check
+available to both the Qwen target and its native MTP head.
+"""
+
+from contextlib import contextmanager
+from contextvars import ContextVar
+from typing import Any, Iterator, Optional
+
+_ACTIVE_GENERATION_FORWARD = ContextVar("mlx_lm_generation_forward", default=None)
+
+
+@contextmanager
+def generation_forward_context(forward) -> Iterator[None]:
+    """Expose one :class:`GenerationForward` to a compatible model call.
+
+    The generation wrapper still controls acknowledgement activation.  This
+    scope only transports immutable metadata; it is always reset on normal
+    exit, cancellation, or a model error.
+    """
+
+    token = _ACTIVE_GENERATION_FORWARD.set(forward)
+    try:
+        yield
+    finally:
+        _ACTIVE_GENERATION_FORWARD.reset(token)
+
+
+def consume_generation_positions(
+    model: Any,
+    cache: Any,
+    input_tokens: Any,
+    *,
+    mtp: bool,
+) -> Optional[Any]:
+    """Return exact logical positions for the active Qwen call, if any.
+
+    This is intentionally a fail-closed bridge.  A context for another model,
+    cache, phase, or input shape cannot be consumed by this forward.  The
+    acknowledgement object performs the final immutable value check while the
+    model call is active.
+    """
+
+    forward = _ACTIVE_GENERATION_FORWARD.get()
+    if forward is None or forward.logical_positions is None:
+        return None
+    if forward.model is not model:
+        raise RuntimeError("generation_logical_position_model_mismatch")
+    if forward.cache is not cache:
+        raise RuntimeError("generation_logical_position_cache_mismatch")
+    if tuple(forward.input_tokens.shape) != tuple(input_tokens.shape):
+        raise RuntimeError("generation_logical_position_input_shape_mismatch")
+    phase_value = getattr(forward.phase, "value", forward.phase)
+    if (mtp and phase_value != "mtp_draft") or (not mtp and phase_value == "mtp_draft"):
+        raise RuntimeError("generation_logical_position_phase_mismatch")
+    acknowledgement = forward.logical_position_ack
+    if acknowledgement is None:
+        raise RuntimeError("generation_logical_position_ack_missing")
+    acknowledgement._assert_consumer_binding(
+        model=model,
+        cache=cache,
+        phase=forward.phase,
+        input_shape=tuple(input_tokens.shape),
+    )
+    acknowledgement.acknowledge(forward.logical_positions)
+    return forward.logical_positions

--- a/mlx_lm/models/qwen3_5.py
+++ b/mlx_lm/models/qwen3_5.py
@@ -893,6 +893,12 @@ class Model(nn.Module):
     def layers(self):
         return self.language_model.model.pipeline_layers
 
+    @property
+    def mtp(self):
+        """Expose the exact owned MTP topology without registering an alias."""
+
+        return self.language_model.mtp
+
     def make_cache(self):
         return self.language_model.make_cache()
 

--- a/mlx_lm/models/qwen3_5.py
+++ b/mlx_lm/models/qwen3_5.py
@@ -13,7 +13,7 @@ from .base import (
     create_attention_mask,
     create_ssm_mask,
 )
-from .cache import ArraysCache, KVCache
+from .cache import ArraysCache, KVCache, NativeMTPRequestCache
 from .gated_delta import gated_delta_update
 from .pipeline import PipelineMixin
 from .qwen3_next import Qwen3NextAttention as Attention
@@ -516,6 +516,16 @@ class TextModel(nn.Module):
         self._require_mtp()
         return [KVCache() for _ in self.mtp.layers]
 
+    def make_mtp_request_cache(self, *, prompt_cache: Optional[Any] = None):
+        """Return fresh, request-local native-MTP cache state.
+
+        Generic prefix caches are intentionally rejected here: they cannot yet
+        establish exact recurrent/MTP-head alignment.  The generation layer
+        will use this structured owner instead of positional cache splitting.
+        """
+
+        return NativeMTPRequestCache.create(self, prompt_cache=prompt_cache)
+
     @staticmethod
     def _weight_handshake(weights):
         """Identify the exact sanitized key/array mapping handed to the loader."""
@@ -922,6 +932,9 @@ class Model(nn.Module):
 
     def make_mtp_cache(self) -> List[KVCache]:
         return self.language_model.make_mtp_cache()
+
+    def make_mtp_request_cache(self, *, prompt_cache: Optional[Any] = None):
+        return self.language_model.make_mtp_request_cache(prompt_cache=prompt_cache)
 
     @property
     def quant_predicate(self):

--- a/mlx_lm/models/qwen3_5.py
+++ b/mlx_lm/models/qwen3_5.py
@@ -6,7 +6,7 @@ from typing import Any, Dict, List, Optional, Union
 import mlx.core as mx
 import mlx.nn as nn
 from mlx.nn.layers.distributed import shard_inplace, shard_linear, sum_gradients
-from mlx.utils import tree_map
+from mlx.utils import tree_flatten, tree_map
 
 from .base import (
     BaseModelArgs,
@@ -43,6 +43,11 @@ class TextModelArgs(BaseModelArgs):
     head_dim: Optional[int] = None
     full_attention_interval: int = 4
 
+    # Native Qwen multi-token prediction layers.  A positive value only
+    # declares the checkpoint format; ``supports_mtp`` stays false until
+    # sanitization has validated that all of the head weights are present.
+    mtp_num_hidden_layers: int = 0
+
     # MoE fields (optional, for Qwen3_5MoeForConditionalGeneration)
     num_experts: int = 0
     num_experts_per_tok: int = 0
@@ -67,6 +72,8 @@ class TextModelArgs(BaseModelArgs):
     rope_scaling: Optional[Dict[str, Union[float, str]]] = None
 
     def __post_init__(self):
+        if self.mtp_num_hidden_layers < 0:
+            raise ValueError("mtp_num_hidden_layers must be non-negative")
         if self.head_dim is None:
             self.head_dim = self.hidden_size // self.num_attention_heads
 
@@ -82,6 +89,21 @@ class TextModelArgs(BaseModelArgs):
             )
             self.rope_theta = self.rope_parameters.get("rope_theta", 100000.0)
             self.rope_scaling = self.rope_parameters
+
+
+@dataclass(frozen=True)
+class MTPCapability:
+    """Immutable snapshot of whether this loaded model can run native MTP.
+
+    This is deliberately model-local rather than a configuration flag.  A
+    checkpoint which merely advertises MTP in config is not eligible until its
+    sanitized weights have been checked, and PipelineMixin execution is never
+    eligible because the head is not distributed with the backbone.
+    """
+
+    supported: bool
+    reason: str
+    num_layers: int
 
 
 class GatedDeltaNet(nn.Module):
@@ -241,6 +263,74 @@ class DecoderLayer(nn.Module):
         return out
 
 
+class MTPDecoderLayer(nn.Module):
+    """The full-attention transformer block used by a Qwen native MTP head.
+
+    Qwen's backbone interleaves GatedDeltaNet and attention layers.  Its MTP
+    head does not: it is a small attention-only decoder and consequently owns
+    a separate, ordinary KV cache.
+    """
+
+    def __init__(self, args: TextModelArgs):
+        super().__init__()
+        self.self_attn = Attention(args)
+        self.input_layernorm = nn.RMSNorm(args.hidden_size, eps=args.rms_norm_eps)
+        self.post_attention_layernorm = nn.RMSNorm(
+            args.hidden_size, eps=args.rms_norm_eps
+        )
+        self.mlp = (
+            SparseMoeBlock(args)
+            if args.num_experts > 0
+            else MLP(args.hidden_size, args.intermediate_size)
+        )
+
+    def __call__(
+        self,
+        x: mx.array,
+        mask: Optional[mx.array] = None,
+        cache: Optional[Any] = None,
+    ) -> mx.array:
+        h = x + self.self_attn(self.input_layernorm(x), mask, cache)
+        return h + self.mlp(self.post_attention_layernorm(h))
+
+
+class MTPModule(nn.Module):
+    """Qwen native next-depth prediction head.
+
+    The final output head is intentionally shared with the backbone.  This
+    module therefore produces hidden states only; TextModel applies the shared
+    token projection after its final RMS norm.
+    """
+
+    def __init__(self, args: TextModelArgs):
+        super().__init__()
+        self.pre_fc_norm_hidden = nn.RMSNorm(args.hidden_size, eps=args.rms_norm_eps)
+        self.pre_fc_norm_embedding = nn.RMSNorm(args.hidden_size, eps=args.rms_norm_eps)
+        self.fc = nn.Linear(args.hidden_size * 2, args.hidden_size, bias=False)
+        self.layers = [MTPDecoderLayer(args) for _ in range(args.mtp_num_hidden_layers)]
+        self.norm = nn.RMSNorm(args.hidden_size, eps=args.rms_norm_eps)
+
+    def __call__(
+        self,
+        hidden_states: mx.array,
+        next_token_ids: mx.array,
+        embed_tokens: nn.Embedding,
+        cache: Optional[List[Any]] = None,
+    ) -> mx.array:
+        if cache is None:
+            cache = [None] * len(self.layers)
+        if len(cache) != len(self.layers):
+            raise ValueError("MTP cache length does not match the number of MTP layers")
+
+        embeddings = self.pre_fc_norm_embedding(embed_tokens(next_token_ids))
+        hidden_states = self.pre_fc_norm_hidden(hidden_states)
+        states = self.fc(mx.concatenate([embeddings, hidden_states], axis=-1))
+        mask = create_attention_mask(states, cache[0]) if cache else None
+        for layer, layer_cache in zip(self.layers, cache):
+            states = layer(states, mask, layer_cache)
+        return self.norm(states)
+
+
 class Qwen3_5TextModel(PipelineMixin, nn.Module):
     def __init__(self, args: TextModelArgs):
         super().__init__()
@@ -269,7 +359,12 @@ class Qwen3_5TextModel(PipelineMixin, nn.Module):
         inputs: mx.array,
         cache: Optional[Any] = None,
         input_embeddings: Optional[mx.array] = None,
+        return_pre_norm: bool = False,
     ) -> mx.array:
+        if return_pre_norm and self.pipeline_size != 1:
+            raise RuntimeError(
+                "Native Qwen MTP is not supported with pipeline parallelism"
+            )
         if input_embeddings is not None:
             hidden_states = input_embeddings
         else:
@@ -313,6 +408,8 @@ class Qwen3_5TextModel(PipelineMixin, nn.Module):
                 : hidden_states.shape[0]
             ]
 
+        if return_pre_norm:
+            return hidden_states
         return self.norm(hidden_states)
 
 
@@ -324,19 +421,89 @@ class TextModel(nn.Module):
         self.model = Qwen3_5TextModel(args)
         if not args.tie_word_embeddings:
             self.lm_head = nn.Linear(args.hidden_size, args.vocab_size, bias=False)
+        if args.mtp_num_hidden_layers:
+            self.mtp = MTPModule(args)
+        # This is only changed by sanitize after the complete MTP subtree has
+        # been validated.  A config declaration alone must never enable MTP.
+        self._mtp_weight_keys_validated = False
+        self._mtp_weights_loaded = False
+        self._mtp_pending_load_handshake = None
 
     def __call__(
         self,
         inputs: mx.array,
         cache: Optional[Any] = None,
         input_embeddings: Optional[mx.array] = None,
+        return_hidden: bool = False,
     ) -> mx.array:
-        out = self.model(inputs, cache, input_embeddings=input_embeddings)
+        if return_hidden and not self.supports_mtp:
+            raise RuntimeError(self.mtp_capability.reason)
+        if return_hidden:
+            hidden = self.model(
+                inputs,
+                cache,
+                input_embeddings=input_embeddings,
+                return_pre_norm=True,
+            )
+            out = self.model.norm(hidden)
+        else:
+            out = self.model(inputs, cache, input_embeddings=input_embeddings)
         if self.args.tie_word_embeddings:
             out = self.model.embed_tokens.as_linear(out)
         else:
             out = self.lm_head(out)
+        if return_hidden:
+            return out, hidden
         return out
+
+    @property
+    def mtp_capability(self) -> MTPCapability:
+        """Return an immutable eligibility snapshot for native MTP dispatch."""
+        if not hasattr(self, "mtp"):
+            return MTPCapability(False, "native_mtp_head_not_configured", 0)
+        if self.model.pipeline_size != 1:
+            return MTPCapability(
+                False,
+                "native_mtp_pipeline_parallelism_unsupported",
+                self.args.mtp_num_hidden_layers,
+            )
+        if not self._mtp_weight_keys_validated:
+            return MTPCapability(
+                False,
+                "native_mtp_weights_not_validated",
+                self.args.mtp_num_hidden_layers,
+            )
+        if not self._mtp_weights_loaded:
+            return MTPCapability(
+                False,
+                "native_mtp_weights_not_loaded",
+                self.args.mtp_num_hidden_layers,
+            )
+        return MTPCapability(True, "supported", self.args.mtp_num_hidden_layers)
+
+    @property
+    def supports_mtp(self) -> bool:
+        return self.mtp_capability.supported
+
+    def _require_mtp(self) -> None:
+        capability = self.mtp_capability
+        if not capability.supported:
+            raise RuntimeError(capability.reason)
+
+    def mtp_forward(
+        self,
+        hidden_states: mx.array,
+        next_token_ids: mx.array,
+        mtp_cache: List[Any],
+    ) -> mx.array:
+        """Project an MTP step through the backbone's shared output head."""
+        self._require_mtp()
+        states = self.mtp(
+            hidden_states, next_token_ids, self.model.embed_tokens, mtp_cache
+        )
+        if self.args.tie_word_embeddings:
+            return self.model.embed_tokens.as_linear(states)
+        return self.lm_head(states)
 
     @property
     def layers(self):
@@ -345,13 +512,150 @@ class TextModel(nn.Module):
     def make_cache(self):
         return [ArraysCache(size=2) if l.is_linear else KVCache() for l in self.layers]
 
+    def make_mtp_cache(self) -> List[KVCache]:
+        self._require_mtp()
+        return [KVCache() for _ in self.mtp.layers]
+
+    @staticmethod
+    def _weight_handshake(weights):
+        """Identify the exact sanitized key/array mapping handed to the loader."""
+        try:
+            items = list(weights.items())
+        except AttributeError:
+            items = list(weights)
+        return tuple(sorted((key, id(value)) for key, value in items))
+
+    def _consume_mtp_load_handshake(self, weights) -> bool:
+        pending = self._mtp_pending_load_handshake
+        self._mtp_pending_load_handshake = None
+        if pending is None:
+            return False
+        return pending == self._weight_handshake(weights)
+
+    def _validate_mtp_load_leaves(self, weights) -> None:
+        """Validate MTP arrays against the actual post-quantization module tree."""
+        supplied = {
+            key: value
+            for key, value in weights
+            if key.startswith("language_model.mtp.")
+        }
+        expected = {
+            f"language_model.mtp.{key}": value
+            for key, value in tree_flatten(self.mtp.parameters())
+        }
+        if supplied.keys() != expected.keys():
+            missing = sorted(expected.keys() - supplied.keys())
+            unexpected = sorted(supplied.keys() - expected.keys())
+            details = []
+            if missing:
+                details.append("missing " + ", ".join(missing[:3]))
+            if unexpected:
+                details.append("unexpected " + ", ".join(unexpected[:3]))
+            raise ValueError(
+                "Native Qwen MTP load mapping does not match the runtime head: "
+                + "; ".join(details)
+            )
+
+        mismatches = []
+        for key, expected_value in expected.items():
+            supplied_value = supplied[key]
+            same_type = type(supplied_value) is type(expected_value)
+            same_shape = getattr(supplied_value, "shape", None) == getattr(
+                expected_value, "shape", None
+            )
+            if not same_type or not same_shape:
+                mismatches.append(
+                    f"{key} expected {type(expected_value).__name__}"
+                    f"{tuple(expected_value.shape)} got "
+                    f"{type(supplied_value).__name__}"
+                    f"{tuple(getattr(supplied_value, 'shape', ()))}"
+                )
+        if mismatches:
+            raise ValueError(
+                "Native Qwen MTP load leaf type/shape mismatch: "
+                + "; ".join(mismatches[:3])
+            )
+
+    def load_weights(self, weights, strict=True):
+        if isinstance(weights, (str, bytes)) or hasattr(weights, "__fspath__"):
+            matches_pending = False
+            load_weights = weights
+        else:
+            load_weights = (
+                list(weights.items()) if hasattr(weights, "items") else list(weights)
+            )
+            matches_pending = self._consume_mtp_load_handshake(load_weights)
+            if matches_pending:
+                self._validate_mtp_load_leaves(load_weights)
+        result = super().load_weights(load_weights, strict=strict)
+        if hasattr(self, "mtp") and self._mtp_weight_keys_validated and matches_pending:
+            self._mtp_weights_loaded = True
+        return result
+
     def sanitize(self, weights):
-        has_mtp_weights = any("mtp." in k for k in weights)
         has_unsanitized_conv1d = any(
             "conv1d.weight" in k and v.shape[-1] != 1 for k, v in weights.items()
         )
-        should_shift_norm_weights = has_mtp_weights or has_unsanitized_conv1d
-        weights = {k: v for k, v in weights.items() if "mtp." not in k}
+        should_shift_norm_weights = has_unsanitized_conv1d
+        if not hasattr(self, "mtp"):
+            # A base checkpoint may carry a draft head intended for a different
+            # loader.  Never accidentally expose it on a no-head model.
+            weights = {k: v for k, v in weights.items() if "mtp." not in k}
+        else:
+            # Every sanitation attempt starts a fresh, one-shot load handshake.
+            # A later invalid checkpoint must invalidate any earlier pending map.
+            self._mtp_weight_keys_validated = False
+            self._mtp_weights_loaded = False
+            self._mtp_pending_load_handshake = None
+            expected = {
+                f"language_model.mtp.{name}"
+                for name, _ in tree_flatten(self.mtp.parameters())
+            }
+            quantizable = {
+                f"language_model.mtp.{name}"
+                for name, module in tree_flatten(
+                    self.mtp.leaf_modules(), is_leaf=nn.Module.is_module
+                )
+                if hasattr(module, "to_quantized")
+            }
+            supplied = {key for key in weights if key.startswith("language_model.mtp.")}
+            quant_auxiliary = set()
+            partial_quantization = []
+            for weight_key in (
+                key
+                for key in expected
+                if key.endswith(".weight")
+                and key.removesuffix(".weight") in quantizable
+            ):
+                prefix = weight_key.removesuffix(".weight")
+                scales_key = f"{prefix}.scales"
+                biases_key = f"{prefix}.biases"
+                has_scales = scales_key in supplied
+                has_biases = biases_key in supplied
+                if has_scales != has_biases:
+                    partial_quantization.append(prefix)
+                elif has_scales:
+                    quant_auxiliary.update((scales_key, biases_key))
+
+            missing = sorted(expected - supplied)
+            unexpected = sorted(supplied - expected - quant_auxiliary)
+            if missing or unexpected or partial_quantization:
+                details = []
+                if missing:
+                    details.append("missing " + ", ".join(missing[:3]))
+                if unexpected:
+                    details.append("unexpected " + ", ".join(unexpected[:3]))
+                if partial_quantization:
+                    details.append(
+                        "incomplete quantized triplet "
+                        + ", ".join(sorted(partial_quantization)[:3])
+                    )
+                raise ValueError(
+                    "Native Qwen MTP weights do not match the configured head: "
+                    + "; ".join(details)
+                )
+            self._mtp_weight_keys_validated = True
+            self._mtp_weights_loaded = False
 
         if self.args.tie_word_embeddings:
             weights.pop("lm_head.weight", None)
@@ -362,6 +666,9 @@ class TextModel(nn.Module):
             "model.norm.weight",
             ".q_norm.weight",
             ".k_norm.weight",
+            ".pre_fc_norm_hidden.weight",
+            ".pre_fc_norm_embedding.weight",
+            "mtp.norm.weight",
         )
         for k, v in weights.items():
             if "conv1d.weight" in k and v.shape[-1] != 1:
@@ -369,11 +676,13 @@ class TextModel(nn.Module):
             if should_shift_norm_weights and any(k.endswith(sfx) for sfx in norm_keys):
                 if v.ndim == 1:
                     weights[k] = v + 1.0
+        if hasattr(self, "mtp"):
+            self._mtp_pending_load_handshake = self._weight_handshake(weights)
         return weights
 
     @property
     def quant_predicate(self):
-        if self.args.num_experts <= 0:
+        if self.args.num_experts <= 0 and self.args.mtp_num_hidden_layers <= 0:
             return None
 
         def predicate(path, _):
@@ -417,9 +726,13 @@ class Model(nn.Module):
         inputs: mx.array,
         cache=None,
         input_embeddings: Optional[mx.array] = None,
+        return_hidden: bool = False,
     ):
         return self.language_model(
-            inputs, cache=cache, input_embeddings=input_embeddings
+            inputs,
+            cache=cache,
+            input_embeddings=input_embeddings,
+            return_hidden=return_hidden,
         )
 
     @property
@@ -431,9 +744,11 @@ class Model(nn.Module):
         for key, value in weights.items():
             if key.startswith("vision_tower") or key.startswith("model.visual"):
                 continue
-            if key.startswith("model.visual"):
-                continue
-            if key.startswith("model.language_model"):
+            if key.startswith("model.language_model.mtp."):
+                # The VLM wrapper's MTP head belongs beside language_model.model
+                # rather than underneath the backbone ``model`` module.
+                key = key.replace("model.language_model.", "language_model.", 1)
+            elif key.startswith("model.language_model"):
                 key = key.replace("model.language_model", "language_model.model")
             elif key.startswith("language_model."):
                 pass
@@ -443,6 +758,10 @@ class Model(nn.Module):
         return self.language_model.sanitize(sanitized)
 
     def shard(self, group=None):
+        if self.language_model.args.mtp_num_hidden_layers:
+            raise RuntimeError(
+                "Native Qwen MTP does not support tensor/distributed sharding"
+            )
         group = group or mx.distributed.init()
         N = group.size()
         rank = group.rank()
@@ -566,6 +885,43 @@ class Model(nn.Module):
 
     def make_cache(self):
         return self.language_model.make_cache()
+
+    def load_weights(self, weights, strict=True):
+        if isinstance(weights, (str, bytes)) or hasattr(weights, "__fspath__"):
+            matches_pending = False
+            load_weights = weights
+        else:
+            load_weights = (
+                list(weights.items()) if hasattr(weights, "items") else list(weights)
+            )
+            matches_pending = self.language_model._consume_mtp_load_handshake(
+                load_weights
+            )
+            if matches_pending:
+                self.language_model._validate_mtp_load_leaves(load_weights)
+        result = super().load_weights(load_weights, strict=strict)
+        if self.language_model._mtp_weight_keys_validated and matches_pending:
+            self.language_model._mtp_weights_loaded = True
+        return result
+
+    @property
+    def mtp_capability(self) -> MTPCapability:
+        return self.language_model.mtp_capability
+
+    @property
+    def supports_mtp(self) -> bool:
+        return self.language_model.supports_mtp
+
+    def mtp_forward(
+        self,
+        hidden_states: mx.array,
+        next_token_ids: mx.array,
+        mtp_cache: List[Any],
+    ) -> mx.array:
+        return self.language_model.mtp_forward(hidden_states, next_token_ids, mtp_cache)
+
+    def make_mtp_cache(self) -> List[KVCache]:
+        return self.language_model.make_mtp_cache()
 
     @property
     def quant_predicate(self):

--- a/mlx_lm/models/qwen3_5.py
+++ b/mlx_lm/models/qwen3_5.py
@@ -15,6 +15,10 @@ from .base import (
 )
 from .cache import ArraysCache, KVCache, NativeMTPRequestCache
 from .gated_delta import gated_delta_update
+from .generation_context import (
+    consume_generation_positions,
+    generation_forward_context,
+)
 from .pipeline import PipelineMixin
 from .qwen3_next import Qwen3NextAttention as Attention
 from .qwen3_next import Qwen3NextMLP as MLP
@@ -157,8 +161,16 @@ class GatedDeltaNet(nn.Module):
         inputs: mx.array,
         mask: Optional[mx.array] = None,
         cache: Optional[Any] = None,
+        position_ids: Optional[mx.array] = None,
     ) -> mx.array:
         B, S, _ = inputs.shape
+
+        # Gated-delta recurrence has no absolute-position transform: its state
+        # evolves with the ordered token stream.  Still accept and validate the
+        # same matrix that attention consumes, so a batched logical-position
+        # context cannot be accidentally applied to only part of a Qwen block.
+        if position_ids is not None and tuple(position_ids.shape) != (B, S):
+            raise ValueError("qwen_position_ids_shape_mismatch")
 
         if self.sharding_group is not None:
             inputs = sum_gradients(self.sharding_group)(inputs)
@@ -253,11 +265,16 @@ class DecoderLayer(nn.Module):
         x: mx.array,
         mask: Optional[mx.array] = None,
         cache: Optional[Any] = None,
+        position_ids: Optional[mx.array] = None,
     ) -> mx.array:
         if self.is_linear:
-            r = self.linear_attn(self.input_layernorm(x), mask, cache)
+            r = self.linear_attn(
+                self.input_layernorm(x), mask, cache, position_ids=position_ids
+            )
         else:
-            r = self.self_attn(self.input_layernorm(x), mask, cache)
+            r = self.self_attn(
+                self.input_layernorm(x), mask, cache, position_ids=position_ids
+            )
         h = x + r
         out = h + self.mlp(self.post_attention_layernorm(h))
         return out
@@ -289,8 +306,11 @@ class MTPDecoderLayer(nn.Module):
         x: mx.array,
         mask: Optional[mx.array] = None,
         cache: Optional[Any] = None,
+        position_ids: Optional[mx.array] = None,
     ) -> mx.array:
-        h = x + self.self_attn(self.input_layernorm(x), mask, cache)
+        h = x + self.self_attn(
+            self.input_layernorm(x), mask, cache, position_ids=position_ids
+        )
         return h + self.mlp(self.post_attention_layernorm(h))
 
 
@@ -316,6 +336,7 @@ class MTPModule(nn.Module):
         next_token_ids: mx.array,
         embed_tokens: nn.Embedding,
         cache: Optional[List[Any]] = None,
+        position_ids: Optional[mx.array] = None,
     ) -> mx.array:
         if cache is None:
             cache = [None] * len(self.layers)
@@ -327,7 +348,7 @@ class MTPModule(nn.Module):
         states = self.fc(mx.concatenate([embeddings, hidden_states], axis=-1))
         mask = create_attention_mask(states, cache[0]) if cache else None
         for layer, layer_cache in zip(self.layers, cache):
-            states = layer(states, mask, layer_cache)
+            states = layer(states, mask, layer_cache, position_ids=position_ids)
         return self.norm(states)
 
 
@@ -360,6 +381,7 @@ class Qwen3_5TextModel(PipelineMixin, nn.Module):
         cache: Optional[Any] = None,
         input_embeddings: Optional[mx.array] = None,
         return_pre_norm: bool = False,
+        position_ids: Optional[mx.array] = None,
     ) -> mx.array:
         if return_pre_norm and self.pipeline_size != 1:
             raise RuntimeError(
@@ -389,7 +411,12 @@ class Qwen3_5TextModel(PipelineMixin, nn.Module):
 
         for layer, c in zip(self.pipeline_layers, cache):
             mask = ssm_mask if layer.is_linear else fa_mask
-            hidden_states = layer(hidden_states, mask=mask, cache=c)
+            hidden_states = layer(
+                hidden_states,
+                mask=mask,
+                cache=c,
+                position_ids=position_ids,
+            )
 
         # Send to the next process in the pipeline
         if pipeline_rank != 0:
@@ -435,6 +462,7 @@ class TextModel(nn.Module):
         cache: Optional[Any] = None,
         input_embeddings: Optional[mx.array] = None,
         return_hidden: bool = False,
+        position_ids: Optional[mx.array] = None,
     ) -> mx.array:
         if return_hidden and not self.supports_mtp:
             raise RuntimeError(self.mtp_capability.reason)
@@ -444,10 +472,16 @@ class TextModel(nn.Module):
                 cache,
                 input_embeddings=input_embeddings,
                 return_pre_norm=True,
+                position_ids=position_ids,
             )
             out = self.model.norm(hidden)
         else:
-            out = self.model(inputs, cache, input_embeddings=input_embeddings)
+            out = self.model(
+                inputs,
+                cache,
+                input_embeddings=input_embeddings,
+                position_ids=position_ids,
+            )
         if self.args.tie_word_embeddings:
             out = self.model.embed_tokens.as_linear(out)
         else:
@@ -495,11 +529,16 @@ class TextModel(nn.Module):
         hidden_states: mx.array,
         next_token_ids: mx.array,
         mtp_cache: List[Any],
+        position_ids: Optional[mx.array] = None,
     ) -> mx.array:
         """Project an MTP step through the backbone's shared output head."""
         self._require_mtp()
         states = self.mtp(
-            hidden_states, next_token_ids, self.model.embed_tokens, mtp_cache
+            hidden_states,
+            next_token_ids,
+            self.model.embed_tokens,
+            mtp_cache,
+            position_ids=position_ids,
         )
         if self.args.tie_word_embeddings:
             return self.model.embed_tokens.as_linear(states)
@@ -725,6 +764,11 @@ class ModelArgs(BaseModelArgs):
 
 
 class Model(nn.Module):
+    # Public model-owned hook selected by native MTP when logical positions
+    # are active.  ``staticmethod`` preserves the canonical callable identity
+    # used to reject a conflicting external consumer.
+    generation_forward_context = staticmethod(generation_forward_context)
+
     def __init__(self, args: ModelArgs):
         super().__init__()
         self.args = args
@@ -738,11 +782,17 @@ class Model(nn.Module):
         input_embeddings: Optional[mx.array] = None,
         return_hidden: bool = False,
     ):
+        positions = consume_generation_positions(self, cache, inputs, mtp=False)
+        if positions is not None:
+            positions = mx.array(positions, dtype=mx.uint32)
+            if positions.ndim == 1:
+                positions = positions[None]
         return self.language_model(
             inputs,
             cache=cache,
             input_embeddings=input_embeddings,
             return_hidden=return_hidden,
+            position_ids=positions,
         )
 
     @property
@@ -934,7 +984,16 @@ class Model(nn.Module):
         next_token_ids: mx.array,
         mtp_cache: List[Any],
     ) -> mx.array:
-        return self.language_model.mtp_forward(hidden_states, next_token_ids, mtp_cache)
+        positions = consume_generation_positions(
+            self, mtp_cache, next_token_ids, mtp=True
+        )
+        if positions is not None:
+            positions = mx.array(positions, dtype=mx.uint32)
+            if positions.ndim == 1:
+                positions = positions[None]
+        return self.language_model.mtp_forward(
+            hidden_states, next_token_ids, mtp_cache, position_ids=positions
+        )
 
     def make_mtp_cache(self) -> List[KVCache]:
         return self.language_model.make_mtp_cache()

--- a/mlx_lm/models/qwen3_5_moe.py
+++ b/mlx_lm/models/qwen3_5_moe.py
@@ -2,6 +2,8 @@
 
 from dataclasses import dataclass
 
+import mlx.core as mx
+
 from .base import BaseModelArgs
 from .qwen3_5 import Model as Qwen3_5Model
 
@@ -18,35 +20,95 @@ class ModelArgs(BaseModelArgs):
         return super().from_dict(params)
 
 
-class Model(Qwen3_5Model):
+def _normalize_experts(weights, prefix, num_experts):
+    """Normalize one Qwen MoE block to MLX ``switch_mlp`` tensors.
 
+    Exporters use three legitimate layouts: a fused ``gate_up_proj`` tensor,
+    individual per-expert projections, or already-stacked ``switch_mlp``
+    tensors.  Treat a mixture or an incomplete layout as a corrupt artifact;
+    silently choosing one representation can make an MTP checkpoint load with
+    a different expert ordering than the backbone.
+    """
+
+    fused_gate_up = f"{prefix}.experts.gate_up_proj"
+    fused_down = f"{prefix}.experts.down_proj"
+    stacked = [
+        f"{prefix}.switch_mlp.{name}.weight"
+        for name in ("gate_proj", "up_proj", "down_proj")
+    ]
+    per_expert = [
+        f"{prefix}.experts.{expert}.{name}.weight"
+        for expert in range(num_experts)
+        for name in ("gate_proj", "up_proj", "down_proj")
+    ]
+
+    has_fused = fused_gate_up in weights or fused_down in weights
+    has_stacked = any(key in weights for key in stacked)
+    has_per_expert = any(key in weights for key in per_expert)
+    formats = sum((has_fused, has_stacked, has_per_expert))
+    if formats == 0:
+        return
+    if formats != 1:
+        raise ValueError(f"Mixed MoE expert layouts at {prefix}")
+
+    if has_fused:
+        if fused_gate_up not in weights or fused_down not in weights:
+            raise ValueError(f"Incomplete fused MoE expert weights at {prefix}")
+        gate_up = weights.pop(fused_gate_up)
+        if gate_up.shape[-2] % 2:
+            raise ValueError(f"Odd fused gate/up dimension at {prefix}")
+        middle = gate_up.shape[-2] // 2
+        weights[f"{prefix}.switch_mlp.gate_proj.weight"] = gate_up[..., :middle, :]
+        weights[f"{prefix}.switch_mlp.up_proj.weight"] = gate_up[..., middle:, :]
+        weights[f"{prefix}.switch_mlp.down_proj.weight"] = weights.pop(fused_down)
+        return
+
+    if has_stacked:
+        missing = [key for key in stacked if key not in weights]
+        if missing:
+            raise ValueError(
+                f"Incomplete stacked MoE expert weights at {prefix}: {missing[0]}"
+            )
+        return
+
+    missing = [key for key in per_expert if key not in weights]
+    if missing:
+        raise ValueError(f"Incomplete per-expert MoE weights at {prefix}: {missing[0]}")
+    for name in ("gate_proj", "up_proj", "down_proj"):
+        weights[f"{prefix}.switch_mlp.{name}.weight"] = mx.stack(
+            [
+                weights.pop(f"{prefix}.experts.{expert}.{name}.weight")
+                for expert in range(num_experts)
+            ]
+        )
+
+
+class Model(Qwen3_5Model):
     def sanitize(self, weights):
-        new_weights = {}
+        normalized = {}
         for key, value in weights.items():
             if key.startswith("vision_tower") or key.startswith("model.visual"):
                 continue
-            if key.startswith("model.language_model"):
+            if key.startswith("model.language_model.mtp."):
+                key = key.replace("model.language_model.", "language_model.", 1)
+            elif key.startswith("model.language_model"):
                 key = key.replace("model.language_model", "language_model.model")
-            elif key.startswith("language_model."):
-                pass
-            else:
+            elif not key.startswith("language_model."):
                 key = "language_model." + key
-            new_weights[key] = value
+            normalized[key] = value
 
-        for l in range(self.language_model.args.num_hidden_layers):
-            prefix = f"language_model.model.layers.{l}.mlp"
-            gate_up_key = f"{prefix}.experts.gate_up_proj"
-            if gate_up_key in new_weights:
-                gate_up = new_weights.pop(gate_up_key)
-                mid = gate_up.shape[-2] // 2
-                new_weights[f"{prefix}.switch_mlp.gate_proj.weight"] = gate_up[
-                    ..., :mid, :
-                ]
-                new_weights[f"{prefix}.switch_mlp.up_proj.weight"] = gate_up[
-                    ..., mid:, :
-                ]
-                new_weights[f"{prefix}.switch_mlp.down_proj.weight"] = new_weights.pop(
-                    f"{prefix}.experts.down_proj"
-                )
+        args = self.language_model.args
+        for layer_idx in range(args.num_hidden_layers):
+            _normalize_experts(
+                normalized,
+                f"language_model.model.layers.{layer_idx}.mlp",
+                args.num_experts,
+            )
+        for layer_idx in range(args.mtp_num_hidden_layers):
+            _normalize_experts(
+                normalized,
+                f"language_model.mtp.layers.{layer_idx}.mlp",
+                args.num_experts,
+            )
 
-        return self.language_model.sanitize(new_weights)
+        return self.language_model.sanitize(normalized)

--- a/mlx_lm/models/qwen3_next.py
+++ b/mlx_lm/models/qwen3_next.py
@@ -123,6 +123,7 @@ class Qwen3NextAttention(nn.Module):
         x: mx.array,
         mask: Optional[mx.array] = None,
         cache: Optional[Any] = None,
+        position_ids: Optional[mx.array] = None,
     ) -> mx.array:
         B, L, D = x.shape
 
@@ -142,13 +143,31 @@ class Qwen3NextAttention(nn.Module):
             0, 2, 1, 3
         )
 
-        if cache is not None:
+        if position_ids is not None:
+            if tuple(position_ids.shape) != (B, L):
+                raise ValueError("qwen_position_ids_shape_mismatch")
+
+            # ``rope`` supports a batch-vector offset, not an arbitrary BxS
+            # matrix.  Flatten BxS tokens into a B*S batch of one-token calls
+            # so every row/column receives its exact logical position in one
+            # device graph, without a host loop or per-row realization.
+            def apply_positions(values):
+                heads, width = values.shape[1], values.shape[-1]
+                flattened = values.transpose(0, 2, 1, 3).reshape(B * L, heads, 1, width)
+                rotated = self.rope(flattened, offset=position_ids.reshape(B * L))
+                return rotated.reshape(B, L, heads, width).transpose(0, 2, 1, 3)
+
+            queries = apply_positions(queries)
+            keys = apply_positions(keys)
+        elif cache is not None:
             queries = self.rope(queries, offset=cache.offset)
             keys = self.rope(keys, offset=cache.offset)
-            keys, values = cache.update_and_fetch(keys, values)
         else:
             queries = self.rope(queries)
             keys = self.rope(keys)
+
+        if cache is not None:
+            keys, values = cache.update_and_fetch(keys, values)
 
         output = scaled_dot_product_attention(
             queries, keys, values, cache=cache, scale=self.scale, mask=mask

--- a/mlx_lm/server.py
+++ b/mlx_lm/server.py
@@ -34,6 +34,7 @@ from huggingface_hub import scan_cache_dir
 from ._version import __version__
 from .generate import (
     BatchGenerator,
+    NativeMTPSamplingConfig,
     StopSequenceMatcher,
     TextStateMachine,
     make_stop_matcher,
@@ -43,6 +44,10 @@ from .generate import (
 from .models.cache import LRUPromptCache, make_prompt_cache
 from .sample_utils import make_logits_processors, make_sampler
 from .utils import _parse_size, load, sharded_load
+
+
+class NativeMTPRequestError(ValueError):
+    """A native-MTP request cannot be executed under the server contract."""
 
 
 def get_system_fingerprint():
@@ -191,6 +196,7 @@ class GenerationArguments:
     top_logprobs: int
     seed: Optional[int]
     chat_template_kwargs: Optional[Dict[str, Any]]
+    mtp: bool = False
 
 
 @dataclass
@@ -229,6 +235,9 @@ class Response:
     logprob: float
     finish_reason: Optional[str]
     top_tokens: Tuple[Dict[str, Any]]
+    mtp_drafts: int = 0
+    mtp_accepted: int = 0
+    mtp_bypass_reason: Optional[str] = None
 
 
 class TimeBudget:
@@ -391,7 +400,7 @@ def _make_sampler(args, tokenizer):
 
 
 def _make_logits_processors(args):
-    return make_logits_processors(
+    processors = make_logits_processors(
         args.logits.logit_bias,
         args.logits.repetition_penalty,
         args.logits.repetition_context_size,
@@ -400,6 +409,44 @@ def _make_logits_processors(args):
         args.logits.frequency_penalty,
         args.logits.frequency_context_size,
     )
+    # The built-in processors are pure functions of token history and logits,
+    # so native MTP can replay them exactly after a rejected verification.
+    for processor in processors:
+        processor.native_mtp_replay_safe = True
+    return processors
+
+
+def _make_native_mtp_sampling_config(sampling, seed):
+    if sampling.xtc_probability != 0:
+        raise ValueError("native_mtp_xtc_unsupported")
+    return NativeMTPSamplingConfig(
+        temperature=sampling.temperature,
+        top_p=sampling.top_p,
+        top_k=sampling.top_k,
+        min_p=sampling.min_p,
+        seed=seed,
+    )
+
+
+def _validate_native_mtp_model(model, sampling):
+    capability = getattr(model, "mtp_capability", None)
+    if capability is None or not capability.supported:
+        reason = (
+            "native_mtp_model_capability_missing"
+            if capability is None
+            else capability.reason
+        )
+        raise NativeMTPRequestError(reason or "native_mtp_model_unsupported")
+
+    vocab_size = getattr(model, "vocab_size", None)
+    if vocab_size is None:
+        vocab_size = getattr(getattr(model, "args", None), "vocab_size", None)
+    if not isinstance(vocab_size, int) or isinstance(vocab_size, bool):
+        raise NativeMTPRequestError("native_mtp_vocab_size_unavailable")
+    if sampling.top_k > 0 and sampling.top_k >= vocab_size:
+        raise NativeMTPRequestError(
+            "native MTP top_k must be smaller than vocabulary size"
+        )
 
 
 def _format_top_logprobs(logprobs, top_n, tokenizer) -> Tuple[Dict[str, Any]]:
@@ -619,7 +666,7 @@ class ResponseGenerator:
         return stop_matcher, text_sm
 
     def _is_batchable(self, args):
-        return self.model_provider.is_batchable and args.seed is None
+        return self.model_provider.is_batchable and args.seed is None and not args.mtp
 
     def _generate(self):
         # Local thread stream that we 'll pass to the BatchGenerator to make
@@ -877,9 +924,24 @@ class ResponseGenerator:
             model = self.model_provider.model
             tokenizer = self.model_provider.tokenizer
             draft_model = self.model_provider.draft_model
+            if args.mtp and draft_model is not None:
+                raise NativeMTPRequestError("native_mtp_external_draft_unsupported")
+            if args.mtp:
+                if isinstance(args.max_tokens, bool) or args.max_tokens <= 0:
+                    raise NativeMTPRequestError(
+                        "native_mtp_max_tokens_must_be_positive"
+                    )
+                _validate_native_mtp_model(model, args.sampling)
+            mtp_sampling_config = (
+                _make_native_mtp_sampling_config(args.sampling, args.seed)
+                if args.mtp
+                else None
+            )
 
             # Prepare the prompt and state machine
             prompt, _, _, initial_state = self._tokenize(tokenizer, request, args)
+            if args.mtp and not prompt:
+                raise NativeMTPRequestError("native_mtp_prompt_must_be_nonempty")
             stop_matcher, text_sm = self._make_state_machine(
                 self.model_provider.model_key,
                 tokenizer,
@@ -898,28 +960,35 @@ class ResponseGenerator:
             rqueue.put(ctx)
 
             # Seed if requested
-            if args.seed is not None:
+            if args.seed is not None and not args.mtp:
                 mx.random.seed(args.seed)
 
             # Make the sampler and logit processor
-            sampler = _make_sampler(args, tokenizer)
+            sampler = None if args.mtp else _make_sampler(args, tokenizer)
             logits_processors = _make_logits_processors(args)
 
             # Load the KV cache
-            self._log_cache_stats()
-            cache, rest = self.prompt_cache.fetch_nearest_cache(
-                self.model_provider.model_key, prompt
-            )
-            ctx.prompt_cache_count = len(prompt) - len(rest)
             cache_key = prompt[:]
-            if cache is None:
-                cache = make_prompt_cache(self.model_provider.model)
-                if self.model_provider.draft_model is not None:
-                    cache += make_prompt_cache(self.model_provider.draft_model)
+            if args.mtp:
+                # Native MTP owns a request-local transactional target+MTP
+                # cache.  Generic prefix reuse is deliberately fail-closed.
+                cache = None
+                rest = prompt
+                ctx.prompt_cache_count = 0
+            else:
+                self._log_cache_stats()
+                cache, rest = self.prompt_cache.fetch_nearest_cache(
+                    self.model_provider.model_key, prompt
+                )
+                ctx.prompt_cache_count = len(prompt) - len(rest)
+                if cache is None:
+                    cache = make_prompt_cache(self.model_provider.model)
+                    if self.model_provider.draft_model is not None:
+                        cache += make_prompt_cache(self.model_provider.draft_model)
 
             # Process the prompt and generate tokens
             stop_state = stop_matcher.make_state()
-            for gen in stream_generate(
+            generation_kwargs = dict(
                 model=model,
                 tokenizer=tokenizer,
                 prompt=rest,
@@ -931,43 +1000,57 @@ class ResponseGenerator:
                 num_draft_tokens=args.num_draft_tokens,
                 prompt_progress_callback=progress,
                 prefill_step_size=self.cli_args.prefill_step_size,
-            ):
-                finish_reason = gen.finish_reason
-
-                # Token-level stop word detection
-                stop_state, matched = StopSequenceMatcher.match(
-                    stop_state, stop_matcher._trie, gen.token
+            )
+            if args.mtp:
+                generation_kwargs.update(
+                    mtp=True,
+                    mtp_sampling_config=mtp_sampling_config,
                 )
-                if matched:
-                    finish_reason = "stop"
+            generation = stream_generate(**generation_kwargs)
+            try:
+                for gen in generation:
+                    finish_reason = gen.finish_reason
 
-                rqueue.put(
-                    Response(
-                        gen.text,
-                        gen.token,
-                        gen.logprobs[gen.token].item(),
-                        finish_reason,
-                        _format_top_logprobs(
-                            gen.logprobs, args.top_logprobs, tokenizer
-                        ),
+                    # Token-level stop word detection
+                    stop_state, matched = StopSequenceMatcher.match(
+                        stop_state, stop_matcher._trie, gen.token
                     )
-                )
-                cache_key.append(gen.token)
+                    if matched:
+                        finish_reason = "stop"
 
-                if ctx._should_stop:
-                    if self._is_distributed:
-                        raise NotImplementedError()
-                    break
+                    rqueue.put(
+                        Response(
+                            gen.text,
+                            gen.token,
+                            gen.logprobs[gen.token].item(),
+                            finish_reason,
+                            _format_top_logprobs(
+                                gen.logprobs, args.top_logprobs, tokenizer
+                            ),
+                            mtp_drafts=gen.mtp_drafts,
+                            mtp_accepted=gen.mtp_accepted,
+                            mtp_bypass_reason=gen.mtp_bypass_reason,
+                        )
+                    )
+                    cache_key.append(gen.token)
 
-                if finish_reason is not None:
-                    break
+                    if ctx._should_stop:
+                        if self._is_distributed:
+                            raise NotImplementedError()
+                        break
+
+                    if finish_reason is not None:
+                        break
+            finally:
+                generation.close()
 
             rqueue.put(None)
 
             # Save the KV cache again
-            self.prompt_cache.insert_cache(
-                self.model_provider.model_key, cache_key, cache
-            )
+            if not args.mtp:
+                self.prompt_cache.insert_cache(
+                    self.model_provider.model_key, cache_key, cache
+                )
 
         except Exception as e:
             rqueue.put(e)
@@ -1042,6 +1125,22 @@ class APIHandler(BaseHTTPRequestHandler):
         self.send_header("Content-type", "text/event-stream")
         self.send_header("Cache-Control", "no-cache")
         self._set_cors_headers()
+
+    def _send_structured_error(self, status_code: int, error: Exception):
+        payload = json.dumps(
+            {
+                "error": {
+                    "message": str(error),
+                    "type": "invalid_request_error",
+                    "code": str(error),
+                }
+            }
+        ).encode()
+        self._set_completion_headers(status_code)
+        self.send_header("Content-Length", str(len(payload)))
+        self.end_headers()
+        self.wfile.write(payload)
+        self.wfile.flush()
 
     def do_OPTIONS(self):
         self._set_completion_headers(204)
@@ -1138,8 +1237,13 @@ class APIHandler(BaseHTTPRequestHandler):
         self.logprobs = self.body.get("logprobs", False)
         self.top_logprobs = self.body.get("top_logprobs", -1)
         self.seed = self.body.get("seed", None)
+        self.mtp = self.body.get("mtp", False)
         self.chat_template_kwargs = self.body.get("chat_template_kwargs")
-        self.validate_model_parameters()
+        try:
+            self.validate_model_parameters()
+        except (TypeError, ValueError) as error:
+            self._send_structured_error(422, error)
+            return
 
         # Get stop sequences
         stop_words = self.body.get("stop")
@@ -1147,7 +1251,11 @@ class APIHandler(BaseHTTPRequestHandler):
         stop_words = [stop_words] if isinstance(stop_words, str) else stop_words
 
         # Create the completion request
-        request = request_factories[self.path]()
+        try:
+            request = request_factories[self.path]()
+        except (AssertionError, TypeError, ValueError) as error:
+            self._send_structured_error(400, error)
+            return
         self.handle_completion(request, stop_words)
 
     def _validate(
@@ -1178,6 +1286,7 @@ class APIHandler(BaseHTTPRequestHandler):
     def validate_model_parameters(self):
         """Validate that the passed model parameters have correct types and values."""
         self._validate("stream", bool)
+        self._validate("mtp", bool)
         self._validate("max_tokens", int, min_val=0)
         self._validate("temperature", (float, int), min_val=0)
         self._validate("top_p", (float, int), min_val=0, max_val=1)
@@ -1199,6 +1308,30 @@ class APIHandler(BaseHTTPRequestHandler):
         self._validate("seed", int, optional=True)
         self._validate("logit_bias", dict, optional=True)
 
+        if self.mtp:
+            if isinstance(self.max_tokens, bool) or self.max_tokens <= 0:
+                raise NativeMTPRequestError("native_mtp_max_tokens_must_be_positive")
+            configured_draft = (
+                self.body.get("draft_model")
+                if "draft_model" in self.body
+                else getattr(self.response_generator.cli_args, "draft_model", None)
+            )
+            if configured_draft is not None:
+                raise NativeMTPRequestError("native_mtp_external_draft_unsupported")
+            if self.body.get("prompt_cache") not in (None, False):
+                raise NativeMTPRequestError("native_mtp_prefix_reuse_unsupported")
+            _make_native_mtp_sampling_config(
+                SamplingArguments(
+                    self.temperature,
+                    self.top_p,
+                    self.top_k,
+                    self.min_p,
+                    self.xtc_probability,
+                    self.xtc_threshold,
+                ),
+                self.seed,
+            )
+
         if self.logit_bias is not None:
             try:
                 self.logit_bias = {int(k): float(v) for k, v in self.logit_bias.items()}
@@ -1217,6 +1350,9 @@ class APIHandler(BaseHTTPRequestHandler):
         tokens: Optional[List[int]] = None,
         tool_calls: Optional[List[str]] = None,
         reasoning_text: Optional[str] = None,
+        mtp_drafts: Optional[int] = None,
+        mtp_accepted: Optional[int] = None,
+        mtp_bypass_reason: Optional[str] = None,
     ) -> dict:
         """
         Generate a single response packet based on response type (stream or
@@ -1262,6 +1398,12 @@ class APIHandler(BaseHTTPRequestHandler):
                 },
             ],
         }
+        if mtp_drafts is not None:
+            response["generation_metadata"] = {
+                "mtp_drafts": mtp_drafts,
+                "mtp_accepted": mtp_accepted or 0,
+                "mtp_bypass_reason": mtp_bypass_reason,
+            }
 
         if top_logprobs:
             response["choices"][0]["logprobs"] = {
@@ -1352,6 +1494,7 @@ class APIHandler(BaseHTTPRequestHandler):
             top_logprobs=self.top_logprobs,
             seed=self.seed,
             chat_template_kwargs=self.chat_template_kwargs,
+            mtp=self.mtp,
         )
 
         # Keep connection allive during long prompt processing (and also log
@@ -1371,9 +1514,12 @@ class APIHandler(BaseHTTPRequestHandler):
                 progress_callback=keepalive_callback,
             )
         except Exception as e:
-            self._set_completion_headers(404)
-            self.end_headers()
-            self.wfile.write(json.dumps({"error": str(e)}).encode())
+            if isinstance(e, (TypeError, ValueError)):
+                self._send_structured_error(422, e)
+            else:
+                self._set_completion_headers(404)
+                self.end_headers()
+                self.wfile.write(json.dumps({"error": str(e)}).encode())
             return
 
         # Prepare the headers
@@ -1402,6 +1548,9 @@ class APIHandler(BaseHTTPRequestHandler):
         tokens = []
         token_logprobs = []
         top_tokens = []
+        mtp_drafts = 0
+        mtp_accepted = 0
+        mtp_bypass_reason = None
 
         try:
             for gen in response:
@@ -1460,6 +1609,9 @@ class APIHandler(BaseHTTPRequestHandler):
 
                 if gen.finish_reason is not None:
                     finish_reason = gen.finish_reason
+                mtp_drafts = gen.mtp_drafts
+                mtp_accepted = gen.mtp_accepted
+                mtp_bypass_reason = gen.mtp_bypass_reason
 
                 prev_state = current_state
 
@@ -1476,6 +1628,9 @@ class APIHandler(BaseHTTPRequestHandler):
                     finish_reason,
                     tool_calls=tool_formatter(tool_calls),
                     reasoning_text=reasoning_text,
+                    mtp_drafts=mtp_drafts if self.mtp else None,
+                    mtp_accepted=mtp_accepted,
+                    mtp_bypass_reason=mtp_bypass_reason,
                 )
                 self.wfile.write(f"data: {json.dumps(resp)}\n\n".encode())
                 self.wfile.flush()
@@ -1504,6 +1659,9 @@ class APIHandler(BaseHTTPRequestHandler):
                     tokens=tokens,
                     reasoning_text=reasoning_text,
                     tool_calls=tool_formatter(tool_calls),
+                    mtp_drafts=mtp_drafts if self.mtp else None,
+                    mtp_accepted=mtp_accepted,
+                    mtp_bypass_reason=mtp_bypass_reason,
                 )
                 if logging.getLogger().isEnabledFor(logging.DEBUG):
                     response_debug = json.dumps(resp, indent="\t")
@@ -1516,6 +1674,7 @@ class APIHandler(BaseHTTPRequestHandler):
                 self.wfile.flush()
         finally:
             ctx.stop()
+            response.close()
 
     def completion_usage_response(
         self,

--- a/tests/test_generation_forward_context.py
+++ b/tests/test_generation_forward_context.py
@@ -1,0 +1,335 @@
+# Copyright © 2026 Apple Inc.
+
+from contextlib import contextmanager, nullcontext
+import unittest
+from unittest.mock import patch
+from typing import List, Optional
+
+import mlx.core as mx
+
+from mlx_lm.generate import (
+    GenerationForward,
+    GenerationForwardPhase,
+    generate_step,
+    speculative_generate_step,
+    stream_generate,
+)
+
+
+class SyntheticCache:
+    """Minimal trimmable cache for generation plumbing tests."""
+
+    def __init__(self):
+        self.offset = 0
+        self.state = mx.array(0)
+
+    def is_trimmable(self):
+        return True
+
+    def trim(self, num_to_trim):
+        self.offset = max(self.offset - num_to_trim, 0)
+
+
+class SyntheticModel:
+    """A small model double that constructs MLX logits without loading weights."""
+
+    def __init__(self):
+        self.layers = [object()]
+
+    def make_cache(self):
+        return [SyntheticCache()]
+
+    def __call__(self, input_tokens, *, cache, input_embeddings=None):
+        del input_embeddings
+        cache[0].offset += input_tokens.shape[1]
+        cache[0].state = mx.array(cache[0].offset)
+        return mx.zeros((input_tokens.shape[0], input_tokens.shape[1], 8))
+
+
+class FailingModel(SyntheticModel):
+    """A cache-compatible synthetic model whose Python forward always fails."""
+
+    def __call__(self, *args, **kwargs):
+        del args, kwargs
+        raise RuntimeError("forward failure")
+
+
+class ForwardContextRecorder:
+    """Records forward scope lifetime without retaining active contexts."""
+
+    def __init__(self):
+        self.events: List[GenerationForward] = []
+        self.exits: List[Optional[BaseException]] = []
+        self.active = 0
+
+    @contextmanager
+    def context(self, forward):
+        self.events.append(forward)
+        self.active += 1
+        error = None
+        try:
+            yield
+        except BaseException as exc:
+            error = exc
+            raise
+        finally:
+            self.exits.append(error)
+            self.active -= 1
+
+
+class FakeDetokenizer:
+    def __init__(self):
+        self.last_segment = ""
+
+    def add_token(self, token):
+        self.last_segment = str(token)
+
+    def finalize(self):
+        pass
+
+
+class FakeTokenizerWrapper:
+    """The small stream_generate surface needed by this callback test."""
+
+    def __init__(self):
+        self.detokenizer = FakeDetokenizer()
+        self.eos_token_ids = set()
+
+
+class TestGenerationForwardContext(unittest.TestCase):
+    def test_generate_step_context_preserves_default_parity_and_metadata(self):
+        prompt = mx.array([1, 2, 3, 4])
+        baseline = list(
+            generate_step(
+                prompt,
+                SyntheticModel(),
+                max_tokens=2,
+                prefill_step_size=1,
+            )
+        )
+        model = SyntheticModel()
+        recorder = ForwardContextRecorder()
+        observed = list(
+            generate_step(
+                prompt,
+                model,
+                max_tokens=2,
+                prefill_step_size=1,
+                model_forward_context=recorder.context,
+            )
+        )
+
+        self.assertEqual(
+            [token for token, _ in observed], [token for token, _ in baseline]
+        )
+        for (_, observed_logprobs), (_, baseline_logprobs) in zip(observed, baseline):
+            self.assertTrue(mx.allclose(observed_logprobs, baseline_logprobs))
+
+        self.assertEqual(recorder.active, 0)
+        self.assertEqual(len(recorder.events), len(recorder.exits))
+        self.assertEqual(
+            [event.phase for event in recorder.events],
+            [
+                GenerationForwardPhase.PREFILL,
+                GenerationForwardPhase.PREFILL,
+                GenerationForwardPhase.PREFILL,
+                GenerationForwardPhase.PREFILL,
+                GenerationForwardPhase.DECODE,
+                GenerationForwardPhase.DECODE,
+            ],
+        )
+        for event in recorder.events:
+            self.assertIs(event.model, model)
+            self.assertEqual(event.input_tokens.ndim, 2)
+            self.assertEqual(event.input_tokens.shape[0], 1)
+            self.assertIsNone(event.input_embeddings)
+
+    def test_supplied_populated_cache_classifies_final_prompt_step_as_decode(self):
+        model = SyntheticModel()
+        prompt_cache = model.make_cache()
+        model(mx.array([[1, 2]]), cache=prompt_cache)
+        recorder = ForwardContextRecorder()
+
+        list(
+            generate_step(
+                mx.array([3]),
+                model,
+                max_tokens=1,
+                prompt_cache=prompt_cache,
+                model_forward_context=recorder.context,
+            )
+        )
+
+        self.assertEqual(
+            [event.phase for event in recorder.events],
+            [GenerationForwardPhase.DECODE, GenerationForwardPhase.DECODE],
+        )
+
+    def test_generate_step_context_reports_input_embeddings(self):
+        prompt = mx.array([1, 2, 3])
+        input_embeddings = mx.zeros((3, 4))
+        recorder = ForwardContextRecorder()
+
+        list(
+            generate_step(
+                prompt,
+                SyntheticModel(),
+                max_tokens=1,
+                prefill_step_size=1,
+                input_embeddings=input_embeddings,
+                model_forward_context=recorder.context,
+            )
+        )
+
+        embedded_events = [
+            event for event in recorder.events if event.input_embeddings is not None
+        ]
+        self.assertTrue(embedded_events)
+        for event in embedded_events:
+            self.assertEqual(
+                event.input_embeddings.shape[0], event.input_tokens.shape[0]
+            )
+            self.assertEqual(
+                event.input_embeddings.shape[1], event.input_tokens.shape[1]
+            )
+
+    def test_generate_step_context_unwinds_on_forward_error(self):
+        recorder = ForwardContextRecorder()
+        model = FailingModel()
+
+        with self.assertRaisesRegex(RuntimeError, "forward failure"):
+            list(
+                generate_step(
+                    mx.array([1, 2]),
+                    model,
+                    max_tokens=1,
+                    model_forward_context=recorder.context,
+                )
+            )
+
+        self.assertEqual(recorder.active, 0)
+        self.assertEqual(len(recorder.events), 1)
+        self.assertIs(recorder.events[0].model, model)
+        self.assertIsInstance(recorder.exits[0], RuntimeError)
+
+    def test_generate_step_context_is_inactive_while_generator_is_yielded(self):
+        recorder = ForwardContextRecorder()
+        generator = generate_step(
+            mx.array([1, 2, 3]),
+            SyntheticModel(),
+            max_tokens=2,
+            prefill_step_size=1,
+            model_forward_context=recorder.context,
+        )
+
+        next(generator)
+        self.assertEqual(recorder.active, 0)
+        generator.close()
+        self.assertEqual(recorder.active, 0)
+        self.assertEqual(len(recorder.events), len(recorder.exits))
+
+    def test_external_speculative_context_reports_target_and_draft(self):
+        target = SyntheticModel()
+        draft = SyntheticModel()
+        recorder = ForwardContextRecorder()
+
+        list(
+            speculative_generate_step(
+                mx.array([1, 2, 3, 4]),
+                target,
+                draft,
+                max_tokens=1,
+                num_draft_tokens=1,
+                prefill_step_size=1,
+                model_forward_context=recorder.context,
+            )
+        )
+
+        target_events = [event for event in recorder.events if event.model is target]
+        draft_events = [event for event in recorder.events if event.model is draft]
+        self.assertTrue(target_events)
+        self.assertTrue(draft_events)
+        self.assertIn(
+            GenerationForwardPhase.PREFILL,
+            [event.phase for event in target_events],
+        )
+        self.assertIn(
+            GenerationForwardPhase.PREFILL,
+            [event.phase for event in draft_events],
+        )
+        self.assertIn(
+            GenerationForwardPhase.DRAFT,
+            [event.phase for event in draft_events],
+        )
+        self.assertIn(
+            GenerationForwardPhase.VERIFY,
+            [event.phase for event in target_events],
+        )
+        self.assertEqual(
+            [event.phase for event in recorder.events],
+            [
+                GenerationForwardPhase.PREFILL,
+                GenerationForwardPhase.PREFILL,
+                GenerationForwardPhase.PREFILL,
+                GenerationForwardPhase.PREFILL,
+                GenerationForwardPhase.PREFILL,
+                GenerationForwardPhase.PREFILL,
+                GenerationForwardPhase.DRAFT,
+                GenerationForwardPhase.VERIFY,
+            ],
+        )
+        self.assertEqual(len({id(event.cache) for event in target_events}), 1)
+        self.assertEqual(len({id(event.cache) for event in draft_events}), 1)
+        self.assertNotEqual(id(target_events[0].cache), id(draft_events[0].cache))
+        for event in recorder.events:
+            self.assertEqual(event.input_tokens.ndim, 2)
+            self.assertEqual(event.input_tokens.shape[0], 1)
+            self.assertIsNone(event.input_embeddings)
+        self.assertEqual(recorder.active, 0)
+
+    def test_external_speculative_without_drafts_reports_prefill_then_decode(self):
+        target = SyntheticModel()
+        draft = SyntheticModel()
+        recorder = ForwardContextRecorder()
+
+        list(
+            speculative_generate_step(
+                mx.array([1]),
+                target,
+                draft,
+                max_tokens=2,
+                num_draft_tokens=0,
+                model_forward_context=recorder.context,
+            )
+        )
+
+        target_phases = [
+            event.phase for event in recorder.events if event.model is target
+        ]
+        self.assertEqual(
+            target_phases,
+            [GenerationForwardPhase.PREFILL, GenerationForwardPhase.DECODE],
+        )
+        self.assertNotIn(GenerationForwardPhase.VERIFY, target_phases)
+        self.assertEqual(recorder.active, 0)
+
+    def test_stream_generate_forwards_model_forward_context(self):
+        recorder = ForwardContextRecorder()
+        tokenizer = FakeTokenizerWrapper()
+
+        with patch("mlx_lm.generate.TokenizerWrapper", FakeTokenizerWrapper), patch(
+            "mlx_lm.generate.wired_limit", lambda *_args, **_kwargs: nullcontext()
+        ):
+            responses = list(
+                stream_generate(
+                    SyntheticModel(),
+                    tokenizer,
+                    mx.array([1, 2, 3]),
+                    max_tokens=1,
+                    model_forward_context=recorder.context,
+                )
+            )
+
+        self.assertEqual(len(responses), 1)
+        self.assertTrue(recorder.events)
+        self.assertEqual(recorder.active, 0)

--- a/tests/test_native_mtp_batch_lifecycle.py
+++ b/tests/test_native_mtp_batch_lifecycle.py
@@ -1,0 +1,1234 @@
+# Copyright © 2026 Apple Inc.
+"""Typed public lifecycle coverage for native-MTP cohort admission."""
+
+from dataclasses import dataclass
+from collections import deque
+
+import mlx.core as mx
+import pytest
+
+from test_qwen3_5_mtp_model import _checkpoint, _model, _sanitize_and_load
+
+from mlx_lm.generate import (
+    NativeMTPAdmission,
+    NativeMTPBatchGenerator,
+    NativeMTPEmission,
+    NativeMTPRejectedEpoch,
+    NativeMTPRowSpec,
+    NativeMTPSamplingConfig,
+    mtp_generate_step,
+)
+from mlx_lm.generate import (
+    _NativeMTPCohortCache,
+    _NativeMTPCohortMutationDelta,
+    _NativeMTPSamplingState,
+)
+from mlx_lm.models.cache import ArraysCache, KVCache, NativeMTPRequestCache
+
+
+@dataclass(frozen=True)
+class _Capability:
+    supported: bool = True
+    reason: str = "supported"
+
+
+class _Model:
+    mtp_capability = _Capability()
+
+    def __init__(self):
+        self.layers = [type("_Attention", (), {"is_linear": False})()]
+        self.mtp = type("_MTP", (), {"layers": [object()]})()
+
+
+def _request(model):
+    request = NativeMTPRequestCache(model, [KVCache()], [KVCache()])
+    request.retain(backbone_tokens=0, mtp_tokens=0)
+    return request
+
+
+class _BatchModel(_Model):
+    """Actual tiny dense target/MTP pair; each row has a known +1 oracle."""
+
+    vocab_size = 7
+
+    def make_cache(self):
+        return [KVCache()]
+
+    def make_mtp_cache(self):
+        return [KVCache()]
+
+    def make_mtp_request_cache(self):
+        return NativeMTPRequestCache.create(self)
+
+    @staticmethod
+    def _write(entry, inputs):
+        values = inputs.astype(mx.float32)[:, None, :, None]
+        values = mx.broadcast_to(values, (*values.shape[:3], 32))
+        entry.update_and_fetch(values, values)
+
+    def _logits(self, inputs, delta=1):
+        ids = (inputs.astype(mx.int32) + delta) % self.vocab_size
+        logits = mx.full((*inputs.shape, self.vocab_size), -20.0)
+        for row in range(inputs.shape[0]):
+            for column in range(inputs.shape[1]):
+                logits[row, column, ids[row, column]] = 20.0
+        return logits
+
+    def __call__(self, inputs, *, cache, return_hidden=False):
+        self._write(cache[0], inputs)
+        hidden = mx.stack(
+            (inputs.astype(mx.float32), inputs.astype(mx.float32)), axis=-1
+        )
+        logits = self._logits(inputs)
+        return (logits, hidden) if return_hidden else logits
+
+    def mtp_forward(self, hidden, next_tokens, cache):
+        self._write(cache[0], next_tokens)
+        return self._logits(next_tokens)
+
+
+class _FailingBatchModel(_BatchModel):
+    def mtp_forward(self, hidden, next_tokens, cache):
+        raise RuntimeError("injected_mtp_failure")
+
+
+class _PrefillSplitFailureModel(_BatchModel):
+    def __call__(self, inputs, *, cache, return_hidden=False):
+        raise RuntimeError("injected_prefill_target_failure")
+
+
+class _MixedRerunFailureModel(_BatchModel):
+    def __init__(self):
+        super().__init__()
+        self.fail_rerun = False
+
+    def __call__(self, inputs, *, cache, return_hidden=False):
+        if self.fail_rerun:
+            raise RuntimeError("injected_mixed_rerun_failure")
+        return super().__call__(inputs, cache=cache, return_hidden=return_hidden)
+
+
+def _admission(*, max_tokens=8):
+    model = _Model()
+    rows = (
+        NativeMTPRowSpec(7, (1,), max_tokens, seed=17),
+        NativeMTPRowSpec(3, (2,), max_tokens, seed=29),
+    )
+    return NativeMTPAdmission.create(model, rows, (_request(model), _request(model)))
+
+
+def _emission(uid, token, *, draft=False, finish_reason=None):
+    return NativeMTPEmission(
+        uid=uid,
+        token=token,
+        logprobs=mx.zeros((5,), dtype=mx.float32),
+        from_draft=draft,
+        finish_reason=finish_reason,
+    )
+
+
+@pytest.mark.parametrize(
+    "kwargs, reason",
+    (
+        ({"prefix_cache": object()}, "prefix_reuse"),
+        ({"media": object()}, "media"),
+        ({"external_draft": object()}, "external_draft"),
+        ({"sparse_bootstrap": object()}, "sparse_bootstrap"),
+        ({"logits_processors": [object()]}, "logits_processors"),
+        ({"kv_bits": 8}, "quantized_cache"),
+        ({"max_kv_size": 16}, "rotating_cache"),
+    ),
+)
+def test_admission_fails_closed_for_unqualified_composition(kwargs, reason):
+    model = _Model()
+    with pytest.raises(ValueError, match=reason):
+        NativeMTPAdmission.create(
+            model,
+            (NativeMTPRowSpec(1, (1,), 2),),
+            (_request(model),),
+            **kwargs,
+        )
+
+
+def test_arrays_delta_matrix_matches_real_advance_for_optional_vectors():
+    entry = ArraysCache(1, left_padding=[2, 0])
+    entry.prepare(lengths=[5, 3])
+    before = _NativeMTPCohortCache._host_metadata((entry,))
+    entry.advance(1)
+    after = _NativeMTPCohortCache._host_metadata((entry,))
+    _NativeMTPCohortCache._validate_delta("backbone", before, after, ((1, 1),))
+
+    # Both ArraysCache vectors are part of the live recurrent-cache contract.
+    malformed = ((None, after[0][1], after[0][2][:-1]),)
+    with pytest.raises(RuntimeError, match="arrays_metadata_changed"):
+        _NativeMTPCohortCache._validate_delta("backbone", before, malformed, ((1, 1),))
+
+    # Qwen's recurrent cache commonly provides left_padding without lengths.
+    left_padding_only = ArraysCache(1, left_padding=[2, 0])
+    before = _NativeMTPCohortCache._host_metadata((left_padding_only,))
+    left_padding_only.advance(1)
+    after = _NativeMTPCohortCache._host_metadata((left_padding_only,))
+    _NativeMTPCohortCache._validate_delta("backbone", before, after, ((1, 1),))
+
+    lengths_only = ArraysCache(1)
+    lengths_only.prepare(lengths=[5, 3])
+    before = _NativeMTPCohortCache._host_metadata((lengths_only,))
+    lengths_only.advance(1)
+    after = _NativeMTPCohortCache._host_metadata((lengths_only,))
+    _NativeMTPCohortCache._validate_delta("backbone", before, after, ((1, 1),))
+
+    unpadded = ArraysCache(1)
+    before = _NativeMTPCohortCache._host_metadata((unpadded,))
+    unpadded.advance(1)
+    after = _NativeMTPCohortCache._host_metadata((unpadded,))
+    _NativeMTPCohortCache._validate_delta("backbone", before, after, ((1,),))
+
+
+def test_arrays_delta_allows_real_unpadded_advance_noop_seal():
+    model = _Model()
+    model.layers = [type("_Linear", (), {"is_linear": True})()]
+    request = NativeMTPRequestCache(model, [ArraysCache(1)], [KVCache()])
+    request.retain(backbone_tokens=0, mtp_tokens=0)
+    cohort = _NativeMTPCohortCache(model, (request,), uids=(7,))
+    for entry in cohort.backbone:
+        entry.left_padding = None
+        entry.lengths = None
+    cohort._binding = cohort._make_binding()
+    cohort.bind_before_mutation()
+    for entry in cohort.backbone:
+        entry.advance(3)
+    cohort.seal_after_mutation(
+        _NativeMTPCohortMutationDelta(backbone=((3,),), mtp=((0,),))
+    )
+    assert not cohort.poisoned
+
+
+def _arrays_cohort_for_seal(*, left_padding=None, lengths=None):
+    model = _Model()
+    model.layers = [type("_Linear", (), {"is_linear": True})()]
+    request = NativeMTPRequestCache(model, [ArraysCache(1)], [KVCache()])
+    request.retain(backbone_tokens=0, mtp_tokens=0)
+    cohort = _NativeMTPCohortCache(model, (request,), uids=(7,))
+    entry = cohort.backbone[0]
+    entry.left_padding = (
+        None if left_padding is None else mx.array(left_padding, dtype=mx.int32)
+    )
+    entry.lengths = None if lengths is None else mx.array(lengths, dtype=mx.int32)
+    cohort._binding = cohort._make_binding()
+    return cohort
+
+
+def _assert_arrays_seal_rejected_and_poisoned(cohort):
+    with pytest.raises(RuntimeError, match="native_mtp_cohort"):
+        cohort.seal_after_mutation(
+            _NativeMTPCohortMutationDelta(backbone=((1,),), mtp=((0,),))
+        )
+    assert cohort.poisoned
+
+
+def test_arrays_seal_rejects_and_poisons_absent_to_present_metadata():
+    cohort = _arrays_cohort_for_seal()
+    cohort.bind_before_mutation()
+    entry = cohort.backbone[0]
+    entry.left_padding = mx.array([0], dtype=mx.int32)
+    entry.lengths = mx.array([1], dtype=mx.int32)
+    _assert_arrays_seal_rejected_and_poisoned(cohort)
+
+
+def test_arrays_seal_rejects_and_poisons_present_to_absent_metadata():
+    cohort = _arrays_cohort_for_seal(left_padding=[2], lengths=[4])
+    cohort.bind_before_mutation()
+    entry = cohort.backbone[0]
+    entry.left_padding = None
+    entry.lengths = None
+    _assert_arrays_seal_rejected_and_poisoned(cohort)
+
+
+def test_arrays_seal_rejects_and_poisons_wrong_left_padding_delta():
+    cohort = _arrays_cohort_for_seal(left_padding=[2], lengths=[4])
+    cohort.bind_before_mutation()
+    entry = cohort.backbone[0]
+    entry.advance(1)
+    entry.left_padding = mx.array([0], dtype=mx.int32)
+    _assert_arrays_seal_rejected_and_poisoned(cohort)
+
+
+def test_arrays_seal_rejects_and_poisons_wrong_lengths_delta():
+    cohort = _arrays_cohort_for_seal(left_padding=[2], lengths=[4])
+    cohort.bind_before_mutation()
+    entry = cohort.backbone[0]
+    entry.advance(1)
+    entry.lengths = mx.array([2], dtype=mx.int32)
+    _assert_arrays_seal_rejected_and_poisoned(cohort)
+
+
+def test_public_decision_methods_reject_positional_and_keyword_forgery():
+    model = _BatchModel()
+    rows = (NativeMTPRowSpec(7, (1, 2), 8), NativeMTPRowSpec(3, (4,), 8))
+    generator = NativeMTPBatchGenerator(
+        NativeMTPAdmission.create(model, rows, (_request(model), _request(model)))
+    )
+    assert not hasattr(generator, "initial")
+    _, initial = generator.prefill(prefill_step_size=1)
+    with pytest.raises(TypeError):
+        initial.resume((7,))
+    with pytest.raises(TypeError):
+        initial.resume(draft_uids=(7,))
+    ready = initial.resume()
+    with pytest.raises(TypeError):
+        ready.decide((7,))
+    with pytest.raises(TypeError):
+        ready.decide(accepted_uids=(7,))
+    decision = ready.decide()
+    with pytest.raises(TypeError):
+        decision.accept((7,))
+    with pytest.raises(TypeError):
+        decision.accept(emissions=())
+    with pytest.raises(TypeError):
+        decision.reject((3,))
+    with pytest.raises(TypeError):
+        decision.reject(emissions=())
+    accepted = decision.accept()
+    with pytest.raises(TypeError):
+        accepted.bonus(())
+    with pytest.raises(TypeError):
+        accepted.bonus(emissions=())
+    bonus = accepted.bonus()
+    with pytest.raises(TypeError):
+        bonus.catch_up(())
+    with pytest.raises(TypeError):
+        bonus.catch_up(draft_uids=())
+    rejected = NativeMTPRejectedEpoch(generator, "rejected", ())
+    with pytest.raises(TypeError):
+        rejected.redraft(())
+    with pytest.raises(TypeError):
+        rejected.redraft(draft_uids=())
+
+
+def test_mixed_terminal_rows_are_removed_before_bonus_catchup_and_join():
+    model = _BatchModel()
+    rows = tuple(NativeMTPRowSpec(uid, (uid % 7,), 8) for uid in (7, 3, 11, 13))
+    generator = NativeMTPBatchGenerator(
+        NativeMTPAdmission.create(model, rows, tuple(_request(model) for _ in rows))
+    )
+    rejected_owner = generator._move_to_front((7, 3))
+    generator._mixed_accepted_owner = generator._cohort
+    generator._mixed_rejected_owner = rejected_owner
+    generator._prune_mixed_terminal_owners(
+        (
+            _emission(7, 1, finish_reason="eos"),
+            _emission(3, 2),
+            _emission(11, 3, finish_reason="length"),
+            _emission(13, 4),
+        ),
+        (7, 3),
+        (11, 13),
+    )
+    assert generator._mixed_accepted_uids == (3,)
+    assert generator._mixed_rejected_uids == (13,)
+    assert generator._mixed_accepted_owner.uids == (3,)
+    assert generator._mixed_rejected_owner.uids == (13,)
+
+    generator._mixed_accepted_ready = ()
+    generator._mixed_rejected_ready = (13,)
+    generator._mixed_accepted_uids = ()
+    generator._mixed_accepted_owner = generator._filter_owner_uids(
+        generator._mixed_accepted_owner, ()
+    )
+    assert generator._mixed_accepted_owner is None
+    assert generator._mixed_rejected_owner.uids == (13,)
+    ready = generator._mixed_after_bonus(None)
+    assert ready.active_uids == (13,)
+    assert generator._cohort.uids == ready.active_uids
+    assert generator._cohort.backbone[0].offset.size == 1
+
+
+def test_injected_mtp_failure_closes_the_consumed_cohort_owner():
+    model = _FailingBatchModel()
+    rows = (NativeMTPRowSpec(7, (1, 2), 4),)
+    generator = NativeMTPBatchGenerator(
+        NativeMTPAdmission.create(model, rows, (_request(model),))
+    )
+    with pytest.raises(RuntimeError, match="injected_mtp_failure"):
+        generator.prefill(prefill_step_size=1)
+    assert generator.closed
+    assert generator._cohort.poisoned
+
+
+def test_prefill_target_failure_after_split_poison_selected_and_remaining_owners():
+    model = _PrefillSplitFailureModel()
+    rows = (NativeMTPRowSpec(7, (1, 2, 3), 4), NativeMTPRowSpec(3, (4,), 4))
+    generator = NativeMTPBatchGenerator(
+        NativeMTPAdmission.create(model, rows, (_request(model), _request(model)))
+    )
+    with pytest.raises(RuntimeError, match="injected_prefill_target_failure"):
+        generator.prefill(prefill_step_size=1)
+    assert generator.closed
+    assert len(generator._last_failed_owners) == 2
+    assert all(owner.poisoned for owner in generator._last_failed_owners)
+
+
+def test_mixed_rerun_failure_preserves_primary_and_poisoned_branch_owners():
+    model = _MixedRerunFailureModel()
+    rows = (NativeMTPRowSpec(7, (1, 2), 8), NativeMTPRowSpec(3, (4,), 8))
+    generator = NativeMTPBatchGenerator(
+        NativeMTPAdmission.create(model, rows, (_request(model), _request(model)))
+    )
+    _, initial = generator.prefill(prefill_step_size=1)
+    decision = initial.resume().decide()
+    # The public decision is model-derived; this test only controls the
+    # private branch fixture so the accepted rerun becomes injectable.
+    decision.accepted_uids = (7,)
+    decision.rejected_uids = (3,)
+    model.fail_rerun = True
+    with pytest.raises(RuntimeError, match="injected_mixed_rerun_failure"):
+        decision.resolve()
+    assert generator.closed
+    assert len(generator._last_failed_owners) == 2
+    assert all(owner.poisoned for owner in generator._last_failed_owners)
+
+
+def test_actual_merged_chunked_prefill_and_all_accepted_round():
+    model = _BatchModel()
+    rows = (
+        NativeMTPRowSpec(7, (1, 2, 3), 8, seed=17),
+        NativeMTPRowSpec(3, (4,), 8, seed=29),
+    )
+    generator = NativeMTPBatchGenerator(
+        NativeMTPAdmission.create(model, rows, (_request(model), _request(model)))
+    )
+    emissions, initial = generator.prefill(prefill_step_size=2)
+    assert tuple(emission.token for emission in emissions) == (4, 5)
+    ready = initial.resume()
+    decision = ready.decide()
+    assert decision.accepted_uids == (7, 3)
+    accepted = decision.accept()
+    bonus = accepted.bonus()
+    ready = bonus.catch_up()
+    assert ready.phase == "ready"
+
+
+def test_bonus_uses_verified_target_logits_not_hidden_width():
+    model = _BatchModel()
+    rows = (
+        NativeMTPRowSpec(7, (1, 2, 3), 8, seed=17),
+        NativeMTPRowSpec(3, (4,), 8, seed=29),
+    )
+    generator = NativeMTPBatchGenerator(
+        NativeMTPAdmission.create(model, rows, (_request(model), _request(model)))
+    )
+    _, initial = generator.prefill(prefill_step_size=2)
+    decision = initial.resume().decide()
+    bonus = decision.accept().bonus()
+    # The tiny model's hidden width is 2 while its vocabulary is 7.  These
+    # values can only be correct when bonus sampling reads verify logits[:, 1].
+    assert bonus.active_uids == (7, 3)
+    assert tuple(generator._head[uid].item() for uid in (7, 3)) == (6, 0)
+
+
+def test_actual_dense_batch_initial_tokens_match_independent_b1_oracles():
+    prompts = ((1, 2, 3), (4,))
+    oracle = []
+    for prompt in prompts:
+        stream = mtp_generate_step(
+            mx.array(prompt, dtype=mx.uint32), _BatchModel(), max_tokens=2
+        )
+        oracle.append(next(stream)[0])
+        stream.close()
+
+    model = _BatchModel()
+    rows = tuple(
+        NativeMTPRowSpec(uid, prompt, 2, seed=uid)
+        for uid, prompt in zip((7, 3), prompts)
+    )
+    generator = NativeMTPBatchGenerator(
+        NativeMTPAdmission.create(model, rows, (_request(model), _request(model)))
+    )
+    emissions, _ = generator.prefill(prefill_step_size=2)
+    assert tuple(emission.token for emission in emissions) == tuple(oracle)
+
+
+def test_uid_rng_uses_post_initial_b1_sequential_draw_chain():
+    model = _BatchModel()
+    row = NativeMTPRowSpec(
+        7,
+        (1, 2, 3),
+        8,
+        seed=17,
+        sampling_config=NativeMTPSamplingConfig(temperature=0.7, seed=17),
+    )
+    generator = NativeMTPBatchGenerator(
+        NativeMTPAdmission.create(model, (row,), (_request(model),))
+    )
+    _, initial = generator.prefill(prefill_step_size=2)
+    decision = initial.resume().decide()
+    decision.accept().bonus()
+
+    # B=1 draws initial, draft, acceptance, then accepted bonus.  The retained
+    # key remains UID-owned, so cohort reordering cannot affect this chain.
+    expected = mx.random.key(17)
+    for _ in range(4):
+        expected, _ = mx.random.split(expected)
+    mx.eval(expected, generator._rng_key[7])
+    assert mx.array_equal(expected, generator._rng_key[7]).item()
+
+
+@pytest.mark.parametrize("moe", (False, True))
+def test_actual_qwen_dense_and_moe_variable_prefill_admission_fixture(moe):
+    """Exercise real Qwen layers: MoE includes its recurrent+KV backbone."""
+    model = _model(moe=moe)
+    _sanitize_and_load(model, _checkpoint(model, moe=moe))
+    target = model.language_model
+    rows = (
+        NativeMTPRowSpec(7, (1, 2, 3), 4, seed=17),
+        NativeMTPRowSpec(3, (4,), 4, seed=29),
+    )
+    requests = tuple(model.make_mtp_request_cache() for _ in rows)
+    generator = NativeMTPBatchGenerator(
+        NativeMTPAdmission.create(target, rows, requests)
+    )
+    emissions, initial = generator.prefill(prefill_step_size=1)
+    assert len(emissions) == 2
+    assert initial.active_uids == (7, 3)
+    assert generator._cohort.backbone[-1].offset.tolist() == [3, 1]
+
+
+def _force_acceptance_uniform(monkeypatch, values):
+    values = deque(values)
+
+    def forced_uniform(*args, **kwargs):
+        return mx.array(values.popleft(), dtype=mx.float32)
+
+    monkeypatch.setattr(mx.random, "uniform", forced_uniform)
+
+
+def _shared_qwen_checkpoint(*, moe):
+    """Freeze one synthetic backbone for every oracle/batch comparison."""
+
+    reference = _model(moe=moe)
+    return _checkpoint(reference, moe=moe)
+
+
+def _load_shared_qwen_checkpoint(model, weights):
+    """Give sanitize a fresh mapping while preserving the frozen MLX leaves."""
+
+    _sanitize_and_load(model, dict(weights))
+
+
+def _tiny_qwen_b1_emissions(
+    monkeypatch, *, moe, weights, prompt, sampling, uniform, count
+):
+    model = _model(moe=moe)
+    _load_shared_qwen_checkpoint(model, weights)
+    with monkeypatch.context() as local_monkeypatch:
+        requests = []
+        make_request = model.language_model.make_mtp_request_cache
+
+        def capture_request(*args, **kwargs):
+            request = make_request(*args, **kwargs)
+            requests.append(request)
+            return request
+
+        local_monkeypatch.setattr(
+            model.language_model, "make_mtp_request_cache", capture_request
+        )
+        _force_acceptance_uniform(local_monkeypatch, uniform)
+        stream = mtp_generate_step(
+            mx.array(prompt, dtype=mx.uint32),
+            model.language_model,
+            max_tokens=8,
+            prefill_step_size=1,
+            sampling_config=sampling,
+        )
+        try:
+            emissions = tuple(next(stream) for _ in range(count))
+        finally:
+            stream.close()
+    return emissions, requests[0]
+
+
+def _assert_cohort_recurrent_row_matches_b1(owner, uid, request):
+    row = owner.uids.index(uid)
+    for cohort_entry, b1_entry in zip(owner.backbone, request.backbone):
+        if not isinstance(cohort_entry, ArraysCache):
+            continue
+        assert isinstance(b1_entry, ArraysCache)
+        for cohort_value, b1_value in zip(cohort_entry.cache, b1_entry.cache):
+            if b1_value is None:
+                assert cohort_value is None
+            else:
+                assert mx.allclose(
+                    cohort_value[row : row + 1],
+                    b1_value,
+                    rtol=1e-4,
+                    atol=1e-5,
+                ).item()
+        for name in ("left_padding", "lengths"):
+            cohort_value = getattr(cohort_entry, name)
+            b1_value = getattr(b1_entry, name)
+            if b1_value is None:
+                continue
+            else:
+                assert mx.array_equal(cohort_value[row : row + 1], b1_value).item()
+
+
+def _assert_cohort_offsets_match_b1(owner, uid, request):
+    row = owner.uids.index(uid)
+    for cohort_entry, b1_entry in zip(
+        owner.backbone + owner.mtp, request.backbone + request.mtp
+    ):
+        if isinstance(cohort_entry, ArraysCache):
+            continue
+        assert cohort_entry.offset[row].item() == b1_entry.offset
+
+
+class _B1PhaseOracle:
+    """Test-local pause-point oracle for B1 native-MTP cache transitions."""
+
+    def __init__(self, model, prompt, sampling):
+        self.model = model
+        self.request = model.make_mtp_request_cache()
+        self.sampling = _NativeMTPSamplingState(sampling, seed=sampling.seed)
+        self.history = mx.array(prompt, dtype=mx.uint32)
+        self._prefill()
+
+    def _target(self, tokens):
+        return self.model(
+            mx.array(tokens, dtype=mx.uint32)[None],
+            cache=self.request.backbone,
+            return_hidden=True,
+        )
+
+    def _mtp(self, hidden, tokens):
+        return self.model.mtp_forward(
+            hidden, mx.array(tokens, dtype=mx.uint32)[None], self.request.mtp
+        )
+
+    def _retain(self, *, backbone=0, mtp=0):
+        self.request.retain(
+            backbone_tokens=self.request.state.backbone_tokens + backbone,
+            mtp_tokens=self.request.state.mtp_tokens + mtp,
+        )
+
+    def _prefill(self):
+        remaining = self.history
+        while remaining.size > 1:
+            count = remaining.size - 1
+            _, hidden = self._target(remaining[:count])
+            self._mtp(hidden, remaining[1 : count + 1])
+            self._retain(backbone=count, mtp=count)
+            remaining = remaining[count:]
+        logits, hidden = self._target(remaining)
+        self._retain(backbone=1)
+        reported = self.sampling.reported_logprobs(
+            logits[:, -1, :].squeeze(0), remaining
+        )
+        self.head = self.sampling.sample(
+            self.sampling.sampling_distribution(reported)
+        ).reshape(-1)
+        mx.eval(self.head, reported)
+        self.history = mx.concatenate([remaining, self.head])
+        self.hidden = hidden[:, -1:, :]
+        self.initial = (self.head.item(), reported, False)
+
+    def draft(self):
+        logits = self._mtp(self.hidden, self.head)[:, -1, :]
+        self._retain(mtp=1)
+        reported = self.sampling.reported_logprobs(logits.squeeze(0), self.history)
+        self.draft_logprobs = self.sampling.sampling_distribution(reported)
+        self.draft = self.sampling.sample(self.draft_logprobs).reshape(-1)
+        mx.eval(self.draft, reported)
+
+    def verify(self):
+        self.request.checkpoint()
+        logits, hidden = self._target(mx.concatenate([self.head, self.draft]))
+        self.request.seal_verified(
+            backbone_tokens=self.request.state.backbone_tokens + 2,
+            mtp_tokens=self.request.state.mtp_tokens,
+        )
+        reported = self.sampling.reported_logprobs(
+            logits[:, 0, :].squeeze(0), self.history
+        )
+        sampled = self.sampling.sampling_distribution(reported)
+        probability = mx.minimum(
+            mx.exp(sampled[self.draft.item()] - self.draft_logprobs[self.draft.item()]),
+            1.0,
+        )
+        accepted = mx.random.uniform(key=self.sampling.next_rng_key()) < probability
+        mx.eval(accepted)
+        self.accepted = bool(accepted.item())
+        self.verify_hidden, self.verify_logits, self.verify_reported = (
+            hidden,
+            logits,
+            reported,
+        )
+        if not self.accepted:
+            self.replacement, _ = self.sampling.residual_sample(
+                sampled, self.draft_logprobs
+            )
+            self.replacement = self.replacement.reshape(-1)
+            mx.eval(self.replacement)
+
+    def accept_bonus_catchup(self):
+        self.request.commit(
+            backbone_tokens=self.request.state.backbone_tokens + 2,
+            mtp_tokens=self.request.state.mtp_tokens,
+        )
+        accepted = (self.draft.item(), self.verify_reported, True)
+        bonus_history = mx.concatenate([self.history, self.draft])
+        bonus_reported = self.sampling.reported_logprobs(
+            self.verify_logits[:, 1, :].squeeze(0), bonus_history
+        )
+        bonus = self.sampling.sample(
+            self.sampling.sampling_distribution(bonus_reported)
+        ).reshape(-1)
+        mx.eval(bonus, bonus_reported)
+        bonus_emission = (bonus.item(), bonus_reported, False)
+        self.history = mx.concatenate([bonus_history, bonus])
+        self.head = bonus
+        self.hidden = self.verify_hidden[:, 1:2, :]
+        self.draft = self.sampling.sample(
+            self.sampling.sampling_distribution(
+                self._mtp(
+                    self.verify_hidden,
+                    mx.concatenate([self.draft, bonus]),
+                )[:, -1, :]
+            )
+        ).reshape(-1)
+        self._retain(mtp=2)
+        mx.eval(self.draft)
+        return accepted, bonus_emission
+
+    def reject_replay_redraft(self):
+        self.request.reject_partial(accepted_backbone_tokens=1, accepted_mtp_tokens=0)
+        _, replay_hidden = self._target(self.head)
+        self.request.replay_retained(
+            backbone_tokens=self.request.state.backbone_tokens + 1,
+            mtp_tokens=self.request.state.mtp_tokens,
+        )
+        emission = (self.replacement.item(), self.verify_reported, False)
+        self.history = mx.concatenate([self.history, self.replacement])
+        self.head = self.replacement
+        self.hidden = replay_hidden[:, -1:, :]
+        logits = self._mtp(self.hidden, self.head)[:, -1, :]
+        self._retain(mtp=1)
+        self.draft = self.sampling.sample(
+            self.sampling.sampling_distribution(
+                self.sampling.reported_logprobs(logits.squeeze(0), self.history)
+            )
+        ).reshape(-1)
+        mx.eval(self.draft)
+        return emission
+
+
+@pytest.mark.parametrize("moe", (False, True))
+def test_actual_qwen_stochastic_mixed_public_lifecycle_matches_b1_emissions(
+    moe, monkeypatch
+):
+    """Dense and recurrent+KV MoE rows resolve a forced mixed public epoch."""
+
+    accepted_sampling = NativeMTPSamplingConfig(temperature=0.7, seed=17)
+    rejected_sampling = NativeMTPSamplingConfig(temperature=0.7, seed=29)
+    weights = _shared_qwen_checkpoint(moe=moe)
+    accepted_b1, accepted_request = _tiny_qwen_b1_emissions(
+        monkeypatch,
+        moe=moe,
+        weights=weights,
+        prompt=(1, 2, 3),
+        sampling=accepted_sampling,
+        uniform=(-1.0,),
+        count=3,
+    )
+    rejected_b1, _ = _tiny_qwen_b1_emissions(
+        monkeypatch,
+        moe=moe,
+        weights=weights,
+        prompt=(4,),
+        sampling=rejected_sampling,
+        uniform=(2.0,),
+        count=2,
+    )
+
+    model = _model(moe=moe)
+    _load_shared_qwen_checkpoint(model, weights)
+    target = model.language_model
+    rows = (
+        NativeMTPRowSpec(7, (1, 2, 3), 8, seed=17, sampling_config=accepted_sampling),
+        NativeMTPRowSpec(3, (4,), 8, seed=29, sampling_config=rejected_sampling),
+    )
+    requests = tuple(model.make_mtp_request_cache() for _ in rows)
+    generator = NativeMTPBatchGenerator(
+        NativeMTPAdmission.create(target, rows, requests)
+    )
+    with monkeypatch.context() as local_monkeypatch:
+        _force_acceptance_uniform(local_monkeypatch, (-1.0, 2.0))
+        initial_emissions, initial = generator.prefill(prefill_step_size=1)
+        decision = initial.resume().decide()
+        assert decision.accepted_uids == (7,)
+        assert decision.rejected_uids == (3,)
+        resolution_emissions, continuation = decision.resolve()
+        bonus_emissions, bonus_continuation = continuation.resume_after_resolution()
+        _assert_cohort_offsets_match_b1(
+            generator._mixed_accepted_owner, 7, accepted_request
+        )
+        _assert_cohort_recurrent_row_matches_b1(
+            generator._mixed_accepted_owner, 7, accepted_request
+        )
+        ready = bonus_continuation.resume_after_bonus()
+
+    by_uid = {emission.uid: emission for emission in initial_emissions}
+    assert by_uid[7].token == accepted_b1[0][0]
+    assert by_uid[3].token == rejected_b1[0][0]
+    assert mx.allclose(by_uid[7].logprobs, accepted_b1[0][1]).item()
+    assert mx.allclose(by_uid[3].logprobs, rejected_b1[0][1]).item()
+
+    by_uid = {emission.uid: emission for emission in resolution_emissions}
+    assert by_uid[7].token == accepted_b1[1][0]
+    assert by_uid[3].token == rejected_b1[1][0]
+    assert by_uid[7].from_draft is True
+    assert by_uid[3].from_draft is False
+    assert mx.allclose(by_uid[7].logprobs, accepted_b1[1][1]).item()
+    assert mx.allclose(by_uid[3].logprobs, rejected_b1[1][1]).item()
+
+    assert len(bonus_emissions) == 1
+    assert bonus_emissions[0].uid == 7
+    assert bonus_emissions[0].token == accepted_b1[2][0]
+    assert mx.allclose(bonus_emissions[0].logprobs, accepted_b1[2][1]).item()
+    assert ready.active_uids == (7, 3)
+    assert ready._generator._cohort.uids == ready.active_uids
+    with pytest.raises(RuntimeError, match="native_mtp_epoch_moved"):
+        continuation.resume_after_resolution()
+    with pytest.raises(RuntimeError, match="native_mtp_epoch_moved"):
+        bonus_continuation.resume_after_bonus()
+    ready.cancel()
+    assert generator.closed
+
+
+@pytest.mark.parametrize("moe", (False, True))
+def test_actual_qwen_mixed_ready_matches_independent_b1_phase_oracle(moe, monkeypatch):
+    accepted_sampling = NativeMTPSamplingConfig(temperature=0.7, seed=17)
+    rejected_sampling = NativeMTPSamplingConfig(temperature=0.7, seed=29)
+    weights = _shared_qwen_checkpoint(moe=moe)
+
+    accepted_model = _model(moe=moe)
+    _load_shared_qwen_checkpoint(accepted_model, weights)
+    accepted = _B1PhaseOracle(
+        accepted_model.language_model, (1, 2, 3), accepted_sampling
+    )
+    accepted.draft()
+    with monkeypatch.context() as local_monkeypatch:
+        _force_acceptance_uniform(local_monkeypatch, (-1.0,))
+        accepted.verify()
+    assert accepted.accepted
+    accepted_emission, accepted_bonus = accepted.accept_bonus_catchup()
+
+    rejected_model = _model(moe=moe)
+    _load_shared_qwen_checkpoint(rejected_model, weights)
+    rejected = _B1PhaseOracle(rejected_model.language_model, (4,), rejected_sampling)
+    rejected.draft()
+    with monkeypatch.context() as local_monkeypatch:
+        _force_acceptance_uniform(local_monkeypatch, (2.0,))
+        rejected.verify()
+    assert not rejected.accepted
+    rejected_emission = rejected.reject_replay_redraft()
+
+    model = _model(moe=moe)
+    _load_shared_qwen_checkpoint(model, weights)
+    rows = (
+        NativeMTPRowSpec(7, (1, 2, 3), 8, seed=17, sampling_config=accepted_sampling),
+        NativeMTPRowSpec(3, (4,), 8, seed=29, sampling_config=rejected_sampling),
+    )
+    generator = NativeMTPBatchGenerator(
+        NativeMTPAdmission.create(
+            model.language_model,
+            rows,
+            tuple(model.make_mtp_request_cache() for _ in rows),
+        )
+    )
+    with monkeypatch.context() as local_monkeypatch:
+        _force_acceptance_uniform(local_monkeypatch, (-1.0, 2.0))
+        initial_emissions, initial = generator.prefill(prefill_step_size=1)
+        decision = initial.resume().decide()
+        resolution_emissions, continuation = decision.resolve()
+        bonus_emissions, bonus_continuation = continuation.resume_after_resolution()
+        ready = bonus_continuation.resume_after_bonus()
+
+    assert decision.accepted_uids == (7,)
+    assert decision.rejected_uids == (3,)
+    assert tuple(emission.token for emission in initial_emissions) == (
+        accepted.initial[0],
+        rejected.initial[0],
+    )
+    by_uid = {emission.uid: emission for emission in resolution_emissions}
+    assert by_uid[7].token == accepted_emission[0]
+    assert by_uid[3].token == rejected_emission[0]
+    assert mx.allclose(by_uid[7].logprobs, accepted_emission[1]).item()
+    assert mx.allclose(by_uid[3].logprobs, rejected_emission[1]).item()
+    assert bonus_emissions[0].token == accepted_bonus[0]
+    assert mx.allclose(bonus_emissions[0].logprobs, accepted_bonus[1]).item()
+    assert ready.active_uids == (7, 3)
+    _assert_cohort_offsets_match_b1(ready._generator._cohort, 7, accepted.request)
+    _assert_cohort_offsets_match_b1(ready._generator._cohort, 3, rejected.request)
+    _assert_cohort_recurrent_row_matches_b1(
+        ready._generator._cohort, 7, accepted.request
+    )
+    _assert_cohort_recurrent_row_matches_b1(
+        ready._generator._cohort, 3, rejected.request
+    )
+    assert generator._draft[7].item() == accepted.draft.item()
+    assert generator._draft[3].item() == rejected.draft.item()
+    assert mx.array_equal(generator._rng_key[7], accepted.sampling._rng_key).item()
+    assert mx.array_equal(generator._rng_key[3], rejected.sampling._rng_key).item()
+
+
+@pytest.mark.parametrize("after_bonus", (False, True))
+def test_mixed_continuation_cancel_is_move_only_and_closes_all_owners(
+    after_bonus, monkeypatch
+):
+    sampling = NativeMTPSamplingConfig(temperature=0.7, seed=17)
+    model = _BatchModel()
+    rows = (
+        NativeMTPRowSpec(7, (1, 2), 8, seed=17, sampling_config=sampling),
+        NativeMTPRowSpec(
+            3,
+            (4,),
+            8,
+            seed=29,
+            sampling_config=NativeMTPSamplingConfig(temperature=0.7, seed=29),
+        ),
+    )
+    generator = NativeMTPBatchGenerator(
+        NativeMTPAdmission.create(model, rows, (_request(model), _request(model)))
+    )
+    with monkeypatch.context() as local_monkeypatch:
+        _force_acceptance_uniform(local_monkeypatch, (-1.0, 2.0))
+        _, initial = generator.prefill(prefill_step_size=1)
+        _, continuation = initial.resume().decide().resolve()
+        handle = continuation
+        if after_bonus:
+            _, handle = continuation.resume_after_resolution()
+        handle.cancel()
+    assert generator.closed
+    assert all(owner.poisoned for owner in generator._last_failed_owners)
+    with pytest.raises(RuntimeError, match="native_mtp_epoch_moved"):
+        handle.cancel()
+    with pytest.raises(RuntimeError, match="native_mtp_epoch_moved"):
+        (
+            handle.resume_after_bonus()
+            if after_bonus
+            else handle.resume_after_resolution()
+        )
+
+
+def _visible_cohort_state(generator):
+    """Return UID-keyed, order-independent state after an owner transition."""
+
+    owner = generator._cohort
+    result = {}
+    for index, uid in enumerate(owner.uids):
+        cache = []
+        for entry in owner.backbone + owner.mtp:
+            if isinstance(entry, ArraysCache):
+                slots = tuple(
+                    None if value is None else value[index : index + 1]
+                    for value in entry.cache
+                )
+                cache.append(
+                    (
+                        "arrays",
+                        slots,
+                        (
+                            entry.left_padding[index : index + 1]
+                            if entry.left_padding is not None
+                            else None
+                        ),
+                        (
+                            entry.lengths[index : index + 1]
+                            if entry.lengths is not None
+                            else None
+                        ),
+                    )
+                )
+            else:
+                cache.append(
+                    (
+                        "kv",
+                        entry.offset[index : index + 1],
+                        (
+                            entry.left_padding[index : index + 1]
+                            if entry.left_padding is not None
+                            else None
+                        ),
+                    )
+                )
+        result[uid] = (
+            generator._head[uid],
+            generator._draft[uid],
+            generator._rng_key[uid],
+            generator._history[uid],
+            tuple(cache),
+        )
+    return result
+
+
+def _assert_visible_state_equal(left, right):
+    assert left.keys() == right.keys()
+    for uid in left:
+        for expected, actual in zip(left[uid][:4], right[uid][:4]):
+            assert mx.array_equal(expected, actual).item(), uid
+        for expected_entry, actual_entry in zip(left[uid][4], right[uid][4]):
+            assert expected_entry[0] == actual_entry[0]
+            for expected, actual in zip(expected_entry[1:], actual_entry[1:]):
+                if isinstance(expected, tuple):
+                    assert isinstance(actual, tuple)
+                    for expected_slot, actual_slot in zip(expected, actual):
+                        if expected_slot is None:
+                            assert actual_slot is None
+                        else:
+                            assert mx.array_equal(
+                                expected_slot, actual_slot
+                            ).item(), uid
+                elif expected is None:
+                    assert actual is None
+                else:
+                    assert mx.array_equal(expected, actual).item(), uid
+
+
+def _run_actual_qwen_mixed_epoch(monkeypatch, *, moe, weights, row_order):
+    """Resolve the same UID-owned mixed epoch under an arbitrary input order."""
+
+    configs = {
+        7: NativeMTPSamplingConfig(temperature=0.7, seed=17),
+        3: NativeMTPSamplingConfig(temperature=0.7, seed=29),
+    }
+    prompts = {7: (1, 2, 3), 3: (4,)}
+    model = _model(moe=moe)
+    _load_shared_qwen_checkpoint(model, weights)
+    rows = tuple(
+        NativeMTPRowSpec(
+            uid, prompts[uid], 8, seed=configs[uid].seed, sampling_config=configs[uid]
+        )
+        for uid in row_order
+    )
+    generator = NativeMTPBatchGenerator(
+        NativeMTPAdmission.create(
+            model.language_model,
+            rows,
+            tuple(model.make_mtp_request_cache() for _ in rows),
+        )
+    )
+    # Acceptance draws occur in current cohort order.  Bind values to UIDs,
+    # rather than accidentally granting positional RNG semantics in the test.
+    uniforms = tuple(-1.0 if uid == 7 else 2.0 for uid in row_order)
+    with monkeypatch.context() as local_monkeypatch:
+        _force_acceptance_uniform(local_monkeypatch, uniforms)
+        initial, initial_epoch = generator.prefill(prefill_step_size=1)
+        decision = initial_epoch.resume().decide()
+        resolution, continuation = decision.resolve()
+        bonus, after_bonus = continuation.resume_after_resolution()
+        ready = after_bonus.resume_after_bonus()
+    return generator, initial, resolution, bonus, ready
+
+
+@pytest.mark.parametrize("moe", (False, True))
+def test_actual_qwen_uid_stochastic_state_survives_reorder_split_filter_join(
+    moe, monkeypatch
+):
+    """UID-owned stochastic state is invariant to batch order and branch moves."""
+
+    weights = _shared_qwen_checkpoint(moe=moe)
+    ordered = _run_actual_qwen_mixed_epoch(
+        monkeypatch, moe=moe, weights=weights, row_order=(7, 3)
+    )
+    reordered = _run_actual_qwen_mixed_epoch(
+        monkeypatch, moe=moe, weights=weights, row_order=(3, 7)
+    )
+    for boundary in range(3):
+        left = {emission.uid: emission for emission in ordered[boundary + 1]}
+        right = {emission.uid: emission for emission in reordered[boundary + 1]}
+        assert left.keys() == right.keys()
+        for uid in left:
+            assert (left[uid].token, left[uid].from_draft, left[uid].finish_reason) == (
+                right[uid].token,
+                right[uid].from_draft,
+                right[uid].finish_reason,
+            )
+            assert mx.allclose(left[uid].logprobs, right[uid].logprobs).item()
+    assert set(ordered[-1].active_uids) == set(reordered[-1].active_uids) == {3, 7}
+    _assert_visible_state_equal(
+        _visible_cohort_state(ordered[0]), _visible_cohort_state(reordered[0])
+    )
+
+
+@pytest.mark.parametrize("moe", (False, True))
+def test_actual_qwen_mixed_eos_and_length_rows_skip_later_branch_work(moe, monkeypatch):
+    """Model-derived terminal resolution rows never replay, bonus, or catch up."""
+
+    accepted_config = NativeMTPSamplingConfig(temperature=0.7, seed=17)
+    weights = _shared_qwen_checkpoint(moe=moe)
+    oracle_model = _model(moe=moe)
+    _load_shared_qwen_checkpoint(oracle_model, weights)
+    oracle = _B1PhaseOracle(oracle_model.language_model, (1, 2, 3), accepted_config)
+    oracle.draft()
+    eos_draft = oracle.draft.item()
+
+    model = _model(moe=moe)
+    _load_shared_qwen_checkpoint(model, weights)
+    rows = (
+        NativeMTPRowSpec(
+            7,
+            (1, 2, 3),
+            8,
+            seed=17,
+            eos_token_ids=frozenset({eos_draft}),
+            sampling_config=accepted_config,
+        ),
+        NativeMTPRowSpec(
+            3,
+            (4,),
+            2,
+            seed=29,
+            sampling_config=NativeMTPSamplingConfig(temperature=0.7, seed=29),
+        ),
+        NativeMTPRowSpec(
+            11,
+            (2,),
+            8,
+            seed=43,
+            sampling_config=NativeMTPSamplingConfig(temperature=0.7, seed=43),
+        ),
+    )
+    generator = NativeMTPBatchGenerator(
+        NativeMTPAdmission.create(
+            model.language_model,
+            rows,
+            tuple(model.make_mtp_request_cache() for _ in rows),
+        )
+    )
+    with monkeypatch.context() as local_monkeypatch:
+        _force_acceptance_uniform(local_monkeypatch, (-1.0, 2.0, -1.0))
+        _, initial = generator.prefill(prefill_step_size=1)
+        decision = initial.resume().decide()
+        resolution, continuation = decision.resolve()
+        terminal_rng = {uid: generator._rng_key[uid] for uid in (7, 3)}
+        terminal_history = {uid: generator._history[uid] for uid in (7, 3)}
+        terminal_draft = {uid: generator._draft[uid] for uid in (7, 3)}
+        bonus, after_bonus = continuation.resume_after_resolution()
+        ready = after_bonus.resume_after_bonus()
+
+    by_uid = {emission.uid: emission for emission in resolution}
+    assert by_uid[7].finish_reason == "eos"
+    assert by_uid[3].finish_reason == "length"
+    assert tuple(emission.uid for emission in bonus) == (11,)
+    assert ready.active_uids == (11,)
+    assert generator._cohort.uids == (11,)
+    for uid in (7, 3):
+        assert mx.array_equal(generator._rng_key[uid], terminal_rng[uid]).item()
+        assert mx.array_equal(generator._history[uid], terminal_history[uid]).item()
+        assert mx.array_equal(generator._draft[uid], terminal_draft[uid]).item()
+
+
+class _FailureBoundaryModel(_BatchModel):
+    def __init__(self):
+        super().__init__()
+        self.fail_target = False
+        self.fail_mtp = False
+
+    def __call__(self, inputs, *, cache, return_hidden=False):
+        if self.fail_target:
+            raise RuntimeError("injected_rejected_replay_target_failure")
+        return super().__call__(inputs, cache=cache, return_hidden=return_hidden)
+
+    def mtp_forward(self, hidden, next_tokens, cache):
+        if self.fail_mtp:
+            raise RuntimeError("injected_accepted_catchup_failure")
+        return super().mtp_forward(hidden, next_tokens, cache)
+
+
+def _mixed_failure_fixture(monkeypatch):
+    model = _FailureBoundaryModel()
+    rows = (
+        NativeMTPRowSpec(
+            7,
+            (1, 2),
+            8,
+            seed=17,
+            sampling_config=NativeMTPSamplingConfig(temperature=0.7, seed=17),
+        ),
+        NativeMTPRowSpec(
+            3,
+            (4,),
+            8,
+            seed=29,
+            sampling_config=NativeMTPSamplingConfig(temperature=0.7, seed=29),
+        ),
+    )
+    generator = NativeMTPBatchGenerator(
+        NativeMTPAdmission.create(model, rows, (_request(model), _request(model)))
+    )
+    _force_acceptance_uniform(monkeypatch, (-1.0, 2.0))
+    _, initial = generator.prefill(prefill_step_size=1)
+    _, continuation = initial.resume().decide().resolve()
+    return model, generator, continuation
+
+
+def _assert_mixed_failure_closed(generator, owners, message):
+    assert generator.closed
+    assert len(generator._last_failed_owners) == len({id(owner) for owner in owners})
+    assert all(
+        owner.poisoned and owner._checkpoint is None for owner in owners
+    ), message
+
+
+def test_rejected_replay_target_failure_poison_closes_and_clears_checkpoints(
+    monkeypatch,
+):
+    model, generator, continuation = _mixed_failure_fixture(monkeypatch)
+    owners = (generator._mixed_accepted_owner, generator._mixed_rejected_owner)
+    model.fail_target = True
+    with pytest.raises(RuntimeError, match="injected_rejected_replay_target_failure"):
+        continuation.resume_after_resolution()
+    _assert_mixed_failure_closed(generator, owners, "rejected replay")
+
+
+def test_accepted_bonus_sampling_failure_poison_closes_and_preserves_primary(
+    monkeypatch,
+):
+    model, generator, continuation = _mixed_failure_fixture(monkeypatch)
+    del model
+    owners = (generator._mixed_accepted_owner, generator._mixed_rejected_owner)
+    accepted_state = generator._sampling[7]
+    original_sample = accepted_state.sample
+
+    def fail_bonus_sample(*args, **kwargs):
+        raise RuntimeError("injected_accepted_bonus_sampling_failure")
+
+    monkeypatch.setattr(accepted_state, "sample", fail_bonus_sample)
+    with pytest.raises(RuntimeError, match="injected_accepted_bonus_sampling_failure"):
+        continuation.resume_after_resolution()
+    monkeypatch.setattr(accepted_state, "sample", original_sample)
+    _assert_mixed_failure_closed(generator, owners, "accepted bonus")
+
+
+def test_accepted_mtp_catchup_failure_poison_closes_and_clears_checkpoints(monkeypatch):
+    model, generator, continuation = _mixed_failure_fixture(monkeypatch)
+    owners = (generator._mixed_accepted_owner, generator._mixed_rejected_owner)
+    _, after_bonus = continuation.resume_after_resolution()
+    model.fail_mtp = True
+    with pytest.raises(RuntimeError, match="injected_accepted_catchup_failure"):
+        after_bonus.resume_after_bonus()
+    _assert_mixed_failure_closed(generator, owners, "accepted catchup")
+
+
+def test_ready_owner_join_failure_poison_closes_and_preserves_primary(monkeypatch):
+    _, generator, continuation = _mixed_failure_fixture(monkeypatch)
+    owners = (generator._mixed_accepted_owner, generator._mixed_rejected_owner)
+    _, after_bonus = continuation.resume_after_resolution()
+
+    def fail_join(self, other):
+        raise RuntimeError("injected_ready_owner_join_failure")
+
+    monkeypatch.setattr(type(owners[0]), "join", fail_join)
+    with pytest.raises(RuntimeError, match="injected_ready_owner_join_failure"):
+        after_bonus.resume_after_bonus()
+    _assert_mixed_failure_closed(generator, owners, "ready join")

--- a/tests/test_native_mtp_batch_lifecycle.py
+++ b/tests/test_native_mtp_batch_lifecycle.py
@@ -1,6 +1,7 @@
 # Copyright © 2026 Apple Inc.
 """Typed public lifecycle coverage for native-MTP cohort admission."""
 
+from contextlib import contextmanager
 from dataclasses import dataclass
 from collections import deque
 
@@ -10,18 +11,24 @@ import pytest
 from test_qwen3_5_mtp_model import _checkpoint, _model, _sanitize_and_load
 
 from mlx_lm.generate import (
+    GenerationForward,
+    GenerationForwardPositionAck,
+    GenerationForwardPhase,
     NativeMTPAdmission,
     NativeMTPBatchGenerator,
     NativeMTPEmission,
     NativeMTPRejectedEpoch,
     NativeMTPRowSpec,
     NativeMTPSamplingConfig,
+    NativeMTPSparseBootstrap,
+    attested_target_forward,
     mtp_generate_step,
 )
 from mlx_lm.generate import (
     _NativeMTPCohortCache,
     _NativeMTPCohortMutationDelta,
     _NativeMTPSamplingState,
+    _native_mtp_position_context,
 )
 from mlx_lm.models.cache import ArraysCache, KVCache, NativeMTPRequestCache
 
@@ -106,6 +113,94 @@ class _MixedRerunFailureModel(_BatchModel):
         if self.fail_rerun:
             raise RuntimeError("injected_mixed_rerun_failure")
         return super().__call__(inputs, cache=cache, return_hidden=return_hidden)
+
+
+class _SparseBatchModel(_BatchModel):
+    """Tiny B>1 target/MTP double with an acknowledged Qwen position seam."""
+
+    def __init__(self):
+        # Exercise the same topology checks as real Qwen rather than relying
+        # on inherited class attributes that happen to look cache-compatible.
+        self.layers = [type("_Attention", (), {"is_linear": False})()]
+        self.mtp = type("_MTP", (), {"layers": [object()]})()
+        self.forwards = []
+        self.target_calls = 0
+        self.mtp_calls = 0
+        self._forward = None
+
+    @contextmanager
+    def generation_forward_context(self, forward):
+        self.forwards.append(forward)
+        previous, self._forward = self._forward, forward
+        try:
+            yield
+        finally:
+            self._forward = previous
+
+    def _ack(self):
+        if self._forward is not None and self._forward.logical_position_ack is not None:
+            self._forward.logical_position_ack.acknowledge(
+                self._forward.logical_positions
+            )
+
+    def __call__(self, inputs, *, cache, return_hidden=False):
+        self.target_calls += 1
+        self._ack()
+        return super().__call__(inputs, cache=cache, return_hidden=return_hidden)
+
+    def mtp_forward(self, hidden, next_tokens, cache):
+        self.mtp_calls += 1
+        self._ack()
+        return super().mtp_forward(hidden, next_tokens, cache)
+
+
+class _SparseMoEBatchModel(_SparseBatchModel):
+    """Token-routed tiny MoE oracle; cache behavior remains identical."""
+
+    architecture = "qwen3_5_moe"
+    num_experts = 2
+
+    def _logits(self, inputs, delta=1):
+        expert = inputs.astype(mx.int32) % self.num_experts
+        zero = inputs.astype(mx.int32) + delta
+        one = inputs.astype(mx.int32) - (self.vocab_size - delta)
+        ids = mx.where(expert == 0, zero, one) % self.vocab_size
+        logits = mx.full((*inputs.shape, self.vocab_size), -20.0)
+        for row in range(inputs.shape[0]):
+            for column in range(inputs.shape[1]):
+                logits[row, column, ids[row, column]] = 20.0
+        return logits
+
+
+def _sparse_bootstrap(model, tokens, positions, *, chunks=(1, 1)):
+    cache = model.make_cache()
+    successors = tuple((token + 1) % model.vocab_size for token in tokens[:-1])
+    receipts = []
+    start = 0
+    for size in chunks:
+        end = start + size
+        (_, _), receipt = attested_target_forward(
+            model,
+            tuple(tokens[start:end]),
+            cache,
+            phase=GenerationForwardPhase.PREFILL,
+            logical_positions=tuple(positions[start:end]),
+            immediate_successor_token_ids=tuple(
+                successors[start : min(end, len(successors))]
+            ),
+            model_forward_context=model.generation_forward_context,
+        )
+        receipts.append(receipt)
+        start = end
+    assert start == len(tokens)
+    return NativeMTPSparseBootstrap(
+        receipts=tuple(receipts),
+        selected_logical_positions=tuple(positions),
+        selected_token_ids=tuple(tokens),
+        immediate_successor_token_ids=successors,
+        target_cache=cache,
+        next_logical_position=positions[-1] + 1,
+    )
 
 
 def _admission(*, max_tokens=8):
@@ -619,6 +714,77 @@ def _tiny_qwen_b1_emissions(
     return emissions, requests[0]
 
 
+def _actual_sparse_bootstrap(target, token_ids, logical_positions, *, chunk_sizes):
+    """Produce real Qwen sparse evidence without reconstructing hidden rows."""
+
+    target_cache = target.make_cache()
+    successors = tuple(token_ids[1:])
+    receipts = []
+    start = 0
+    for size in chunk_sizes:
+        end = start + size
+        (_, _), receipt = attested_target_forward(
+            target,
+            tuple(token_ids[start:end]),
+            target_cache,
+            phase=GenerationForwardPhase.PREFILL,
+            logical_positions=tuple(logical_positions[start:end]),
+            immediate_successor_token_ids=tuple(
+                successors[start : min(end, len(successors))]
+            ),
+            model_forward_context=target.generation_forward_context,
+        )
+        receipts.append(receipt)
+        start = end
+    assert start == len(token_ids)
+    return NativeMTPSparseBootstrap(
+        receipts=tuple(receipts),
+        selected_logical_positions=tuple(logical_positions),
+        selected_token_ids=tuple(token_ids),
+        immediate_successor_token_ids=successors,
+        target_cache=target_cache,
+        next_logical_position=logical_positions[-1] + 1,
+    )
+
+
+def _tiny_qwen_b1_sparse_emissions(
+    monkeypatch, *, moe, weights, tokens, positions, sampling, uniform, count
+):
+    """Pause a real sparse B1 stream at the same lifecycle boundary as batch."""
+
+    model = _model(moe=moe)
+    _load_shared_qwen_checkpoint(model, weights)
+    bootstrap = _actual_sparse_bootstrap(
+        model, tokens, positions, chunk_sizes=(1,) * len(tokens)
+    )
+    requests = []
+    original_adopt = NativeMTPRequestCache.adopt_sparse_target.__func__
+
+    def capture_adopt(cls, *args, **kwargs):
+        request = original_adopt(cls, *args, **kwargs)
+        requests.append(request)
+        return request
+
+    with monkeypatch.context() as local_monkeypatch:
+        local_monkeypatch.setattr(
+            NativeMTPRequestCache, "adopt_sparse_target", classmethod(capture_adopt)
+        )
+        _force_acceptance_uniform(local_monkeypatch, uniform)
+        stream = mtp_generate_step(
+            None,
+            model,
+            max_tokens=8,
+            prefill_step_size=1,
+            sampling_config=sampling,
+            sparse_bootstrap=bootstrap,
+        )
+        try:
+            emissions = tuple(next(stream) for _ in range(count))
+        finally:
+            stream.close()
+    return emissions, requests[0]
+
+
 def _assert_cohort_recurrent_row_matches_b1(owner, uid, request):
     row = owner.uids.index(uid)
     for cohort_entry, b1_entry in zip(owner.backbone, request.backbone):
@@ -652,6 +818,251 @@ def _assert_cohort_offsets_match_b1(owner, uid, request):
         if isinstance(cohort_entry, ArraysCache):
             continue
         assert cohort_entry.offset[row].item() == b1_entry.offset
+
+
+def _assert_cohort_cache_payload_row_matches_b1(owner, uid, request):
+    """Compare the live KV and recurrent payloads, not merely their offsets."""
+
+    row = owner.uids.index(uid)
+    for cohort_entry, b1_entry in zip(
+        owner.backbone + owner.mtp, request.backbone + request.mtp
+    ):
+        if isinstance(cohort_entry, ArraysCache):
+            continue
+        for name in ("keys", "values"):
+            cohort_value = getattr(cohort_entry, name)
+            b1_value = getattr(b1_entry, name)
+            if b1_value is None:
+                assert cohort_value is None
+            else:
+                offset = b1_entry.offset
+                padding = cohort_entry.left_padding[row].item()
+                assert mx.allclose(
+                    cohort_value[row : row + 1, ..., padding : padding + offset, :],
+                    b1_value[..., :offset, :],
+                    rtol=1e-4,
+                    atol=1e-5,
+                ).item()
+
+
+class _B1SparsePhaseOracle:
+    """Manual sparse B1 transaction stopped exactly at the Ready boundary."""
+
+    def __init__(self, model, tokens, positions, sampling, *, accepted):
+        bootstrap = _actual_sparse_bootstrap(
+            model, tokens, positions, chunk_sizes=(1,) * len(tokens)
+        )
+        claim = bootstrap.claim(model)
+        self.request = NativeMTPRequestCache.adopt_sparse_target(
+            model,
+            target_cache=claim.target_cache,
+            target_tokens=len(claim.selected_token_ids),
+            next_logical_position=claim.next_logical_position,
+        )
+        self.context = _native_mtp_position_context(model, None)
+        NativeMTPAdmission._initialize_sparse_mtp_request(
+            model, self.request, claim, self.context
+        )
+        self.model = model
+        self.sampling = _NativeMTPSamplingState(sampling, seed=sampling.seed)
+        self.history = mx.array([tokens[-1]], dtype=mx.uint32)
+        self.cursor = claim.next_logical_position
+        self._initial(claim)
+        self._draft_initial(positions[-1])
+        self._verify(expected_accepted=accepted)
+        if self.accepted:
+            self.emissions = self._accept_bonus_catchup()
+        else:
+            self.emissions = (self._reject_replay_redraft(),)
+
+    def _target(self, tokens, positions, phase):
+        inputs = mx.array(tokens, dtype=mx.uint32)[None]
+        ack = GenerationForwardPositionAck(
+            tuple(positions), model=self.model, cache=self.request.backbone, phase=phase
+        )
+        forward = GenerationForward(
+            model=self.model,
+            input_tokens=inputs,
+            cache=self.request.backbone,
+            phase=phase,
+            logical_positions=tuple(positions),
+            logical_position_ack=ack,
+        )
+        with self.context(forward):
+            ack._activate()
+            try:
+                result = self.model(
+                    inputs, cache=self.request.backbone, return_hidden=True
+                )
+                ack._require_acknowledged()
+                return result
+            finally:
+                ack._finish()
+
+    def _mtp(self, hidden, tokens, positions):
+        inputs = mx.array(tokens, dtype=mx.uint32)[None]
+        ack = GenerationForwardPositionAck(
+            tuple(positions),
+            model=self.model,
+            cache=self.request.mtp,
+            phase=GenerationForwardPhase.MTP_DRAFT,
+        )
+        forward = GenerationForward(
+            model=self.model,
+            input_tokens=inputs,
+            cache=self.request.mtp,
+            phase=GenerationForwardPhase.MTP_DRAFT,
+            logical_positions=tuple(positions),
+            logical_position_ack=ack,
+        )
+        with self.context(forward):
+            ack._activate()
+            try:
+                result = self.model.mtp_forward(hidden, inputs, self.request.mtp)
+                ack._require_acknowledged()
+                return result
+            finally:
+                ack._finish()
+
+    def _sample(self, reported):
+        return self.sampling.sample(
+            self.sampling.sampling_distribution(reported),
+            rng_key=(
+                self.sampling.next_rng_key()
+                if self.sampling.config.stochastic
+                else None
+            ),
+        ).reshape(-1)
+
+    def _initial(self, claim):
+        reported = self.sampling.reported_logprobs(
+            claim.final_target_logits[0, -1, :], self.history
+        )
+        self.head = self._sample(reported)
+        self.hidden = claim.final_target_hidden
+        mx.eval(self.head, reported)
+        self.history = mx.concatenate([self.history, self.head])
+        self.cursor += 1
+        self.initial = (self.head.item(), reported, False)
+
+    def _draft_initial(self, initial_mtp_position):
+        logits = self._mtp(self.hidden, self.head, (initial_mtp_position,))[:, -1, :]
+        self.request.retain(
+            backbone_tokens=self.request.state.backbone_tokens,
+            mtp_tokens=self.request.state.mtp_tokens + 1,
+        )
+        self.draft_logprobs = self.sampling.sampling_distribution(
+            self.sampling.reported_logprobs(logits.squeeze(0), self.history)
+        )
+        self.draft = self.sampling.sample(
+            self.draft_logprobs,
+            rng_key=(
+                self.sampling.next_rng_key()
+                if self.sampling.config.stochastic
+                else None
+            ),
+        ).reshape(-1)
+        mx.eval(self.draft)
+
+    def _verify(self, *, expected_accepted):
+        self.request.checkpoint()
+        positions = (self.cursor - 1, self.cursor)
+        logits, hidden = self._target(
+            mx.concatenate([self.head, self.draft]),
+            positions,
+            GenerationForwardPhase.VERIFY,
+        )
+        self.request.seal_verified(
+            backbone_tokens=self.request.state.backbone_tokens + 2,
+            mtp_tokens=self.request.state.mtp_tokens,
+        )
+        self.verify_positions = positions
+        self.verify_logits, self.verify_hidden = logits, hidden
+        self.verify_reported = self.sampling.reported_logprobs(
+            logits[:, 0, :].squeeze(0), self.history
+        )
+        sampled = self.sampling.sampling_distribution(self.verify_reported)
+        probability = mx.minimum(
+            mx.exp(sampled[self.draft.item()] - self.draft_logprobs[self.draft.item()]),
+            1.0,
+        )
+        accepted = mx.random.uniform(key=self.sampling.next_rng_key()) < probability
+        mx.eval(accepted)
+        self.accepted = bool(accepted.item())
+        assert self.accepted is expected_accepted
+
+    def _accept_bonus_catchup(self):
+        self.request.commit(
+            backbone_tokens=self.request.state.backbone_tokens + 2,
+            mtp_tokens=self.request.state.mtp_tokens,
+        )
+        accepted = (self.draft.item(), self.verify_reported, True)
+        self.cursor += 1
+        history = mx.concatenate([self.history, self.draft])
+        bonus_reported = self.sampling.reported_logprobs(
+            self.verify_logits[:, 1, :].squeeze(0), history
+        )
+        self.head = self._sample(bonus_reported)
+        mx.eval(self.head, bonus_reported)
+        self.history = mx.concatenate([history, self.head])
+        self.cursor += 1
+        logits = self._mtp(
+            self.verify_hidden,
+            mx.concatenate([self.draft, self.head]),
+            self.verify_positions,
+        )[:, -1, :]
+        self.request.retain(
+            backbone_tokens=self.request.state.backbone_tokens,
+            mtp_tokens=self.request.state.mtp_tokens + 2,
+        )
+        reported = self.sampling.reported_logprobs(logits.squeeze(0), self.history)
+        self.draft_logprobs = self.sampling.sampling_distribution(reported)
+        self.draft = self.sampling.sample(
+            self.draft_logprobs,
+            rng_key=(
+                self.sampling.next_rng_key()
+                if self.sampling.config.stochastic
+                else None
+            ),
+        ).reshape(-1)
+        mx.eval(self.draft)
+        return accepted, (self.head.item(), bonus_reported, False)
+
+    def _reject_replay_redraft(self):
+        self.request.reject_partial(accepted_backbone_tokens=1, accepted_mtp_tokens=0)
+        replay_position = self.cursor - 1
+        _, hidden = self._target(
+            self.head, (replay_position,), GenerationForwardPhase.DECODE
+        )
+        self.request.replay_retained(
+            backbone_tokens=self.request.state.backbone_tokens + 1,
+            mtp_tokens=self.request.state.mtp_tokens,
+        )
+        sampled = self.sampling.sampling_distribution(self.verify_reported)
+        self.head, _ = self.sampling.residual_sample(
+            sampled, self.draft_logprobs, rng_key=self.sampling.next_rng_key()
+        )
+        self.head = self.head.reshape(-1)
+        mx.eval(self.head)
+        self.history = mx.concatenate([self.history, self.head])
+        self.cursor += 1
+        logits = self._mtp(hidden[:, -1:, :], self.head, (replay_position,))[:, -1, :]
+        self.request.retain(
+            backbone_tokens=self.request.state.backbone_tokens,
+            mtp_tokens=self.request.state.mtp_tokens + 1,
+        )
+        reported = self.sampling.reported_logprobs(logits.squeeze(0), self.history)
+        self.draft_logprobs = self.sampling.sampling_distribution(reported)
+        self.draft = self.sampling.sample(
+            self.draft_logprobs,
+            rng_key=(
+                self.sampling.next_rng_key()
+                if self.sampling.config.stochastic
+                else None
+            ),
+        ).reshape(-1)
+        mx.eval(self.draft)
+        return self.head.item(), self.verify_reported, False
 
 
 class _B1PhaseOracle:
@@ -951,6 +1362,192 @@ def test_actual_qwen_mixed_ready_matches_independent_b1_phase_oracle(moe, monkey
     assert generator._draft[3].item() == rejected.draft.item()
     assert mx.array_equal(generator._rng_key[7], accepted.sampling._rng_key).item()
     assert mx.array_equal(generator._rng_key[3], rejected.sampling._rng_key).item()
+
+
+@pytest.mark.parametrize("moe", (False, True))
+def test_actual_qwen_sparse_mixed_lifecycle_matches_independent_b1_oracles(
+    moe, monkeypatch
+):
+    """Sparse B>=2 Ready is identical to the manual B1 sparse transaction."""
+
+    accepted_sampling = NativeMTPSamplingConfig(temperature=0.7, seed=17)
+    rejected_sampling = NativeMTPSamplingConfig(temperature=0.7, seed=29)
+    weights = _shared_qwen_checkpoint(moe=moe)
+    accepted_tokens, accepted_positions = (1, 2, 3), (2, 7, 12)
+    rejected_tokens, rejected_positions = (4, 5), (3, 11)
+    accepted_model = _model(moe=moe)
+    _load_shared_qwen_checkpoint(accepted_model, weights)
+    with monkeypatch.context() as local_monkeypatch:
+        _force_acceptance_uniform(local_monkeypatch, (-1.0,))
+        accepted_b1 = _B1SparsePhaseOracle(
+            accepted_model,
+            accepted_tokens,
+            accepted_positions,
+            accepted_sampling,
+            accepted=True,
+        )
+    rejected_model = _model(moe=moe)
+    _load_shared_qwen_checkpoint(rejected_model, weights)
+    with monkeypatch.context() as local_monkeypatch:
+        _force_acceptance_uniform(local_monkeypatch, (2.0,))
+        rejected_b1 = _B1SparsePhaseOracle(
+            rejected_model,
+            rejected_tokens,
+            rejected_positions,
+            rejected_sampling,
+            accepted=False,
+        )
+
+    model = _model(moe=moe)
+    _load_shared_qwen_checkpoint(model, weights)
+    rows = (
+        NativeMTPRowSpec(
+            7, accepted_tokens, 8, seed=17, sampling_config=accepted_sampling
+        ),
+        NativeMTPRowSpec(
+            3, rejected_tokens, 8, seed=29, sampling_config=rejected_sampling
+        ),
+    )
+    admission = NativeMTPAdmission.create_from_sparse_bootstraps(
+        model,
+        rows,
+        (
+            _actual_sparse_bootstrap(
+                model, accepted_tokens, accepted_positions, chunk_sizes=(1, 2)
+            ),
+            _actual_sparse_bootstrap(
+                model, rejected_tokens, rejected_positions, chunk_sizes=(1, 1)
+            ),
+        ),
+    )
+    generator = NativeMTPBatchGenerator(admission)
+    with monkeypatch.context() as local_monkeypatch:
+        _force_acceptance_uniform(local_monkeypatch, (-1.0, 2.0))
+        initial, initial_epoch = generator.start_sparse()
+        decision = initial_epoch.resume().decide()
+        resolution, continuation = decision.resolve()
+        bonus, bonus_continuation = continuation.resume_after_resolution()
+        ready = bonus_continuation.resume_after_bonus()
+
+    assert decision.accepted_uids == (7,)
+    assert decision.rejected_uids == (3,)
+    for actual, expected in zip(initial, (accepted_b1.initial, rejected_b1.initial)):
+        assert actual.token == expected[0]
+        assert mx.allclose(actual.logprobs, expected[1]).item()
+    resolved = {item.uid: item for item in resolution}
+    assert resolved[7].token == accepted_b1.emissions[0][0]
+    assert resolved[3].token == rejected_b1.emissions[0][0]
+    assert mx.allclose(resolved[7].logprobs, accepted_b1.emissions[0][1]).item()
+    assert mx.allclose(resolved[3].logprobs, rejected_b1.emissions[0][1]).item()
+    assert bonus[0].token == accepted_b1.emissions[1][0]
+    assert mx.allclose(bonus[0].logprobs, accepted_b1.emissions[1][1]).item()
+    assert generator._history[7].tolist() == accepted_b1.history.tolist()
+    assert generator._history[3].tolist() == rejected_b1.history.tolist()
+    assert generator._verify_position_by_uid == {7: (13, 14), 3: (12, 13)}
+    assert generator._logical_cursor == {7: 16, 3: 14}
+    assert generator._logical_cursor == {7: accepted_b1.cursor, 3: rejected_b1.cursor}
+    for uid, oracle in ((7, accepted_b1), (3, rejected_b1)):
+        assert mx.array_equal(generator._rng_key[uid], oracle.sampling._rng_key).item()
+        assert generator._head[uid].item() == oracle.head.item()
+        assert generator._draft[uid].item() == oracle.draft.item()
+        _assert_cohort_offsets_match_b1(ready._generator._cohort, uid, oracle.request)
+        _assert_cohort_recurrent_row_matches_b1(
+            ready._generator._cohort, uid, oracle.request
+        )
+        _assert_cohort_cache_payload_row_matches_b1(
+            ready._generator._cohort, uid, oracle.request
+        )
+    ready.cancel()
+    assert generator.closed
+
+
+@pytest.mark.parametrize("moe", (False, True))
+def test_actual_qwen_sparse_terminal_rows_are_filtered_before_ready_join(
+    moe, monkeypatch
+):
+    """A sparse mixed epoch retains only the non-terminal survivor's owner."""
+
+    weights = _shared_qwen_checkpoint(moe=moe)
+    model = _model(moe=moe)
+    _load_shared_qwen_checkpoint(model, weights)
+    configs = {
+        7: NativeMTPSamplingConfig(temperature=0.7, seed=17),
+        3: NativeMTPSamplingConfig(temperature=0.7, seed=29),
+        11: NativeMTPSamplingConfig(temperature=0.7, seed=43),
+    }
+    values = {
+        7: ((1, 2), (2, 8)),
+        3: ((4, 5), (3, 10)),
+        11: ((6, 7), (4, 12)),
+    }
+    rows = tuple(
+        NativeMTPRowSpec(
+            uid,
+            values[uid][0],
+            2 if uid in (7, 3) else 8,
+            seed=configs[uid].seed,
+            sampling_config=configs[uid],
+        )
+        for uid in (7, 3, 11)
+    )
+    admission = NativeMTPAdmission.create_from_sparse_bootstraps(
+        model,
+        rows,
+        tuple(
+            _actual_sparse_bootstrap(
+                model, values[uid][0], values[uid][1], chunk_sizes=(1, 1)
+            )
+            for uid in (7, 3, 11)
+        ),
+    )
+    generator = NativeMTPBatchGenerator(admission)
+    with monkeypatch.context() as local_monkeypatch:
+        _force_acceptance_uniform(local_monkeypatch, (-1.0, 2.0, -1.0))
+        _, initial = generator.start_sparse()
+        resolution, continuation = initial.resume().decide().resolve()
+        bonus, after_bonus = continuation.resume_after_resolution()
+        ready = after_bonus.resume_after_bonus()
+    by_uid = {item.uid: item for item in resolution}
+    assert by_uid[7].finish_reason == "length"
+    assert by_uid[3].finish_reason == "length"
+    assert tuple(item.uid for item in bonus) == (11,)
+    assert ready.active_uids == (11,)
+    assert ready._generator._cohort.uids == (11,)
+
+
+@pytest.mark.parametrize("moe", (False, True))
+def test_actual_qwen_sparse_partial_admission_failure_consumes_every_bootstrap(
+    moe, monkeypatch
+):
+    """A later B1 MTP-init failure cannot leave a claim or owner reusable."""
+
+    weights = _shared_qwen_checkpoint(moe=moe)
+    model = _model(moe=moe)
+    _load_shared_qwen_checkpoint(model, weights)
+    first = _actual_sparse_bootstrap(model, (1, 2), (2, 8), chunk_sizes=(1, 1))
+    second = _actual_sparse_bootstrap(model, (4, 5), (3, 10), chunk_sizes=(1, 1))
+    original_mtp = model.mtp_forward
+    calls = 0
+
+    def fail_second_mtp(*args, **kwargs):
+        nonlocal calls
+        calls += 1
+        if calls == 2:
+            raise RuntimeError("injected_sparse_second_mtp_init_failure")
+        return original_mtp(*args, **kwargs)
+
+    rows = (NativeMTPRowSpec(7, (1, 2), 8), NativeMTPRowSpec(3, (4, 5), 8))
+    with monkeypatch.context() as local_monkeypatch:
+        local_monkeypatch.setattr(model, "mtp_forward", fail_second_mtp)
+        with pytest.raises(
+            RuntimeError, match="injected_sparse_second_mtp_init_failure"
+        ):
+            NativeMTPAdmission.create_from_sparse_bootstraps(
+                model, rows, (first, second)
+            )
+    for bootstrap in (first, second):
+        with pytest.raises(RuntimeError, match="already_claimed"):
+            bootstrap.claim(model)
 
 
 @pytest.mark.parametrize("after_bonus", (False, True))
@@ -1304,3 +1901,124 @@ def test_ready_owner_join_failure_poison_closes_and_preserves_primary(monkeypatc
     with pytest.raises(RuntimeError, match="injected_ready_owner_join_failure"):
         after_bonus.resume_after_bonus()
     _assert_mixed_failure_closed(generator, owners, "ready join")
+
+
+@pytest.mark.parametrize("model_type", (_SparseBatchModel, _SparseMoEBatchModel))
+def test_sparse_admission_claims_b1_receipts_then_starts_batched_without_target_replay(
+    model_type,
+):
+    model = model_type()
+    bootstraps = (
+        _sparse_bootstrap(model, (1, 2), (5, 8)),
+        _sparse_bootstrap(model, (4, 5), (11, 14)),
+    )
+    target_calls_before = model.target_calls
+    rows = (
+        NativeMTPRowSpec(7, (1, 2), 8, seed=17),
+        NativeMTPRowSpec(3, (4, 5), 8, seed=29),
+    )
+
+    admission = NativeMTPAdmission.create_from_sparse_bootstraps(
+        model, rows, bootstraps
+    )
+    generator = NativeMTPBatchGenerator(admission)
+    emissions, initial = generator.start_sparse()
+
+    assert [item.uid for item in emissions] == [7, 3]
+    assert initial.phase == "initial"
+    # Sparse admission performs MTP initialization only; sampling initial
+    # heads must retain the receipts' compact final target logits.
+    assert model.target_calls == target_calls_before
+    assert model.mtp_calls == 2
+    # ``start_sparse`` emits the initial head, so each cursor has already
+    # advanced once beyond its bootstrap's attested next logical position.
+    assert generator._logical_cursor == {7: 10, 3: 16}
+    assert admission.cohort.uids == (7, 3)
+
+
+def test_sparse_ready_uses_explicit_per_row_target_position_matrix():
+    model = _SparseBatchModel()
+    rows = (
+        NativeMTPRowSpec(7, (1, 2), 8),
+        NativeMTPRowSpec(3, (4, 5), 8),
+    )
+    generator = NativeMTPBatchGenerator(
+        NativeMTPAdmission.create_from_sparse_bootstraps(
+            model,
+            rows,
+            (
+                _sparse_bootstrap(model, (1, 2), (2, 9)),
+                _sparse_bootstrap(model, (4, 5), (11, 14)),
+            ),
+        )
+    )
+    _, initial = generator.start_sparse()
+    decision = initial.resume().decide()
+
+    assert decision.active_uids == (7, 3)
+    verify = [
+        forward
+        for forward in model.forwards
+        if forward.phase is GenerationForwardPhase.VERIFY
+    ]
+    assert verify[-1].logical_positions == ((10, 11), (15, 16))
+
+
+def test_sparse_admission_uses_original_noncontiguous_successors_and_exact_cursor():
+    model = _SparseBatchModel()
+    cache = model.make_cache()
+    # The successor is intentionally not derived from the sparse token IDs.
+    (_, _), first = attested_target_forward(
+        model,
+        (1,),
+        cache,
+        phase=GenerationForwardPhase.PREFILL,
+        logical_positions=(2,),
+        immediate_successor_token_ids=(6,),
+        model_forward_context=model.generation_forward_context,
+    )
+    (_, _), final = attested_target_forward(
+        model,
+        (6,),
+        cache,
+        phase=GenerationForwardPhase.PREFILL,
+        logical_positions=(9,),
+        immediate_successor_token_ids=(),
+        model_forward_context=model.generation_forward_context,
+    )
+    bootstrap = NativeMTPSparseBootstrap(
+        receipts=(first, final),
+        selected_logical_positions=(2, 9),
+        selected_token_ids=(1, 6),
+        immediate_successor_token_ids=(6,),
+        target_cache=cache,
+        next_logical_position=10,
+    )
+    admission = NativeMTPAdmission.create_from_sparse_bootstraps(
+        model, (NativeMTPRowSpec(9, (1, 6), 8),), (bootstrap,)
+    )
+    generator = NativeMTPBatchGenerator(admission)
+    _, initial = generator.start_sparse()
+    ready = initial.resume()
+
+    mtp_forwards = [
+        forward
+        for forward in model.forwards
+        if forward.phase is GenerationForwardPhase.MTP_DRAFT
+    ]
+    assert mtp_forwards[0].logical_positions == (2,)
+    assert mtp_forwards[-1].logical_positions == (9,)
+    assert generator._logical_cursor == {9: 11}
+    assert ready.active_uids == (9,)
+
+
+def test_sparse_admission_prevalidation_preserves_unclaimed_receipts():
+    model = _SparseBatchModel()
+    first = _sparse_bootstrap(model, (1, 2), (0, 3))
+    second = _sparse_bootstrap(model, (3, 4), (1, 4))
+    # Row metadata is rejected before any bootstrap is claimed or adopted.
+    rows = (NativeMTPRowSpec(1, (1, 2), 8), NativeMTPRowSpec(2, (0,), 8))
+    with pytest.raises(ValueError, match="row_prompt_mismatch"):
+        NativeMTPAdmission.create_from_sparse_bootstraps(model, rows, (first, second))
+    assert first.claim(model).selected_token_ids == (1, 2)
+    assert second.claim(model).selected_token_ids == (3, 4)

--- a/tests/test_native_mtp_batch_lifecycle.py
+++ b/tests/test_native_mtp_batch_lifecycle.py
@@ -288,7 +288,7 @@ def test_public_decision_methods_reject_positional_and_keyword_forgery():
         decision.reject((3,))
     with pytest.raises(TypeError):
         decision.reject(emissions=())
-    accepted = decision.accept()
+    _, accepted = decision.accept()
     with pytest.raises(TypeError):
         accepted.bonus(())
     with pytest.raises(TypeError):
@@ -402,10 +402,80 @@ def test_actual_merged_chunked_prefill_and_all_accepted_round():
     ready = initial.resume()
     decision = ready.decide()
     assert decision.accepted_uids == (7, 3)
-    accepted = decision.accept()
+    _, accepted = decision.accept()
     bonus = accepted.bonus()
     ready = bonus.catch_up()
     assert ready.phase == "ready"
+
+
+def test_public_b1_all_accept_returns_one_resolution_emission_and_epoch():
+    model = _BatchModel()
+    row = NativeMTPRowSpec(7, (1, 2), 8)
+    generator = NativeMTPBatchGenerator(
+        NativeMTPAdmission.create(model, (row,), (_request(model),))
+    )
+
+    initial_emissions, initial = generator.prefill(prefill_step_size=1)
+    decision = initial.resume().decide()
+    emissions, accepted = decision.accept()
+
+    assert len(initial_emissions) == 1
+    assert decision.accepted_uids == (7,)
+    assert decision.rejected_uids == ()
+    assert len(emissions) == 1
+    assert emissions[0].uid == 7
+    assert emissions[0].token == generator._draft[7].item()
+    assert emissions[0].from_draft is True
+    assert emissions[0].finish_reason is None
+    assert accepted.phase == "accepted"
+    assert accepted.active_uids == (7,)
+
+
+def test_public_b1_all_reject_returns_one_resolution_emission_and_epoch(monkeypatch):
+    sampling = NativeMTPSamplingConfig(temperature=0.7, seed=17)
+    model = _BatchModel()
+    row = NativeMTPRowSpec(7, (1, 2), 8, seed=17, sampling_config=sampling)
+    generator = NativeMTPBatchGenerator(
+        NativeMTPAdmission.create(model, (row,), (_request(model),))
+    )
+
+    with monkeypatch.context() as local_monkeypatch:
+        _force_acceptance_uniform(local_monkeypatch, (2.0,))
+        _, initial = generator.prefill(prefill_step_size=1)
+        decision = initial.resume().decide()
+        emissions, rejected = decision.reject()
+
+    assert decision.accepted_uids == ()
+    assert decision.rejected_uids == (7,)
+    assert len(emissions) == 1
+    assert emissions[0].uid == 7
+    assert emissions[0].token == generator._replacement[7].item()
+    assert emissions[0].from_draft is False
+    assert emissions[0].finish_reason is None
+    assert rejected.phase == "rejected"
+    assert rejected.active_uids == (7,)
+
+
+@pytest.mark.parametrize("accepted", (True, False))
+def test_public_b1_terminal_resolution_emission_is_returned(accepted, monkeypatch):
+    sampling = NativeMTPSamplingConfig(temperature=0.7, seed=17)
+    model = _BatchModel()
+    row = NativeMTPRowSpec(7, (1, 2), 2, seed=17, sampling_config=sampling)
+    generator = NativeMTPBatchGenerator(
+        NativeMTPAdmission.create(model, (row,), (_request(model),))
+    )
+
+    with monkeypatch.context() as local_monkeypatch:
+        _force_acceptance_uniform(local_monkeypatch, ((-1.0,) if accepted else (2.0,)))
+        _, initial = generator.prefill(prefill_step_size=1)
+        decision = initial.resume().decide()
+        emissions, epoch = decision.accept() if accepted else decision.reject()
+
+    assert len(emissions) == 1
+    assert emissions[0].uid == 7
+    assert emissions[0].from_draft is accepted
+    assert emissions[0].finish_reason == "length"
+    assert epoch.active_uids == ()
 
 
 def test_bonus_uses_verified_target_logits_not_hidden_width():
@@ -419,7 +489,8 @@ def test_bonus_uses_verified_target_logits_not_hidden_width():
     )
     _, initial = generator.prefill(prefill_step_size=2)
     decision = initial.resume().decide()
-    bonus = decision.accept().bonus()
+    _, accepted = decision.accept()
+    bonus = accepted.bonus()
     # The tiny model's hidden width is 2 while its vocabulary is 7.  These
     # values can only be correct when bonus sampling reads verify logits[:, 1].
     assert bonus.active_uids == (7, 3)
@@ -462,7 +533,8 @@ def test_uid_rng_uses_post_initial_b1_sequential_draw_chain():
     )
     _, initial = generator.prefill(prefill_step_size=2)
     decision = initial.resume().decide()
-    decision.accept().bonus()
+    _, accepted = decision.accept()
+    accepted.bonus()
 
     # B=1 draws initial, draft, acceptance, then accepted bonus.  The retained
     # key remains UID-owned, so cohort reordering cannot affect this chain.

--- a/tests/test_native_mtp_cache.py
+++ b/tests/test_native_mtp_cache.py
@@ -1,0 +1,305 @@
+# Copyright © 2026 Apple Inc.
+"""Synthetic transaction coverage for request-local native Qwen MTP caches."""
+
+from dataclasses import dataclass
+
+import mlx.core as mx
+import pytest
+
+import mlx_lm.models.cache as cache_module
+from mlx_lm.models.cache import (
+    ArraysCache,
+    KVCache,
+    NativeMTPRequestCache,
+    QuantizedKVCache,
+)
+
+
+@dataclass(frozen=True)
+class _Capability:
+    supported: bool = True
+    reason: str = "supported"
+
+
+class _Model:
+    mtp_capability = _Capability()
+
+    def __init__(self, backbone=None, mtp=None):
+        self._backbone = backbone
+        self._mtp = mtp
+        self.layers = [
+            type("_Layer", (), {"is_linear": isinstance(entry, ArraysCache)})()
+            for entry in backbone
+        ]
+        self.mtp = type("_MTP", (), {"layers": [object() for _ in mtp]})()
+
+    def make_cache(self):
+        return self._backbone
+
+    def make_mtp_cache(self):
+        return self._mtp
+
+
+def _tokens(count, dim=32):
+    values = mx.arange(count * dim, dtype=mx.float32).reshape(1, 1, count, dim)
+    return values, values + 100
+
+
+def _advance(cache, count, dim=32):
+    keys, values = _tokens(count, dim)
+    cache.update_and_fetch(keys, values)
+
+
+def _cache_pair():
+    recurrent = ArraysCache(2)
+    recurrent[0] = mx.array([[1.0, 2.0]])
+    recurrent[1] = mx.array([[3.0, 4.0]])
+    backbone_attention = KVCache()
+    mtp_attention = KVCache()
+    return [recurrent, backbone_attention], [mtp_attention]
+
+
+def test_commit_asserts_every_attention_cache_matches_its_logical_position():
+    backbone, mtp = _cache_pair()
+    request = NativeMTPRequestCache(_Model(backbone, mtp), backbone, mtp)
+
+    _advance(backbone[1], 2)
+    _advance(mtp[0], 1)
+    request.retain(backbone_tokens=2, mtp_tokens=1)
+    assert request.state.backbone_tokens == 2
+    assert request.state.mtp_tokens == 1
+
+    request.checkpoint()
+    _advance(backbone[1], 1)
+    _advance(mtp[0], 1)
+    request.seal_verified(backbone_tokens=3, mtp_tokens=2)
+    request.commit(backbone_tokens=3, mtp_tokens=2)
+    assert request.state.backbone_tokens == 3
+    assert request.state.mtp_tokens == 2
+
+    _advance(backbone[1], 1)
+    with pytest.raises(RuntimeError, match="backbone_cache_position_mismatch"):
+        request.retain(backbone_tokens=3, mtp_tokens=2)
+
+
+def test_rollback_restores_recurrent_and_attention_state_without_copying_kv_prefix():
+    backbone, mtp = _cache_pair()
+    request = NativeMTPRequestCache(_Model(backbone, mtp), backbone, mtp)
+    _advance(backbone[1], 2)
+    _advance(mtp[0], 1)
+    request.retain(backbone_tokens=2, mtp_tokens=1)
+    initial_recurrent = backbone[0][0]
+
+    request.checkpoint()
+    _advance(backbone[1], 1)
+    _advance(mtp[0], 1)
+    backbone[0][0] = mx.array([[9.0, 9.0]])
+    request.seal_verified(backbone_tokens=3, mtp_tokens=2)
+    request.rollback()
+    mx.eval(backbone[0][0])
+
+    assert backbone[1].offset == 2
+    assert mtp[0].offset == 1
+    assert mx.array_equal(backbone[0][0], initial_recurrent).item()
+    assert request.state.backbone_tokens == 2
+    assert request.state.mtp_tokens == 1
+
+
+def test_quantization_replaces_entries_through_the_caller_owned_containers():
+    backbone, mtp = _cache_pair()
+    request = NativeMTPRequestCache(_Model(backbone, mtp), backbone, mtp)
+    _advance(backbone[1], 2)
+    _advance(mtp[0], 1)
+    request.retain(backbone_tokens=2, mtp_tokens=1)
+    caller_backbone = backbone
+    caller_mtp = mtp
+
+    assert request.quantize(kv_bits=8, kv_group_size=32) == 2
+    assert request.backbone is caller_backbone
+    assert request.mtp is caller_mtp
+    assert isinstance(backbone[1], QuantizedKVCache)
+    assert isinstance(mtp[0], QuantizedKVCache)
+    request.assert_aligned(backbone_tokens=2, mtp_tokens=1)
+
+
+def test_rollback_restores_pre_quantization_entry_objects_and_positions():
+    backbone, mtp = _cache_pair()
+    request = NativeMTPRequestCache(_Model(backbone, mtp), backbone, mtp)
+    _advance(backbone[1], 2)
+    _advance(mtp[0], 2)
+    request.retain(backbone_tokens=2, mtp_tokens=2)
+    original_backbone = backbone[1]
+    original_mtp = mtp[0]
+
+    request.checkpoint()
+    request.quantize(kv_bits=8, kv_group_size=32)
+    _advance(backbone[1], 1)
+    _advance(mtp[0], 1)
+    request.seal_verified(backbone_tokens=3, mtp_tokens=3)
+    request.rollback()
+
+    assert backbone[1] is original_backbone
+    assert mtp[0] is original_mtp
+    assert backbone[1].offset == 2
+    assert mtp[0].offset == 2
+
+
+def test_prefix_reuse_batch_and_external_replacement_fail_closed():
+    backbone, mtp = _cache_pair()
+    model = _Model(backbone, mtp)
+    with pytest.raises(ValueError, match="native_mtp_prefix_reuse_unsupported"):
+        NativeMTPRequestCache.create(model, prompt_cache=backbone)
+
+    request = NativeMTPRequestCache(model, backbone, mtp)
+    backbone[1] = KVCache()
+    with pytest.raises(RuntimeError, match="entry_replaced_externally"):
+        request.assert_aligned(backbone_tokens=0, mtp_tokens=0)
+
+    multi_batch = KVCache()
+    keys = mx.zeros((2, 1, 1, 32))
+    multi_batch.update_and_fetch(keys, keys)
+    with pytest.raises(RuntimeError, match="native_mtp_batch_size_unsupported"):
+        NativeMTPRequestCache(
+            _Model([multi_batch], [KVCache()]), [multi_batch], [KVCache()]
+        )
+
+
+def test_pipeline_parallelism_is_rejected_before_any_cache_transaction():
+    backbone, mtp = _cache_pair()
+    model = _Model(backbone, mtp)
+    model.model = type("_Pipeline", (), {"pipeline_size": 2})()
+    with pytest.raises(
+        RuntimeError, match="native_mtp_pipeline_parallelism_unsupported"
+    ):
+        NativeMTPRequestCache(model, backbone, mtp)
+
+
+@pytest.mark.parametrize("accepted", (1, 2))
+def test_partial_acceptance_requires_rollback_and_sequential_replay(accepted):
+    """Replaying the accepted prefix matches a synthetic recurrent dense path."""
+
+    backbone, mtp = _cache_pair()
+    request = NativeMTPRequestCache(_Model(backbone, mtp), backbone, mtp)
+    request.checkpoint()
+    for _ in range(3):
+        _advance(backbone[1], 1)
+        _advance(mtp[0], 1)
+        backbone[0][0] = backbone[0][0] + 1
+    request.seal_verified(backbone_tokens=3, mtp_tokens=3)
+
+    # Direct attention trimming cannot make the recurrent state a valid
+    # accepted-prefix state; commit must still force full rollback + replay.
+    backbone[1].trim(3 - accepted)
+    mtp[0].trim(3 - accepted)
+    with pytest.raises(RuntimeError, match="native_mtp_partial_commit_requires_replay"):
+        request.commit(backbone_tokens=accepted, mtp_tokens=accepted)
+    replay = request.reject_partial(
+        accepted_backbone_tokens=accepted, accepted_mtp_tokens=accepted
+    )
+    assert replay.replay_to_backbone_tokens == accepted
+    assert request.replay_required is replay
+    assert mx.array_equal(backbone[0][0], mx.array([[1.0, 2.0]])).item()
+
+    for token in range(1, accepted + 1):
+        _advance(backbone[1], 1)
+        _advance(mtp[0], 1)
+        backbone[0][0] = backbone[0][0] + 1
+        request.replay_retained(backbone_tokens=token, mtp_tokens=token)
+    assert request.replay_required is None
+    assert mx.array_equal(
+        backbone[0][0], mx.array([[1.0 + accepted, 2.0 + accepted]])
+    ).item()
+
+
+def test_topology_rejects_truncated_swapped_duplicate_and_cross_alias_caches():
+    backbone, mtp = _cache_pair()
+    model = _Model(backbone, mtp)
+    with pytest.raises(ValueError, match="backbone_cache_topology_mismatch"):
+        NativeMTPRequestCache(model, backbone[:1], mtp)
+    with pytest.raises(TypeError, match="backbone_cache_type_mismatch"):
+        NativeMTPRequestCache(model, [backbone[1], backbone[0]], mtp)
+    duplicate = [backbone[0], backbone[0]]
+    duplicate_model = _Model(duplicate, mtp)
+    with pytest.raises(ValueError, match="entries_must_be_unique"):
+        NativeMTPRequestCache(duplicate_model, duplicate, mtp)
+    alias_backbone, alias_mtp = _cache_pair()
+    alias_mtp[0] = alias_backbone[1]
+    alias_model = _Model(alias_backbone, alias_mtp)
+    with pytest.raises(ValueError, match="entries_must_be_unique"):
+        NativeMTPRequestCache(alias_model, alias_backbone, alias_mtp)
+
+
+class _FailingKVCache(KVCache):
+    def to_quantized(self, *args, **kwargs):
+        raise ValueError("synthetic quantization conversion failure")
+
+
+def _quantization_failure_caches(*, fail_in):
+    recurrent = ArraysCache(2)
+    recurrent[0] = mx.array([[1.0]])
+    recurrent[1] = mx.array([[2.0]])
+    first = KVCache()
+    second = _FailingKVCache() if fail_in == "backbone" else KVCache()
+    head = _FailingKVCache() if fail_in == "mtp" else KVCache()
+    for entry in (first, second, head):
+        _advance(entry, 1)
+    backbone, mtp = [recurrent, first, second], [head]
+    request = NativeMTPRequestCache(_Model(backbone, mtp), backbone, mtp)
+    request.retain(backbone_tokens=1, mtp_tokens=1)
+    return request, backbone, mtp
+
+
+@pytest.mark.parametrize("fail_in", ("backbone", "mtp"))
+def test_quantization_conversion_failure_never_publishes_a_partial_container(fail_in):
+    request, backbone, mtp = _quantization_failure_caches(fail_in=fail_in)
+    before_backbone = tuple(backbone)
+    before_mtp = tuple(mtp)
+
+    with pytest.raises(ValueError, match="synthetic quantization conversion failure"):
+        request.quantize(kv_bits=8, kv_group_size=32)
+
+    assert tuple(backbone) == before_backbone
+    assert tuple(mtp) == before_mtp
+    assert all(isinstance(entry, KVCache) for entry in (*backbone[1:], *mtp))
+
+
+def test_quantization_evaluation_failure_never_publishes_staged_replacements(
+    monkeypatch,
+):
+    backbone, mtp = _cache_pair()
+    request = NativeMTPRequestCache(_Model(backbone, mtp), backbone, mtp)
+    _advance(backbone[1], 1)
+    _advance(mtp[0], 1)
+    request.retain(backbone_tokens=1, mtp_tokens=1)
+    before_backbone = tuple(backbone)
+    before_mtp = tuple(mtp)
+
+    def fail_eval(*_args, **_kwargs):
+        raise RuntimeError("synthetic lazy evaluation failure")
+
+    monkeypatch.setattr(cache_module.mx, "eval", fail_eval)
+    with pytest.raises(RuntimeError, match="native_mtp_cache_quantization_failed"):
+        request.quantize(kv_bits=8, kv_group_size=32)
+
+    assert tuple(backbone) == before_backbone
+    assert tuple(mtp) == before_mtp
+    assert isinstance(backbone[1], KVCache)
+    assert isinstance(mtp[0], KVCache)
+
+
+@pytest.mark.parametrize("reason", ("eos", "length", "cancelled", "generator_closed"))
+def test_finish_rolls_back_active_draft_and_is_idempotent(reason):
+    backbone, mtp = _cache_pair()
+    request = NativeMTPRequestCache(_Model(backbone, mtp), backbone, mtp)
+    _advance(backbone[1], 1)
+    _advance(mtp[0], 1)
+    request.retain(backbone_tokens=1, mtp_tokens=1)
+    request.checkpoint()
+    _advance(backbone[1], 1)
+    _advance(mtp[0], 1)
+
+    request.finish(reason)
+    assert request.closed
+    assert backbone[1].offset == 1
+    assert mtp[0].offset == 1
+    request.finish(reason)

--- a/tests/test_native_mtp_cache.py
+++ b/tests/test_native_mtp_cache.py
@@ -144,6 +144,72 @@ def test_rollback_restores_pre_quantization_entry_objects_and_positions():
     assert mtp[0].offset == 2
 
 
+def test_sparse_target_adoption_checkpoints_fresh_mtp_before_any_write():
+    backbone, mtp = _cache_pair()
+    _advance(backbone[1], 3)
+    request = NativeMTPRequestCache.adopt_sparse_target(
+        _Model(backbone, mtp),
+        target_cache=backbone,
+        target_tokens=3,
+        next_logical_position=8,
+    )
+
+    assert request.state.backbone_tokens == 3
+    assert request.state.mtp_tokens == 0
+    assert request.state.next_logical_position == 8
+    assert request.checkpoint_active
+    assert request.mtp[0].offset == 0
+
+    _advance(request.mtp[0], 2)
+    request.seal_verified(backbone_tokens=3, mtp_tokens=2)
+    request.commit(backbone_tokens=3, mtp_tokens=2)
+    assert not request.checkpoint_active
+    assert request.state.mtp_tokens == 2
+
+
+def test_sparse_target_adoption_rolls_back_bootstrap_suffix_on_close():
+    backbone, mtp = _cache_pair()
+    _advance(backbone[1], 2)
+    request = NativeMTPRequestCache.adopt_sparse_target(
+        _Model(backbone, mtp),
+        target_cache=backbone,
+        target_tokens=2,
+        next_logical_position=4,
+    )
+    _advance(request.mtp[0], 1)
+
+    request.finish("cancelled")
+
+    assert request.closed
+    assert not request.checkpoint_active
+    assert request.backbone[1].offset == 2
+    assert request.mtp[0].offset == 0
+
+
+def test_sparse_target_adoption_failure_closes_constructed_request(monkeypatch):
+    backbone, mtp = _cache_pair()
+    _advance(backbone[1], 2)
+    constructed = []
+
+    def fail_checkpoint(self):
+        constructed.append(self)
+        raise RuntimeError("synthetic adoption checkpoint failure")
+
+    monkeypatch.setattr(NativeMTPRequestCache, "checkpoint", fail_checkpoint)
+    with pytest.raises(RuntimeError, match="adoption checkpoint failure"):
+        NativeMTPRequestCache.adopt_sparse_target(
+            _Model(backbone, mtp),
+            target_cache=backbone,
+            target_tokens=2,
+            next_logical_position=4,
+        )
+    request = constructed[0]
+    assert request.closed
+    assert not request.checkpoint_active
+    assert request.backbone[1].offset == 2
+    assert request.mtp[0].offset == 0
+
+
 def test_prefix_reuse_batch_and_external_replacement_fail_closed():
     backbone, mtp = _cache_pair()
     model = _Model(backbone, mtp)

--- a/tests/test_native_mtp_cohort_cache.py
+++ b/tests/test_native_mtp_cohort_cache.py
@@ -1,0 +1,408 @@
+# Copyright © 2026 Apple Inc.
+"""Move-only cache ownership coverage for batched native Qwen MTP."""
+
+from dataclasses import dataclass
+import inspect
+
+import mlx.core as mx
+import pytest
+
+from mlx_lm.generate import _NativeMTPCohortCache, _NativeMTPCohortMutationDelta
+from mlx_lm.models.cache import (
+    ArraysCache,
+    BatchKVCache,
+    KVCache,
+    NativeMTPRequestCache,
+    QuantizedKVCache,
+)
+
+
+@dataclass(frozen=True)
+class _Capability:
+    supported: bool = True
+    reason: str = "supported"
+
+
+class _Model:
+    mtp_capability = _Capability()
+
+    def __init__(self):
+        self.layers = [
+            type("_Linear", (), {"is_linear": True})(),
+            type("_Attention", (), {"is_linear": False})(),
+        ]
+        self.mtp = type("_MTP", (), {"layers": [object()]})()
+
+
+def _advance(entry, count, *, heads=1):
+    if entry.keys is None and isinstance(entry, BatchKVCache):
+        assert entry.offset.size == entry.left_padding.size
+        batch_size = entry.offset.size
+    else:
+        batch_size = entry.keys.shape[0] if entry.keys is not None else 1
+    values = mx.arange(batch_size * count * heads * 32, dtype=mx.float32).reshape(
+        batch_size, heads, count, 32
+    )
+    entry.update_and_fetch(values, values)
+
+
+def _request(model, value, *, backbone_heads=1, recurrent_shape=(1, 1), token_count=2):
+    if recurrent_shape is not None and recurrent_shape[0] != 1:
+        raise ValueError("cohort fixtures must enter through B=1 owners")
+    if token_count < 0:
+        raise ValueError("cohort fixtures require non-negative token counts")
+    recurrent = ArraysCache(1)
+    if recurrent_shape is not None:
+        recurrent[0] = mx.zeros(recurrent_shape, dtype=mx.float32) + value
+    backbone = [recurrent, KVCache()]
+    mtp = [KVCache()]
+    if token_count:
+        _advance(backbone[1], token_count, heads=backbone_heads)
+        _advance(mtp[0], token_count)
+    request = NativeMTPRequestCache(model, backbone, mtp)
+    request.retain(backbone_tokens=token_count, mtp_tokens=token_count)
+    return request
+
+
+def _empty_two_slot_request(model):
+    recurrent = ArraysCache(2)
+    request = NativeMTPRequestCache(model, [recurrent, KVCache()], [KVCache()])
+    request.retain(backbone_tokens=0, mtp_tokens=0)
+    return request
+
+
+def _assert_valid_b1_owner(request):
+    request.assert_aligned(
+        backbone_tokens=request.state.backbone_tokens,
+        mtp_tokens=request.state.mtp_tokens,
+    )
+    for entry in request.backbone + request.mtp:
+        if not isinstance(entry, ArraysCache) and entry.keys is not None:
+            assert entry.keys.shape[0] == 1
+
+
+def test_cohort_rollback_restores_recurrent_values_and_kv_offsets():
+    model = _Model()
+    cohort = _NativeMTPCohortCache(model, [_request(model, 1), _request(model, 2)])
+    before = cohort.backbone[0][0]
+    backbone_keys = cohort.backbone[1].keys
+    mtp_keys = cohort.mtp[0].keys
+    backbone_entry = cohort.backbone[1]
+    mtp_entry = cohort.mtp[0]
+
+    cohort.checkpoint()
+    _advance(cohort.backbone[1], 1)
+    _advance(cohort.mtp[0], 1)
+    cohort.backbone[0][0] = cohort.backbone[0][0] + 10
+    cohort.rollback()
+    mx.eval(before, cohort.backbone[0][0])
+
+    assert cohort.size == 2
+    assert cohort.backbone[1]._idx == 2
+    assert cohort.mtp[0]._idx == 2
+    assert cohort.backbone[1] is backbone_entry
+    assert cohort.mtp[0] is mtp_entry
+    assert mx.array_equal(cohort.backbone[1].keys[..., :2, :], backbone_keys).item()
+    assert mx.array_equal(cohort.mtp[0].keys[..., :2, :], mtp_keys).item()
+    assert mx.array_equal(cohort.backbone[0][0], before).item()
+
+
+def test_cohort_split_join_filters_without_cache_aliasing():
+    model = _Model()
+    rows = [_request(model, 1), _request(model, 2)]
+    cohort = _NativeMTPCohortCache(model, rows, uids=(11, 12))
+    assert all(row.closed for row in rows)
+
+    selected = cohort.split([0])
+    assert cohort.size == selected.size == 1
+    assert cohort.uids == (12,)
+    assert selected.uids == (11,)
+    assert cohort.backbone[1] is not selected.backbone[1]
+
+    cohort.join(selected)
+    assert cohort.size == 2
+    with pytest.raises(RuntimeError, match="native_mtp_cohort_moved"):
+        selected.bind_before_mutation()
+
+
+def test_cohort_empty_batch_cache_preserves_merged_batch_width():
+    model = _Model()
+    rows = [
+        _request(model, 1, token_count=0),
+        _request(model, 2, token_count=0),
+    ]
+    for row in rows:
+        _assert_valid_b1_owner(row)
+
+    cohort = _NativeMTPCohortCache(model, rows)
+    for entry in (cohort.backbone[1], cohort.mtp[0]):
+        assert isinstance(entry, BatchKVCache)
+        assert entry.keys is None
+        assert entry.offset.size == entry.left_padding.size == cohort.size == 2
+        assert _NativeMTPCohortCache._entry_schema(entry)[1] == cohort.size
+
+    cohort.checkpoint()
+    _advance(cohort.backbone[1], 1)
+    _advance(cohort.mtp[0], 1)
+    assert cohort.backbone[1].keys.shape[0] == cohort.mtp[0].keys.shape[0] == 2
+    cohort.seal_after_mutation(
+        _NativeMTPCohortMutationDelta(
+            backbone=((), (1, 1)),
+            mtp=((1, 1),),
+        )
+    )
+    cohort.commit()
+
+
+def test_cohort_allows_first_population_of_empty_recurrent_slots():
+    model = _Model()
+    rows = [
+        _request(model, 1, recurrent_shape=None, token_count=0),
+        _request(model, 2, recurrent_shape=None, token_count=0),
+    ]
+    for row in rows:
+        _assert_valid_b1_owner(row)
+
+    cohort = _NativeMTPCohortCache(model, rows)
+    recurrent = cohort.backbone[0]
+    assert recurrent.batch_size == cohort.size == 2
+    assert recurrent[0] is None
+    cohort.checkpoint()
+    recurrent[0] = mx.zeros((2, 3), dtype=mx.float32)
+    cohort.seal_after_mutation(
+        _NativeMTPCohortMutationDelta(
+            backbone=((), (0, 0)),
+            mtp=((0, 0),),
+        )
+    )
+    cohort.commit()
+    cohort.bind_before_mutation()
+    assert _NativeMTPCohortCache._entry_schema(recurrent)[2][0] == (
+        2,
+        2,
+        (3,),
+        mx.float32,
+    )
+
+
+def test_cohort_rejects_mismatched_batch_first_population_of_empty_arrays_slots():
+    model = _Model()
+    rows = [_empty_two_slot_request(model), _empty_two_slot_request(model)]
+    for row in rows:
+        _assert_valid_b1_owner(row)
+
+    cohort = _NativeMTPCohortCache(model, rows)
+    recurrent = cohort.backbone[0]
+    assert recurrent.batch_size == cohort.size == 2
+    assert recurrent.cache == [None, None]
+    cohort.checkpoint()
+    recurrent[0] = mx.zeros((2, 3), dtype=mx.float32)
+    recurrent[1] = mx.zeros((1, 3), dtype=mx.float32)
+
+    with pytest.raises(RuntimeError, match="unexpected_layout_change"):
+        cohort.seal_after_mutation(
+            _NativeMTPCohortMutationDelta(
+                backbone=((), (0, 0)),
+                mtp=((0, 0),),
+            )
+        )
+    assert cohort.poisoned
+
+
+@pytest.mark.parametrize("transition", ("partial", "mismatched_batch"))
+def test_cohort_rejects_invalid_empty_kv_schema_transitions(transition):
+    model = _Model()
+    rows = [
+        _request(model, 1, token_count=0),
+        _request(model, 2, token_count=0),
+    ]
+    for row in rows:
+        _assert_valid_b1_owner(row)
+
+    cohort = _NativeMTPCohortCache(model, rows)
+    cohort.checkpoint()
+    entry = cohort.backbone[1]
+    if transition == "partial":
+        entry.keys = mx.zeros((2, 1, 1, 32), dtype=mx.float32)
+    else:
+        entry.keys = mx.zeros((1, 1, 1, 32), dtype=mx.float32)
+        entry.values = mx.zeros((1, 1, 1, 32), dtype=mx.float32)
+
+    with pytest.raises(RuntimeError, match="unexpected_layout_change"):
+        cohort.seal_after_mutation(
+            _NativeMTPCohortMutationDelta(
+                backbone=((), (0, 0)),
+                mtp=((0, 0),),
+            )
+        )
+    assert cohort.poisoned
+
+
+def test_cohort_refuses_quantized_row_cache_and_poisoned_rebinding():
+    model = _Model()
+    request = _request(model, 1)
+    request.quantize(kv_bits=8, kv_group_size=32)
+    with pytest.raises(RuntimeError, match="cache_layout_unsupported"):
+        _NativeMTPCohortCache(model, [request])
+
+    cohort = _NativeMTPCohortCache(model, [_request(model, 1)])
+    cohort.backbone[1] = KVCache()
+    with pytest.raises(RuntimeError, match="cache_binding_changed"):
+        cohort.bind_before_mutation()
+    assert cohort.poisoned
+
+
+def test_cohort_partition_never_calls_row_extraction(monkeypatch):
+    model = _Model()
+    cohort = _NativeMTPCohortCache(model, [_request(model, 1), _request(model, 2)])
+
+    with monkeypatch.context() as partition_patch:
+        partition_patch.setattr(
+            BatchKVCache,
+            "extract",
+            lambda *_: pytest.fail("cohort partition must not extract cache rows"),
+        )
+        partition_patch.setattr(
+            ArraysCache,
+            "extract",
+            lambda *_: pytest.fail("cohort partition must not extract recurrent rows"),
+        )
+        partition_patch.setattr(
+            mx,
+            "eval",
+            lambda *_: pytest.fail("cohort partition must not synchronize"),
+        )
+        partition_patch.setattr(
+            mx,
+            "contiguous",
+            lambda *_: pytest.fail("cohort partition must not copy complete rows"),
+        )
+        cohort._partition((0,))
+    selected = cohort.split([0])
+    cohort.join(selected)
+    assert cohort.size == 2
+    source = inspect.getsource(_NativeMTPCohortCache._partition)
+    assert ".item(" not in source
+    assert "mx.eval" not in source
+    source = inspect.getsource(_NativeMTPCohortCache._partition_entry)
+    assert ".item(" not in source
+    assert "mx.eval" not in source
+    assert "mx.contiguous" not in source
+
+
+def test_cohort_binding_tracks_batch_metadata_and_recurrent_size_bound():
+    model = _Model()
+    cohort = _NativeMTPCohortCache(model, [_request(model, 1)])
+    cohort.backbone[1].offset = mx.array([7])
+    with pytest.raises(RuntimeError, match="cache_binding_changed"):
+        cohort.bind_before_mutation()
+
+    recurrent = ArraysCache(1)
+    recurrent[0] = mx.zeros((1, 65537), dtype=mx.float32)
+    oversized = NativeMTPRequestCache(model, [recurrent, KVCache()], [KVCache()])
+    with pytest.raises(RuntimeError, match="recurrent_state_too_large"):
+        _NativeMTPCohortCache(model, [oversized])
+
+
+def test_cohort_binding_rejects_arrays_metadata_and_entry_replacement():
+    model = _Model()
+    cohort = _NativeMTPCohortCache(model, [_request(model, 1)])
+    cohort.backbone[0].left_padding = mx.array([0])
+    cohort._binding = cohort._make_binding()
+    cohort.backbone[0].left_padding = mx.array([1])
+    with pytest.raises(RuntimeError, match="cache_binding_changed"):
+        cohort.bind_before_mutation()
+
+    cohort = _NativeMTPCohortCache(model, [_request(model, 1)])
+    assert isinstance(cohort.backbone[1], BatchKVCache)
+    replacement = BatchKVCache([0])
+    replacement.offset = object()
+    cohort.backbone[1] = replacement
+    with pytest.raises(RuntimeError, match="cache_binding_changed"):
+        cohort.bind_before_mutation()
+    assert cohort.poisoned
+
+
+def test_cohort_rejects_incompatible_kv_and_recurrent_storage_schemas():
+    model = _Model()
+    kv_a = _request(model, 1)
+    kv_b = _request(model, 2, backbone_heads=2)
+    _assert_valid_b1_owner(kv_a)
+    _assert_valid_b1_owner(kv_b)
+    with pytest.raises(TypeError, match="storage_schema_mismatch"):
+        _NativeMTPCohortCache(model, [kv_a, kv_b])
+
+    recurrent_a = _request(model, 1)
+    recurrent_b = _request(model, 2, recurrent_shape=(1, 2))
+    _assert_valid_b1_owner(recurrent_a)
+    _assert_valid_b1_owner(recurrent_b)
+    with pytest.raises(TypeError, match="storage_schema_mismatch"):
+        _NativeMTPCohortCache(model, [recurrent_a, recurrent_b])
+
+
+def test_cohort_seal_poison_on_recurrent_padding_or_lengths_drift():
+    model = _Model()
+    cohort = _NativeMTPCohortCache(model, [_request(model, 1)])
+    cohort.backbone[0].left_padding = mx.array([0])
+    cohort.backbone[0].lengths = mx.array([1])
+    cohort._binding = cohort._make_binding()
+    cohort.checkpoint()
+    cohort.backbone[0].left_padding = mx.array([1])
+    with pytest.raises(RuntimeError, match="arrays_metadata_changed"):
+        cohort.seal_after_mutation(
+            _NativeMTPCohortMutationDelta(backbone=((), (0,)), mtp=((0,),))
+        )
+    assert cohort.poisoned
+
+
+def test_cohort_seal_requires_declared_layer_row_deltas_before_commit():
+    model = _Model()
+    cohort = _NativeMTPCohortCache(model, [_request(model, 1), _request(model, 2)])
+    cohort.checkpoint()
+    with pytest.raises(RuntimeError, match="mutation_not_sealed"):
+        cohort.commit()
+    _advance(cohort.backbone[1], 1)
+    _advance(cohort.mtp[0], 1)
+    cohort.seal_after_mutation(
+        _NativeMTPCohortMutationDelta(
+            backbone=((), (1, 1)),
+            mtp=((1, 1),),
+        )
+    )
+    cohort.commit()
+
+
+def test_cohort_seal_allows_recurrent_replacement_and_kv_capacity_growth():
+    model = _Model()
+    cohort = _NativeMTPCohortCache(model, [_request(model, 1), _request(model, 2)])
+    cohort.checkpoint()
+    cohort.backbone[0][0] = cohort.backbone[0][0] + 3
+    _advance(cohort.backbone[1], 300)
+    _advance(cohort.mtp[0], 300)
+    cohort.seal_after_mutation(
+        _NativeMTPCohortMutationDelta(
+            backbone=((), (300, 300)),
+            mtp=((300, 300),),
+        )
+    )
+    cohort.commit()
+
+
+def test_cohort_source_consume_failure_closes_every_source_and_poison_cohort(
+    monkeypatch,
+):
+    model = _Model()
+    rows = [_request(model, 1), _request(model, 2)]
+    original_finish = NativeMTPRequestCache.finish
+    calls = []
+
+    def fail_second(self, reason):
+        calls.append(self)
+        if len(calls) == 2:
+            raise RuntimeError("finish failed")
+        return original_finish(self, reason)
+
+    monkeypatch.setattr(NativeMTPRequestCache, "finish", fail_second)
+    with pytest.raises(RuntimeError, match="finish failed"):
+        _NativeMTPCohortCache(model, rows)
+    assert all(row.closed for row in rows)

--- a/tests/test_native_mtp_generate.py
+++ b/tests/test_native_mtp_generate.py
@@ -288,6 +288,20 @@ class _StreamTokenizer:
     def __init__(self):
         self.detokenizer = _StreamDetokenizer()
         self.eos_token_ids = frozenset()
+        self.eos_token_id = 0
+        self.chat_template = None
+
+    @staticmethod
+    def get_vocab():
+        return {}
+
+    @staticmethod
+    def encode(_text, *, add_special_tokens=False):
+        return [1]
+
+    @staticmethod
+    def decode(tokens):
+        return "".join(str(token) for token in tokens)
 
 
 def _make_sparse_bootstrap(
@@ -340,9 +354,7 @@ def test_sparse_receipts_retain_one_hidden_copy_and_only_final_compact_logits():
     chunk_count = 8
     positions = tuple(range(chunk_size * chunk_count))
     token_ids = tuple(position % model.vocab_size for position in positions)
-    successors = tuple(
-        (position + 1) % model.vocab_size for position in positions[:-1]
-    )
+    successors = tuple((position + 1) % model.vocab_size for position in positions[:-1])
     receipts = []
     immediate_results = []
     for chunk_index in range(chunk_count):
@@ -354,9 +366,7 @@ def test_sparse_receipts_retain_one_hidden_copy_and_only_final_compact_logits():
             target_cache,
             phase=GenerationForwardPhase.PREFILL,
             logical_positions=positions[start:end],
-            immediate_successor_token_ids=successors[
-                start : min(end, len(successors))
-            ],
+            immediate_successor_token_ids=successors[start : min(end, len(successors))],
             model_forward_context=context.context,
         )
         immediate_results.append(result)
@@ -376,9 +386,12 @@ def test_sparse_receipts_retain_one_hidden_copy_and_only_final_compact_logits():
     assert all(record.logits is None for record in records[:-1])
     assert receipts[-1].logits.shape == (1, 1, model.vocab_size)
     assert records[-1].logits is receipts[-1].logits
-    assert sum(
-        0 if receipt.logits is None else receipt.logits.size for receipt in receipts
-    ) == model.vocab_size
+    assert (
+        sum(
+            0 if receipt.logits is None else receipt.logits.size for receipt in receipts
+        )
+        == model.vocab_size
+    )
     for (original_logits, original_hidden), receipt, record in zip(
         immediate_results, receipts, records
     ):
@@ -408,7 +421,9 @@ def test_sparse_bootstrap_close_before_iteration_is_idempotent_and_non_mutating(
         chunk_sizes=(1, 1),
     )
     target_offset = bootstrap.target_cache[1].offset
-    assert all(_receipt_authority(receipt) is not None for receipt in bootstrap.receipts)
+    assert all(
+        _receipt_authority(receipt) is not None for receipt in bootstrap.receipts
+    )
 
     bootstrap.close()
     bootstrap.close()
@@ -416,7 +431,9 @@ def test_sparse_bootstrap_close_before_iteration_is_idempotent_and_non_mutating(
     assert all(_receipt_authority(receipt) is None for receipt in bootstrap.receipts)
     assert bootstrap.target_cache[1].offset == target_offset
     assert model.requests == []
-    with pytest.raises(RuntimeError, match="native_mtp_sparse_bootstrap_already_claimed"):
+    with pytest.raises(
+        RuntimeError, match="native_mtp_sparse_bootstrap_already_claimed"
+    ):
         bootstrap.claim(model)
 
 
@@ -483,7 +500,9 @@ def test_sparse_bootstrap_close_and_claim_have_exactly_one_owner(monkeypatch):
     if any(kind == "claim" for kind, _ in outcomes):
         assert any(kind == "claim" for kind, _ in outcomes)
     else:
-        assert any("already_claimed" in value for kind, value in outcomes if kind == "error")
+        assert any(
+            "already_claimed" in value for kind, value in outcomes if kind == "error"
+        )
     assert all(_receipt_authority(receipt) is None for receipt in bootstrap.receipts)
     assert model.requests == []
 
@@ -522,7 +541,9 @@ def test_sparse_bootstrap_close_preserves_reserved_claim_failure_cleanup(monkeyp
     thread.start()
     assert blocked.wait(timeout=5)
     bootstrap.close()
-    assert all(_receipt_authority(receipt) is not None for receipt in bootstrap.receipts)
+    assert all(
+        _receipt_authority(receipt) is not None for receipt in bootstrap.receipts
+    )
     release.set()
     thread.join(timeout=10)
 
@@ -530,7 +551,9 @@ def test_sparse_bootstrap_close_preserves_reserved_claim_failure_cleanup(monkeyp
     assert errors == ["synthetic claimed verification failure"]
     assert all(_receipt_authority(receipt) is None for receipt in bootstrap.receipts)
     assert model.requests == []
-    with pytest.raises(RuntimeError, match="native_mtp_sparse_bootstrap_already_claimed"):
+    with pytest.raises(
+        RuntimeError, match="native_mtp_sparse_bootstrap_already_claimed"
+    ):
         bootstrap.claim(model)
 
 
@@ -924,15 +947,60 @@ def test_stream_generate_rejects_invalid_sparse_none_combinations_before_prompt_
     if bootstrap == "valid":
         bootstrap = valid_bootstrap
 
-    def prompt_conversion_forbidden(*_args, **_kwargs):
-        raise AssertionError("prompt conversion must not run before sparse validation")
+    calls = {
+        "adopt": 0,
+        "request_cache": 0,
+        "mtp_cache": 0,
+        "target_forward": 0,
+        "mtp_forward": 0,
+        "prompt_encode": 0,
+    }
+    original_adopt = NativeMTPRequestCache.adopt_sparse_target.__func__
+    original_target_forward = _NativeMTPModel.__call__
+    original_mtp_forward = _NativeMTPModel.mtp_forward
+    original_prompt_encode = _StreamTokenizer.encode
 
-    monkeypatch.setattr(generate_module.mx, "array", prompt_conversion_forbidden)
+    def capture_adopt(cls, *args, **kwargs):
+        calls["adopt"] += 1
+        return original_adopt(cls, *args, **kwargs)
+
+    def capture_request_cache(*args, **kwargs):
+        calls["request_cache"] += 1
+        return original_request_cache(*args, **kwargs)
+
+    def capture_mtp_cache(*args, **kwargs):
+        calls["mtp_cache"] += 1
+        return original_mtp_cache(*args, **kwargs)
+
+    def capture_target_forward(self, *args, **kwargs):
+        calls["target_forward"] += 1
+        return original_target_forward(self, *args, **kwargs)
+
+    def capture_mtp_forward(self, *args, **kwargs):
+        calls["mtp_forward"] += 1
+        return original_mtp_forward(self, *args, **kwargs)
+
+    def capture_prompt_encode(*args, **kwargs):
+        calls["prompt_encode"] += 1
+        return original_prompt_encode(*args, **kwargs)
+
+    original_request_cache = model.make_mtp_request_cache
+    original_mtp_cache = model.make_mtp_cache
+    tokenizer = _StreamTokenizer()
+    monkeypatch.setattr(
+        NativeMTPRequestCache, "adopt_sparse_target", classmethod(capture_adopt)
+    )
+    monkeypatch.setattr(model, "make_mtp_request_cache", capture_request_cache)
+    monkeypatch.setattr(model, "make_mtp_cache", capture_mtp_cache)
+    monkeypatch.setattr(_NativeMTPModel, "__call__", capture_target_forward)
+    monkeypatch.setattr(_NativeMTPModel, "mtp_forward", capture_mtp_forward)
+    monkeypatch.setattr(tokenizer, "encode", capture_prompt_encode)
+
     with pytest.raises((TypeError, ValueError), match=message):
         list(
             stream_generate(
                 model,
-                _StreamTokenizer(),
+                tokenizer,
                 prompt,
                 mtp=mtp,
                 draft_model=draft_model,
@@ -941,12 +1009,13 @@ def test_stream_generate_rejects_invalid_sparse_none_combinations_before_prompt_
                 **kwargs,
             )
         )
+    assert calls == {name: 0 for name in calls}
 
 
 @pytest.mark.parametrize(
     ("model_capability", "context", "message"),
     (
-        (None, None, "native_mtp_sparse_bootstrap_requires_position_context"),
+        (None, None, "native_mtp_position_context_missing"),
         (
             _Capability(False, "native_mtp_weights_not_loaded"),
             "context",
@@ -972,15 +1041,60 @@ def test_stream_generate_sparse_rejects_context_and_capability_before_mutation(
     if context == "context":
         context = position_context.context
 
-    def prompt_conversion_forbidden(*_args, **_kwargs):
-        raise AssertionError("prompt conversion must not run before sparse validation")
+    calls = {
+        "adopt": 0,
+        "request_cache": 0,
+        "mtp_cache": 0,
+        "target_forward": 0,
+        "mtp_forward": 0,
+        "prompt_encode": 0,
+    }
+    original_adopt = NativeMTPRequestCache.adopt_sparse_target.__func__
+    original_target_forward = _NativeMTPModel.__call__
+    original_mtp_forward = _NativeMTPModel.mtp_forward
+    original_prompt_encode = _StreamTokenizer.encode
 
-    monkeypatch.setattr(generate_module.mx, "array", prompt_conversion_forbidden)
+    def capture_adopt(cls, *args, **kwargs):
+        calls["adopt"] += 1
+        return original_adopt(cls, *args, **kwargs)
+
+    def capture_request_cache(*args, **kwargs):
+        calls["request_cache"] += 1
+        return original_request_cache(*args, **kwargs)
+
+    def capture_mtp_cache(*args, **kwargs):
+        calls["mtp_cache"] += 1
+        return original_mtp_cache(*args, **kwargs)
+
+    def capture_target_forward(self, *args, **kwargs):
+        calls["target_forward"] += 1
+        return original_target_forward(self, *args, **kwargs)
+
+    def capture_mtp_forward(self, *args, **kwargs):
+        calls["mtp_forward"] += 1
+        return original_mtp_forward(self, *args, **kwargs)
+
+    def capture_prompt_encode(*args, **kwargs):
+        calls["prompt_encode"] += 1
+        return original_prompt_encode(*args, **kwargs)
+
+    original_request_cache = model.make_mtp_request_cache
+    original_mtp_cache = model.make_mtp_cache
+    tokenizer = _StreamTokenizer()
+    monkeypatch.setattr(
+        NativeMTPRequestCache, "adopt_sparse_target", classmethod(capture_adopt)
+    )
+    monkeypatch.setattr(model, "make_mtp_request_cache", capture_request_cache)
+    monkeypatch.setattr(model, "make_mtp_cache", capture_mtp_cache)
+    monkeypatch.setattr(_NativeMTPModel, "__call__", capture_target_forward)
+    monkeypatch.setattr(_NativeMTPModel, "mtp_forward", capture_mtp_forward)
+    monkeypatch.setattr(tokenizer, "encode", capture_prompt_encode)
+
     with pytest.raises((RuntimeError, ValueError), match=message):
         list(
             stream_generate(
                 model,
-                _StreamTokenizer(),
+                tokenizer,
                 None,
                 mtp=True,
                 sparse_bootstrap=bootstrap,
@@ -988,6 +1102,11 @@ def test_stream_generate_sparse_rejects_context_and_capability_before_mutation(
             )
         )
     assert model.requests == []
+    # TokenizerWrapper performs one detokenizer capability probe.  Sparse
+    # prompt conversion is still absent (the prompt is None), and every
+    # model/cache authority boundary remains untouched.
+    assert calls.pop("prompt_encode") in (0, 1)
+    assert calls == {name: 0 for name in calls}
 
 
 def test_stream_generate_sparse_bootstrap_is_one_shot_and_closes_on_failure(
@@ -1031,7 +1150,9 @@ def test_stream_generate_sparse_bootstrap_is_one_shot_and_closes_on_failure(
     assert request.closed
     assert context.active == 0
 
-    with pytest.raises(RuntimeError, match="native_mtp_sparse_bootstrap_already_claimed"):
+    with pytest.raises(
+        RuntimeError, match="native_mtp_sparse_bootstrap_already_claimed"
+    ):
         list(
             stream_generate(
                 model,
@@ -1990,7 +2111,7 @@ def test_sparse_bootstrap_admission_fails_before_request_adoption():
         immediate_successor_token_ids=(),
         chunk_sizes=(1,),
     )
-    with pytest.raises(ValueError, match="requires_position_context"):
+    with pytest.raises(ValueError, match="native_mtp_position_context_missing"):
         list(mtp_generate_step(None, model, sparse_bootstrap=bootstrap))
     with pytest.raises(ValueError, match="owns_selected_tokens"):
         list(

--- a/tests/test_native_mtp_generate.py
+++ b/tests/test_native_mtp_generate.py
@@ -16,6 +16,7 @@ from mlx_lm.generate import (
     GenerationForwardPositionReceipt,
     NativeMTPSamplingConfig,
     NativeMTPSparseBootstrap,
+    abandon_native_mtp_sparse_receipts,
     attested_target_forward,
     mtp_generate_step,
     stream_generate,
@@ -325,6 +326,212 @@ def _make_sparse_bootstrap(
         target_cache=target_cache,
         next_logical_position=positions[-1] + 1,
     )
+
+
+def _receipt_authority(receipt):
+    return generate_module._GENERATION_FORWARD_RECEIPTS.get(receipt._record_token)
+
+
+def test_sparse_bootstrap_close_before_iteration_is_idempotent_and_non_mutating():
+    model = _NativeMTPModel()
+    context = _PositionContext()
+    bootstrap = _make_sparse_bootstrap(
+        model,
+        context,
+        positions=(0, 3),
+        selected_token_ids=(0, 3),
+        immediate_successor_token_ids=(1,),
+        chunk_sizes=(1, 1),
+    )
+    target_offset = bootstrap.target_cache[1].offset
+    assert all(_receipt_authority(receipt) is not None for receipt in bootstrap.receipts)
+
+    bootstrap.close()
+    bootstrap.close()
+
+    assert all(_receipt_authority(receipt) is None for receipt in bootstrap.receipts)
+    assert bootstrap.target_cache[1].offset == target_offset
+    assert model.requests == []
+    with pytest.raises(RuntimeError, match="native_mtp_sparse_bootstrap_already_claimed"):
+        bootstrap.claim(model)
+
+
+def test_sparse_bootstrap_close_after_claim_is_idempotent_and_non_mutating():
+    model = _NativeMTPModel()
+    context = _PositionContext()
+    bootstrap = _make_sparse_bootstrap(
+        model,
+        context,
+        positions=(0, 3),
+        selected_token_ids=(0, 3),
+        immediate_successor_token_ids=(1,),
+        chunk_sizes=(1, 1),
+    )
+    target_offset = bootstrap.target_cache[1].offset
+
+    claim = bootstrap.claim(model)
+    bootstrap.close()
+    bootstrap.close()
+
+    assert claim.target_cache is bootstrap.target_cache
+    assert all(_receipt_authority(receipt) is None for receipt in bootstrap.receipts)
+    assert bootstrap.target_cache[1].offset == target_offset
+    assert model.requests == []
+
+
+def test_sparse_bootstrap_close_and_claim_have_exactly_one_owner(monkeypatch):
+    model = _NativeMTPModel()
+    context = _PositionContext()
+    bootstrap = _make_sparse_bootstrap(
+        model,
+        context,
+        positions=(0, 3),
+        selected_token_ids=(0, 3),
+        immediate_successor_token_ids=(1,),
+        chunk_sizes=(1, 1),
+    )
+    barrier = threading.Barrier(2)
+    outcomes = []
+
+    def claim():
+        barrier.wait(timeout=5)
+        try:
+            outcomes.append(("claim", bootstrap.claim(model)))
+        except RuntimeError as error:
+            outcomes.append(("error", str(error)))
+
+    def close():
+        barrier.wait(timeout=5)
+        bootstrap.close()
+        outcomes.append(("close", None))
+
+    threads = [threading.Thread(target=claim), threading.Thread(target=close)]
+    for thread in threads:
+        thread.start()
+    for thread in threads:
+        thread.join(timeout=10)
+
+    assert all(not thread.is_alive() for thread in threads)
+    assert [kind for kind, _ in outcomes].count("close") == 1
+    assert [kind for kind, _ in outcomes].count("claim") + [
+        kind for kind, _ in outcomes
+    ].count("error") == 1
+    if any(kind == "claim" for kind, _ in outcomes):
+        assert any(kind == "claim" for kind, _ in outcomes)
+    else:
+        assert any("already_claimed" in value for kind, value in outcomes if kind == "error")
+    assert all(_receipt_authority(receipt) is None for receipt in bootstrap.receipts)
+    assert model.requests == []
+
+
+def test_sparse_bootstrap_close_preserves_reserved_claim_failure_cleanup(monkeypatch):
+    model = _NativeMTPModel()
+    context = _PositionContext()
+    bootstrap = _make_sparse_bootstrap(
+        model,
+        context,
+        positions=(0, 3),
+        selected_token_ids=(0, 3),
+        immediate_successor_token_ids=(1,),
+        chunk_sizes=(1, 1),
+    )
+    blocked = threading.Event()
+    release = threading.Event()
+    errors = []
+
+    def fail_after_reservation(_records):
+        blocked.set()
+        assert release.wait(timeout=5)
+        raise RuntimeError("synthetic claimed verification failure")
+
+    monkeypatch.setattr(
+        generate_module, "_verify_sparse_canonical_content", fail_after_reservation
+    )
+
+    def claim():
+        try:
+            bootstrap.claim(model)
+        except RuntimeError as error:
+            errors.append(str(error))
+
+    thread = threading.Thread(target=claim)
+    thread.start()
+    assert blocked.wait(timeout=5)
+    bootstrap.close()
+    assert all(_receipt_authority(receipt) is not None for receipt in bootstrap.receipts)
+    release.set()
+    thread.join(timeout=10)
+
+    assert not thread.is_alive()
+    assert errors == ["synthetic claimed verification failure"]
+    assert all(_receipt_authority(receipt) is None for receipt in bootstrap.receipts)
+    assert model.requests == []
+    with pytest.raises(RuntimeError, match="native_mtp_sparse_bootstrap_already_claimed"):
+        bootstrap.claim(model)
+
+
+def test_abandon_sparse_receipts_cleans_partial_chunks_after_later_forward_failure():
+    class _FailSecondTarget(_NativeMTPModel):
+        def __init__(self):
+            super().__init__()
+            self.target_calls = 0
+
+        def __call__(self, *args, **kwargs):
+            self.target_calls += 1
+            if self.target_calls == 2:
+                raise RuntimeError("synthetic later target chunk failure")
+            return super().__call__(*args, **kwargs)
+
+    model = _FailSecondTarget()
+    context = _PositionContext()
+    target_cache = model.make_cache()
+    (_, _), first_receipt = attested_target_forward(
+        model,
+        (0,),
+        target_cache,
+        phase=GenerationForwardPhase.PREFILL,
+        logical_positions=(0,),
+        immediate_successor_token_ids=(1,),
+        model_forward_context=context.context,
+    )
+    target_offset = target_cache[1].offset
+    with pytest.raises(RuntimeError, match="synthetic later target chunk failure"):
+        attested_target_forward(
+            model,
+            (1,),
+            target_cache,
+            phase=GenerationForwardPhase.PREFILL,
+            logical_positions=(1,),
+            immediate_successor_token_ids=(),
+            model_forward_context=context.context,
+        )
+
+    abandon_native_mtp_sparse_receipts([first_receipt])
+    abandon_native_mtp_sparse_receipts([first_receipt])
+
+    assert _receipt_authority(first_receipt) is None
+    assert target_cache[1].offset == target_offset
+    assert model.requests == []
+
+
+def test_sparse_bootstrap_close_cleans_mutated_canonical_receipt_authority():
+    model = _NativeMTPModel()
+    context = _PositionContext()
+    bootstrap = _make_sparse_bootstrap(
+        model,
+        context,
+        positions=(0,),
+        selected_token_ids=(0,),
+        immediate_successor_token_ids=(),
+        chunk_sizes=(1,),
+    )
+    receipt = bootstrap.receipts[0]
+    object.__setattr__(receipt, "logical_positions", (99,))
+
+    bootstrap.close()
+
+    assert _receipt_authority(receipt) is None
+    assert model.requests == []
 
 
 def test_stream_generate_dispatches_attested_sparse_bootstrap_without_prompt_array(

--- a/tests/test_native_mtp_generate.py
+++ b/tests/test_native_mtp_generate.py
@@ -1,0 +1,395 @@
+# Copyright © 2026 Apple Inc.
+"""Synthetic streaming coverage for the native Qwen MTP generator."""
+
+from contextlib import contextmanager
+from dataclasses import dataclass
+
+import mlx.core as mx
+import pytest
+
+from mlx_lm.generate import (
+    GenerationForwardPhase,
+    NativeMTPSamplingConfig,
+    mtp_generate_step,
+)
+from mlx_lm.models.cache import ArraysCache, KVCache, NativeMTPRequestCache
+
+
+@dataclass(frozen=True)
+class _Capability:
+    supported: bool = True
+    reason: str = "supported"
+
+
+class _NativeMTPModel:
+    """Tiny cache-writing target/MTP pair with a known dense next-token rule."""
+
+    mtp_capability = _Capability()
+    vocab_size = 7
+
+    def __init__(self, *, wrong_draft=False, fail_mtp_offsets=()):
+        self.wrong_draft = wrong_draft
+        self.fail_mtp_offsets = frozenset(fail_mtp_offsets)
+        self.layers = [
+            type("_Linear", (), {"is_linear": True})(),
+            type("_Attention", (), {"is_linear": False})(),
+        ]
+        self.mtp = type("_MTP", (), {"layers": [object()]})()
+        self.requests = []
+        self.target_offset = 0
+        self.target_offsets = []
+        self.mtp_offsets = []
+        self.mtp_attempt_offsets = []
+
+    def make_cache(self):
+        recurrent = ArraysCache(2)
+        recurrent[0] = mx.array([[0.0]])
+        recurrent[1] = mx.array([[0.0]])
+        return [recurrent, KVCache()]
+
+    def make_mtp_cache(self):
+        return [KVCache()]
+
+    def make_mtp_request_cache(self):
+        request = NativeMTPRequestCache.create(self)
+        self.requests.append(request)
+        return request
+
+    @staticmethod
+    def _write_attention(entry, count):
+        values = mx.zeros((1, 1, count, 32))
+        entry.update_and_fetch(values, values)
+
+    def _logits(self, inputs, *, offset=1):
+        ids = (inputs.astype(mx.int32) + offset) % self.vocab_size
+        logits = mx.full((1, inputs.shape[1], self.vocab_size), -20.0)
+        for index in range(inputs.shape[1]):
+            logits[:, index, ids[0, index]] = 20.0
+        return logits
+
+    def __call__(self, inputs, *, cache, return_hidden=False):
+        count = inputs.shape[1]
+        cache[0][0] = cache[0][0] + count
+        cache[0][1] = cache[0][1] + count
+        cache[0].advance(count)
+        self._write_attention(cache[1], count)
+        self.target_offset = cache[1].offset
+        self.target_offsets.append(self.target_offset)
+        logits = self._logits(inputs)
+        hidden = inputs.astype(mx.float32)[..., None]
+        return (logits, hidden) if return_hidden else logits
+
+    def mtp_forward(self, hidden, next_token_ids, cache):
+        self.mtp_attempt_offsets.append(cache[0].offset)
+        if cache[0].offset in self.fail_mtp_offsets:
+            raise RuntimeError("synthetic unexpected next draft")
+        self._write_attention(cache[0], next_token_ids.shape[1])
+        self.mtp_offsets.append(cache[0].offset)
+        offset = 2 if self.wrong_draft or cache[0].offset != self.target_offset else 1
+        return self._logits(next_token_ids, offset=offset)
+
+
+def _run(model, *, max_tokens=4, prompt=(0, 1), **kwargs):
+    telemetry = {}
+    output = list(
+        mtp_generate_step(
+            mx.array(prompt, dtype=mx.uint32),
+            model,
+            max_tokens=max_tokens,
+            telemetry=telemetry,
+            **kwargs,
+        )
+    )
+    return output, telemetry
+
+
+def test_greedy_mtp_matches_dense_token_rule_and_uses_target_logprobs_for_drafts():
+    output, telemetry = _run(_NativeMTPModel(), max_tokens=4)
+    tokens = [token for token, _, _ in output]
+    from_draft = [draft for _, _, draft in output]
+
+    assert tokens == [2, 3, 4, 5]
+    assert from_draft == [False, True, False, True]
+    assert telemetry == {
+        "mtp_drafts": 2,
+        "mtp_accepted": 2,
+        "mtp_bypass_reason": None,
+    }
+    for token, logprobs, from_draft in output:
+        if from_draft:
+            assert mx.argmax(logprobs).item() == token
+
+
+def test_rejected_draft_rolls_back_and_replays_the_recurrent_prefix():
+    model = _NativeMTPModel(wrong_draft=True)
+    output, telemetry = _run(model, max_tokens=3)
+
+    assert [token for token, _, _ in output] == [2, 3, 4]
+    assert not any(from_draft for _, _, from_draft in output)
+    assert telemetry["mtp_drafts"] == 2
+    assert telemetry["mtp_accepted"] == 0
+    request = model.requests[-1]
+    assert request.closed
+    # Prompt tokens plus the two replayed prior outputs are physically retained.
+    assert request.backbone[1].offset == 4
+    assert request.mtp[0].offset == 3
+    assert mx.array_equal(request.backbone[0][0], mx.array([[4.0]])).item()
+
+
+def test_forward_context_labels_target_prefill_verify_decode_and_mtp_draft():
+    model = _NativeMTPModel(wrong_draft=True)
+    phases = []
+
+    @contextmanager
+    def context(forward):
+        phases.append(forward.phase)
+        yield
+
+    _run(model, max_tokens=3, model_forward_context=context)
+    assert GenerationForwardPhase.PREFILL in phases
+    assert GenerationForwardPhase.MTP_DRAFT in phases
+    assert GenerationForwardPhase.VERIFY in phases
+    assert GenerationForwardPhase.DECODE in phases
+
+
+@pytest.mark.parametrize(
+    "sampling",
+    (
+        NativeMTPSamplingConfig(temperature=0.7, seed=17),
+        NativeMTPSamplingConfig(temperature=0.7, top_p=0.9, seed=17),
+        NativeMTPSamplingConfig(temperature=0.7, top_k=3, seed=17),
+        NativeMTPSamplingConfig(
+            temperature=0.7, min_p=0.01, min_tokens_to_keep=2, seed=17
+        ),
+    ),
+)
+def test_stochastic_sampling_configs_are_seeded_and_request_local(sampling):
+    first, first_telemetry = _run(
+        _NativeMTPModel(), max_tokens=4, sampling_config=sampling
+    )
+    second, second_telemetry = _run(
+        _NativeMTPModel(), max_tokens=4, sampling_config=sampling
+    )
+    assert [token for token, _, _ in first] == [token for token, _, _ in second]
+    assert first_telemetry == second_telemetry
+
+
+def test_opaque_sampling_and_non_replay_safe_processors_fail_before_cache_mutation():
+    model = _NativeMTPModel()
+    with pytest.raises(ValueError, match="native_mtp_opaque_sampler_unsupported"):
+        _run(
+            model,
+            max_tokens=1,
+            sampler=lambda logits: mx.argmax(logits, axis=-1),
+        )
+    assert model.requests == []
+
+    stochastic_model = _NativeMTPModel()
+    with pytest.raises(ValueError, match="native_mtp_opaque_sampler_unsupported"):
+        _run(
+            stochastic_model,
+            max_tokens=1,
+            sampling_config=NativeMTPSamplingConfig(temperature=1, seed=4),
+            sampler=lambda logits: mx.argmax(logits, axis=-1),
+        )
+    assert stochastic_model.requests == []
+
+    processor_model = _NativeMTPModel()
+    with pytest.raises(ValueError, match="native_mtp_non_replay_safe_logits_processor"):
+        _run(processor_model, logits_processors=[lambda _tokens, logits: logits])
+    assert processor_model.requests == []
+
+
+def test_explicitly_deterministic_sampler_preserves_greedy_equivalence():
+    def deterministic_sampler(logprobs):
+        return mx.argmax(logprobs, axis=-1)
+
+    deterministic_sampler.native_mtp_deterministic = True
+    output, _ = _run(_NativeMTPModel(), max_tokens=4, sampler=deterministic_sampler)
+    assert [token for token, _, _ in output] == [2, 3, 4, 5]
+
+
+def test_replay_safe_processor_observes_dense_histories_and_bonus_only_after_accept():
+    histories = []
+
+    def processor(tokens, logits):
+        histories.append(tokens.tolist())
+        return logits
+
+    processor.native_mtp_replay_safe = True
+    _run(_NativeMTPModel(), max_tokens=3, logits_processors=[processor])
+    assert histories == [
+        [1],
+        [1, 2],
+        [1, 2],
+        [1, 2, 3],
+    ]
+
+    rejected_histories = []
+
+    def rejected_processor(tokens, logits):
+        rejected_histories.append(tokens.tolist())
+        return logits
+
+    rejected_processor.native_mtp_replay_safe = True
+    output, _ = _run(
+        _NativeMTPModel(wrong_draft=True),
+        max_tokens=2,
+        logits_processors=[rejected_processor],
+    )
+    assert [token for token, _, _ in output] == [2, 3]
+    assert [1, 2, 4] not in rejected_histories
+    assert mx.argmax(output[-1][1]).item() == 3
+
+
+def test_prompt_and_accept_reject_paths_keep_target_and_mtp_offsets_aligned():
+    accepted = _NativeMTPModel()
+    _run(accepted, max_tokens=4)
+    accepted_request = accepted.requests[-1]
+    assert accepted.target_offsets[:2] == [1, 2]
+    assert accepted.mtp_offsets[:2] == [1, 2]
+    assert accepted_request.backbone[1].offset == 6
+    assert accepted_request.mtp[0].offset == 4
+
+    rejected = _NativeMTPModel(wrong_draft=True)
+    _run(rejected, max_tokens=3)
+    rejected_request = rejected.requests[-1]
+    assert rejected.target_offsets[:2] == [1, 2]
+    assert rejected.mtp_offsets[:2] == [1, 2]
+    assert rejected_request.backbone[1].offset == 4
+    assert rejected_request.mtp[0].offset == 3
+
+
+def test_shifted_prompt_prefill_is_cache_sensitive_and_exactly_aligned():
+    model = _NativeMTPModel()
+    output, _ = _run(model, prompt=(0, 1, 2, 3), max_tokens=1, prefill_step_size=2)
+    assert [token for token, _, _ in output] == [4]
+    assert model.target_offsets[:2] == [2, 3]
+    assert model.mtp_offsets[:2] == [2, 3]
+    request = model.requests[-1]
+    assert request.backbone[1].offset == 4
+    assert request.mtp[0].offset == 3
+
+
+@pytest.mark.parametrize(
+    ("model", "max_tokens", "eos_token_ids", "expected", "drafts", "accepted"),
+    (
+        (_NativeMTPModel(fail_mtp_offsets={1}), 1, (), [2], 0, 0),
+        (_NativeMTPModel(fail_mtp_offsets={1}), 4, (2,), [2], 0, 0),
+        (_NativeMTPModel(fail_mtp_offsets={2}), 2, (), [2, 3], 1, 1),
+        (_NativeMTPModel(fail_mtp_offsets={2}), 3, (), [2, 3, 4], 1, 1),
+        (
+            _NativeMTPModel(wrong_draft=True, fail_mtp_offsets={2}),
+            2,
+            (),
+            [2, 3],
+            1,
+            0,
+        ),
+    ),
+)
+def test_terminal_yields_do_not_start_unobservable_speculative_work(
+    model, max_tokens, eos_token_ids, expected, drafts, accepted
+):
+    output, telemetry = _run(model, max_tokens=max_tokens, eos_token_ids=eos_token_ids)
+    assert [token for token, _, _ in output] == expected
+    assert telemetry["mtp_drafts"] == drafts
+    assert telemetry["mtp_accepted"] == accepted
+
+
+@pytest.mark.parametrize(
+    "sampling",
+    (
+        NativeMTPSamplingConfig(temperature=0.1, seed=9),
+        NativeMTPSamplingConfig(temperature=0.7, top_p=0.5, seed=9),
+        NativeMTPSamplingConfig(temperature=0.7, top_k=1, seed=9),
+    ),
+)
+def test_filtered_sampling_returns_dense_normalized_target_logprobs(sampling):
+    model = _NativeMTPModel()
+    output, _ = _run(model, max_tokens=3, sampling_config=sampling)
+
+    expected_logits = model._logits(mx.array([[1]], dtype=mx.uint32))[:, -1, :]
+    expected = (
+        expected_logits - mx.logsumexp(expected_logits, axis=-1, keepdims=True)
+    ).squeeze(0)
+    assert mx.allclose(output[0][1], expected).item()
+    for _, reported_logprobs, _ in output:
+        assert mx.all(mx.isfinite(reported_logprobs)).item()
+        assert mx.allclose(mx.sum(mx.exp(reported_logprobs)), mx.array(1.0)).item()
+
+
+def test_rejection_reports_target_logits_not_filtered_residual_distribution():
+    output, _ = _run(
+        _NativeMTPModel(wrong_draft=True),
+        max_tokens=2,
+        sampling_config=NativeMTPSamplingConfig(
+            temperature=0.7, top_p=0.5, top_k=1, seed=13
+        ),
+    )
+    assert [token for token, _, _ in output] == [2, 3]
+    rejection_logprobs = output[-1][1]
+    assert mx.argmax(rejection_logprobs).item() == 3
+    assert mx.all(mx.isfinite(rejection_logprobs)).item()
+
+
+@pytest.mark.parametrize(
+    ("kwargs", "message"),
+    (
+        ({"temperature": True}, "temperature must be a finite number"),
+        ({"temperature": float("nan")}, "temperature must be a finite number"),
+        ({"temperature": float("inf")}, "temperature must be a finite number"),
+        ({"top_p": True}, "top_p must be a finite number"),
+        ({"top_p": float("nan")}, "top_p must be a finite number"),
+        ({"min_p": float("inf")}, "min_p must be a finite number"),
+        ({"top_k": True}, "top_k must be an integer"),
+        ({"top_k": 1.5}, "top_k must be an integer"),
+        ({"min_tokens_to_keep": False}, "min_tokens_to_keep must be an integer"),
+        ({"seed": True}, "seed must be an integer or None"),
+        ({"seed": -1}, "seed must be non-negative"),
+    ),
+)
+def test_native_sampling_config_rejects_invalid_values(kwargs, message):
+    with pytest.raises(ValueError, match=message):
+        NativeMTPSamplingConfig(**kwargs)
+
+
+def test_top_k_is_validated_against_vocab_before_cache_mutation():
+    model = _NativeMTPModel()
+    with pytest.raises(ValueError, match="top_k must be smaller than vocabulary size"):
+        _run(
+            model,
+            max_tokens=1,
+            sampling_config=NativeMTPSamplingConfig(temperature=1, top_k=7),
+        )
+    assert model.requests == []
+
+
+def test_prefix_capability_and_generator_close_fail_closed_or_cleanup():
+    with pytest.raises(ValueError, match="native_mtp_prefix_reuse_unsupported"):
+        list(
+            mtp_generate_step(
+                mx.array([0], dtype=mx.uint32),
+                _NativeMTPModel(),
+                prompt_cache=[],
+            )
+        )
+
+    unsupported = _NativeMTPModel()
+    unsupported.mtp_capability = _Capability(False, "native_mtp_weights_not_loaded")
+    with pytest.raises(RuntimeError, match="native_mtp_weights_not_loaded"):
+        next(mtp_generate_step(mx.array([0], dtype=mx.uint32), unsupported))
+
+    model = _NativeMTPModel()
+    iterator = mtp_generate_step(mx.array([0, 1], dtype=mx.uint32), model)
+    next(iterator)
+    iterator.close()
+    assert model.requests[-1].closed
+
+
+def test_zero_length_finishes_without_forward_or_uninitialized_state():
+    model = _NativeMTPModel()
+    output, telemetry = _run(model, max_tokens=0)
+    assert output == []
+    assert telemetry["mtp_drafts"] == 0
+    assert model.requests[-1].closed

--- a/tests/test_native_mtp_generate.py
+++ b/tests/test_native_mtp_generate.py
@@ -332,6 +332,70 @@ def _receipt_authority(receipt):
     return generate_module._GENERATION_FORWARD_RECEIPTS.get(receipt._record_token)
 
 
+def test_sparse_receipts_retain_one_hidden_copy_and_only_final_compact_logits():
+    model = _NativeMTPModel()
+    context = _PositionContext()
+    target_cache = model.make_cache()
+    chunk_size = 3
+    chunk_count = 8
+    positions = tuple(range(chunk_size * chunk_count))
+    token_ids = tuple(position % model.vocab_size for position in positions)
+    successors = tuple(
+        (position + 1) % model.vocab_size for position in positions[:-1]
+    )
+    receipts = []
+    immediate_results = []
+    for chunk_index in range(chunk_count):
+        start = chunk_index * chunk_size
+        end = start + chunk_size
+        result, receipt = attested_target_forward(
+            model,
+            token_ids[start:end],
+            target_cache,
+            phase=GenerationForwardPhase.PREFILL,
+            logical_positions=positions[start:end],
+            immediate_successor_token_ids=successors[
+                start : min(end, len(successors))
+            ],
+            model_forward_context=context.context,
+        )
+        immediate_results.append(result)
+        receipts.append(receipt)
+
+    bootstrap = NativeMTPSparseBootstrap(
+        receipts=tuple(receipts),
+        selected_logical_positions=positions,
+        selected_token_ids=token_ids,
+        immediate_successor_token_ids=successors,
+        target_cache=target_cache,
+        next_logical_position=positions[-1] + 1,
+    )
+    records = tuple(_receipt_authority(receipt).record for receipt in receipts)
+
+    assert all(receipt.logits is None for receipt in receipts[:-1])
+    assert all(record.logits is None for record in records[:-1])
+    assert receipts[-1].logits.shape == (1, 1, model.vocab_size)
+    assert records[-1].logits is receipts[-1].logits
+    assert sum(
+        0 if receipt.logits is None else receipt.logits.size for receipt in receipts
+    ) == model.vocab_size
+    for (original_logits, original_hidden), receipt, record in zip(
+        immediate_results, receipts, records
+    ):
+        assert original_hidden is not receipt.hidden_rows
+        assert receipt.hidden_rows is record.hidden_rows
+        assert original_logits is not record.logits
+        assert record.hidden_content_digest.shape == (2,)
+    assert records[-1].logits_content_digest.shape == (2,)
+    retained_payload_bytes = sum(record.hidden_rows.nbytes for record in records)
+    retained_payload_bytes += records[-1].logits.nbytes
+    expected_payload_bytes = sum(result[1].nbytes for result in immediate_results)
+    expected_payload_bytes += model.vocab_size * records[-1].logits.itemsize
+    assert retained_payload_bytes == expected_payload_bytes
+
+    bootstrap.validate(model)
+
+
 def test_sparse_bootstrap_close_before_iteration_is_idempotent_and_non_mutating():
     model = _NativeMTPModel()
     context = _PositionContext()
@@ -468,6 +532,195 @@ def test_sparse_bootstrap_close_preserves_reserved_claim_failure_cleanup(monkeyp
     assert model.requests == []
     with pytest.raises(RuntimeError, match="native_mtp_sparse_bootstrap_already_claimed"):
         bootstrap.claim(model)
+
+
+def test_sparse_bootstrap_try_abandon_and_claim_race_has_one_owner():
+    model = _NativeMTPModel()
+    context = _PositionContext()
+    bootstrap = _make_sparse_bootstrap(
+        model,
+        context,
+        positions=(0, 3),
+        selected_token_ids=(0, 3),
+        immediate_successor_token_ids=(1,),
+        chunk_sizes=(1, 1),
+    )
+    barrier = threading.Barrier(2)
+    outcomes = []
+
+    def claim():
+        barrier.wait(timeout=5)
+        try:
+            outcomes.append(("claim", bootstrap.claim(model)))
+        except RuntimeError as error:
+            outcomes.append(("claim_error", str(error)))
+
+    def abandon():
+        barrier.wait(timeout=5)
+        outcomes.append(("abandon", bootstrap.try_abandon_unclaimed()))
+
+    threads = [threading.Thread(target=claim), threading.Thread(target=abandon)]
+    for thread in threads:
+        thread.start()
+    for thread in threads:
+        thread.join(timeout=10)
+
+    assert all(not thread.is_alive() for thread in threads)
+    abandoned = next(value for kind, value in outcomes if kind == "abandon")
+    if abandoned:
+        assert any(kind == "claim_error" for kind, _ in outcomes)
+    else:
+        assert any(kind == "claim" for kind, _ in outcomes)
+    assert all(_receipt_authority(receipt) is None for receipt in bootstrap.receipts)
+    assert model.requests == []
+
+
+@pytest.mark.parametrize(
+    ("kwargs", "message"),
+    (
+        ({"sampler": lambda _logprobs: mx.array(0)}, "opaque_sampler"),
+        ({"logits_processors": [lambda _tokens, logits: logits]}, "non_replay_safe"),
+        ({"prefill_step_size": 0}, "prefill_step_size"),
+    ),
+)
+def test_preclaim_native_mtp_validation_failure_can_abandon_for_dense_replay(
+    kwargs, message
+):
+    model = _NativeMTPModel()
+    context = _PositionContext()
+    bootstrap = _make_sparse_bootstrap(
+        model,
+        context,
+        positions=(0, 3),
+        selected_token_ids=(0, 3),
+        immediate_successor_token_ids=(1,),
+        chunk_sizes=(1, 1),
+    )
+
+    with pytest.raises(ValueError, match=message):
+        next(
+            mtp_generate_step(
+                None,
+                model,
+                sparse_bootstrap=bootstrap,
+                model_forward_context=context.context,
+                **kwargs,
+            )
+        )
+
+    assert bootstrap.try_abandon_unclaimed()
+    assert not bootstrap.try_abandon_unclaimed()
+    assert model.requests == []
+
+
+def test_postclaim_failure_cannot_authorize_dense_replay():
+    model = _NativeMTPModel(fail_mtp_offsets={0})
+    context = _PositionContext()
+    bootstrap = _make_sparse_bootstrap(
+        model,
+        context,
+        positions=(0, 3),
+        selected_token_ids=(0, 3),
+        immediate_successor_token_ids=(1,),
+        chunk_sizes=(1, 1),
+    )
+
+    with pytest.raises(RuntimeError, match="synthetic unexpected next draft"):
+        list(
+            mtp_generate_step(
+                None,
+                model,
+                sparse_bootstrap=bootstrap,
+                model_forward_context=context.context,
+            )
+        )
+
+    assert not bootstrap.try_abandon_unclaimed()
+
+
+def test_try_abandon_rejects_mutated_and_mixed_authority_without_partial_delete():
+    first_model = _NativeMTPModel()
+    first_context = _PositionContext()
+    first = _make_sparse_bootstrap(
+        first_model,
+        first_context,
+        positions=(0,),
+        selected_token_ids=(0,),
+        immediate_successor_token_ids=(),
+        chunk_sizes=(1,),
+    )
+    second_model = _NativeMTPModel()
+    second_context = _PositionContext()
+    second = _make_sparse_bootstrap(
+        second_model,
+        second_context,
+        positions=(1,),
+        selected_token_ids=(1,),
+        immediate_successor_token_ids=(),
+        chunk_sizes=(1,),
+    )
+    mixed = replace(
+        first,
+        receipts=(first.receipts[0], second.receipts[0]),
+        selected_logical_positions=(0, 1),
+        selected_token_ids=(0, 1),
+        immediate_successor_token_ids=(),
+        next_logical_position=2,
+    )
+
+    assert not mixed.try_abandon_unclaimed()
+    assert _receipt_authority(first.receipts[0]) is not None
+    assert _receipt_authority(second.receipts[0]) is not None
+
+    first.receipts[0].hidden_rows[:, 0, 0] += 1
+    assert not first.try_abandon_unclaimed()
+    assert _receipt_authority(first.receipts[0]) is not None
+    first.close()
+    second.close()
+
+
+def test_try_abandon_rejects_boolean_cursor_and_preserves_claim_authority():
+    model = _NativeMTPModel()
+    context = _PositionContext()
+    bootstrap = _make_sparse_bootstrap(
+        model,
+        context,
+        positions=(0,),
+        selected_token_ids=(0,),
+        immediate_successor_token_ids=(),
+        chunk_sizes=(1,),
+    )
+    malformed = replace(bootstrap, next_logical_position=True)
+
+    assert not malformed.try_abandon_unclaimed()
+    assert _receipt_authority(bootstrap.receipts[0]) is not None
+    claim = bootstrap.claim(model)
+    assert claim.target_cache is bootstrap.target_cache
+
+
+@pytest.mark.parametrize("replacement", (KVCache(), object()))
+def test_try_abandon_rejects_same_list_cache_replacement_without_consuming(
+    replacement,
+):
+    model = _NativeMTPModel()
+    context = _PositionContext()
+    bootstrap = _make_sparse_bootstrap(
+        model,
+        context,
+        positions=(0,),
+        selected_token_ids=(0,),
+        immediate_successor_token_ids=(),
+        chunk_sizes=(1,),
+    )
+    original_entry = bootstrap.target_cache[1]
+    bootstrap.target_cache[1] = replacement
+
+    assert not bootstrap.try_abandon_unclaimed()
+    assert _receipt_authority(bootstrap.receipts[0]) is not None
+
+    bootstrap.target_cache[1] = original_entry
+    claim = bootstrap.claim(model)
+    assert claim.target_cache is bootstrap.target_cache
 
 
 def test_abandon_sparse_receipts_cleans_partial_chunks_after_later_forward_failure():
@@ -1404,12 +1657,12 @@ def test_sparse_claim_uses_one_aggregate_host_decision_and_final_cache_scan(
         chunk_sizes=(1, 1),
     )
     assert scans == 1
-    # Two recurrent arrays plus active K and V: one fixed-width reduction each.
-    assert hash_reductions == 4
+    # Two hidden payloads, one final logit, two recurrent arrays, active K/V.
+    assert hash_reductions == 7
     bootstrap.claim(model)
     assert scans == 2
     assert decisions == 1
-    assert hash_reductions == 8
+    assert hash_reductions == 14
 
 
 def test_unrelated_sparse_claim_reserves_while_device_verification_is_blocked(

--- a/tests/test_native_mtp_generate.py
+++ b/tests/test_native_mtp_generate.py
@@ -1,19 +1,32 @@
 # Copyright © 2026 Apple Inc.
 """Synthetic streaming coverage for the native Qwen MTP generator."""
 
+import importlib
+import threading
 from contextlib import contextmanager
 from contextvars import ContextVar
-from dataclasses import dataclass
+from dataclasses import dataclass, replace
 
 import mlx.core as mx
 import pytest
 
 from mlx_lm.generate import (
+    GenerationForward,
     GenerationForwardPhase,
+    GenerationForwardPositionReceipt,
     NativeMTPSamplingConfig,
+    NativeMTPSparseBootstrap,
+    attested_target_forward,
     mtp_generate_step,
 )
-from mlx_lm.models.cache import ArraysCache, KVCache, NativeMTPRequestCache
+from mlx_lm.models.cache import (
+    ArraysCache,
+    KVCache,
+    NativeMTPRequestCache,
+    QuantizedKVCache,
+)
+
+generate_module = importlib.import_module("mlx_lm.generate")
 
 _ACTIVE_FORWARD = ContextVar("native_mtp_test_forward", default=None)
 
@@ -54,6 +67,8 @@ class _NativeMTPModel:
         self.target_offsets = []
         self.mtp_offsets = []
         self.mtp_attempt_offsets = []
+        self.mtp_input_ids = []
+        self.last_mtp_cache = None
 
     def _acknowledge_forward_positions(self):
         forward = _ACTIVE_FORWARD.get()
@@ -75,7 +90,8 @@ class _NativeMTPModel:
         return [recurrent, KVCache()]
 
     def make_mtp_cache(self):
-        return [KVCache()]
+        self.last_mtp_cache = [KVCache()]
+        return self.last_mtp_cache
 
     def make_mtp_request_cache(self):
         request = NativeMTPRequestCache.create(self)
@@ -83,9 +99,17 @@ class _NativeMTPModel:
         return request
 
     @staticmethod
-    def _write_attention(entry, count):
-        values = mx.zeros((1, 1, count, 32))
+    def _write_attention(entry, positions):
+        values = mx.array(positions, dtype=mx.float32).reshape(1, 1, -1, 1)
+        values = mx.broadcast_to(values, (1, 1, len(positions), 32))
         entry.update_and_fetch(values, values)
+
+    @staticmethod
+    def _logical_positions(count, physical_start):
+        forward = _ACTIVE_FORWARD.get()
+        if forward is not None and forward.logical_positions is not None:
+            return forward.logical_positions
+        return tuple(range(physical_start, physical_start + count))
 
     def _logits(self, inputs, *, offset=1):
         ids = (inputs.astype(mx.int32) + offset) % self.vocab_size
@@ -97,25 +121,73 @@ class _NativeMTPModel:
     def __call__(self, inputs, *, cache, return_hidden=False):
         self._acknowledge_forward_positions()
         count = inputs.shape[1]
+        positions = self._logical_positions(count, cache[1].offset)
         cache[0][0] = cache[0][0] + count
         cache[0][1] = cache[0][1] + count
         cache[0].advance(count)
-        self._write_attention(cache[1], count)
+        self._write_attention(cache[1], positions)
         self.target_offset = cache[1].offset
         self.target_offsets.append(self.target_offset)
         logits = self._logits(inputs)
-        hidden = inputs.astype(mx.float32)[..., None]
+        hidden = mx.stack(
+            [
+                inputs.astype(mx.float32),
+                mx.array(positions, dtype=mx.float32)[None],
+            ],
+            axis=-1,
+        )
         return (logits, hidden) if return_hidden else logits
 
     def mtp_forward(self, hidden, next_token_ids, cache):
         self._acknowledge_forward_positions()
+        self.mtp_input_ids.extend(next_token_ids.reshape(-1).tolist())
         self.mtp_attempt_offsets.append(cache[0].offset)
         if cache[0].offset in self.fail_mtp_offsets:
             raise RuntimeError("synthetic unexpected next draft")
-        self._write_attention(cache[0], next_token_ids.shape[1])
+        positions = self._logical_positions(next_token_ids.shape[1], cache[0].offset)
+        self._write_attention(cache[0], positions)
         self.mtp_offsets.append(cache[0].offset)
-        offset = 2 if self.wrong_draft or cache[0].offset != self.target_offset else 1
+        hidden_positions = tuple(int(position) for position in hidden[0, :, 1].tolist())
+        offset = (
+            2
+            if self.wrong_draft
+            or cache[0].offset != self.target_offset
+            or hidden_positions != positions
+            else 1
+        )
         return self._logits(next_token_ids, offset=offset)
+
+
+class _NativeMTPMoEModel(_NativeMTPModel):
+    """Tiny two-expert target/MTP double with token-routed expert logits."""
+
+    architecture = "qwen3_5_moe"
+    num_experts = 2
+
+    def _logits(self, inputs, *, offset=1):
+        expert = inputs.astype(mx.int32) % self.num_experts
+        expert_zero = inputs.astype(mx.int32) + offset
+        expert_one = inputs.astype(mx.int32) - (self.vocab_size - offset)
+        ids = mx.where(expert == 0, expert_zero, expert_one) % self.vocab_size
+        logits = mx.full((1, inputs.shape[1], self.vocab_size), -20.0)
+        for index in range(inputs.shape[1]):
+            logits[:, index, ids[0, index]] = 20.0
+        return logits
+
+
+class _NativeMTPQuantizedTargetModel(_NativeMTPModel):
+    """Target double with a known active packed uint32 authority payload."""
+
+    def make_cache(self):
+        recurrent = ArraysCache(2)
+        recurrent[0] = mx.array([[0.0]])
+        recurrent[1] = mx.array([[0.0]])
+        return [recurrent, QuantizedKVCache(group_size=32, bits=8)]
+
+    def __call__(self, inputs, *, cache, return_hidden=False):
+        result = super().__call__(inputs, cache=cache, return_hidden=return_hidden)
+        cache[1].keys[0][0, 0, 0, 0] = mx.array(16777216, dtype=mx.uint32)
+        return result
 
 
 def _run(model, *, max_tokens=4, prompt=(0, 1), **kwargs):
@@ -198,6 +270,165 @@ class _PositionContext:
             _ACTIVE_FORWARD.reset(token)
 
 
+def _make_sparse_bootstrap(
+    model,
+    context,
+    *,
+    positions,
+    selected_token_ids,
+    immediate_successor_token_ids,
+    chunk_sizes,
+):
+    target_cache = model.make_cache()
+    receipts = []
+    start = 0
+    for chunk_size in chunk_sizes:
+        end = start + chunk_size
+        (_, _), receipt = attested_target_forward(
+            model,
+            selected_token_ids[start:end],
+            target_cache,
+            phase=GenerationForwardPhase.PREFILL,
+            logical_positions=positions[start:end],
+            immediate_successor_token_ids=immediate_successor_token_ids[
+                start : min(end, len(immediate_successor_token_ids))
+            ],
+            model_forward_context=context.context,
+        )
+        receipts.append(receipt)
+        start = end
+    assert start == len(positions)
+    return NativeMTPSparseBootstrap(
+        receipts=tuple(receipts),
+        selected_logical_positions=positions,
+        selected_token_ids=selected_token_ids,
+        immediate_successor_token_ids=immediate_successor_token_ids,
+        target_cache=target_cache,
+        next_logical_position=positions[-1] + 1,
+    )
+
+
+def _direct_positioned_target(model, cache, context, token_ids, positions):
+    tokens = mx.array(token_ids, dtype=mx.uint32)
+    forward = GenerationForward(
+        model=model,
+        input_tokens=tokens[None],
+        cache=cache,
+        phase=GenerationForwardPhase.VERIFY,
+        logical_positions=positions,
+    )
+    with context.context(forward):
+        result = model(tokens[None], cache=cache, return_hidden=True)
+    mx.eval(result)
+    return result
+
+
+def _direct_positioned_mtp(model, cache, context, hidden, token_ids, positions):
+    tokens = mx.array(token_ids, dtype=mx.uint32)
+    forward = GenerationForward(
+        model=model,
+        input_tokens=tokens[None],
+        cache=cache,
+        phase=GenerationForwardPhase.MTP_DRAFT,
+        logical_positions=positions,
+    )
+    with context.context(forward):
+        logits = model.mtp_forward(hidden, tokens[None], cache)
+    mx.eval(logits)
+    return logits
+
+
+def _per_token_native_oracle(
+    model,
+    *,
+    positions,
+    selected_token_ids,
+    immediate_successor_token_ids,
+    rejected,
+):
+    context = _PositionContext()
+    target_cache = model.make_cache()
+    evidence = []
+    for index, (position, token_id) in enumerate(zip(positions, selected_token_ids)):
+        successors = (
+            (immediate_successor_token_ids[index],)
+            if index < len(immediate_successor_token_ids)
+            else ()
+        )
+        result, _ = attested_target_forward(
+            model,
+            (token_id,),
+            target_cache,
+            phase=GenerationForwardPhase.PREFILL,
+            logical_positions=(position,),
+            immediate_successor_token_ids=successors,
+            model_forward_context=context.context,
+        )
+        evidence.append(result)
+
+    mtp_cache = model.make_mtp_cache()
+    for index, successor in enumerate(immediate_successor_token_ids):
+        _direct_positioned_mtp(
+            model,
+            mtp_cache,
+            context,
+            evidence[index][1],
+            (successor,),
+            (positions[index],),
+        )
+    final_logits, final_hidden = evidence[-1]
+    first_logprobs = final_logits[:, -1, :].squeeze(0)
+    first_logprobs = first_logprobs - mx.logsumexp(first_logprobs)
+    current = mx.argmax(first_logprobs).item()
+    draft_logits = _direct_positioned_mtp(
+        model,
+        mtp_cache,
+        context,
+        final_hidden,
+        (current,),
+        (positions[-1],),
+    )
+    draft = mx.argmax(draft_logits[:, -1, :]).item()
+
+    verify_positions = (positions[-1] + 1, positions[-1] + 2)
+    if rejected:
+        disposable = model.make_cache()
+        for position, token_id in zip(positions, selected_token_ids):
+            _direct_positioned_target(
+                model, disposable, context, (token_id,), (position,)
+            )
+        verify_logits, _ = _direct_positioned_target(
+            model, disposable, context, (current, draft), verify_positions
+        )
+        replacement = mx.argmax(verify_logits[:, 0, :]).item()
+        _direct_positioned_target(
+            model, target_cache, context, (current,), (verify_positions[0],)
+        )
+        second = replacement
+    else:
+        verify_logits, _ = _direct_positioned_target(
+            model, target_cache, context, (current, draft), verify_positions
+        )
+        second = draft
+    second_logprobs = verify_logits[:, 0, :].squeeze(0)
+    second_logprobs = second_logprobs - mx.logsumexp(second_logprobs)
+    return (current, second), (first_logprobs, second_logprobs), target_cache, mtp_cache
+
+
+def _assert_kv_cache_equal(left, right):
+    assert left.offset == right.offset
+    active = slice(0, left.offset)
+    assert mx.array_equal(left.keys[..., active, :], right.keys[..., active, :]).item()
+    assert mx.array_equal(
+        left.values[..., active, :], right.values[..., active, :]
+    ).item()
+
+
+def _assert_arrays_cache_equal(left, right):
+    for left_value, right_value in zip(left.cache, right.cache):
+        assert mx.array_equal(left_value, right_value).item()
+
+
 def _event_contract(events):
     return [(event.phase, event.logical_positions) for event in events]
 
@@ -228,6 +459,826 @@ def test_sparse_positions_cover_exact_native_phase_order_and_shared_cursor():
     assert request.mtp[0].offset == 4
     assert request.state.next_logical_position == 8
     assert context.active == 0
+
+
+@pytest.mark.parametrize("model_type", (_NativeMTPModel, _NativeMTPMoEModel))
+def test_attested_keep_one_bootstrap_matches_dense_prefill(model_type, monkeypatch):
+    dense_model = model_type()
+    dense_output, dense_telemetry = _run(
+        dense_model, prompt=(0, 1, 2, 3), max_tokens=4, prefill_step_size=2
+    )
+    sparse_model = model_type()
+    context = _PositionContext()
+    bootstrap = _make_sparse_bootstrap(
+        sparse_model,
+        context,
+        positions=(0, 1, 2, 3),
+        selected_token_ids=(0, 1, 2, 3),
+        immediate_successor_token_ids=(1, 2, 3),
+        chunk_sizes=(2, 2),
+    )
+    context.events.clear()
+    sparse_telemetry = {}
+    adopted = []
+    original = NativeMTPRequestCache.adopt_sparse_target.__func__
+
+    def capture(cls, *args, **kwargs):
+        request = original(cls, *args, **kwargs)
+        adopted.append(request)
+        return request
+
+    monkeypatch.setattr(
+        NativeMTPRequestCache, "adopt_sparse_target", classmethod(capture)
+    )
+
+    sparse_output = list(
+        mtp_generate_step(
+            None,
+            sparse_model,
+            max_tokens=4,
+            prefill_step_size=2,
+            sparse_bootstrap=bootstrap,
+            model_forward_context=context.context,
+            telemetry=sparse_telemetry,
+        )
+    )
+
+    assert [(token, drafted) for token, _, drafted in sparse_output] == [
+        (token, drafted) for token, _, drafted in dense_output
+    ]
+    assert sparse_telemetry == dense_telemetry
+    for (_, dense_logprobs, _), (_, sparse_logprobs, _) in zip(
+        dense_output, sparse_output
+    ):
+        assert mx.allclose(dense_logprobs, sparse_logprobs).item()
+    assert sparse_model.mtp_input_ids[:3] == [1, 2, 3]
+    assert not any(
+        event.phase is GenerationForwardPhase.PREFILL for event in context.events
+    )
+    dense_request = dense_model.requests[-1]
+    sparse_request = adopted[0]
+    _assert_arrays_cache_equal(dense_request.backbone[0], bootstrap.target_cache[0])
+    _assert_kv_cache_equal(dense_request.backbone[1], bootstrap.target_cache[1])
+    _assert_kv_cache_equal(dense_request.mtp[0], sparse_request.mtp[0])
+    assert sparse_request.state.next_logical_position == 8
+
+
+def _native_position_oracle(*, rejected):
+    phases = [
+        (GenerationForwardPhase.MTP_DRAFT, (0,)),
+        (GenerationForwardPhase.MTP_DRAFT, (3,)),
+        (GenerationForwardPhase.MTP_DRAFT, (7,)),
+        (GenerationForwardPhase.VERIFY, (8, 9)),
+    ]
+    if rejected:
+        phases.append((GenerationForwardPhase.DECODE, (8,)))
+    return phases
+
+
+@pytest.mark.parametrize("model_type", (_NativeMTPModel, _NativeMTPMoEModel))
+@pytest.mark.parametrize("rejected", (False, True))
+def test_attested_noncontiguous_positions_match_per_token_oracle(
+    model_type, rejected, monkeypatch
+):
+    oracle = _per_token_native_oracle(
+        model_type(wrong_draft=rejected),
+        positions=(0, 3, 7),
+        selected_token_ids=(0, 3, 5),
+        immediate_successor_token_ids=(1, 4),
+        rejected=rejected,
+    )
+    model = model_type(wrong_draft=rejected)
+    context = _PositionContext()
+    bootstrap = _make_sparse_bootstrap(
+        model,
+        context,
+        positions=(0, 3, 7),
+        selected_token_ids=(0, 3, 5),
+        immediate_successor_token_ids=(1, 4),
+        chunk_sizes=(1, 2),
+    )
+    context.events.clear()
+    adopted = []
+    original = NativeMTPRequestCache.adopt_sparse_target.__func__
+
+    def capture(cls, *args, **kwargs):
+        request = original(cls, *args, **kwargs)
+        adopted.append(request)
+        return request
+
+    monkeypatch.setattr(
+        NativeMTPRequestCache, "adopt_sparse_target", classmethod(capture)
+    )
+
+    output = list(
+        mtp_generate_step(
+            None,
+            model,
+            max_tokens=2,
+            prefill_step_size=1,
+            sparse_bootstrap=bootstrap,
+            model_forward_context=context.context,
+        )
+    )
+
+    oracle_tokens, oracle_logprobs, oracle_target, oracle_mtp = oracle
+    assert tuple(token for token, _, _ in output) == oracle_tokens
+    for (_, logprobs, _), expected in zip(output, oracle_logprobs):
+        assert mx.allclose(logprobs, expected).item()
+    assert _event_contract(context.events) == _native_position_oracle(rejected=rejected)
+    assert model.mtp_input_ids[:2] == [1, 4]
+    request = adopted[0]
+    _assert_arrays_cache_equal(bootstrap.target_cache[0], oracle_target[0])
+    _assert_kv_cache_equal(bootstrap.target_cache[1], oracle_target[1])
+    _assert_kv_cache_equal(request.mtp[0], oracle_mtp[0])
+    assert request.state.next_logical_position == 10
+
+
+def test_attested_receipts_are_sealed_and_duplicate_authority_must_match():
+    with pytest.raises(TypeError):
+        GenerationForwardPositionReceipt()
+
+    model = _NativeMTPModel()
+    context = _PositionContext()
+    bootstrap = _make_sparse_bootstrap(
+        model,
+        context,
+        positions=(0, 3),
+        selected_token_ids=(0, 3),
+        immediate_successor_token_ids=(1,),
+        chunk_sizes=(1, 1),
+    )
+    forged = object.__new__(GenerationForwardPositionReceipt)
+    for name in (
+        "model_id",
+        "cache_container_id",
+        "cache_entry_ids",
+        "capability",
+        "phase",
+        "logical_positions",
+        "token_ids",
+        "immediate_successor_token_ids",
+        "logits",
+        "hidden_rows",
+        "_issuer_seal",
+        "_record_token",
+    ):
+        object.__setattr__(forged, name, getattr(bootstrap.receipts[0], name))
+    with pytest.raises(RuntimeError, match="receipt_canonical_mismatch"):
+        replace(bootstrap, receipts=(forged, bootstrap.receipts[1])).validate(model)
+    with pytest.raises(ValueError, match="receipt_successors_mismatch"):
+        replace(bootstrap, immediate_successor_token_ids=(2,)).validate(model)
+
+
+def test_sparse_bootstrap_requires_final_canonical_logits_evidence():
+    model = _NativeMTPModel()
+    context = _PositionContext()
+    bootstrap = _make_sparse_bootstrap(
+        model,
+        context,
+        positions=(0, 3),
+        selected_token_ids=(0, 3),
+        immediate_successor_token_ids=(1,),
+        chunk_sizes=(1, 1),
+    )
+    malformed = replace(
+        bootstrap,
+        receipts=tuple(reversed(bootstrap.receipts)),
+    )
+    with pytest.raises(RuntimeError, match="final_logits_evidence_missing"):
+        malformed.validate(model)
+
+
+@pytest.mark.parametrize(
+    "mutation",
+    (
+        "host",
+        "cache",
+        "model_id",
+        "cache_container_id",
+        "cache_entry_ids",
+        "capability",
+        "phase",
+        "logical_positions",
+        "token_ids",
+        "successors",
+        "logits",
+        "logits_content",
+        "hidden_rows",
+        "hidden_content",
+        "record_token",
+    ),
+)
+def test_sparse_bootstrap_canonical_authority_rejects_mutation(mutation):
+    model = _NativeMTPModel()
+    context = _PositionContext()
+    bootstrap = _make_sparse_bootstrap(
+        model,
+        context,
+        positions=(0, 3),
+        selected_token_ids=(0, 3),
+        immediate_successor_token_ids=(1,),
+        chunk_sizes=(1, 1),
+    )
+    if mutation == "host":
+        candidate = replace(bootstrap, selected_token_ids=(0, 2))
+    elif mutation == "cache":
+        candidate = replace(bootstrap, target_cache=list(bootstrap.target_cache))
+    else:
+        receipt = bootstrap.receipts[-1]
+        if mutation == "logits_content":
+            receipt.logits[:, -1, 0] = receipt.logits[:, -1, 0] + 1
+            candidate = bootstrap
+        elif mutation == "hidden_content":
+            receipt.hidden_rows[:, -1, 0] = receipt.hidden_rows[:, -1, 0] + 1
+            candidate = bootstrap
+        else:
+            mutations = {
+                "model_id": receipt.model_id + 1,
+                "cache_container_id": receipt.cache_container_id + 1,
+                "cache_entry_ids": tuple(reversed(receipt.cache_entry_ids)),
+                "capability": replace(receipt.capability, reason="mutated"),
+                "phase": GenerationForwardPhase.VERIFY,
+                "logical_positions": (2,),
+                "token_ids": (2,),
+                "successors": (1,),
+                "logits": receipt.logits + 0,
+                "hidden_rows": receipt.hidden_rows + 0,
+                "record_token": bootstrap.receipts[0]._record_token,
+            }
+            field_name = (
+                "immediate_successor_token_ids"
+                if mutation == "successors"
+                else f"_{mutation}" if mutation == "record_token" else mutation
+            )
+            object.__setattr__(receipt, field_name, mutations[mutation])
+            candidate = bootstrap
+
+    with pytest.raises((ValueError, RuntimeError, TypeError)):
+        candidate.validate(model)
+
+
+@pytest.mark.parametrize("cache_kind", ("arrays", "kv"))
+def test_sparse_claim_rejects_same_identity_cache_content_mutation_permanently(
+    cache_kind,
+):
+    model = _NativeMTPModel()
+    context = _PositionContext()
+    bootstrap = _make_sparse_bootstrap(
+        model,
+        context,
+        positions=(0, 3),
+        selected_token_ids=(0, 3),
+        immediate_successor_token_ids=(1,),
+        chunk_sizes=(1, 1),
+    )
+    if cache_kind == "arrays":
+        state = bootstrap.target_cache[0][0]
+        state[0, 0] = state[0, 0] + 1
+    else:
+        keys = bootstrap.target_cache[1].keys
+        keys[0, 0, 0, 0] = keys[0, 0, 0, 0] + 1
+
+    with pytest.raises(RuntimeError, match="evidence_content_mismatch"):
+        bootstrap.claim(model)
+    with pytest.raises(RuntimeError, match="already_claimed"):
+        bootstrap.claim(model)
+
+
+def test_sparse_claim_detects_exact_active_quantized_packed_word_mutation():
+    model = _NativeMTPQuantizedTargetModel()
+    context = _PositionContext()
+    bootstrap = _make_sparse_bootstrap(
+        model,
+        context,
+        positions=(0,),
+        selected_token_ids=(0,),
+        immediate_successor_token_ids=(),
+        chunk_sizes=(1,),
+    )
+    packed_keys = bootstrap.target_cache[1].keys[0]
+    assert packed_keys[0, 0, 0, 0].item() == 16777216
+    packed_keys[0, 0, 0, 0] = mx.array(16777217, dtype=mx.uint32)
+
+    with pytest.raises(RuntimeError, match="evidence_content_mismatch"):
+        bootstrap.claim(model)
+    with pytest.raises(RuntimeError, match="already_claimed"):
+        bootstrap.claim(model)
+
+
+def test_sparse_claim_uses_one_aggregate_host_decision_and_final_cache_scan(
+    monkeypatch,
+):
+    scans = 0
+    decisions = 0
+    hash_reductions = 0
+    original_digest = generate_module._cache_content_digest
+    original_decision = generate_module._sparse_attestation_host_decision
+    original_sum = mx.sum
+
+    def count_digest(entries):
+        nonlocal scans
+        scans += 1
+        return original_digest(entries)
+
+    def count_decision(value):
+        nonlocal decisions
+        decisions += 1
+        return original_decision(value)
+
+    def count_sum(value, *args, **kwargs):
+        nonlocal hash_reductions
+        axis = kwargs.get("axis", args[0] if args else None)
+        if (
+            value.dtype == mx.uint64
+            and value.ndim > 1
+            and value.shape[-1] == 2
+            and axis == tuple(range(value.ndim - 1))
+        ):
+            hash_reductions += 1
+        return original_sum(value, *args, **kwargs)
+
+    monkeypatch.setattr(generate_module, "_cache_content_digest", count_digest)
+    monkeypatch.setattr(
+        generate_module, "_sparse_attestation_host_decision", count_decision
+    )
+    monkeypatch.setattr(mx, "sum", count_sum)
+    model = _NativeMTPModel()
+    context = _PositionContext()
+    bootstrap = _make_sparse_bootstrap(
+        model,
+        context,
+        positions=(0, 3),
+        selected_token_ids=(0, 3),
+        immediate_successor_token_ids=(1,),
+        chunk_sizes=(1, 1),
+    )
+    assert scans == 1
+    # Two recurrent arrays plus active K and V: one fixed-width reduction each.
+    assert hash_reductions == 4
+    bootstrap.claim(model)
+    assert scans == 2
+    assert decisions == 1
+    assert hash_reductions == 8
+
+
+def test_unrelated_sparse_claim_reserves_while_device_verification_is_blocked(
+    monkeypatch,
+):
+    first_model = _NativeMTPModel()
+    first_context = _PositionContext()
+    first = _make_sparse_bootstrap(
+        first_model,
+        first_context,
+        positions=(0,),
+        selected_token_ids=(0,),
+        immediate_successor_token_ids=(),
+        chunk_sizes=(1,),
+    )
+    second_model = _NativeMTPModel()
+    second_context = _PositionContext()
+    second = _make_sparse_bootstrap(
+        second_model,
+        second_context,
+        positions=(0,),
+        selected_token_ids=(0,),
+        immediate_successor_token_ids=(),
+        chunk_sizes=(1,),
+    )
+    blocked = threading.Event()
+    release = threading.Event()
+    result = []
+    original_verify = generate_module._verify_sparse_canonical_content
+    first_receipt_id = id(first.receipts[0])
+
+    def block_first(records):
+        if records[0].receipt_id == first_receipt_id:
+            blocked.set()
+            assert release.wait(timeout=5)
+        return original_verify(records)
+
+    monkeypatch.setattr(
+        generate_module, "_verify_sparse_canonical_content", block_first
+    )
+
+    def claim_first():
+        result.append(first.claim(first_model))
+
+    thread = threading.Thread(target=claim_first)
+    thread.start()
+    assert blocked.wait(timeout=5)
+    second_claim = second.claim(second_model)
+    release.set()
+    thread.join(timeout=10)
+
+    assert not thread.is_alive()
+    assert len(result) == 1
+    assert result[0].target_cache is first.target_cache
+    assert second_claim.target_cache is second.target_cache
+
+
+@pytest.mark.parametrize("failure_kind", ("telemetry", "eos"))
+def test_immediate_post_adoption_failure_closes_and_consumes(failure_kind, monkeypatch):
+    model = _NativeMTPModel()
+    context = _PositionContext()
+    bootstrap = _make_sparse_bootstrap(
+        model,
+        context,
+        positions=(0, 3),
+        selected_token_ids=(0, 3),
+        immediate_successor_token_ids=(1,),
+        chunk_sizes=(1, 1),
+    )
+    adopted = []
+    original = NativeMTPRequestCache.adopt_sparse_target.__func__
+
+    def capture(cls, *args, **kwargs):
+        request = original(cls, *args, **kwargs)
+        adopted.append(request)
+        return request
+
+    class FailingTelemetry(dict):
+        def update(self, *args, **kwargs):
+            raise RuntimeError("synthetic immediate post-adoption failure")
+
+    monkeypatch.setattr(
+        NativeMTPRequestCache, "adopt_sparse_target", classmethod(capture)
+    )
+    kwargs = (
+        {"telemetry": FailingTelemetry()}
+        if failure_kind == "telemetry"
+        else {"eos_token_ids": [[]]}
+    )
+    with pytest.raises((RuntimeError, TypeError)):
+        next(
+            mtp_generate_step(
+                None,
+                model,
+                sparse_bootstrap=bootstrap,
+                model_forward_context=context.context,
+                **kwargs,
+            )
+        )
+    request = adopted[0]
+    assert request.closed
+    assert not request.checkpoint_active
+    assert request.backbone[1].offset == 2
+    assert request.mtp[0].offset == 0
+    with pytest.raises(RuntimeError, match="already_claimed"):
+        next(
+            mtp_generate_step(
+                None,
+                model,
+                sparse_bootstrap=bootstrap,
+                model_forward_context=context.context,
+            )
+        )
+
+
+def test_baseexception_after_adoption_is_inside_generator_cleanup(monkeypatch):
+    class SyntheticAbort(BaseException):
+        pass
+
+    model = _NativeMTPModel()
+    context = _PositionContext()
+    bootstrap = _make_sparse_bootstrap(
+        model,
+        context,
+        positions=(0, 3),
+        selected_token_ids=(0, 3),
+        immediate_successor_token_ids=(1,),
+        chunk_sizes=(1, 1),
+    )
+    adopted = []
+    original_adopt = NativeMTPRequestCache.adopt_sparse_target.__func__
+
+    def capture(cls, *args, **kwargs):
+        request = original_adopt(cls, *args, **kwargs)
+        adopted.append(request)
+        return request
+
+    def abort_rng(*args, **kwargs):
+        raise SyntheticAbort("synthetic former-gap abort")
+
+    monkeypatch.setattr(
+        NativeMTPRequestCache, "adopt_sparse_target", classmethod(capture)
+    )
+    monkeypatch.setattr(mx.random, "key", abort_rng)
+    with pytest.raises(SyntheticAbort, match="former-gap abort"):
+        next(
+            mtp_generate_step(
+                None,
+                model,
+                sparse_bootstrap=bootstrap,
+                model_forward_context=context.context,
+            )
+        )
+
+    assert len(adopted) == 1
+    assert adopted[0].closed
+    assert not adopted[0].checkpoint_active
+    assert adopted[0].backbone[1].offset == 2
+    assert adopted[0].mtp[0].offset == 0
+    with pytest.raises(RuntimeError, match="already_claimed"):
+        bootstrap.claim(model)
+
+
+def test_sparse_claim_stays_consumed_when_adoption_fails(monkeypatch):
+    model = _NativeMTPModel()
+    context = _PositionContext()
+    bootstrap = _make_sparse_bootstrap(
+        model,
+        context,
+        positions=(0,),
+        selected_token_ids=(0,),
+        immediate_successor_token_ids=(),
+        chunk_sizes=(1,),
+    )
+    original = NativeMTPRequestCache.adopt_sparse_target.__func__
+
+    def fail_adoption(*args, **kwargs):
+        raise RuntimeError("synthetic adoption failure")
+
+    monkeypatch.setattr(
+        NativeMTPRequestCache,
+        "adopt_sparse_target",
+        classmethod(fail_adoption),
+    )
+    with pytest.raises(RuntimeError, match="synthetic adoption failure"):
+        next(
+            mtp_generate_step(
+                None,
+                model,
+                sparse_bootstrap=bootstrap,
+                model_forward_context=context.context,
+            )
+        )
+    monkeypatch.setattr(
+        NativeMTPRequestCache, "adopt_sparse_target", classmethod(original)
+    )
+    with pytest.raises(RuntimeError, match="already_claimed"):
+        next(
+            mtp_generate_step(
+                None,
+                model,
+                sparse_bootstrap=bootstrap,
+                model_forward_context=context.context,
+            )
+        )
+
+
+@pytest.mark.parametrize("action", ("close", "cancel"))
+def test_sparse_bootstrap_one_shot_double_iterator_and_post_yield_cleanup(
+    action, monkeypatch
+):
+    model = _NativeMTPModel()
+    context = _PositionContext()
+    bootstrap = _make_sparse_bootstrap(
+        model,
+        context,
+        positions=(0, 3),
+        selected_token_ids=(0, 3),
+        immediate_successor_token_ids=(1,),
+        chunk_sizes=(1, 1),
+    )
+    context.events.clear()
+    adopted = []
+    original = NativeMTPRequestCache.adopt_sparse_target.__func__
+
+    def capture(cls, *args, **kwargs):
+        request = original(cls, *args, **kwargs)
+        adopted.append(request)
+        return request
+
+    monkeypatch.setattr(
+        NativeMTPRequestCache, "adopt_sparse_target", classmethod(capture)
+    )
+    first = mtp_generate_step(
+        None,
+        model,
+        max_tokens=4,
+        sparse_bootstrap=bootstrap,
+        model_forward_context=context.context,
+    )
+    second = mtp_generate_step(
+        None,
+        model,
+        max_tokens=4,
+        sparse_bootstrap=bootstrap,
+        model_forward_context=context.context,
+    )
+    next(first)
+    assert context.active == 0
+    with pytest.raises(RuntimeError, match="already_claimed"):
+        next(second)
+    assert context.active == 0
+    if action == "close":
+        first.close()
+    else:
+        with pytest.raises(RuntimeError, match="synthetic cancellation"):
+            first.throw(RuntimeError("synthetic cancellation"))
+    assert adopted[0].closed
+    assert not adopted[0].checkpoint_active
+    assert context.active == 0
+
+
+def test_sparse_bootstrap_concurrent_claim_is_exactly_once():
+    model = _NativeMTPModel()
+    context = _PositionContext()
+    bootstrap = _make_sparse_bootstrap(
+        model,
+        context,
+        positions=(0, 3),
+        selected_token_ids=(0, 3),
+        immediate_successor_token_ids=(1,),
+        chunk_sizes=(1, 1),
+    )
+    context.events.clear()
+    claim_barrier = threading.Barrier(2)
+    outcomes = []
+
+    def claim():
+        try:
+            claim_barrier.wait(timeout=5)
+            claimed = bootstrap.claim(model)
+        except RuntimeError as error:
+            outcomes.append(("error", str(error)))
+        else:
+            outcomes.append(("success", claimed))
+
+    threads = [threading.Thread(target=claim) for _ in range(2)]
+    for thread in threads:
+        thread.start()
+    for thread in threads:
+        thread.join(timeout=10)
+
+    assert all(not thread.is_alive() for thread in threads)
+    assert [outcome[0] for outcome in outcomes].count("success") == 1
+    assert [outcome[0] for outcome in outcomes].count("error") == 1
+    assert any(
+        status == "error" and "already_claimed" in value for status, value in outcomes
+    )
+    claimed = next(value for status, value in outcomes if status == "success")
+    # Claiming only transfers opaque authority.  The losing owner must fail
+    # before either the attested target cache or a fresh MTP cache is mutated.
+    assert claimed.target_cache[1].offset == 2
+    request = NativeMTPRequestCache.adopt_sparse_target(
+        model,
+        target_cache=claimed.target_cache,
+        target_tokens=len(claimed.selected_token_ids),
+        next_logical_position=claimed.next_logical_position,
+    )
+    request.finish("cancelled")
+    assert request.closed
+    assert not request.checkpoint_active
+    assert request.backbone[1].offset == 2
+    assert request.mtp[0].offset == 0
+    assert context.active == 0
+
+
+def test_sparse_bootstrap_admission_fails_before_request_adoption():
+    model = _NativeMTPModel()
+    context = _PositionContext()
+    bootstrap = _make_sparse_bootstrap(
+        model,
+        context,
+        positions=(0,),
+        selected_token_ids=(0,),
+        immediate_successor_token_ids=(),
+        chunk_sizes=(1,),
+    )
+    with pytest.raises(ValueError, match="requires_position_context"):
+        list(mtp_generate_step(None, model, sparse_bootstrap=bootstrap))
+    with pytest.raises(ValueError, match="owns_selected_tokens"):
+        list(
+            mtp_generate_step(
+                mx.array([0], dtype=mx.uint32),
+                model,
+                sparse_bootstrap=bootstrap,
+                model_forward_context=context.context,
+            )
+        )
+    with pytest.raises(ValueError, match="prefill_step_size"):
+        list(
+            mtp_generate_step(
+                None,
+                model,
+                sparse_bootstrap=bootstrap,
+                model_forward_context=context.context,
+                prefill_step_size=0,
+            )
+        )
+    assert model.requests == []
+
+
+def test_sparse_bootstrap_failure_rolls_back_and_closes(monkeypatch):
+    model = _NativeMTPModel(fail_mtp_offsets={0})
+    context = _PositionContext()
+    bootstrap = _make_sparse_bootstrap(
+        model,
+        context,
+        positions=(0, 3),
+        selected_token_ids=(0, 3),
+        immediate_successor_token_ids=(1,),
+        chunk_sizes=(1, 1),
+    )
+    adopted = []
+    original = NativeMTPRequestCache.adopt_sparse_target.__func__
+
+    def capture(cls, *args, **kwargs):
+        request = original(cls, *args, **kwargs)
+        adopted.append(request)
+        return request
+
+    monkeypatch.setattr(
+        NativeMTPRequestCache, "adopt_sparse_target", classmethod(capture)
+    )
+    with pytest.raises(RuntimeError, match="synthetic unexpected next draft"):
+        list(
+            mtp_generate_step(
+                None,
+                model,
+                sparse_bootstrap=bootstrap,
+                model_forward_context=context.context,
+            )
+        )
+    request = adopted[0]
+    assert request.closed
+    assert not request.checkpoint_active
+    assert request.backbone[1].offset == 2
+    assert request.mtp[0].offset == 0
+
+
+@pytest.mark.parametrize("failure_kind", ("processor", "sampler", "lazy_eval"))
+def test_sparse_pre_output_failure_rolls_back_unpublished_bootstrap(
+    failure_kind, monkeypatch
+):
+    model = _NativeMTPModel()
+    context = _PositionContext()
+    bootstrap = _make_sparse_bootstrap(
+        model,
+        context,
+        positions=(0, 3),
+        selected_token_ids=(0, 3),
+        immediate_successor_token_ids=(1,),
+        chunk_sizes=(1, 1),
+    )
+    adopted = []
+    original_adopt = NativeMTPRequestCache.adopt_sparse_target.__func__
+
+    def capture(cls, *args, **kwargs):
+        request = original_adopt(cls, *args, **kwargs)
+        adopted.append(request)
+        return request
+
+    monkeypatch.setattr(
+        NativeMTPRequestCache, "adopt_sparse_target", classmethod(capture)
+    )
+    kwargs = {}
+    if failure_kind == "processor":
+
+        def processor(_tokens, _logits):
+            raise RuntimeError("synthetic pre-output failure")
+
+        processor.native_mtp_replay_safe = True
+        kwargs["logits_processors"] = [processor]
+    elif failure_kind == "sampler":
+
+        def sampler(_logprobs):
+            raise RuntimeError("synthetic pre-output failure")
+
+        sampler.native_mtp_deterministic = True
+        kwargs["sampler"] = sampler
+    else:
+        original_eval = mx.eval
+
+        def fail_current_eval(*values):
+            if len(values) == 2 and all(
+                isinstance(value, mx.array) for value in values
+            ):
+                raise RuntimeError("synthetic pre-output failure")
+            return original_eval(*values)
+
+        monkeypatch.setattr(mx, "eval", fail_current_eval)
+
+    with pytest.raises(RuntimeError, match="synthetic pre-output failure"):
+        list(
+            mtp_generate_step(
+                None,
+                model,
+                sparse_bootstrap=bootstrap,
+                model_forward_context=context.context,
+                **kwargs,
+            )
+        )
+    request = adopted[0]
+    assert request.closed
+    assert not request.checkpoint_active
+    assert request.replay_required is None
+    assert request.state.backbone_tokens == 2
+    assert request.state.mtp_tokens == 0
+    assert request.backbone[1].offset == 2
+    assert request.mtp[0].offset == 0
 
 
 def test_sparse_rejection_replays_exact_positions_without_cursor_rewind():

--- a/tests/test_native_mtp_generate.py
+++ b/tests/test_native_mtp_generate.py
@@ -18,6 +18,7 @@ from mlx_lm.generate import (
     NativeMTPSparseBootstrap,
     attested_target_forward,
     mtp_generate_step,
+    stream_generate,
 )
 from mlx_lm.models.cache import (
     ArraysCache,
@@ -270,6 +271,24 @@ class _PositionContext:
             _ACTIVE_FORWARD.reset(token)
 
 
+class _StreamDetokenizer:
+    def __init__(self):
+        self.last_segment = ""
+        self.finalized = False
+
+    def add_token(self, token):
+        self.last_segment = str(token)
+
+    def finalize(self):
+        self.finalized = True
+
+
+class _StreamTokenizer:
+    def __init__(self):
+        self.detokenizer = _StreamDetokenizer()
+        self.eos_token_ids = frozenset()
+
+
 def _make_sparse_bootstrap(
     model,
     context,
@@ -306,6 +325,370 @@ def _make_sparse_bootstrap(
         target_cache=target_cache,
         next_logical_position=positions[-1] + 1,
     )
+
+
+def test_stream_generate_dispatches_attested_sparse_bootstrap_without_prompt_array(
+    monkeypatch,
+):
+    model = _NativeMTPModel()
+    context = _PositionContext()
+    bootstrap = _make_sparse_bootstrap(
+        model,
+        context,
+        positions=(0, 3, 7),
+        selected_token_ids=(0, 3, 5),
+        immediate_successor_token_ids=(1, 4),
+        chunk_sizes=(1, 2),
+    )
+    captured = {}
+    logprobs = mx.zeros((model.vocab_size,))
+
+    def fake_mtp_generate_step(prompt, actual_model, **kwargs):
+        captured["prompt"] = prompt
+        captured["model"] = actual_model
+        captured.update(kwargs)
+        kwargs["telemetry"].update(mtp_drafts=4, mtp_accepted=3)
+        yield 6, logprobs, True
+
+    monkeypatch.setattr(generate_module, "TokenizerWrapper", _StreamTokenizer)
+    monkeypatch.setattr(generate_module, "mtp_generate_step", fake_mtp_generate_step)
+    tokenizer = _StreamTokenizer()
+
+    responses = list(
+        stream_generate(
+            model,
+            tokenizer,
+            None,
+            mtp=True,
+            max_tokens=2,
+            sparse_bootstrap=bootstrap,
+            model_forward_context=context.context,
+        )
+    )
+
+    assert captured["prompt"] is None
+    assert captured["model"] is model
+    assert captured["sparse_bootstrap"] is bootstrap
+    assert captured["model_forward_context"] == context.context
+    assert [response.prompt_tokens for response in responses] == [8, 8]
+    assert [response.prompt_tps for response in responses] == [0.0, 0.0]
+    assert [response.mtp_drafts for response in responses] == [4, 4]
+    assert [response.mtp_accepted for response in responses] == [3, 3]
+    assert [response.text for response in responses] == ["6", "6"]
+    assert tokenizer.detokenizer.finalized
+    assert responses[-1].finish_reason == "length"
+
+
+def test_stream_generate_dense_native_mtp_omits_sparse_bootstrap_keyword(monkeypatch):
+    captured = {}
+    logprobs = mx.zeros((7,))
+
+    def fake_mtp_generate_step(prompt, actual_model, **kwargs):
+        captured["prompt"] = prompt
+        captured["model"] = actual_model
+        captured.update(kwargs)
+        yield 2, logprobs, False
+
+    model = _NativeMTPModel()
+    monkeypatch.setattr(generate_module, "TokenizerWrapper", _StreamTokenizer)
+    monkeypatch.setattr(generate_module, "mtp_generate_step", fake_mtp_generate_step)
+    responses = list(
+        stream_generate(
+            model,
+            _StreamTokenizer(),
+            [0, 1],
+            mtp=True,
+            max_tokens=2,
+        )
+    )
+
+    assert captured["prompt"].tolist() == [0, 1]
+    assert captured["model"] is model
+    assert "sparse_bootstrap" not in captured
+    assert [response.prompt_tokens for response in responses] == [2, 2]
+
+
+@pytest.mark.parametrize(
+    ("prompt", "mtp", "draft_model", "bootstrap", "kwargs", "message"),
+    (
+        (None, False, None, "valid", {}, "native_mtp_sparse_bootstrap_requires_mtp"),
+        (
+            None,
+            True,
+            object(),
+            "valid",
+            {},
+            "native_mtp_sparse_bootstrap_external_draft_unsupported",
+        ),
+        (None, True, None, None, {}, "stream_generate requires a prompt"),
+        (
+            (0,),
+            True,
+            None,
+            "valid",
+            {},
+            "native_mtp_sparse_bootstrap_owns_selected_tokens",
+        ),
+        (
+            None,
+            True,
+            None,
+            "valid",
+            {"prompt_logical_positions": (0,)},
+            "native_mtp_sparse_bootstrap_owns_logical_positions",
+        ),
+        (
+            None,
+            True,
+            None,
+            "valid",
+            {"prompt_cache": []},
+            "native_mtp_prefix_reuse_unsupported",
+        ),
+        (None, True, None, object(), {}, "native_mtp_sparse_bootstrap_invalid"),
+    ),
+)
+def test_stream_generate_rejects_invalid_sparse_none_combinations_before_prompt_mutation(
+    monkeypatch, prompt, mtp, draft_model, bootstrap, kwargs, message
+):
+    model = _NativeMTPModel()
+    context = _PositionContext()
+    valid_bootstrap = _make_sparse_bootstrap(
+        model,
+        context,
+        positions=(0,),
+        selected_token_ids=(0,),
+        immediate_successor_token_ids=(),
+        chunk_sizes=(1,),
+    )
+    if bootstrap == "valid":
+        bootstrap = valid_bootstrap
+
+    def prompt_conversion_forbidden(*_args, **_kwargs):
+        raise AssertionError("prompt conversion must not run before sparse validation")
+
+    monkeypatch.setattr(generate_module.mx, "array", prompt_conversion_forbidden)
+    with pytest.raises((TypeError, ValueError), match=message):
+        list(
+            stream_generate(
+                model,
+                _StreamTokenizer(),
+                prompt,
+                mtp=mtp,
+                draft_model=draft_model,
+                sparse_bootstrap=bootstrap,
+                model_forward_context=context.context,
+                **kwargs,
+            )
+        )
+
+
+@pytest.mark.parametrize(
+    ("model_capability", "context", "message"),
+    (
+        (None, None, "native_mtp_sparse_bootstrap_requires_position_context"),
+        (
+            _Capability(False, "native_mtp_weights_not_loaded"),
+            "context",
+            "native_mtp_weights_not_loaded",
+        ),
+    ),
+)
+def test_stream_generate_sparse_rejects_context_and_capability_before_mutation(
+    monkeypatch, model_capability, context, message
+):
+    model = _NativeMTPModel()
+    position_context = _PositionContext()
+    bootstrap = _make_sparse_bootstrap(
+        model,
+        position_context,
+        positions=(0,),
+        selected_token_ids=(0,),
+        immediate_successor_token_ids=(),
+        chunk_sizes=(1,),
+    )
+    if model_capability is not None:
+        model.mtp_capability = model_capability
+    if context == "context":
+        context = position_context.context
+
+    def prompt_conversion_forbidden(*_args, **_kwargs):
+        raise AssertionError("prompt conversion must not run before sparse validation")
+
+    monkeypatch.setattr(generate_module.mx, "array", prompt_conversion_forbidden)
+    with pytest.raises((RuntimeError, ValueError), match=message):
+        list(
+            stream_generate(
+                model,
+                _StreamTokenizer(),
+                None,
+                mtp=True,
+                sparse_bootstrap=bootstrap,
+                model_forward_context=context,
+            )
+        )
+    assert model.requests == []
+
+
+def test_stream_generate_sparse_bootstrap_is_one_shot_and_closes_on_failure(
+    monkeypatch,
+):
+    monkeypatch.setattr(generate_module, "TokenizerWrapper", _StreamTokenizer)
+    adopted = []
+    original_adopt = NativeMTPRequestCache.adopt_sparse_target.__func__
+
+    def capture_adopt(cls, *args, **kwargs):
+        request = original_adopt(cls, *args, **kwargs)
+        adopted.append(request)
+        return request
+
+    monkeypatch.setattr(
+        NativeMTPRequestCache, "adopt_sparse_target", classmethod(capture_adopt)
+    )
+
+    model = _NativeMTPModel()
+    context = _PositionContext()
+    bootstrap = _make_sparse_bootstrap(
+        model,
+        context,
+        positions=(0, 3),
+        selected_token_ids=(0, 3),
+        immediate_successor_token_ids=(1,),
+        chunk_sizes=(2,),
+    )
+    iterator = stream_generate(
+        model,
+        _StreamTokenizer(),
+        None,
+        mtp=True,
+        max_tokens=4,
+        sparse_bootstrap=bootstrap,
+        model_forward_context=context.context,
+    )
+    assert next(iterator).token == 4
+    request = adopted[-1]
+    iterator.close()
+    assert request.closed
+    assert context.active == 0
+
+    with pytest.raises(RuntimeError, match="native_mtp_sparse_bootstrap_already_claimed"):
+        list(
+            stream_generate(
+                model,
+                _StreamTokenizer(),
+                None,
+                mtp=True,
+                sparse_bootstrap=bootstrap,
+                model_forward_context=context.context,
+            )
+        )
+
+    failing_model = _NativeMTPModel(fail_mtp_offsets={0})
+    failing_context = _PositionContext()
+    failing_bootstrap = _make_sparse_bootstrap(
+        failing_model,
+        failing_context,
+        positions=(0, 3),
+        selected_token_ids=(0, 3),
+        immediate_successor_token_ids=(1,),
+        chunk_sizes=(2,),
+    )
+    with pytest.raises(RuntimeError, match="synthetic unexpected next draft"):
+        list(
+            stream_generate(
+                failing_model,
+                _StreamTokenizer(),
+                None,
+                mtp=True,
+                sparse_bootstrap=failing_bootstrap,
+                model_forward_context=failing_context.context,
+            )
+        )
+    assert adopted[-1].closed
+    assert failing_context.active == 0
+
+
+def test_stream_generate_sparse_zero_tokens_finalizes_with_terminal_telemetry(
+    monkeypatch,
+):
+    monkeypatch.setattr(generate_module, "TokenizerWrapper", _StreamTokenizer)
+    adopted = []
+    original_adopt = NativeMTPRequestCache.adopt_sparse_target.__func__
+
+    def capture_adopt(cls, *args, **kwargs):
+        request = original_adopt(cls, *args, **kwargs)
+        adopted.append(request)
+        return request
+
+    monkeypatch.setattr(
+        NativeMTPRequestCache, "adopt_sparse_target", classmethod(capture_adopt)
+    )
+    model = _NativeMTPModel()
+    context = _PositionContext()
+    bootstrap = _make_sparse_bootstrap(
+        model,
+        context,
+        positions=(0, 3),
+        selected_token_ids=(0, 3),
+        immediate_successor_token_ids=(1,),
+        chunk_sizes=(2,),
+    )
+    tokenizer = _StreamTokenizer()
+    responses = list(
+        stream_generate(
+            model,
+            tokenizer,
+            None,
+            mtp=True,
+            max_tokens=0,
+            sparse_bootstrap=bootstrap,
+            model_forward_context=context.context,
+        )
+    )
+
+    assert len(responses) == 1
+    terminal = responses[0]
+    assert tokenizer.detokenizer.finalized
+    assert terminal.text == ""
+    assert terminal.generation_tokens == 0
+    assert terminal.prompt_tokens == 4
+    assert terminal.prompt_tps == 0.0
+    assert terminal.finish_reason == "length"
+    assert terminal.mtp_drafts == 0
+    assert terminal.mtp_accepted == 0
+    assert terminal.mtp_bypass_reason is None
+    assert adopted[-1].closed
+    assert context.active == 0
+
+
+def test_stream_generate_ordinary_prompt_path_is_unchanged(monkeypatch):
+    captured = {}
+    logprobs = mx.zeros((7,))
+
+    def fake_generate_step(prompt, model, **kwargs):
+        captured["prompt"] = prompt
+        captured["model"] = model
+        captured.update(kwargs)
+        yield 2, logprobs
+
+    model = _NativeMTPModel()
+    monkeypatch.setattr(generate_module, "TokenizerWrapper", _StreamTokenizer)
+    monkeypatch.setattr(generate_module, "generate_step", fake_generate_step)
+    responses = list(
+        stream_generate(
+            model,
+            _StreamTokenizer(),
+            [0, 1],
+            max_tokens=2,
+        )
+    )
+
+    assert isinstance(captured["prompt"], mx.array)
+    assert captured["prompt"].tolist() == [0, 1]
+    assert captured["model"] is model
+    assert "sparse_bootstrap" not in captured
+    assert [response.prompt_tokens for response in responses] == [2, 2]
+    assert responses[-1].mtp_bypass_reason is None
 
 
 def _direct_positioned_target(model, cache, context, token_ids, positions):

--- a/tests/test_native_mtp_generate.py
+++ b/tests/test_native_mtp_generate.py
@@ -2,6 +2,7 @@
 """Synthetic streaming coverage for the native Qwen MTP generator."""
 
 from contextlib import contextmanager
+from contextvars import ContextVar
 from dataclasses import dataclass
 
 import mlx.core as mx
@@ -13,6 +14,8 @@ from mlx_lm.generate import (
     mtp_generate_step,
 )
 from mlx_lm.models.cache import ArraysCache, KVCache, NativeMTPRequestCache
+
+_ACTIVE_FORWARD = ContextVar("native_mtp_test_forward", default=None)
 
 
 @dataclass(frozen=True)
@@ -27,9 +30,20 @@ class _NativeMTPModel:
     mtp_capability = _Capability()
     vocab_size = 7
 
-    def __init__(self, *, wrong_draft=False, fail_mtp_offsets=()):
+    def __init__(
+        self,
+        *,
+        wrong_draft=False,
+        fail_mtp_offsets=(),
+        acknowledge_positions=True,
+        tamper_ack=False,
+        reuse_ack=False,
+    ):
         self.wrong_draft = wrong_draft
         self.fail_mtp_offsets = frozenset(fail_mtp_offsets)
+        self.acknowledge_positions = acknowledge_positions
+        self.tamper_ack = tamper_ack
+        self.reuse_ack = reuse_ack
         self.layers = [
             type("_Linear", (), {"is_linear": True})(),
             type("_Attention", (), {"is_linear": False})(),
@@ -40,6 +54,19 @@ class _NativeMTPModel:
         self.target_offsets = []
         self.mtp_offsets = []
         self.mtp_attempt_offsets = []
+
+    def _acknowledge_forward_positions(self):
+        forward = _ACTIVE_FORWARD.get()
+        if forward is None or forward.logical_position_ack is None:
+            return
+        if not self.acknowledge_positions:
+            return
+        positions = forward.logical_positions
+        if self.tamper_ack:
+            positions = positions[:-1] + (positions[-1] + 1,)
+        forward.logical_position_ack.acknowledge(positions)
+        if self.reuse_ack:
+            forward.logical_position_ack.acknowledge(positions)
 
     def make_cache(self):
         recurrent = ArraysCache(2)
@@ -68,6 +95,7 @@ class _NativeMTPModel:
         return logits
 
     def __call__(self, inputs, *, cache, return_hidden=False):
+        self._acknowledge_forward_positions()
         count = inputs.shape[1]
         cache[0][0] = cache[0][0] + count
         cache[0][1] = cache[0][1] + count
@@ -80,6 +108,7 @@ class _NativeMTPModel:
         return (logits, hidden) if return_hidden else logits
 
     def mtp_forward(self, hidden, next_token_ids, cache):
+        self._acknowledge_forward_positions()
         self.mtp_attempt_offsets.append(cache[0].offset)
         if cache[0].offset in self.fail_mtp_offsets:
             raise RuntimeError("synthetic unexpected next draft")
@@ -150,6 +179,244 @@ def test_forward_context_labels_target_prefill_verify_decode_and_mtp_draft():
     assert GenerationForwardPhase.MTP_DRAFT in phases
     assert GenerationForwardPhase.VERIFY in phases
     assert GenerationForwardPhase.DECODE in phases
+
+
+class _PositionContext:
+    def __init__(self):
+        self.events = []
+        self.active = 0
+
+    @contextmanager
+    def context(self, forward):
+        self.events.append(forward)
+        token = _ACTIVE_FORWARD.set(forward)
+        self.active += 1
+        try:
+            yield
+        finally:
+            self.active -= 1
+            _ACTIVE_FORWARD.reset(token)
+
+
+def _event_contract(events):
+    return [(event.phase, event.logical_positions) for event in events]
+
+
+def test_sparse_positions_cover_exact_native_phase_order_and_shared_cursor():
+    model = _NativeMTPModel()
+    context = _PositionContext()
+
+    output, _ = _run(
+        model,
+        max_tokens=4,
+        prompt_logical_positions=(0, 3),
+        model_forward_context=context.context,
+    )
+
+    assert [token for token, _, _ in output] == [2, 3, 4, 5]
+    assert _event_contract(context.events) == [
+        (GenerationForwardPhase.PREFILL, (0,)),
+        (GenerationForwardPhase.MTP_DRAFT, (0,)),
+        (GenerationForwardPhase.PREFILL, (3,)),
+        (GenerationForwardPhase.MTP_DRAFT, (3,)),
+        (GenerationForwardPhase.VERIFY, (4, 5)),
+        (GenerationForwardPhase.MTP_DRAFT, (4, 5)),
+        (GenerationForwardPhase.VERIFY, (6, 7)),
+    ]
+    request = model.requests[-1]
+    assert request.backbone[1].offset == 6
+    assert request.mtp[0].offset == 4
+    assert request.state.next_logical_position == 8
+    assert context.active == 0
+
+
+def test_sparse_rejection_replays_exact_positions_without_cursor_rewind():
+    model = _NativeMTPModel(wrong_draft=True)
+    context = _PositionContext()
+
+    output, _ = _run(
+        model,
+        max_tokens=3,
+        prompt_logical_positions=(0, 3),
+        model_forward_context=context.context,
+    )
+
+    assert [token for token, _, _ in output] == [2, 3, 4]
+    assert _event_contract(context.events) == [
+        (GenerationForwardPhase.PREFILL, (0,)),
+        (GenerationForwardPhase.MTP_DRAFT, (0,)),
+        (GenerationForwardPhase.PREFILL, (3,)),
+        (GenerationForwardPhase.MTP_DRAFT, (3,)),
+        (GenerationForwardPhase.VERIFY, (4, 5)),
+        (GenerationForwardPhase.DECODE, (4,)),
+        (GenerationForwardPhase.MTP_DRAFT, (4,)),
+        (GenerationForwardPhase.VERIFY, (5, 6)),
+        (GenerationForwardPhase.DECODE, (5,)),
+    ]
+    request = model.requests[-1]
+    assert request.backbone[1].offset == 4
+    assert request.mtp[0].offset == 3
+    assert request.state.next_logical_position == 7
+    assert context.active == 0
+
+
+def test_sparse_cursor_advances_before_terminal_yield_and_cancel_cleanup():
+    model = _NativeMTPModel()
+    context = _PositionContext()
+    iterator = mtp_generate_step(
+        mx.array([0, 1], dtype=mx.uint32),
+        model,
+        max_tokens=4,
+        prompt_logical_positions=(0, 3),
+        model_forward_context=context.context,
+    )
+
+    assert next(iterator)[0] == 2
+    request = model.requests[-1]
+    assert request.state.next_logical_position == 5
+    assert context.active == 0
+    iterator.close()
+    assert request.closed
+    assert request.state.next_logical_position == 5
+    assert context.active == 0
+
+    terminal_model = _NativeMTPModel()
+    terminal_context = _PositionContext()
+    terminal, _ = _run(
+        terminal_model,
+        max_tokens=1,
+        prompt_logical_positions=(0, 3),
+        model_forward_context=terminal_context.context,
+    )
+    assert [token for token, _, _ in terminal] == [2]
+    assert terminal_model.requests[-1].closed
+    assert terminal_model.requests[-1].state.next_logical_position == 5
+    assert terminal_context.active == 0
+
+
+@pytest.mark.parametrize("wrong_draft", (False, True))
+def test_sparse_position_context_is_inactive_across_every_yield(wrong_draft):
+    model = _NativeMTPModel(wrong_draft=wrong_draft)
+    context = _PositionContext()
+    iterator = mtp_generate_step(
+        mx.array([0, 1], dtype=mx.uint32),
+        model,
+        max_tokens=4,
+        prompt_logical_positions=(0, 3),
+        model_forward_context=context.context,
+    )
+
+    observed = []
+    for item in iterator:
+        observed.append(item[0])
+        assert context.active == 0
+        assert _ACTIVE_FORWARD.get() is None
+    assert observed == [2, 3, 4, 5]
+    assert context.active == 0
+
+
+@pytest.mark.parametrize(
+    ("model", "message"),
+    (
+        (
+            _NativeMTPModel(acknowledge_positions=False),
+            "generation_logical_positions_not_acknowledged",
+        ),
+        (
+            _NativeMTPModel(tamper_ack=True),
+            "generation_logical_position_ack_mismatch",
+        ),
+        (
+            _NativeMTPModel(reuse_ack=True),
+            "generation_logical_position_ack_reused",
+        ),
+    ),
+)
+def test_sparse_position_ack_missing_tampered_or_reused_fails_closed(model, message):
+    context = _PositionContext()
+    with pytest.raises(RuntimeError, match=message):
+        _run(
+            model,
+            max_tokens=1,
+            prompt_logical_positions=(0, 3),
+            model_forward_context=context.context,
+        )
+    assert model.requests[-1].closed
+    assert context.active == 0
+
+
+def test_sparse_position_ack_rejects_context_entry_pre_ack():
+    model = _NativeMTPModel()
+
+    @contextmanager
+    def pre_ack_context(forward):
+        forward.logical_position_ack.acknowledge(forward.logical_positions)
+        yield
+
+    with pytest.raises(
+        RuntimeError, match="generation_logical_position_ack_outside_forward"
+    ):
+        _run(
+            model,
+            max_tokens=1,
+            prompt_logical_positions=(0, 3),
+            model_forward_context=pre_ack_context,
+        )
+    assert model.requests[-1].closed
+
+
+def test_dense_native_path_has_no_logical_metadata_or_cursor():
+    model = _NativeMTPModel(wrong_draft=True)
+    events = []
+
+    @contextmanager
+    def context(forward):
+        events.append(forward)
+        yield
+
+    output, _ = _run(model, max_tokens=3, model_forward_context=context)
+    assert [token for token, _, _ in output] == [2, 3, 4]
+    assert events
+    assert all(event.logical_positions is None for event in events)
+    assert all(event.logical_position_ack is None for event in events)
+    assert model.requests[-1].state.next_logical_position is None
+
+
+@pytest.mark.parametrize(
+    ("positions", "error", "message"),
+    (
+        ((0,), ValueError, "must match prompt"),
+        ((0, 0), ValueError, "strictly increasing"),
+        ((0, -1), ValueError, "non-negative integers"),
+        ((0, True), ValueError, "non-negative integers"),
+    ),
+)
+def test_sparse_prompt_positions_fail_before_cache_construction(
+    positions, error, message
+):
+    model = _NativeMTPModel()
+    context = _PositionContext()
+    with pytest.raises(error, match=message):
+        _run(
+            model,
+            max_tokens=1,
+            prompt_logical_positions=positions,
+            model_forward_context=context.context,
+        )
+    assert model.requests == []
+
+
+def test_sparse_prompt_positions_reject_device_sequence_before_iteration():
+    model = _NativeMTPModel()
+    context = _PositionContext()
+    with pytest.raises(TypeError, match="host sequence"):
+        _run(
+            model,
+            max_tokens=1,
+            prompt_logical_positions=mx.array([0, 3]),
+            model_forward_context=context.context,
+        )
+    assert model.requests == []
 
 
 @pytest.mark.parametrize(

--- a/tests/test_native_mtp_server.py
+++ b/tests/test_native_mtp_server.py
@@ -1,0 +1,529 @@
+# Copyright © 2026 Apple Inc.
+"""Focused server-contract coverage for request-local native Qwen MTP."""
+
+import http.client
+import json
+import threading
+from http.server import HTTPServer
+from types import SimpleNamespace
+
+import mlx.core as mx
+import pytest
+
+import mlx_lm.server as server
+
+
+def _args(*, mtp=True, seed=17, xtc_probability=0.0, max_tokens=4, top_k=3):
+    return server.GenerationArguments(
+        model=server.ModelDescription("model", "default_model", None),
+        sampling=server.SamplingArguments(
+            temperature=0.7,
+            top_p=0.8,
+            top_k=top_k,
+            min_p=0.05,
+            xtc_probability=xtc_probability,
+            xtc_threshold=0.1,
+        ),
+        logits=server.LogitsProcessorArguments(None, 0, 20, 0, 20, 0, 20),
+        stop_words=[],
+        max_tokens=max_tokens,
+        num_draft_tokens=2,
+        logprobs=False,
+        top_logprobs=0,
+        seed=seed,
+        chat_template_kwargs=None,
+        mtp=mtp,
+    )
+
+
+class _PromptCache:
+    def __init__(self):
+        self.fetches = 0
+        self.inserts = 0
+
+    def fetch_nearest_cache(self, _key, prompt):
+        self.fetches += 1
+        return None, prompt
+
+    def insert_cache(self, *_args, **_kwargs):
+        self.inserts += 1
+
+
+class _Queue:
+    def __init__(self, *, cancel=False):
+        self.items = []
+        self.cancel = cancel
+
+    def put(self, item):
+        self.items.append(item)
+        if isinstance(item, server.GenerationContext):
+            self.ctx = item
+        elif self.cancel and isinstance(item, server.Response):
+            self.ctx.stop()
+
+
+def _validation_handler(body):
+    handler = server.APIHandler.__new__(server.APIHandler)
+    handler.body = body
+    handler.response_generator = SimpleNamespace(
+        cli_args=SimpleNamespace(draft_model=None)
+    )
+    handler.stream = False
+    handler.mtp = body.get("mtp", False)
+    handler.max_tokens = 4
+    handler.temperature = 0.7
+    handler.top_p = 0.8
+    handler.top_k = 3
+    handler.min_p = 0.0
+    handler.num_draft_tokens = 2
+    handler.repetition_penalty = 0.0
+    handler.repetition_context_size = 20
+    handler.presence_penalty = 0.0
+    handler.presence_context_size = 20
+    handler.frequency_penalty = 0.0
+    handler.frequency_context_size = 20
+    handler.logprobs = False
+    handler.top_logprobs = -1
+    handler.xtc_probability = body.get("xtc_probability", 0.0)
+    handler.xtc_threshold = 0.1
+    handler.requested_model = "model"
+    handler.adapter = None
+    handler.seed = 17
+    handler.logit_bias = None
+    return handler
+
+
+def _response_generator(prompt_cache, *, draft_model=None):
+    generator = server.ResponseGenerator.__new__(server.ResponseGenerator)
+    generator.model_provider = SimpleNamespace(
+        model=SimpleNamespace(
+            mtp_capability=SimpleNamespace(supported=True, reason="supported"),
+            vocab_size=7,
+        ),
+        tokenizer=SimpleNamespace(
+            has_thinking=False,
+            has_tool_calling=False,
+            tool_parser=lambda *_: {},
+            convert_ids_to_tokens=lambda ids: [str(i) for i in ids],
+            encode=lambda _text: [],
+            eos_token_ids=set(),
+        ),
+        draft_model=draft_model,
+        model_key=("model", None, None),
+        is_batchable=True,
+        cli_args=SimpleNamespace(prefill_step_size=8),
+    )
+    generator.prompt_cache = prompt_cache
+    generator._is_distributed = False
+    generator._tokenize = lambda *_: ([1, 2], [], [], "normal")
+    stop_matcher = SimpleNamespace(make_state=lambda: None, _trie={})
+    generator._make_state_machine = lambda *_: (stop_matcher, object())
+    generator._log_cache_stats = lambda: None
+    return generator
+
+
+def _completion_stream(closed, *, error=None):
+    try:
+        if error is not None:
+            raise error
+        yield SimpleNamespace(
+            text="ok",
+            token=2,
+            logprobs=mx.array([-2.0, -1.0, 0.0]),
+            finish_reason="length",
+            mtp_drafts=5,
+            mtp_accepted=3,
+            mtp_bypass_reason=None,
+        )
+    finally:
+        closed.append(True)
+
+
+def test_native_sampling_maps_public_fields_and_rejects_xtc():
+    args = _args()
+    config = server._make_native_mtp_sampling_config(args.sampling, args.seed)
+    assert config.temperature == 0.7
+    assert config.top_p == 0.8
+    assert config.top_k == 3
+    assert config.min_p == 0.05
+    assert config.seed == 17
+
+    xtc = _args(xtc_probability=0.1)
+    with pytest.raises(ValueError, match="native_mtp_xtc_unsupported"):
+        server._make_native_mtp_sampling_config(xtc.sampling, xtc.seed)
+
+
+def test_native_mtp_is_never_admitted_to_batching():
+    generator = server.ResponseGenerator.__new__(server.ResponseGenerator)
+    generator.model_provider = SimpleNamespace(is_batchable=True)
+    assert not generator._is_batchable(_args(mtp=True, seed=None))
+    assert generator._is_batchable(_args(mtp=False, seed=None))
+
+
+@pytest.mark.parametrize(
+    ("body", "message"),
+    (
+        (
+            {"mtp": True, "draft_model": "assistant"},
+            "native_mtp_external_draft_unsupported",
+        ),
+        (
+            {"mtp": True, "prompt_cache": True},
+            "native_mtp_prefix_reuse_unsupported",
+        ),
+        (
+            {"mtp": True, "xtc_probability": 0.1},
+            "native_mtp_xtc_unsupported",
+        ),
+    ),
+)
+def test_native_request_contract_rejects_incompatible_fields(body, message):
+    with pytest.raises(ValueError, match=message):
+        _validation_handler(body).validate_model_parameters()
+
+
+def test_single_native_mtp_disables_prompt_cache_and_propagates_metadata(monkeypatch):
+    prompt_cache = _PromptCache()
+    generator = _response_generator(prompt_cache)
+    queue = _Queue()
+    captured = {}
+    closed = []
+
+    monkeypatch.setattr(
+        server.StopSequenceMatcher,
+        "match",
+        staticmethod(lambda state, _trie, _token: (state, False)),
+    )
+
+    def fake_stream_generate(**kwargs):
+        captured.update(kwargs)
+        return _completion_stream(closed)
+
+    monkeypatch.setattr(server, "stream_generate", fake_stream_generate)
+    generator._serve_single((queue, object(), _args()))
+
+    response = next(item for item in queue.items if isinstance(item, server.Response))
+    assert captured["mtp"] is True
+    assert captured["prompt_cache"] is None
+    assert captured["draft_model"] is None
+    assert captured["sampler"] is None
+    assert captured["mtp_sampling_config"].seed == 17
+    assert response.finish_reason == "length"
+    assert (response.mtp_drafts, response.mtp_accepted) == (5, 3)
+    assert prompt_cache.fetches == prompt_cache.inserts == 0
+    assert closed == [True]
+
+
+def test_non_mtp_single_path_preserves_cache_and_dispatch_shape(monkeypatch):
+    prompt_cache = _PromptCache()
+    generator = _response_generator(prompt_cache)
+    queue = _Queue()
+    captured = {}
+    closed = []
+
+    monkeypatch.setattr(server, "make_prompt_cache", lambda _model: [object()])
+    monkeypatch.setattr(
+        server.StopSequenceMatcher,
+        "match",
+        staticmethod(lambda state, _trie, _token: (state, False)),
+    )
+
+    def fake_stream_generate(**kwargs):
+        captured.update(kwargs)
+        return _completion_stream(closed)
+
+    monkeypatch.setattr(server, "stream_generate", fake_stream_generate)
+    generator._serve_single((queue, object(), _args(mtp=False, seed=None)))
+
+    assert "mtp" not in captured
+    assert "mtp_sampling_config" not in captured
+    assert captured["prompt_cache"] is not None
+    assert prompt_cache.fetches == prompt_cache.inserts == 1
+    assert closed == [True]
+
+
+def test_external_draft_fails_before_generation(monkeypatch):
+    generator = _response_generator(_PromptCache(), draft_model=object())
+    queue = _Queue()
+    monkeypatch.setattr(
+        server,
+        "stream_generate",
+        lambda **_kwargs: pytest.fail("generation must not start"),
+    )
+    generator._serve_single((queue, object(), _args()))
+    error = next(item for item in queue.items if isinstance(item, Exception))
+    assert "native_mtp_external_draft_unsupported" in str(error)
+
+
+def test_missing_native_capability_fails_closed_before_generation(monkeypatch):
+    generator = _response_generator(_PromptCache())
+    generator.model_provider.model = object()
+    queue = _Queue()
+    monkeypatch.setattr(
+        server,
+        "stream_generate",
+        lambda **_kwargs: pytest.fail("generation must not start"),
+    )
+    generator._serve_single((queue, object(), _args()))
+    error = next(item for item in queue.items if isinstance(item, Exception))
+    assert "native_mtp_model_capability_missing" in str(error)
+
+
+@pytest.mark.parametrize(
+    ("args", "prompt", "message"),
+    (
+        (
+            _args(max_tokens=0),
+            [1, 2],
+            "native_mtp_max_tokens_must_be_positive",
+        ),
+        (_args(), [], "native_mtp_prompt_must_be_nonempty"),
+        (
+            _args(top_k=7),
+            [1, 2],
+            "native MTP top_k must be smaller than vocabulary size",
+        ),
+    ),
+)
+def test_native_inputs_are_validated_before_context_or_generation(
+    monkeypatch, args, prompt, message
+):
+    generator = _response_generator(_PromptCache())
+    generator._tokenize = lambda *_: (prompt, [], [], "normal")
+    queue = _Queue()
+    monkeypatch.setattr(
+        server,
+        "stream_generate",
+        lambda **_kwargs: pytest.fail("generation must not start"),
+    )
+    generator._serve_single((queue, object(), args))
+    error = next(item for item in queue.items if isinstance(item, Exception))
+    assert message in str(error)
+    assert not any(isinstance(item, server.GenerationContext) for item in queue.items)
+
+
+@pytest.mark.parametrize("error", (None, RuntimeError("synthetic generation error")))
+def test_cancellation_and_errors_close_the_underlying_generator(monkeypatch, error):
+    generator = _response_generator(_PromptCache())
+    queue = _Queue(cancel=error is None)
+    closed = []
+    monkeypatch.setattr(
+        server.StopSequenceMatcher,
+        "match",
+        staticmethod(lambda state, _trie, _token: (state, False)),
+    )
+    monkeypatch.setattr(
+        server,
+        "stream_generate",
+        lambda **_kwargs: _completion_stream(closed, error=error),
+    )
+
+    generator._serve_single((queue, object(), _args()))
+    assert closed == [True]
+    if error is not None:
+        assert any(isinstance(item, RuntimeError) for item in queue.items)
+
+
+@pytest.mark.parametrize("stream", (False, True))
+def test_terminal_response_metadata_is_exposed_for_stream_and_nonstream(stream):
+    handler = server.APIHandler.__new__(server.APIHandler)
+    handler.request_id = "request"
+    handler.system_fingerprint = "fingerprint"
+    handler.object_type = "chat.completion.chunk" if stream else "chat.completion"
+    handler.requested_model = "model"
+    handler.created = 1
+    handler.stream = stream
+
+    response = handler.generate_response(
+        "ok",
+        "stop",
+        None if stream else 2,
+        None if stream else 1,
+        mtp_drafts=8,
+        mtp_accepted=6,
+        mtp_bypass_reason="native_mtp_model_capability_missing",
+    )
+    assert response["choices"][0]["finish_reason"] == "stop"
+    assert response["generation_metadata"] == {
+        "mtp_drafts": 8,
+        "mtp_accepted": 6,
+        "mtp_bypass_reason": "native_mtp_model_capability_missing",
+    }
+
+
+class _WireResponseGenerator:
+    def __init__(self, *, supported=True):
+        self.model = SimpleNamespace(
+            mtp_capability=SimpleNamespace(
+                supported=supported,
+                reason="native_mtp_weights_not_loaded",
+            ),
+            vocab_size=7,
+        )
+        self.cli_args = SimpleNamespace(
+            num_draft_tokens=2,
+            max_tokens=4,
+            temp=0.7,
+            top_p=0.8,
+            top_k=3,
+            min_p=0.0,
+            draft_model=None,
+            allowed_origins=[],
+        )
+
+    def generate(self, request, args, progress_callback=None):
+        if args.mtp:
+            server._make_native_mtp_sampling_config(args.sampling, args.seed)
+            server._validate_native_mtp_model(self.model, args.sampling)
+            if not request.prompt:
+                raise server.NativeMTPRequestError("native_mtp_prompt_must_be_nonempty")
+        text_sm = server.TextStateMachine({"normal": []})
+        ctx = server.GenerationContext(
+            has_tool_calling=False,
+            has_thinking=False,
+            tool_parser=lambda *_: {},
+            text_sm=text_sm,
+            initial_state="normal",
+            prompt=[1, 2],
+            prompt_cache_count=0,
+        )
+
+        def responses():
+            yield server.Response(
+                "ok",
+                2,
+                -0.1,
+                "length",
+                (),
+                mtp_drafts=5,
+                mtp_accepted=3,
+                mtp_bypass_reason=None,
+            )
+
+        return ctx, responses()
+
+
+def _wire_request(body, *, supported=True):
+    response_generator = _WireResponseGenerator(supported=supported)
+    httpd = HTTPServer(
+        ("127.0.0.1", 0),
+        lambda *args, **kwargs: server.APIHandler(
+            response_generator,
+            *args,
+            system_fingerprint="test-fingerprint",
+            **kwargs,
+        ),
+    )
+    thread = threading.Thread(target=httpd.serve_forever, daemon=True)
+    thread.start()
+    connection = http.client.HTTPConnection("127.0.0.1", httpd.server_port, timeout=5)
+    try:
+        connection.request(
+            "POST",
+            "/v1/completions",
+            body=json.dumps(body),
+            headers={"Content-Type": "application/json"},
+        )
+        response = connection.getresponse()
+        payload = response.read().decode()
+        return response.status, payload
+    finally:
+        connection.close()
+        httpd.shutdown()
+        httpd.server_close()
+        thread.join()
+
+
+@pytest.mark.parametrize(
+    ("body", "status", "message"),
+    (
+        ({"prompt": "hi", "mtp": "yes"}, 422, "mtp must be of type bool"),
+        (
+            {"prompt": "hi", "mtp": True, "xtc_probability": 0.1},
+            422,
+            "native_mtp_xtc_unsupported",
+        ),
+        (
+            {"prompt": "hi", "mtp": True, "draft_model": "assistant"},
+            422,
+            "native_mtp_external_draft_unsupported",
+        ),
+        (
+            {"prompt": "hi", "mtp": True, "prompt_cache": True},
+            422,
+            "native_mtp_prefix_reuse_unsupported",
+        ),
+        (
+            {"prompt": "hi", "mtp": True, "max_tokens": 0},
+            422,
+            "native_mtp_max_tokens_must_be_positive",
+        ),
+        (
+            {"prompt": "hi", "mtp": True, "stream": True, "max_tokens": 0},
+            422,
+            "native_mtp_max_tokens_must_be_positive",
+        ),
+        (
+            {"prompt": "hi", "mtp": True, "max_tokens": True},
+            422,
+            "native_mtp_max_tokens_must_be_positive",
+        ),
+        (
+            {"prompt": "", "mtp": True},
+            422,
+            "native_mtp_prompt_must_be_nonempty",
+        ),
+        (
+            {"prompt": "", "mtp": True, "stream": True},
+            422,
+            "native_mtp_prompt_must_be_nonempty",
+        ),
+        (
+            {"prompt": "hi", "mtp": True, "top_k": 7},
+            422,
+            "native MTP top_k must be smaller than vocabulary size",
+        ),
+        (
+            {"prompt": "hi", "mtp": True, "stream": True, "top_k": 7},
+            422,
+            "native MTP top_k must be smaller than vocabulary size",
+        ),
+        ({"mtp": True}, 400, "Request did not contain a prompt"),
+    ),
+)
+def test_wire_validation_errors_are_structured_responses(body, status, message):
+    actual_status, payload = _wire_request(body)
+    assert actual_status == status
+    error = json.loads(payload)["error"]
+    assert error["type"] == "invalid_request_error"
+    assert message in error["message"]
+
+
+def test_wire_unsupported_capability_is_unprocessable_not_404():
+    status, payload = _wire_request({"prompt": "hi", "mtp": True}, supported=False)
+    assert status == 422
+    error = json.loads(payload)["error"]
+    assert error["code"] == "native_mtp_weights_not_loaded"
+
+
+@pytest.mark.parametrize("stream", (False, True))
+def test_wire_terminal_metadata_for_stream_and_nonstream(stream):
+    status, payload = _wire_request(
+        {"prompt": "hi", "mtp": True, "stream": stream, "max_tokens": 2}
+    )
+    assert status == 200
+    if stream:
+        packets = [
+            json.loads(line.removeprefix("data: "))
+            for line in payload.splitlines()
+            if line.startswith("data: ") and line != "data: [DONE]"
+        ]
+        response = packets[-1]
+    else:
+        response = json.loads(payload)
+    assert response["choices"][0]["finish_reason"] == "length"
+    assert response["generation_metadata"] == {
+        "mtp_drafts": 5,
+        "mtp_accepted": 3,
+        "mtp_bypass_reason": None,
+    }

--- a/tests/test_qwen3_5_mtp_model.py
+++ b/tests/test_qwen3_5_mtp_model.py
@@ -12,12 +12,19 @@ import pytest
 from mlx.utils import tree_flatten
 
 from mlx_lm.generate import (
+    GenerationForward,
     GenerationForwardPhase,
+    GenerationForwardPositionAck,
     NativeMTPSparseBootstrap,
     attested_target_forward,
+    mtp_generate_step,
     stream_generate,
 )
-from mlx_lm.models.cache import NativeMTPRequestCache
+from mlx_lm.models.cache import ArraysCache, KVCache, NativeMTPRequestCache
+from mlx_lm.models.generation_context import (
+    consume_generation_positions,
+    generation_forward_context,
+)
 
 HIDDEN = 32
 INTERMEDIATE = 64
@@ -199,6 +206,97 @@ def _sanitize_and_load(model, weights):
     return sanitized
 
 
+def _positioned_target(model, inputs, cache, positions):
+    ack = GenerationForwardPositionAck(
+        positions,
+        model=model,
+        cache=cache,
+        phase=GenerationForwardPhase.VERIFY,
+    )
+    forward = GenerationForward(
+        model=model,
+        input_tokens=inputs,
+        cache=cache,
+        phase=GenerationForwardPhase.VERIFY,
+        logical_positions=positions,
+        logical_position_ack=ack,
+    )
+    with generation_forward_context(forward):
+        ack._activate()
+        try:
+            result = model(inputs, cache=cache, return_hidden=True)
+            ack._require_acknowledged()
+            return result
+        finally:
+            ack._finish()
+
+
+def _positioned_mtp(model, hidden, next_tokens, cache, positions):
+    ack = GenerationForwardPositionAck(
+        positions,
+        model=model,
+        cache=cache,
+        phase=GenerationForwardPhase.MTP_DRAFT,
+    )
+    forward = GenerationForward(
+        model=model,
+        input_tokens=next_tokens,
+        cache=cache,
+        phase=GenerationForwardPhase.MTP_DRAFT,
+        logical_positions=positions,
+        logical_position_ack=ack,
+    )
+    with generation_forward_context(forward):
+        ack._activate()
+        try:
+            result = model.mtp_forward(hidden, next_tokens, cache)
+            ack._require_acknowledged()
+            return result
+        finally:
+            ack._finish()
+
+
+def _assert_float_payload_matches(actual, expected):
+    # Batched and B=1 matmuls may differ in accumulation order by ~1e-6.
+    assert mx.allclose(actual, expected, rtol=1e-4, atol=1e-5).item()
+
+
+def _assert_batched_cache_matches_independent_rows(batched, independent_rows):
+    """Compare active cache payloads and recurrent metadata, row by row."""
+
+    assert len(batched) == len(independent_rows[0])
+    for entry_index, batched_entry in enumerate(batched):
+        row_entries = [row[entry_index] for row in independent_rows]
+        assert all(type(row_entry) is type(batched_entry) for row_entry in row_entries)
+        if isinstance(batched_entry, ArraysCache):
+            for state_index, value in enumerate(batched_entry.cache):
+                if value is None:
+                    assert all(row.cache[state_index] is None for row in row_entries)
+                else:
+                    for row_index, row in enumerate(row_entries):
+                        _assert_float_payload_matches(
+                            value[row_index : row_index + 1], row.cache[state_index]
+                        )
+            for name in ("left_padding", "lengths"):
+                value = getattr(batched_entry, name)
+                if value is None:
+                    assert all(getattr(row, name) is None for row in row_entries)
+                else:
+                    for row_index, row in enumerate(row_entries):
+                        assert mx.array_equal(
+                            value[row_index : row_index + 1], getattr(row, name)
+                        ).item()
+            continue
+        assert isinstance(batched_entry, KVCache)
+        assert all(row.offset == batched_entry.offset for row in row_entries)
+        for name in ("keys", "values"):
+            value = getattr(batched_entry, name)
+            for row_index, row in enumerate(row_entries):
+                _assert_float_payload_matches(
+                    value[row_index : row_index + 1], getattr(row, name)
+                )
+
+
 @contextmanager
 def _acknowledging_forward_context(forward):
     token = _ACTIVE_FORWARD.set(forward)
@@ -224,6 +322,20 @@ class _StreamTokenizer:
     def __init__(self):
         self.detokenizer = _StreamDetokenizer()
         self.eos_token_ids = frozenset()
+        self.eos_token_id = 0
+        self.chat_template = None
+
+    @staticmethod
+    def get_vocab():
+        return {}
+
+    @staticmethod
+    def encode(_text, *, add_special_tokens=False):
+        return [1]
+
+    @staticmethod
+    def decode(tokens):
+        return "".join(str(token) for token in tokens)
 
 
 def _sparse_bootstrap(model):
@@ -235,7 +347,7 @@ def _sparse_bootstrap(model):
         phase=GenerationForwardPhase.PREFILL,
         logical_positions=(0, 1),
         immediate_successor_token_ids=(1,),
-        model_forward_context=_acknowledging_forward_context,
+        model_forward_context=model.generation_forward_context,
     )
     return NativeMTPSparseBootstrap(
         receipts=(receipt,),
@@ -391,7 +503,6 @@ def test_outer_dense_and_moe_sparse_bootstrap_stream_adopts_outer_topology(
             mtp=True,
             max_tokens=1,
             sparse_bootstrap=bootstrap,
-            model_forward_context=_acknowledging_forward_context,
         )
     )
 
@@ -572,3 +683,449 @@ def test_pipeline_parallelism_remains_ineligible():
     assert model.mtp_capability.reason == "native_mtp_pipeline_parallelism_unsupported"
     with pytest.raises(RuntimeError, match="pipeline_parallelism_unsupported"):
         model.make_mtp_cache()
+
+
+@pytest.mark.parametrize("moe", [False, True])
+def test_batched_position_matrix_matches_independent_rows_for_target_and_mtp(moe):
+    """A real B=2 graph honours unequal, non-contiguous row positions."""
+
+    model = _model(moe=moe)
+    _sanitize_and_load(model, _checkpoint(model, moe=moe))
+    inputs = mx.array(((3, 7), (11, 5)), dtype=mx.uint32)
+    positions = ((5, 19), (103, 701))
+
+    batched_cache = model.make_cache()
+    batched_logits, batched_hidden = _positioned_target(
+        model, inputs, batched_cache, positions
+    )
+    assert batched_cache[-1].offset == inputs.shape[1]
+
+    single_targets = []
+    single_hidden = []
+    single_backbone_caches = []
+    for row, row_positions in zip(inputs, positions):
+        row_cache = model.make_cache()
+        logits, hidden = _positioned_target(model, row[None], row_cache, row_positions)
+        single_targets.append(logits)
+        single_hidden.append(hidden)
+        single_backbone_caches.append(row_cache)
+        assert row_cache[-1].offset == inputs.shape[1]
+    _assert_float_payload_matches(
+        batched_logits, mx.concatenate(single_targets, axis=0)
+    )
+    _assert_float_payload_matches(batched_hidden, mx.concatenate(single_hidden, axis=0))
+    _assert_batched_cache_matches_independent_rows(
+        batched_cache, single_backbone_caches
+    )
+
+    next_tokens = mx.array(((17, 23), (29, 31)), dtype=mx.uint32)
+    batched_mtp_cache = model.make_mtp_cache()
+    batched_mtp = _positioned_mtp(
+        model, batched_hidden, next_tokens, batched_mtp_cache, positions
+    )
+    assert batched_mtp_cache[-1].offset == next_tokens.shape[1]
+
+    single_mtp = []
+    single_mtp_caches = []
+    for index, row_positions in enumerate(positions):
+        row_mtp_cache = model.make_mtp_cache()
+        logits = _positioned_mtp(
+            model,
+            single_hidden[index],
+            next_tokens[index : index + 1],
+            row_mtp_cache,
+            row_positions,
+        )
+        single_mtp.append(logits)
+        single_mtp_caches.append(row_mtp_cache)
+        assert row_mtp_cache[-1].offset == next_tokens.shape[1]
+    _assert_float_payload_matches(batched_mtp, mx.concatenate(single_mtp, axis=0))
+    _assert_batched_cache_matches_independent_rows(batched_mtp_cache, single_mtp_caches)
+
+    # A later decode must retain both numerical outputs and every active cache
+    # payload after the heterogeneous first-position matrix.
+    continuation = mx.array(((37,), (43,)), dtype=mx.uint32)
+    continuation_positions = ((1003,), (9007,))
+    continued_logits, continued_hidden = _positioned_target(
+        model, continuation, batched_cache, continuation_positions
+    )
+    row_continued_logits = []
+    row_continued_hidden = []
+    for index, row_positions in enumerate(continuation_positions):
+        logits, hidden = _positioned_target(
+            model,
+            continuation[index : index + 1],
+            single_backbone_caches[index],
+            row_positions,
+        )
+        row_continued_logits.append(logits)
+        row_continued_hidden.append(hidden)
+    _assert_float_payload_matches(
+        continued_logits, mx.concatenate(row_continued_logits, axis=0)
+    )
+    _assert_float_payload_matches(
+        continued_hidden, mx.concatenate(row_continued_hidden, axis=0)
+    )
+    assert batched_cache[-1].offset == 3
+    _assert_batched_cache_matches_independent_rows(
+        batched_cache, single_backbone_caches
+    )
+
+    continued_mtp_tokens = mx.array(((47,), (53,)), dtype=mx.uint32)
+    continued_mtp = _positioned_mtp(
+        model,
+        continued_hidden,
+        continued_mtp_tokens,
+        batched_mtp_cache,
+        continuation_positions,
+    )
+    row_continued_mtp = []
+    for index, row_positions in enumerate(continuation_positions):
+        row_continued_mtp.append(
+            _positioned_mtp(
+                model,
+                row_continued_hidden[index],
+                continued_mtp_tokens[index : index + 1],
+                single_mtp_caches[index],
+                row_positions,
+            )
+        )
+    _assert_float_payload_matches(
+        continued_mtp, mx.concatenate(row_continued_mtp, axis=0)
+    )
+    assert batched_mtp_cache[-1].offset == 3
+    _assert_batched_cache_matches_independent_rows(batched_mtp_cache, single_mtp_caches)
+
+
+@pytest.mark.parametrize("moe", [False, True])
+def test_positioned_qwen_target_and_mtp_are_sensitive_to_each_row_position(moe):
+    """Prevent a B=2 position-matrix acknowledgement from becoming a no-op."""
+
+    model = _model(moe=moe)
+    _sanitize_and_load(model, _checkpoint(model, moe=moe))
+    inputs = mx.array(((3, 7), (11, 5)), dtype=mx.uint32)
+    heterogeneous = ((5, 19), (103, 701))
+    shifted = ((17, 47), (127, 761))
+
+    first_target_cache = model.make_cache()
+    first_logits, first_hidden = _positioned_target(
+        model, inputs, first_target_cache, heterogeneous
+    )
+    second_target_cache = model.make_cache()
+    second_logits, second_hidden = _positioned_target(
+        model, inputs, second_target_cache, shifted
+    )
+
+    # The tiny real-Qwen fixture changes logits by about 1e-6.  Active KV keys
+    # are the direct positional-consumption oracle; exact output inequality
+    # still proves the position matrix reaches the target calculation.
+    assert not mx.array_equal(first_logits, second_logits).item()
+    assert not mx.array_equal(first_hidden, second_hidden).item()
+    assert not mx.array_equal(
+        first_target_cache[-1].keys, second_target_cache[-1].keys
+    ).item()
+
+    next_tokens = mx.array(((17, 23), (29, 31)), dtype=mx.uint32)
+    first_mtp_cache = model.make_mtp_cache()
+    first_mtp_logits = _positioned_mtp(
+        model, first_hidden, next_tokens, first_mtp_cache, heterogeneous
+    )
+    second_mtp_cache = model.make_mtp_cache()
+    second_mtp_logits = _positioned_mtp(
+        model, first_hidden, next_tokens, second_mtp_cache, shifted
+    )
+
+    # Qwen's native MTP topology is attention-only, so its active keys are an
+    # independent direct oracle that the MTP context consumed the matrix too.
+    assert not mx.array_equal(first_mtp_logits, second_mtp_logits).item()
+    assert not mx.array_equal(
+        first_mtp_cache[-1].keys, second_mtp_cache[-1].keys
+    ).item()
+
+
+@pytest.mark.parametrize(
+    ("positions", "message"),
+    (
+        ((1, 2), "batch_requires_matrix"),
+        (((1, 2), (3,)), "matrix_ragged"),
+        (((1, 2, 3), (4, 5, 6)), "input_shape_mismatch"),
+        (((1, -2), (3, 4)), "value_invalid"),
+        (((1, True), (3, 4)), "value_invalid"),
+        (((1, "two"), (3, 4)), "value_invalid"),
+    ),
+)
+def test_batched_position_matrix_rejects_broadcast_ragged_and_malformed_inputs(
+    positions, message
+):
+    with pytest.raises(ValueError, match=message):
+        GenerationForward(
+            model=object(),
+            input_tokens=mx.zeros((2, 2), dtype=mx.uint32),
+            cache=[],
+            phase=GenerationForwardPhase.VERIFY,
+            logical_positions=positions,
+        )
+
+
+def test_position_ack_is_one_shot_and_context_resets_after_model_error():
+    model = _model()
+    _sanitize_and_load(model, _checkpoint(model))
+    inputs = mx.array(((3,),), dtype=mx.uint32)
+    cache = model.make_cache()
+    ack = GenerationForwardPositionAck(
+        (37,), model=model, cache=cache, phase=GenerationForwardPhase.VERIFY
+    )
+    forward = GenerationForward(
+        model=model,
+        input_tokens=inputs,
+        cache=cache,
+        phase=GenerationForwardPhase.VERIFY,
+        logical_positions=(37,),
+        logical_position_ack=ack,
+    )
+    with generation_forward_context(forward):
+        ack._activate()
+        try:
+            model(inputs, cache=cache, return_hidden=True)
+            with pytest.raises(RuntimeError, match="ack_reused"):
+                ack.acknowledge((37,))
+        finally:
+            ack._finish()
+
+    # A failing scoped call must not leak positions into the next unscoped call.
+    with pytest.raises(RuntimeError, match="forced position-context failure"):
+        with generation_forward_context(forward):
+            raise RuntimeError("forced position-context failure")
+    fresh_cache = model.make_cache()
+    logits = model(inputs, cache=fresh_cache)
+    assert logits.shape[:2] == (1, 1)
+
+
+def test_single_row_rejects_matrix_form_before_the_model_is_called():
+    with pytest.raises(ValueError, match="single_row_requires_vector"):
+        GenerationForward(
+            model=object(),
+            input_tokens=mx.zeros((1, 2), dtype=mx.uint32),
+            cache=[],
+            phase=GenerationForwardPhase.VERIFY,
+            logical_positions=((1, 2),),
+        )
+
+
+def test_position_context_rejects_model_cache_phase_and_capability_mismatches():
+    model = _model()
+    other_model = _model()
+    _sanitize_and_load(model, _checkpoint(model))
+    _sanitize_and_load(other_model, _checkpoint(other_model))
+    inputs = mx.array(((3,),), dtype=mx.uint32)
+    cache = model.make_cache()
+    ack = GenerationForwardPositionAck(
+        (11,), model=model, cache=cache, phase=GenerationForwardPhase.VERIFY
+    )
+    forward = GenerationForward(
+        model=model,
+        input_tokens=inputs,
+        cache=cache,
+        phase=GenerationForwardPhase.VERIFY,
+        logical_positions=(11,),
+        logical_position_ack=ack,
+    )
+
+    with generation_forward_context(forward):
+        ack._activate()
+        try:
+            with pytest.raises(RuntimeError, match="model_mismatch"):
+                other_model(inputs, cache=cache, return_hidden=True)
+        finally:
+            ack._finish()
+
+    wrong_cache = model.make_cache()
+    ack = GenerationForwardPositionAck(
+        (11,), model=model, cache=cache, phase=GenerationForwardPhase.VERIFY
+    )
+    forward = GenerationForward(
+        model=model,
+        input_tokens=inputs,
+        cache=cache,
+        phase=GenerationForwardPhase.VERIFY,
+        logical_positions=(11,),
+        logical_position_ack=ack,
+    )
+    with generation_forward_context(forward):
+        ack._activate()
+        try:
+            with pytest.raises(RuntimeError, match="cache_mismatch"):
+                model(inputs, cache=wrong_cache, return_hidden=True)
+        finally:
+            ack._finish()
+
+    mtp_cache = model.make_mtp_cache()
+    phase_ack = GenerationForwardPositionAck(
+        (11,), model=model, cache=mtp_cache, phase=GenerationForwardPhase.VERIFY
+    )
+    phase_forward = GenerationForward(
+        model=model,
+        input_tokens=inputs,
+        cache=mtp_cache,
+        phase=GenerationForwardPhase.VERIFY,
+        logical_positions=(11,),
+        logical_position_ack=phase_ack,
+    )
+    with generation_forward_context(phase_forward):
+        phase_ack._activate()
+        try:
+            with pytest.raises(RuntimeError, match="phase_mismatch"):
+                model.mtp_forward(mx.zeros((1, 1, HIDDEN)), inputs, mtp_cache)
+        finally:
+            phase_ack._finish()
+
+    capability_ack = GenerationForwardPositionAck(
+        (11,), model=model, cache=cache, phase=GenerationForwardPhase.VERIFY
+    )
+    capability_forward = GenerationForward(
+        model=model,
+        input_tokens=inputs,
+        cache=cache,
+        phase=GenerationForwardPhase.VERIFY,
+        logical_positions=(11,),
+        logical_position_ack=capability_ack,
+    )
+    model.language_model._mtp_weights_loaded = False
+    try:
+        with generation_forward_context(capability_forward):
+            capability_ack._activate()
+            try:
+                with pytest.raises(RuntimeError, match="capability_mismatch"):
+                    model(inputs, cache=cache, return_hidden=True)
+            finally:
+                capability_ack._finish()
+    finally:
+        model.language_model._mtp_weights_loaded = True
+
+
+def test_activated_model_error_resets_the_position_context():
+    class ExplodingModel:
+        generation_forward_context = staticmethod(generation_forward_context)
+
+        def __call__(self, inputs, *, cache):
+            consume_generation_positions(self, cache, inputs, mtp=False)
+            raise RuntimeError("forced model failure")
+
+    model = ExplodingModel()
+    inputs = mx.array(((3,),), dtype=mx.uint32)
+    cache = []
+    ack = GenerationForwardPositionAck(
+        (11,), model=model, cache=cache, phase=GenerationForwardPhase.VERIFY
+    )
+    forward = GenerationForward(
+        model=model,
+        input_tokens=inputs,
+        cache=cache,
+        phase=GenerationForwardPhase.VERIFY,
+        logical_positions=(11,),
+        logical_position_ack=ack,
+    )
+    with pytest.raises(RuntimeError, match="forced model failure"):
+        with generation_forward_context(forward):
+            ack._activate()
+            try:
+                model(inputs, cache=cache)
+            finally:
+                ack._finish()
+
+    # The following unscoped call proves the failing active context was reset.
+    with pytest.raises(RuntimeError, match="forced model failure"):
+        model(inputs, cache=[])
+
+
+def test_position_matrix_rope_path_has_no_host_row_extraction_or_sync():
+    import inspect
+    from mlx_lm.models.qwen3_next import Qwen3NextAttention
+
+    source = inspect.getsource(Qwen3NextAttention.__call__)
+    assert "B * L" in source
+    assert ".item(" not in source
+    assert ".tolist(" not in source
+    assert "for row" not in source
+
+
+def test_single_row_vector_is_compatible_with_the_existing_dense_call_shape():
+    model = _model()
+    _sanitize_and_load(model, _checkpoint(model))
+    inputs = mx.array(((3, 7),), dtype=mx.uint32)
+
+    ordinary_cache = model.make_cache()
+    ordinary_logits, ordinary_hidden = model(
+        inputs, cache=ordinary_cache, return_hidden=True
+    )
+    positioned_cache = model.make_cache()
+    positioned_logits, positioned_hidden = _positioned_target(
+        model, inputs, positioned_cache, (0, 1)
+    )
+
+    _assert_float_payload_matches(ordinary_logits, positioned_logits)
+    _assert_float_payload_matches(ordinary_hidden, positioned_hidden)
+    assert ordinary_cache[-1].offset == positioned_cache[-1].offset == 2
+
+
+def test_positioned_mtp_generate_uses_qwen_context_without_manual_ack():
+    model = _model()
+    _sanitize_and_load(model, _checkpoint(model))
+    telemetry = {}
+
+    output = list(
+        mtp_generate_step(
+            mx.array((3, 7), dtype=mx.uint32),
+            model,
+            max_tokens=1,
+            telemetry=telemetry,
+            prompt_logical_positions=(41, 97),
+        )
+    )
+
+    assert len(output) == 1
+    assert telemetry["mtp_bypass_reason"] is None
+
+
+def test_positioned_stream_generate_uses_qwen_context_without_callback(monkeypatch):
+    model = _model()
+    _sanitize_and_load(model, _checkpoint(model))
+    generate_module = importlib.import_module("mlx_lm.generate")
+    monkeypatch.setattr(generate_module, "TokenizerWrapper", _StreamTokenizer)
+    tokenizer = _StreamTokenizer()
+
+    output = list(
+        stream_generate(
+            model,
+            tokenizer,
+            mx.array((3, 7), dtype=mx.uint32),
+            mtp=True,
+            max_tokens=1,
+            prompt_logical_positions=(41, 97),
+        )
+    )
+
+    assert output[-1].mtp_bypass_reason is None
+    assert tokenizer.detokenizer.finalized
+
+
+def test_positioned_qwen_rejects_manual_ack_context_as_ambiguous_before_forward():
+    model = _model()
+    _sanitize_and_load(model, _checkpoint(model))
+
+    @contextmanager
+    def manual_ack(forward):
+        if forward.logical_position_ack is not None:
+            forward.logical_position_ack.acknowledge(forward.logical_positions)
+        yield
+
+    with pytest.raises(ValueError, match="native_mtp_position_context_ambiguous"):
+        list(
+            mtp_generate_step(
+                mx.array((3, 7), dtype=mx.uint32),
+                model,
+                max_tokens=1,
+                prompt_logical_positions=(41, 97),
+                model_forward_context=manual_ack,
+            )
+        )

--- a/tests/test_qwen3_5_mtp_model.py
+++ b/tests/test_qwen3_5_mtp_model.py
@@ -1,0 +1,404 @@
+# Copyright © 2026 Apple Inc.
+"""Synthetic model-only coverage for Qwen native MTP capability handling."""
+
+import importlib
+import math
+
+import mlx.core as mx
+import mlx.nn as nn
+import pytest
+from mlx.utils import tree_flatten
+
+HIDDEN = 32
+INTERMEDIATE = 64
+HEAD_DIM = 8
+NUM_HEADS = 4
+NUM_KV_HEADS = 2
+NUM_EXPERTS = 2
+MOE_INTERMEDIATE = 32
+SHARED_INTERMEDIATE = 64
+
+
+def _config(*, moe=False, mtp_layers=1, tie_word_embeddings=True):
+    config = {
+        "model_type": "qwen3_5_moe" if moe else "qwen3_5",
+        "text_config": {
+            "model_type": "qwen3_5_moe" if moe else "qwen3_5",
+            "hidden_size": HIDDEN,
+            "intermediate_size": INTERMEDIATE,
+            "num_hidden_layers": 2,
+            "num_attention_heads": NUM_HEADS,
+            "num_key_value_heads": NUM_KV_HEADS,
+            "vocab_size": 64,
+            "linear_num_value_heads": 2,
+            "linear_num_key_heads": 2,
+            "linear_key_head_dim": 8,
+            "linear_value_head_dim": 8,
+            "linear_conv_kernel_dim": 3,
+            "full_attention_interval": 2,
+            "tie_word_embeddings": tie_word_embeddings,
+            "rms_norm_eps": 1e-5,
+            "head_dim": HEAD_DIM,
+            "rope_theta": 1000.0,
+            "partial_rotary_factor": 0.5,
+            "max_position_embeddings": 128,
+            "mtp_num_hidden_layers": mtp_layers,
+        },
+    }
+    if moe:
+        config["text_config"].update(
+            {
+                "num_experts": NUM_EXPERTS,
+                "num_experts_per_tok": 1,
+                "decoder_sparse_step": 1,
+                "shared_expert_intermediate_size": SHARED_INTERMEDIATE,
+                "moe_intermediate_size": MOE_INTERMEDIATE,
+            }
+        )
+    return config
+
+
+def _model(*, moe=False, mtp_layers=1, tie_word_embeddings=True):
+    module_name = "mlx_lm.models.qwen3_5_moe" if moe else "mlx_lm.models.qwen3_5"
+    module = importlib.import_module(module_name)
+    model = module.Model(
+        module.ModelArgs.from_dict(
+            _config(
+                moe=moe,
+                mtp_layers=mtp_layers,
+                tie_word_embeddings=tie_word_embeddings,
+            )
+        )
+    )
+    model.set_dtype(mx.float32)
+    mx.eval(model.parameters())
+    return model
+
+
+def _fixture(shape, seed):
+    size = math.prod(shape)
+    return (mx.arange(size, dtype=mx.float32).reshape(shape) + seed) / (size + seed)
+
+
+def _canonical_mtp_weights(*, moe=False, mtp_layers=1):
+    """Build checkpoint keys from the published Qwen schema, not model.parameters."""
+    weights = {
+        "language_model.mtp.pre_fc_norm_hidden.weight": _fixture((HIDDEN,), 1),
+        "language_model.mtp.pre_fc_norm_embedding.weight": _fixture((HIDDEN,), 2),
+        "language_model.mtp.fc.weight": _fixture((HIDDEN, 2 * HIDDEN), 3),
+        "language_model.mtp.norm.weight": _fixture((HIDDEN,), 4),
+    }
+    for layer_idx in range(mtp_layers):
+        prefix = f"language_model.mtp.layers.{layer_idx}"
+        weights.update(
+            {
+                f"{prefix}.input_layernorm.weight": _fixture((HIDDEN,), 10),
+                f"{prefix}.post_attention_layernorm.weight": _fixture((HIDDEN,), 11),
+                f"{prefix}.self_attn.q_proj.weight": _fixture(
+                    (2 * NUM_HEADS * HEAD_DIM, HIDDEN), 12
+                ),
+                f"{prefix}.self_attn.k_proj.weight": _fixture(
+                    (NUM_KV_HEADS * HEAD_DIM, HIDDEN), 13
+                ),
+                f"{prefix}.self_attn.v_proj.weight": _fixture(
+                    (NUM_KV_HEADS * HEAD_DIM, HIDDEN), 14
+                ),
+                f"{prefix}.self_attn.o_proj.weight": _fixture(
+                    (HIDDEN, NUM_HEADS * HEAD_DIM), 15
+                ),
+                f"{prefix}.self_attn.q_norm.weight": _fixture((HEAD_DIM,), 16),
+                f"{prefix}.self_attn.k_norm.weight": _fixture((HEAD_DIM,), 17),
+            }
+        )
+        mlp = f"{prefix}.mlp"
+        if moe:
+            weights.update(
+                {
+                    f"{mlp}.gate.weight": _fixture((NUM_EXPERTS, HIDDEN), 20),
+                    f"{mlp}.switch_mlp.gate_proj.weight": _fixture(
+                        (NUM_EXPERTS, MOE_INTERMEDIATE, HIDDEN), 21
+                    ),
+                    f"{mlp}.switch_mlp.up_proj.weight": _fixture(
+                        (NUM_EXPERTS, MOE_INTERMEDIATE, HIDDEN), 22
+                    ),
+                    f"{mlp}.switch_mlp.down_proj.weight": _fixture(
+                        (NUM_EXPERTS, HIDDEN, MOE_INTERMEDIATE), 23
+                    ),
+                    f"{mlp}.shared_expert.gate_proj.weight": _fixture(
+                        (SHARED_INTERMEDIATE, HIDDEN), 24
+                    ),
+                    f"{mlp}.shared_expert.up_proj.weight": _fixture(
+                        (SHARED_INTERMEDIATE, HIDDEN), 25
+                    ),
+                    f"{mlp}.shared_expert.down_proj.weight": _fixture(
+                        (HIDDEN, SHARED_INTERMEDIATE), 26
+                    ),
+                    f"{mlp}.shared_expert_gate.weight": _fixture((1, HIDDEN), 27),
+                }
+            )
+        else:
+            weights.update(
+                {
+                    f"{mlp}.gate_proj.weight": _fixture((INTERMEDIATE, HIDDEN), 20),
+                    f"{mlp}.up_proj.weight": _fixture((INTERMEDIATE, HIDDEN), 21),
+                    f"{mlp}.down_proj.weight": _fixture((HIDDEN, INTERMEDIATE), 22),
+                }
+            )
+    return weights
+
+
+def _checkpoint(model, *, moe=False):
+    backbone = {
+        key: value
+        for key, value in tree_flatten(model.parameters())
+        if not key.startswith("language_model.mtp.")
+    }
+    backbone.update(
+        _canonical_mtp_weights(
+            moe=moe, mtp_layers=model.language_model.args.mtp_num_hidden_layers
+        )
+    )
+    return backbone
+
+
+def _sanitize_and_load(model, weights):
+    sanitized = model.sanitize(weights)
+    assert model.mtp_capability.reason == "native_mtp_weights_not_loaded"
+    model.load_weights(list(sanitized.items()), strict=True)
+    assert model.supports_mtp
+    return sanitized
+
+
+def _convert_moe_layout(weights, layout):
+    prefix = "language_model.mtp.layers.0.mlp"
+    gate = weights.pop(f"{prefix}.switch_mlp.gate_proj.weight")
+    up = weights.pop(f"{prefix}.switch_mlp.up_proj.weight")
+    down = weights.pop(f"{prefix}.switch_mlp.down_proj.weight")
+    if layout == "fused":
+        weights[f"{prefix}.experts.gate_up_proj"] = mx.concatenate([gate, up], axis=-2)
+        weights[f"{prefix}.experts.down_proj"] = down
+    elif layout == "per_expert":
+        for expert in range(NUM_EXPERTS):
+            weights[f"{prefix}.experts.{expert}.gate_proj.weight"] = gate[expert]
+            weights[f"{prefix}.experts.{expert}.up_proj.weight"] = up[expert]
+            weights[f"{prefix}.experts.{expert}.down_proj.weight"] = down[expert]
+    else:
+        weights[f"{prefix}.switch_mlp.gate_proj.weight"] = gate
+        weights[f"{prefix}.switch_mlp.up_proj.weight"] = up
+        weights[f"{prefix}.switch_mlp.down_proj.weight"] = down
+
+
+def _quantizable_prefixes(*, moe=False):
+    layer = "language_model.mtp.layers.0"
+    prefixes = {
+        "language_model.mtp.fc",
+        *(
+            f"{layer}.self_attn.{name}"
+            for name in ("q_proj", "k_proj", "v_proj", "o_proj")
+        ),
+    }
+    mlp = f"{layer}.mlp"
+    if moe:
+        prefixes.update(
+            {
+                f"{mlp}.gate",
+                f"{mlp}.shared_expert_gate",
+                *(
+                    f"{mlp}.switch_mlp.{name}"
+                    for name in ("gate_proj", "up_proj", "down_proj")
+                ),
+                *(
+                    f"{mlp}.shared_expert.{name}"
+                    for name in ("gate_proj", "up_proj", "down_proj")
+                ),
+            }
+        )
+    else:
+        prefixes.update(
+            f"{mlp}.{name}" for name in ("gate_proj", "up_proj", "down_proj")
+        )
+    return prefixes
+
+
+def test_config_and_missing_weights_do_not_publish_capability():
+    model = _model()
+    assert model.mtp_capability.reason == "native_mtp_weights_not_validated"
+    with pytest.raises(ValueError, match="Native Qwen MTP weights"):
+        model.sanitize({})
+    assert not model.supports_mtp
+
+
+def test_no_head_model_preserves_normal_forward_and_refuses_dispatch():
+    model = _model(mtp_layers=0)
+    logits = model(mx.array([[1, 2, 3]], dtype=mx.uint32))
+    mx.eval(logits)
+    assert logits.shape == (1, 3, 64)
+    assert model.mtp_capability.reason == "native_mtp_head_not_configured"
+    with pytest.raises(RuntimeError, match="native_mtp_head_not_configured"):
+        model.make_mtp_cache()
+
+
+def test_exact_sanitize_load_handshake_rejects_filtered_non_strict_load():
+    model = _model()
+    sanitized = model.sanitize(_checkpoint(model))
+    omitted = "language_model.mtp.fc.weight"
+    filtered = [(key, value) for key, value in sanitized.items() if key != omitted]
+    model.load_weights(filtered, strict=False)
+    assert model.mtp_capability.reason == "native_mtp_weights_not_loaded"
+
+    # The failed handshake is one-shot: replaying the old mapping cannot enable MTP.
+    model.load_weights(list(sanitized.items()), strict=True)
+    assert model.mtp_capability.reason == "native_mtp_weights_not_loaded"
+
+    _sanitize_and_load(model, _checkpoint(model))
+
+
+def test_failed_resanitize_invalidates_an_older_pending_handshake():
+    model = _model()
+    previously_sanitized = model.sanitize(_checkpoint(model))
+    invalid = _checkpoint(model)
+    invalid.pop("language_model.mtp.fc.weight")
+    with pytest.raises(ValueError, match="missing language_model.mtp.fc.weight"):
+        model.sanitize(invalid)
+
+    model.load_weights(list(previously_sanitized.items()), strict=True)
+    assert model.mtp_capability.reason == "native_mtp_weights_not_validated"
+
+
+def test_exact_strict_false_wrong_shape_load_is_rejected_and_not_activated():
+    model = _model()
+    weights = _checkpoint(model)
+    weights["language_model.mtp.fc.weight"] = _fixture((HIDDEN - 1, 2 * HIDDEN), 101)
+    sanitized = model.sanitize(weights)
+    with pytest.raises(ValueError, match="MTP load leaf type/shape mismatch"):
+        model.load_weights(list(sanitized.items()), strict=False)
+    assert model.mtp_capability.reason == "native_mtp_weights_not_loaded"
+
+
+def test_dense_mtp_preserves_normal_logits_and_returns_numeric_pre_norm_hidden():
+    model = _model(tie_word_embeddings=False)
+    inputs = mx.array([[1, 2, 3]], dtype=mx.uint32)
+    baseline = model(inputs)
+    _sanitize_and_load(model, _checkpoint(model))
+    logits, hidden = model(inputs, return_hidden=True)
+    normed = model.model.norm(hidden)
+    expected = model.language_model.lm_head(normed)
+    incorrectly_post_norm_contract = model.language_model.lm_head(hidden)
+    mx.eval(baseline, logits, hidden, normed, expected, incorrectly_post_norm_contract)
+    assert mx.allclose(baseline, logits).item()
+    assert mx.allclose(logits, expected).item()
+    assert not mx.allclose(logits, incorrectly_post_norm_contract, atol=1e-5).item()
+
+    mtp_cache = model.make_mtp_cache()
+    mtp_hidden = model.language_model.mtp(
+        hidden[:, -1:], mx.array([[4]]), model.model.embed_tokens, mtp_cache
+    )
+    shared_head_logits = model.language_model.lm_head(mtp_hidden)
+    actual = model.mtp_forward(hidden[:, -1:], mx.array([[4]]), model.make_mtp_cache())
+    mx.eval(shared_head_logits, actual)
+    assert mx.allclose(actual, shared_head_logits).item()
+
+
+def test_vlm_wrapper_mtp_keys_map_beside_backbone():
+    model = _model()
+    weights = _checkpoint(model)
+    for key in list(weights):
+        if key.startswith("language_model.mtp."):
+            suffix = key.removeprefix("language_model.")
+            weights[f"model.language_model.{suffix}"] = weights.pop(key)
+    sanitized = _sanitize_and_load(model, weights)
+    assert not any(key.startswith("language_model.model.mtp.") for key in sanitized)
+
+
+@pytest.mark.parametrize("layout", ["fused", "per_expert", "stacked"])
+def test_moe_accepts_independent_canonical_expert_layouts(layout):
+    model = _model(moe=True)
+    weights = _checkpoint(model, moe=True)
+    _convert_moe_layout(weights, layout)
+    sanitized = _sanitize_and_load(model, weights)
+    prefix = "language_model.mtp.layers.0.mlp.switch_mlp"
+    assert all(
+        f"{prefix}.{name}.weight" in sanitized
+        for name in ("gate_proj", "up_proj", "down_proj")
+    )
+
+
+def test_moe_rejects_mixed_expert_layouts():
+    model = _model(moe=True)
+    weights = _checkpoint(model, moe=True)
+    weights["language_model.mtp.layers.0.mlp.experts.gate_up_proj"] = _fixture(
+        (NUM_EXPERTS, 2 * MOE_INTERMEDIATE, HIDDEN), 99
+    )
+    with pytest.raises(ValueError, match="Mixed MoE expert layouts"):
+        model.sanitize(weights)
+
+
+@pytest.mark.parametrize("moe", [False, True])
+def test_quantized_mtp_complete_triplets_load_but_partial_triplets_fail(moe):
+    model = _model(moe=moe)
+    weights = _checkpoint(model, moe=moe)
+    prefixes = _quantizable_prefixes(moe=moe)
+    for prefix in prefixes:
+        weight_key = f"{prefix}.weight"
+        quantized, scales, biases = mx.quantize(
+            weights[weight_key], group_size=32, bits=4
+        )
+        weights[weight_key] = quantized
+        weights[f"{prefix}.scales"] = scales
+        weights[f"{prefix}.biases"] = biases
+
+    sanitized = model.sanitize(weights)
+    nn.quantize(
+        model,
+        group_size=32,
+        bits=4,
+        class_predicate=lambda path, module: (
+            path in prefixes and hasattr(module, "to_quantized")
+        ),
+    )
+    # Exact, shape-valid post-quantization mappings may activate under
+    # strict=False; the safety decision is independent of unrelated leaves.
+    model.load_weights(list(sanitized.items()), strict=False)
+    assert model.supports_mtp
+
+    partial_model = _model(moe=moe)
+    partial = _checkpoint(partial_model, moe=moe)
+    prefix = "language_model.mtp.fc"
+    _, scales, _ = mx.quantize(partial[f"{prefix}.weight"], group_size=32, bits=4)
+    partial[f"{prefix}.scales"] = scales
+    with pytest.raises(ValueError, match="incomplete quantized triplet"):
+        partial_model.sanitize(partial)
+
+
+def test_tensor_sharding_fails_before_group_or_parameter_mutation():
+    model = _model()
+    before = [(key, id(value)) for key, value in tree_flatten(model.parameters())]
+
+    class ExplodingGroup:
+        def rank(self):
+            raise AssertionError("group inspected before MTP sharding guard")
+
+        def size(self):
+            raise AssertionError("group inspected before MTP sharding guard")
+
+    with pytest.raises(RuntimeError, match="does not support tensor/distributed"):
+        model.shard(ExplodingGroup())
+    after = [(key, id(value)) for key, value in tree_flatten(model.parameters())]
+    assert before == after
+
+
+def test_pipeline_parallelism_remains_ineligible():
+    model = _model()
+    _sanitize_and_load(model, _checkpoint(model))
+
+    class TwoRanks:
+        def rank(self):
+            return 0
+
+        def size(self):
+            return 2
+
+    model.model.pipeline(TwoRanks())
+    assert model.mtp_capability.reason == "native_mtp_pipeline_parallelism_unsupported"
+    with pytest.raises(RuntimeError, match="pipeline_parallelism_unsupported"):
+        model.make_mtp_cache()

--- a/tests/test_qwen3_5_mtp_model.py
+++ b/tests/test_qwen3_5_mtp_model.py
@@ -238,6 +238,20 @@ def test_no_head_model_preserves_normal_forward_and_refuses_dispatch():
         model.make_mtp_cache()
 
 
+@pytest.mark.parametrize("moe", (False, True))
+def test_dense_and_moe_models_expose_the_same_structured_mtp_cache_contract(moe):
+    model = _model(moe=moe)
+    _sanitize_and_load(model, _checkpoint(model, moe=moe))
+
+    request = model.make_mtp_request_cache()
+    assert request.backbone is not request.mtp
+    assert request.state.backbone_tokens == 0
+    assert request.state.mtp_tokens == 0
+    request.assert_aligned(backbone_tokens=0, mtp_tokens=0)
+    with pytest.raises(ValueError, match="native_mtp_prefix_reuse_unsupported"):
+        model.make_mtp_request_cache(prompt_cache=model.make_cache())
+
+
 def test_exact_sanitize_load_handshake_rejects_filtered_non_strict_load():
     model = _model()
     sanitized = model.sanitize(_checkpoint(model))

--- a/tests/test_qwen3_5_mtp_model.py
+++ b/tests/test_qwen3_5_mtp_model.py
@@ -3,11 +3,21 @@
 
 import importlib
 import math
+from contextlib import contextmanager
+from contextvars import ContextVar
 
 import mlx.core as mx
 import mlx.nn as nn
 import pytest
 from mlx.utils import tree_flatten
+
+from mlx_lm.generate import (
+    GenerationForwardPhase,
+    NativeMTPSparseBootstrap,
+    attested_target_forward,
+    stream_generate,
+)
+from mlx_lm.models.cache import NativeMTPRequestCache
 
 HIDDEN = 32
 INTERMEDIATE = 64
@@ -17,6 +27,7 @@ NUM_KV_HEADS = 2
 NUM_EXPERTS = 2
 MOE_INTERMEDIATE = 32
 SHARED_INTERMEDIATE = 64
+_ACTIVE_FORWARD = ContextVar("qwen3_5_mtp_wrapper_forward", default=None)
 
 
 def _config(*, moe=False, mtp_layers=1, tie_word_embeddings=True):
@@ -58,10 +69,29 @@ def _config(*, moe=False, mtp_layers=1, tie_word_embeddings=True):
     return config
 
 
-def _model(*, moe=False, mtp_layers=1, tie_word_embeddings=True):
+def _model(*, moe=False, mtp_layers=1, tie_word_embeddings=True, acknowledge=False):
     module_name = "mlx_lm.models.qwen3_5_moe" if moe else "mlx_lm.models.qwen3_5"
     module = importlib.import_module(module_name)
-    model = module.Model(
+    model_type = module.Model
+    if acknowledge:
+
+        class _AcknowledgingModel(model_type):
+            @staticmethod
+            def _acknowledge_positions():
+                forward = _ACTIVE_FORWARD.get()
+                if forward is not None and forward.logical_position_ack is not None:
+                    forward.logical_position_ack.acknowledge(forward.logical_positions)
+
+            def __call__(self, *args, **kwargs):
+                self._acknowledge_positions()
+                return super().__call__(*args, **kwargs)
+
+            def mtp_forward(self, *args, **kwargs):
+                self._acknowledge_positions()
+                return super().mtp_forward(*args, **kwargs)
+
+        model_type = _AcknowledgingModel
+    model = model_type(
         module.ModelArgs.from_dict(
             _config(
                 moe=moe,
@@ -169,6 +199,54 @@ def _sanitize_and_load(model, weights):
     return sanitized
 
 
+@contextmanager
+def _acknowledging_forward_context(forward):
+    token = _ACTIVE_FORWARD.set(forward)
+    try:
+        yield
+    finally:
+        _ACTIVE_FORWARD.reset(token)
+
+
+class _StreamDetokenizer:
+    def __init__(self):
+        self.last_segment = ""
+        self.finalized = False
+
+    def add_token(self, token):
+        self.last_segment = str(token)
+
+    def finalize(self):
+        self.finalized = True
+
+
+class _StreamTokenizer:
+    def __init__(self):
+        self.detokenizer = _StreamDetokenizer()
+        self.eos_token_ids = frozenset()
+
+
+def _sparse_bootstrap(model):
+    target_cache = model.make_cache()
+    (_, _), receipt = attested_target_forward(
+        model,
+        (0, 1),
+        target_cache,
+        phase=GenerationForwardPhase.PREFILL,
+        logical_positions=(0, 1),
+        immediate_successor_token_ids=(1,),
+        model_forward_context=_acknowledging_forward_context,
+    )
+    return NativeMTPSparseBootstrap(
+        receipts=(receipt,),
+        selected_logical_positions=(0, 1),
+        selected_token_ids=(0, 1),
+        immediate_successor_token_ids=(1,),
+        target_cache=target_cache,
+        next_logical_position=2,
+    )
+
+
 def _convert_moe_layout(weights, layout):
     prefix = "language_model.mtp.layers.0.mlp"
     gate = weights.pop(f"{prefix}.switch_mlp.gate_proj.weight")
@@ -244,12 +322,90 @@ def test_dense_and_moe_models_expose_the_same_structured_mtp_cache_contract(moe)
     _sanitize_and_load(model, _checkpoint(model, moe=moe))
 
     request = model.make_mtp_request_cache()
+    assert model.mtp is model.language_model.mtp
+    assert request.model is model.language_model
+    assert not any(
+        key.startswith("mtp.") for key, _ in tree_flatten(model.parameters())
+    )
     assert request.backbone is not request.mtp
     assert request.state.backbone_tokens == 0
     assert request.state.mtp_tokens == 0
     request.assert_aligned(backbone_tokens=0, mtp_tokens=0)
     with pytest.raises(ValueError, match="native_mtp_prefix_reuse_unsupported"):
         model.make_mtp_request_cache(prompt_cache=model.make_cache())
+
+
+def test_outer_mtp_topology_view_preserves_unloaded_fail_closed_behavior():
+    model = _model()
+    target_cache = model.make_cache()
+
+    assert model.mtp is model.language_model.mtp
+    with pytest.raises(RuntimeError, match="native_mtp_weights_not_validated"):
+        NativeMTPRequestCache.adopt_sparse_target(
+            model,
+            target_cache=target_cache,
+            target_tokens=1,
+            next_logical_position=1,
+        )
+
+    assert target_cache[1].offset == 0
+
+
+@pytest.mark.parametrize("moe", (False, True))
+def test_outer_dense_and_moe_sparse_bootstrap_stream_adopts_outer_topology(
+    monkeypatch, moe
+):
+    model = _model(moe=moe, acknowledge=True)
+    _sanitize_and_load(model, _checkpoint(model, moe=moe))
+    bootstrap = _sparse_bootstrap(model)
+    adopted = []
+    sealed = []
+    original_adopt = NativeMTPRequestCache.adopt_sparse_target.__func__
+    original_seal = NativeMTPRequestCache.seal_verified
+
+    def capture_adopt(cls, *args, **kwargs):
+        request = original_adopt(cls, *args, **kwargs)
+        adopted.append(request)
+        return request
+
+    def capture_seal(self, *, backbone_tokens, mtp_tokens):
+        result = original_seal(
+            self, backbone_tokens=backbone_tokens, mtp_tokens=mtp_tokens
+        )
+        sealed.append((backbone_tokens, mtp_tokens, result))
+        return result
+
+    generate_module = importlib.import_module("mlx_lm.generate")
+    monkeypatch.setattr(generate_module, "TokenizerWrapper", _StreamTokenizer)
+    monkeypatch.setattr(
+        NativeMTPRequestCache, "adopt_sparse_target", classmethod(capture_adopt)
+    )
+    monkeypatch.setattr(NativeMTPRequestCache, "seal_verified", capture_seal)
+    tokenizer = _StreamTokenizer()
+
+    responses = list(
+        stream_generate(
+            model,
+            tokenizer,
+            None,
+            mtp=True,
+            max_tokens=1,
+            sparse_bootstrap=bootstrap,
+            model_forward_context=_acknowledging_forward_context,
+        )
+    )
+
+    request = adopted[0]
+    assert request.model is model
+    assert request.backbone is bootstrap.target_cache
+    assert (sealed[0][0], sealed[0][1]) == (2, 1)
+    assert sealed[0][2].backbone_tokens == 2
+    assert sealed[0][2].mtp_tokens == 1
+    assert request.closed
+    assert not request.checkpoint_active
+    assert tokenizer.detokenizer.finalized
+    assert responses[-1].prompt_tokens == 2
+    assert responses[-1].generation_tokens == 1
 
 
 def test_exact_sanitize_load_handshake_rejects_filtered_non_strict_load():


### PR DESCRIPTION
## Summary

Adds a request-local native Qwen MTP implementation with transactional cache ownership, typed batched lifecycle phases, per-row logical positions, and atomic admission from attested sparse target-prefill receipts.

The ordinary generation and BatchGenerator paths remain unchanged unless the explicit native-MTP request contract is used. Unsupported cache layouts, processors, prefix reuse, and ambiguous position consumers fail closed.

## Why

Native Qwen MTP requires the backbone and MTP-head caches, RNG, acceptance/rejection replay, and sparse logical positions to move as one request-owned transaction. Existing legacy speculative hooks do not provide that ownership boundary, particularly for mixed batched accept/reject outcomes or sparse target-prefill adoption.

## Main changes

- validated Qwen native-MTP model and cache capability
- request-local sampling and forward-context contracts
- transactional B=1 native generation with sparse bootstrap authority
- move-only batched cohort cache owner and typed lifecycle
- uniform and mixed accept/reject, replay, bonus, cancellation, and failure cleanup
- per-row noncontiguous logical-position matrices for target and MTP forwards
- atomic batched adoption from attested sparse receipts without dense target replay

## Validation

- complete focused lifecycle/cache/Qwen/position/sparse/server matrix: **286 passed**
- dense and recurrent+KV MoE tiny-model B1-vs-batch parity, mixed accept/reject, terminal filtering, cancellation, and injected-failure coverage
- static compile, formatting/diff checks, and independent blocker reviews passed
- downstream vllm-mlx PR #700 pins this immutable head in Apple CI; its Linux 3.10–3.13 and Apple 3.11/3.13 jobs are green

All model tests use tiny synthetic Qwen configurations. Real-checkpoint throughput and memory qualification remains downstream evidence and is not claimed by this API PR.

## Downstream

Companion draft: waybarrios/vllm-mlx#700. It consumes only this public lifecycle for request-local SimpleEngine and continuous-batching SpecPrefill integration.
