### PR TITLE
Fix off-by-one in _parse_size from float truncation

### DIFF
--- a/mlx_lm/utils.py
+++ b/mlx_lm/utils.py
@@ -8,6 +8,7 @@ import json
 import os
 import resource
 import shutil
+from decimal import Decimal
 from pathlib import Path
 from textwrap import dedent
 from typing import (
@@ -59,13 +60,13 @@ MAX_FILE_SIZE_GB = 5
 
 
 def _parse_size(x):
-    sizes = {"M": 1e6, "G": 1e9, "MB": 1e6, "GB": 1e9, "": 1}
+    sizes = {"M": 10**6, "G": 10**9, "MB": 10**6, "GB": 10**9, "": 1}
     split = 0
     for xi in x:
         if not (xi.isdigit() or xi == "."):
             break
         split += 1
-    digits = float(x[:split])
+    digits = Decimal(x[:split])
     size = (x[split:]).strip().upper()
     return int(digits * sizes[size])
 

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -59,6 +59,17 @@ class TestUtils(unittest.TestCase):
         shards = utils.make_shards(dict(weights), 1)
         self.assertTrue(gb <= len(shards) <= gb + 1)
 
+    def test_parse_size(self):
+        self.assertEqual(utils._parse_size("1024"), 1024)
+        self.assertEqual(utils._parse_size("20G"), 20_000_000_000)
+        self.assertEqual(utils._parse_size("512M"), 512_000_000)
+        self.assertEqual(utils._parse_size("4.1MB"), 4_100_000)
+        self.assertEqual(utils._parse_size("4.1M"), 4_100_000)
+        self.assertEqual(utils._parse_size("4.1GB"), 4_100_000_000)
+        self.assertEqual(utils._parse_size("8.2MB"), 8_200_000)
+        self.assertEqual(utils._parse_size("16.9GB"), 16_900_000_000)
+        self.assertEqual(utils._parse_size("2.7GB"), 2_700_000_000)
+
     def test_quantize(self):
         from mlx_lm.models import llama
 


### PR DESCRIPTION
Fixes #1677. 

`_parse_size` computed `int(float(digits) * unit)`, so fractional sizes truncated one byte low, e.g. `4.1GB` gave 4,099,999,999 instead of 4,100,000,000. This parses the numeric part with `Decimal` and uses integer unit multipliers so the result is exact. 

Adds `TestUtils.test_parse_size` covering the reporter's cases plus whole-number and unit-less controls.