### PR TITLE
Validate adapter tensors in load_adapters

### DIFF
--- a/mlx_lm/tuner/utils.py
+++ b/mlx_lm/tuner/utils.py
@@ -4,6 +4,7 @@ import types
 from pathlib import Path
 from typing import Dict
 
+import mlx.core as mx
 import mlx.nn as nn
 import mlx.optimizers as opt
 from mlx.utils import tree_flatten, tree_unflatten
@@ -134,7 +135,23 @@ def load_adapters(model: nn.Module, adapter_path: str) -> nn.Module:
             config.lora_parameters,
             use_dora=(fine_tune_type == "dora"),
         )
-    model.load_weights(str(adapter_path / "adapters.safetensors"), strict=False)
+    weights = mx.load(str(adapter_path / "adapters.safetensors"))
+    params = dict(tree_flatten(model.parameters()))
+    errors = []
+    for name, w in weights.items():
+        if name not in params:
+            errors.append(f"  {name}: not a parameter in the model")
+        elif w.shape != params[name].shape:
+            errors.append(
+                f"  {name}: adapter shape {tuple(w.shape)} does not match "
+                f"model parameter shape {tuple(params[name].shape)}"
+            )
+    if errors:
+        raise ValueError(
+            f"Adapter at {adapter_path} contains incompatible tensors:\n"
+            + "\n".join(errors)
+        )
+    model.load_weights(list(weights.items()), strict=False)
     return model
 
 

--- a/mlx_lm/tuner/utils.py
+++ b/mlx_lm/tuner/utils.py
@@ -137,14 +137,23 @@ def load_adapters(model: nn.Module, adapter_path: str) -> nn.Module:
         )
     weights = mx.load(str(adapter_path / "adapters.safetensors"))
     params = dict(tree_flatten(model.parameters()))
+    if fine_tune_type == "full":
+        allowed = params
+    else:
+        adapter_leaves = {"lora_a", "lora_b", "m"}
+        allowed = {
+            name: shape
+            for name, shape in params.items()
+            if name.rsplit(".", 1)[-1] in adapter_leaves
+        }
     errors = []
     for name, w in weights.items():
-        if name not in params:
-            errors.append(f"  {name}: not a parameter in the model")
-        elif w.shape != params[name].shape:
+        if name not in allowed:
+            errors.append(f"  {name}: not an adapter parameter in the model")
+        elif w.shape != allowed[name].shape:
             errors.append(
                 f"  {name}: adapter shape {tuple(w.shape)} does not match "
-                f"model parameter shape {tuple(params[name].shape)}"
+                f"model parameter shape {tuple(allowed[name].shape)}"
             )
     if errors:
         raise ValueError(

--- a/tests/test_tuner_utils.py
+++ b/tests/test_tuner_utils.py
@@ -1,14 +1,18 @@
 # Copyright © 2024 Apple Inc.
 
+import json
 import sys
+import tempfile
 import unittest
 from io import StringIO
+from pathlib import Path
 from unittest.mock import MagicMock
 
+import mlx.core as mx
 import mlx.nn as nn
 
 from mlx_lm.tuner.lora import LoRALinear
-from mlx_lm.tuner.utils import print_trainable_parameters
+from mlx_lm.tuner.utils import load_adapters, print_trainable_parameters
 
 
 class TestTunerUtils(unittest.TestCase):
@@ -80,6 +84,70 @@ class TestTunerUtils(unittest.TestCase):
         expected_output = "Trainable parameters: 50.000% (3.000M/6.000M)\n"
         print_trainable_parameters(model)
         self.assertEqual(self.capturedOutput.getvalue(), expected_output)
+
+
+class TinyLayer(nn.Module):
+    def __init__(self):
+        super().__init__()
+        self.proj = nn.Linear(4, 3, bias=False)
+
+
+class TinyModel(nn.Module):
+    def __init__(self):
+        super().__init__()
+        self.layers = [TinyLayer()]
+
+
+def _make_adapter(weights):
+    path = Path(tempfile.mkdtemp())
+    config = {
+        "fine_tune_type": "lora",
+        "num_layers": 1,
+        "lora_parameters": {
+            "keys": ["proj"],
+            "rank": 2,
+            "scale": 1.0,
+            "dropout": 0.0,
+        },
+    }
+    (path / "adapter_config.json").write_text(json.dumps(config))
+    mx.save_safetensors(str(path / "adapters.safetensors"), weights)
+    return path
+
+
+class TestLoadAdapters(unittest.TestCase):
+    def test_unknown_tensor_name_raises(self):
+        path = _make_adapter(
+            {
+                "layers.0.proj.lora_a": mx.zeros((4, 2)),
+                "layers.0.proj.lora_b": mx.zeros((2, 3)),
+                "layers.0.proj.lora_typo": mx.zeros((1,)),
+            }
+        )
+        with self.assertRaises(ValueError) as cm:
+            load_adapters(TinyModel(), path)
+        self.assertIn("lora_typo", str(cm.exception))
+
+    def test_wrong_tensor_shape_raises(self):
+        path = _make_adapter(
+            {
+                "layers.0.proj.lora_a": mx.zeros((5, 2)),
+                "layers.0.proj.lora_b": mx.zeros((2, 3)),
+            }
+        )
+        with self.assertRaises(ValueError) as cm:
+            load_adapters(TinyModel(), path)
+        self.assertIn("shape", str(cm.exception))
+
+    def test_valid_adapter_loads(self):
+        path = _make_adapter(
+            {
+                "layers.0.proj.lora_a": mx.zeros((4, 2)),
+                "layers.0.proj.lora_b": mx.zeros((2, 3)),
+            }
+        )
+        model = load_adapters(TinyModel(), path)
+        self.assertIsInstance(model, nn.Module)
 
 
 if __name__ == "__main__":

--- a/tests/test_tuner_utils.py
+++ b/tests/test_tuner_utils.py
@@ -149,6 +149,42 @@ class TestLoadAdapters(unittest.TestCase):
         model = load_adapters(TinyModel(), path)
         self.assertIsInstance(model, nn.Module)
 
+    def test_base_weight_tensor_rejected(self):
+        path = _make_adapter(
+            {
+                "layers.0.proj.lora_a": mx.zeros((4, 2)),
+                "layers.0.proj.lora_b": mx.zeros((2, 3)),
+                "layers.0.proj.linear.weight": mx.full((3, 4), 42.0),
+            }
+        )
+        with self.assertRaises(ValueError) as cm:
+            load_adapters(TinyModel(), path)
+        self.assertIn("linear.weight", str(cm.exception))
+
+    def test_valid_dora_adapter_loads(self):
+        path = Path(tempfile.mkdtemp())
+        config = {
+            "fine_tune_type": "dora",
+            "num_layers": 1,
+            "lora_parameters": {
+                "keys": ["proj"],
+                "rank": 2,
+                "scale": 1.0,
+                "dropout": 0.0,
+            },
+        }
+        (path / "adapter_config.json").write_text(json.dumps(config))
+        mx.save_safetensors(
+            str(path / "adapters.safetensors"),
+            {
+                "layers.0.proj.lora_a": mx.zeros((4, 2)),
+                "layers.0.proj.lora_b": mx.zeros((2, 3)),
+                "layers.0.proj.m": mx.zeros((3,)),
+            },
+        )
+        model = load_adapters(TinyModel(), path)
+        self.assertIsInstance(model, nn.Module)
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
Fixes #1725.

load_adapters loaded adapters with load_weights(strict=False), which silently ignores adapter tensors whose names match no model parameter and tensors whose shapes are incompatible. A typo'd key or an adapter built for a different target then loads without error and produces silently wrong results, failing only later at inference or fusion.

This validates every supplied adapter tensor against the model's parameters after the LoRA layers are built: each tensor must name a real parameter and match its shape, otherwise a clear ValueError is raised listing all mismatches. An adapter is still allowed to provide only a subset of parameters, so the non-strict subset load is preserved.

Adds regression tests in tests/test_tuner_utils.py covering the unknown-name and wrong-shape cases from the issue, plus a valid adapter that still loads.

Thanks to @FU-max-boop for the precise diagnosis and reproduction.