### PR TITLE
Docs: add optional post-fusion checkpoint verification

### DIFF
--- a/mlx_lm/LORA.md
+++ b/mlx_lm/LORA.md
@@ -149,6 +149,26 @@ mlx_lm.fuse --model <path_to_model>
 This will by default load the adapters from `adapters/`, and save the fused
 model in the path `fused_model/`. All of these are configurable.
 
+### Verify a fused checkpoint (optional)
+
+For supported local, non-quantized LoRA artifacts,
+[AdapterProof](https://github.com/FU-max-boop/adapterproof) can independently
+check declared target coverage, compare the saved fused tensors with the base
+model and adapter, and write a JSON verification report:
+
+```shell
+adapterproof verify \
+    --base <path_to_local_base_model> \
+    --adapter <path_to_adapters> \
+    --fused <path_to_fused_model> \
+    --certificate adapterproof-certificate.json
+```
+
+AdapterProof is an optional third-party tool, not an MLX LM dependency. Its
+v0.1 contract covers local, non-quantized `LoRALinear` artifacts and does not
+verify generation quality or GGUF output. Check its compatibility
+documentation before use.
+
 To upload a fused model, supply the `--upload-repo` and `--hf-path` arguments
 to `mlx_lm.fuse`. The latter is the repo name of the original model, which is
 useful for the sake of attribution and model versioning.


### PR DESCRIPTION
## Summary

- add a short optional post-fusion verification section to `mlx_lm/LORA.md`
- show how to compare local base, adapter, and fused artifacts with AdapterProof
- state the boundary explicitly: third-party tool, no MLX-LM dependency, and v0.1 limited to supported local non-quantized `LoRALinear` artifacts

## Why

Load-time validation and post-fusion verification answer different questions. MLX-LM PR #1727 addresses names and shapes of tensors supplied to the adapter loader. This docs-only addition describes an optional independent postcondition check on the saved fused checkpoint: expected LoRA arithmetic, target coverage, unchanged unrelated tensors, and shard/index consistency.

There is now a pinned public run rather than only a synthetic example. In that run, the real `mlx_lm.convert` and `mlx_lm.fuse` CLIs exited `0`; all 32 supplied Phi-3 `o_proj` adapter pairs matched the expected fp16 fused tensors exactly (maximum absolute/relative error `0.0`). The verifier separately rejected three explicit q/k/v selectors that matched no Phi-3 module. Those q/k/v tensors were absent from the adapter, not lost by MLX-LM during fusion.

- [public evidence record](https://github.com/FU-max-boop/adapterproof/blob/9c95ba263f30b97b4b920c43b75895f7c790fef5/evidence/README.md#public-phi-3-selector-coverage-failure)
- [checked evidence bundle](https://github.com/FU-max-boop/adapterproof/blob/9c95ba263f30b97b4b920c43b75895f7c790fef5/evidence/phi3-selector-coverage-bundle.json)
- [artifact-author report](https://github.com/DidierRLopes/fine-tune-llm/issues/1)

## Scope

This changes one documentation file only. It adds no import, dependency, CLI flag, or MLX-LM code path, and it does not present AdapterProof as a replacement for MLX-LM's native validation. Generation quality and GGUF output remain explicitly out of scope.

## Validation

- checked the documented command against AdapterProof v0.1.1
- validated the pinned certificate/receipt bundle with the checked-in bundle verifier
- documentation-only change; no MLX-LM runtime behavior changes

Disclosure: I maintain AdapterProof. I kept this proposal deliberately optional and docs-only; I am happy to adjust the wording or placement if a community-tools reference would be preferable.
