### PR TITLE
Fix silent Qwen3.5/3.6 corruption from double RMSNorm shift

### DIFF
--- a/mlx_lm/models/qwen3_5.py
+++ b/mlx_lm/models/qwen3_5.py
@@ -346,11 +346,15 @@ class TextModel(nn.Module):
         return [ArraysCache(size=2) if l.is_linear else KVCache() for l in self.layers]
 
     def sanitize(self, weights):
-        has_mtp_weights = any("mtp." in k for k in weights)
+        # The Conv1D layout is the only reliable signal that a checkpoint is
+        # still in raw HF form and therefore needs the RMSNorm +1 conversion.
+        # MTP tensor presence is not: an already-converted checkpoint may keep
+        # its MTP head, and shifting its norms a second time silently destroys
+        # the model (gamma 0.94 -> 1.94 -> generation becomes noise, with no
+        # error raised anywhere).
         has_unsanitized_conv1d = any(
             "conv1d.weight" in k and v.shape[-1] != 1 for k, v in weights.items()
         )
-        should_shift_norm_weights = has_mtp_weights or has_unsanitized_conv1d
         weights = {k: v for k, v in weights.items() if "mtp." not in k}
 
         if self.args.tie_word_embeddings:
@@ -366,7 +370,7 @@ class TextModel(nn.Module):
         for k, v in weights.items():
             if "conv1d.weight" in k and v.shape[-1] != 1:
                 weights[k] = v.moveaxis(2, 1)
-            if should_shift_norm_weights and any(k.endswith(sfx) for sfx in norm_keys):
+            if has_unsanitized_conv1d and any(k.endswith(sfx) for sfx in norm_keys):
                 if v.ndim == 1:
                     weights[k] = v + 1.0
         return weights

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -647,7 +647,9 @@ class TestModels(unittest.TestCase):
             "max_position_embeddings": 64,
         }
         hf_norm_key = "model.language_model.layers.0.input_layernorm.weight"
+        hf_conv_key = "model.language_model.layers.0.linear_attn.conv1d.weight"
         mlx_norm_key = "language_model.model.layers.0.input_layernorm.weight"
+        mlx_conv_key = "language_model.model.layers.0.linear_attn.conv1d.weight"
 
         for model_type, hf_mtp_key in (
             ("qwen3_5", "mtp.fc.weights"),
@@ -663,22 +665,37 @@ class TestModels(unittest.TestCase):
             model = module.Model(args)
 
             base = mx.arange(8, dtype=mx.float32)
+            raw_conv = mx.zeros((4, 1, 3), dtype=mx.float32)
 
-            # Simulate convert sanitize on HF-style keys.
+            # Raw HF Conv1D layout is what proves the norm weights are still
+            # zero-centered and need the +1 conversion.
             converted = model.sanitize(
                 {
                     hf_norm_key: base,
+                    hf_conv_key: raw_conv,
                     hf_mtp_key: mx.zeros((1,), dtype=mx.float32),
                 }
             )
             self.assertIn(mlx_norm_key, converted)
             self.assertTrue(mx.array_equal(converted[mlx_norm_key], base + 1.0))
+            self.assertEqual(converted[mlx_conv_key].shape, (4, 3, 1))
             self.assertFalse(any("mtp." in k for k in converted))
 
             # Simulate load sanitize on already-converted keys.
             loaded = model.sanitize(converted)
             self.assertTrue(
                 mx.array_equal(loaded[mlx_norm_key], converted[mlx_norm_key])
+            )
+
+            # A converted checkpoint that still ships its MTP head must not be
+            # mistaken for a raw one. This is the case that reaches users: such
+            # a checkpoint loads without error and generates noise, because the
+            # norms get shifted a second time.
+            with_mtp = dict(converted)
+            with_mtp[hf_mtp_key] = mx.zeros((1,), dtype=mx.float32)
+            reloaded = model.sanitize(with_mtp)
+            self.assertTrue(
+                mx.array_equal(reloaded[mlx_norm_key], converted[mlx_norm_key])
             )
 
     def test_gemma4_convert_then_load_keeps_language_model_prefix(self):


### PR DESCRIPTION
Fixes the root cause behind #1197. This overlaps with #1623, which reaches the same conclusion independently — I am opening this as an alternative in case that one has stalled, and because I have end-to-end evidence on a different architecture plus a regression case it does not cover. Happy to close this in favour of #1623 if a maintainer prefers it.

## The bug

`Qwen3_5` `sanitize` treats the presence of MTP tensors as evidence that a checkpoint is still in raw HF form:

```python
should_shift_norm_weights = has_mtp_weights or has_unsanitized_conv1d
```

That is not what MTP presence means. A checkpoint can be fully converted — Conv1D already in MLX layout, RMSNorm weights already shifted — and still ship its MTP head. Loading it shifts every norm a second time (γ 0.94 → 1.94). No error is raised anywhere; the model just generates noise. That is the failure mode reported in #1197, and it is easy to misattribute to the quantization.

The Conv1D layout already carries the signal reliably, and it is what the conversion itself keys off, so I use it alone.

## Reproduction

I hit this on `Qwen/Qwen3.8-27B` (dense `qwen3_5`, 64 layers, hybrid GatedDeltaNet/full-attention), converted to 4-bit with the MTP head preserved. Teacher-forced NLL on a fixed Korean passage, identical weights, identical prompt:

| mlx-lm | NLL |
| --- | --- |
| current `main` | 17.460 |
| this patch | 1.679 |

17.46 is worse than uniform over a 248k vocab, so the logits are actively wrong rather than merely degraded. The number reproduces to three decimals across runs, and generation through `mlx_lm.generate` is fluent once patched. Builds without an MTP head were never affected, which is why this hides so well — it looks like the MTP-bearing quantization is what broke.

This is a different model from the one in #1197 (dense 27B here, 35B MoE there), so the two reports together cover both branches of the family.

## What changed

- drop MTP presence from the predicate; keep the raw-Conv1D check
- extend the existing regression test with the case that reaches users: an already-converted checkpoint that *still contains* MTP tensors must load unshifted

The existing test only re-sanitized weights that had already had their MTP keys stripped, so it could not catch this. Reverting the one-line predicate change makes the new assertion fail.

## Validation

- `python -m unittest tests.test_models`: 78 passed, 1 skipped
- `black --check mlx_lm/models/qwen3_5.py tests/test_models.py`: clean
- end-to-end on the 27B checkpoint above, before and after