### PR TITLE
Fix batched generation for hybrid-cache models (silent corruption + broadcast crash)

### DIFF
--- a/mlx_lm/models/cache.py
+++ b/mlx_lm/models/cache.py
@@ -689,14 +689,21 @@ class ArraysCache(_BaseCache):
             self.left_padding -= N
 
     def make_mask(self, N: int):
+        # Combine the constraints instead of prioritizing left padding: after ``merge`` the
+        # cache carries ``left_padding = [0] * B`` (an array, not ``None``), and returning the
+        # all-true left-padding mask here silently discarded the ``lengths`` (right-padding)
+        # mask during chunked prefill — pad tokens then updated the recurrent state of every
+        # sequence whose final partial chunk was co-scheduled with longer ones, corrupting
+        # batched generation for hybrid (SSM/gated-delta) models.
+        mask = None
         if self.left_padding is not None:
             pos = mx.arange(N)
-            return pos >= self.left_padding[:, None]
-        elif self.lengths is not None:
+            mask = pos >= self.left_padding[:, None]
+        if self.lengths is not None:
             pos = mx.arange(N)
-            return pos < self.lengths[:, None]
-        else:
-            return None
+            right = pos < self.lengths[:, None]
+            mask = right if mask is None else (mask & right)
+        return mask
 
     @classmethod
     def merge(cls, caches):
@@ -1023,12 +1030,14 @@ class BatchKVCache(_BaseCache):
         self.offset = self.offset[batch_indices]
         self.left_padding = self.left_padding[batch_indices]
 
-        # Shift left to reduce padding
+        # Shift left to reduce padding. Only when keys exist: on an empty cache there is
+        # nothing to shift, and decrementing ``_idx`` below zero produced a zero-length
+        # causal mask (``arange(offset + N)`` with a negative offset) that later crashed
+        # attention with a broadcast error.
         min_left_pad = self.left_padding.min().item()
-        if min_left_pad > 0:
-            if self.keys is not None:
-                self.keys = self.keys[..., min_left_pad:, :]
-                self.values = self.values[..., min_left_pad:, :]
+        if min_left_pad > 0 and self.keys is not None:
+            self.keys = self.keys[..., min_left_pad:, :]
+            self.values = self.values[..., min_left_pad:, :]
             self._idx -= min_left_pad
             self.left_padding -= min_left_pad
 

--- a/tests/test_prompt_cache.py
+++ b/tests/test_prompt_cache.py
@@ -769,5 +769,54 @@ class TestPromptCache(unittest.TestCase):
         self.assertTrue(mx.array_equal(mask, expected))
 
 
+class TestHybridBatchCache(unittest.TestCase):
+    """Regression tests for batched generation with hybrid (SSM / gated-delta) caches."""
+
+    def test_arrays_cache_mask_combines_lengths_and_left_padding(self):
+        # After ``ArraysCache.merge`` the cache carries ``left_padding = [0] * B`` (an
+        # array, not None). ``make_mask`` used to return only the left-padding mask in
+        # that state, silently dropping the ``lengths`` (right-padding) mask set by
+        # ``prepare`` during chunked prefill — so pad tokens updated the recurrent state
+        # and corrupted batched generation for hybrid models.
+        caches = [ArraysCache(size=1) for _ in range(3)]
+        merged = ArraysCache.merge(caches)
+        self.assertIsNotNone(merged.left_padding)
+
+        merged.prepare(lengths=[4, 2, 1])
+        mask = merged.make_mask(4)
+        expected = mx.array(
+            [
+                [True, True, True, True],
+                [True, True, False, False],
+                [True, False, False, False],
+            ]
+        )
+        self.assertIsNotNone(mask)
+        self.assertTrue(mx.array_equal(mask, expected))
+
+        # Both constraints together: skip left-padded positions AND right-padded tail.
+        merged.left_padding = mx.array([1, 0, 0])
+        mask = merged.make_mask(4)
+        expected = mx.array(
+            [
+                [False, True, True, True],
+                [True, True, False, False],
+                [True, False, False, False],
+            ]
+        )
+        self.assertTrue(mx.array_equal(mask, expected))
+
+    def test_batch_kv_cache_filter_empty(self):
+        # Filtering an empty BatchKVCache with nonzero left padding used to decrement
+        # ``_idx`` below zero; the next ``make_mask`` then built a zero-length causal
+        # mask (``arange(offset + N)`` with a negative offset) which crashed attention
+        # with a broadcast error.
+        c = BatchKVCache(left_padding=[2, 1])
+        c.filter([1])
+        self.assertEqual(c._idx, 0)
+        mask = c.make_mask(1)
+        self.assertEqual(mask.shape[-1], 1)
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Problem

Batched generation is broken for hybrid-architecture models (Gated DeltaNet / SSM layers using `ArraysCache`, e.g. Qwen3.5) in two ways:

1. **Silent output corruption** with mixed-length prompts at batch >= 2: `ArraysCache.make_mask` returns only the left-padding mask whenever `left_padding` is set — and `ArraysCache.merge` always sets `left_padding = [0] * B` — so the `lengths` (right-padding) mask installed by `prepare()` during chunked prefill is silently dropped. Pad tokens then update the recurrent state of any sequence whose final partial chunk is co-scheduled with longer chunks. Attention layers happen to survive (causality excludes trailing pads); a recurrent state does not.

2. **Broadcast crash**: `BatchKVCache.filter` on an *empty* cache with nonzero left padding decrements `_idx` below zero; the next `make_mask` builds a zero-length causal mask (`arange(offset + N)` with a negative offset) which crashes attention with `[broadcast_shapes] Shapes (1,1,1,0) and (1,16,1,N) cannot be broadcast`.

Both were found serving `mlx-community/Qwen3.5-27B-6bit` behind a continuous-batching server: the engine loop died under concurrency, and — worse — sequences that avoided the crash could return corrupted tokens. Related: #980, #1403 (this appears to be the concrete mechanism behind the batch >= 2 corruption reports for GDN models).

## Repro

Staggered-arrival harness driving `BatchGenerator` on a small random-weight `qwen3_5` `TextModel` (greedy sampling), comparing each sequence's batched output against solo generation:

- Before: 3 of 5 staggered mixed-length sequences produce different tokens than solo (both the Metal kernel and the ops path — the kernel is not at fault); specific arrival timings crash with the broadcast error above.
- After: batched == solo for every sequence in every tested configuration (same-time and staggered arrivals, mixed lengths, chunked prefill through `prefill_step_size`).

## Changes

- `ArraysCache.make_mask` combines the left-padding and lengths constraints instead of prioritizing left padding.
- `BatchKVCache.filter` only performs the left-shift compaction when keys exist.
- Regression tests for both in `tests/test_prompt_cache.py` (`TestHybridBatchCache`).

`tests/test_prompt_cache.py` and `tests/test_generate.py` pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)