### PR TITLE
fix(utils): honor donate_model in save() so --export-gguf can read weights (#1723)

### DIFF
--- a/mlx_lm/utils.py
+++ b/mlx_lm/utils.py
@@ -982,7 +982,7 @@ def save(
         hf_repo = None
 
     dst_path = Path(dst_path)
-    save_model(dst_path, model, donate_model=True)
+    save_model(dst_path, model, donate_model=donate_model)
     save_config(config, config_path=dst_path / "config.json")
     tokenizer.save_pretrained(dst_path)
 


### PR DESCRIPTION
## Summary

Fixes #1723.

`save()` in `mlx_lm/utils.py` accepts a `donate_model` parameter, but its body hardcoded `donate_model=True` when calling `save_model()`, ignoring the argument entirely:

```python
def save(..., donate_model: bool = True):
    ...
    save_model(dst_path, model, donate_model=True)   # <- always True
```

When `save_model()` donates, it frees memory by replacing every parameter with an empty array right after writing it to disk:

```python
if donate_model:
    model.update(tree_map(lambda _: mx.array([]), model.parameters()))
```

`mlx_lm.fuse.main()` deliberately passes `donate_model=False` to `save()` precisely because it still needs `model.parameters()` for the `--export-gguf` step immediately afterward:

```python
save(save_path, args.model, model, tokenizer, config, donate_model=False)
if args.export_gguf:
    ...
    weights = dict(tree_flatten(model.parameters()))   # reads EMPTY arrays
    convert_to_gguf(save_path, weights, config, ...)
```

Because `save()` ignored the flag and donated anyway, every tensor handed to `mx.save_gguf` had shape `(0,)`. That surfaces as the misleading error:

```
ValueError: [save_gguf] can only serialize row-major arrays
```

(the row-major message is `mx.save_gguf` reacting to a batch of empty arrays, not a stride/permutation problem).

## Fix

Pass the parameter through so `save()` respects its own contract:

```python
save_model(dst_path, model, donate_model=donate_model)
```

This is the general fix (fix #1 in the issue): any caller relying on `donate_model=False` now keeps its weights. Existing callers that use the default `donate_model=True` are unaffected. The issue reporter confirmed this resolves the end-to-end `fuse → dequantize → GGUF export → quantize` flow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
