### PR TITLE
Add load() overloads so return_config narrows the return type

### DIFF
--- a/mlx_lm/utils.py
+++ b/mlx_lm/utils.py
@@ -15,10 +15,12 @@ from typing import (
     Callable,
     Dict,
     List,
+    Literal,
     Optional,
     Tuple,
     Type,
     Union,
+    overload,
 )
 
 import mlx.core as mx
@@ -479,6 +481,32 @@ def load_tokenizer(model_path, tokenizer_config_extra=None, eos_token_ids=None):
     )
 
 
+@overload
+def load(
+    path_or_hf_repo: str,
+    tokenizer_config: Optional[Dict[str, Any]] = ...,
+    model_config: Optional[Dict[str, Any]] = ...,
+    adapter_path: Optional[str] = ...,
+    lazy: bool = ...,
+    return_config: Literal[False] = ...,
+    revision: Optional[str] = ...,
+    trust_remote_code: bool = ...,
+) -> Tuple[nn.Module, TokenizerWrapper]: ...
+
+
+@overload
+def load(
+    path_or_hf_repo: str,
+    tokenizer_config: Optional[Dict[str, Any]] = ...,
+    model_config: Optional[Dict[str, Any]] = ...,
+    adapter_path: Optional[str] = ...,
+    lazy: bool = ...,
+    return_config: Literal[True] = ...,
+    revision: Optional[str] = ...,
+    trust_remote_code: bool = ...,
+) -> Tuple[nn.Module, TokenizerWrapper, Dict[str, Any]]: ...
+
+
 def load(
     path_or_hf_repo: str,
     tokenizer_config: Optional[Dict[str, Any]] = None,
@@ -512,8 +540,8 @@ def load(
             executing a custom Python file specified in their config.
             Default: ``False``.
     Returns:
-        Union[Tuple[nn.Module, TokenizerWrapper], Tuple[nn.Module, TokenizerWrapper, Dict[str, Any]]]:
-            A tuple containing the loaded model, tokenizer and, if requested, the model config.
+        Tuple[nn.Module, TokenizerWrapper]: A tuple containing the loaded model and
+            tokenizer, with the model config appended when ``return_config`` is ``True``.
 
     Raises:
         FileNotFoundError: If config file or safetensors are not found.


### PR DESCRIPTION
## What

Add `@overload` declarations for `load()` so its return type narrows on `return_config`

## Why

Closes #1732. `load()` is annotated as `Union[Tuple[nn.Module, TokenizerWrapper], Tuple[nn.Module, TokenizerWrapper, Dict[str, Any]]]`, so a checker sees a union of a 2-tuple and a 3-tuple and cannot tell which one a call returns. The two-value unpack in the README fails:

```
error: Too many values to unpack (2 expected, 3 provided)  [misc]
```

pyrefly reports the same as `bad-unpacking`. Today the documented entry point needs a `# type: ignore` to pass a typed build.

## How

Two overloads keyed on `return_config`, `Literal[False]` returning the 2-tuple and `Literal[True]` returning the 3-tuple. The implementation signature and body are unchanged, and the docstring now describes both forms. Overload declarations are erased at import, so runtime behavior is identical.

`sharded_load` has the same `return_config` branch but carries no return annotation, so it does not error today. I left it alone to keep this to one change, happy to follow up if you want it typed as well.

## Test plan

Ran on Apple Silicon with mlx 0.32.0 and Python 3.12. The README example type checks after the change, and every call form resolves, with `return_config=True` narrowing the third element to `dict[str, Any]`. `pre-commit run --files mlx_lm/utils.py` passes black and isort with the file unchanged.

`python -m unittest discover tests/` ran 211 tests with 1 skip and 1 error. That error, `tests/test_datsets.py` loading `billsum`, reproduces on an unmodified tree and is already addressed by #1434.

Since this only changes annotations I did not add a runtime test, as there is no type-checking gate in the suite today. Happy to add one if you would like the overloads pinned.
