### PR TITLE
Fix batch cache extract() leaking pending right padding

### DIFF
--- a/mlx_lm/models/cache.py
+++ b/mlx_lm/models/cache.py
@@ -1080,8 +1080,15 @@ class BatchKVCache(_BaseCache):
     def extract(self, idx):
         cache = KVCache()
         padding = self.left_padding[idx].item()
-        cache.keys = mx.contiguous(self.keys[idx : idx + 1, :, padding : self._idx])
-        cache.values = mx.contiguous(self.values[idx : idx + 1, :, padding : self._idx])
+        # Pending (un-finalized) right padding must not leak into the
+        # extracted cache: those trailing positions are pad garbage, and
+        # counting them corrupts both content and the offset bookkeeping of
+        # any prompt-cache entry stored from a segment boundary.
+        end = self._idx
+        if self._right_padding is not None:
+            end -= int(self._right_padding[idx].item())
+        cache.keys = mx.contiguous(self.keys[idx : idx + 1, :, padding:end])
+        cache.values = mx.contiguous(self.values[idx : idx + 1, :, padding:end])
         cache.offset = cache.keys.shape[2]
         return cache
 
@@ -1426,8 +1433,17 @@ class BatchRotatingKVCache(_BaseCache):
             cache.keys = mx.roll(cache.keys, -self._idx, axis=2)
             cache.values = mx.roll(cache.values, -self._idx, axis=2)
             cache._idx = self.max_size
-        cache.keys = mx.contiguous(cache.keys[:, :, padding : cache._idx])
-        cache.values = mx.contiguous(cache.values[:, :, padding : cache._idx])
+        # Pending (un-finalized) right padding must not leak into the
+        # extracted cache; see BatchKVCache.extract. _lengths holds the
+        # per-sequence true end offsets while a right-padded chunk is in
+        # flight, so the pad amount is offset - _lengths clamped at 0.
+        end = cache._idx
+        if self._lengths is not None:
+            pad = max(0, int((self.offset - self._lengths).tolist()[idx]))
+            end -= pad
+            offset -= pad
+        cache.keys = mx.contiguous(cache.keys[:, :, padding:end])
+        cache.values = mx.contiguous(cache.values[:, :, padding:end])
         cache.offset = offset
         cache._idx = cache.keys.shape[2]
         return cache

--- a/tests/test_prompt_cache.py
+++ b/tests/test_prompt_cache.py
@@ -769,5 +769,77 @@ class TestPromptCache(unittest.TestCase):
         self.assertTrue(mx.array_equal(mask, expected))
 
 
+class TestBatchCacheExtract(unittest.TestCase):
+    """Regression test: extract() from a batch that has pending
+    (un-finalized) right padding must not leak the padding into the
+    extracted cache.
+
+    mlx_lm.server hits this path when it stores a prompt-cache entry at a
+    segment boundary while a mixed-length batched prefill is in flight:
+    between update_and_fetch() on a right-padded chunk and finalize(), the
+    batch buffer holds pad cells and per-sequence bookkeeping that
+    finalize() has not yet reconciled. An extract() in that window used to
+    return a cache containing the pad cells, with an offset that counted
+    them. Restoring such an entry later desynchronizes cache length vs.
+    attention-mask width by exactly the pad amount (broadcast errors in
+    attention, hung generation).
+
+    The constants mirror the production incident this was root-caused
+    from: four concurrent requests sharing a 52-token cached prompt
+    prefix, with per-request remainders of 270/280/272/271 tokens, so
+    sequence 0 carries 10 tokens of right padding.
+    """
+
+    def _restored_prefix_cache(self, cls, **kwargs):
+        # A single-sequence cache holding a 52-token prefix, built the way
+        # the server produces one: fill with more tokens (92), then trim
+        # back (by 40), as fetch_nearest_cache() does when it restores a
+        # stored entry to the shared-prefix point. Key contents are
+        # arange() so positions are identifiable when debugging.
+        c = cls(**kwargs)
+        k = mx.broadcast_to(
+            mx.arange(92, dtype=mx.float32).reshape(1, 1, 92, 1), (1, 2, 92, 4)
+        )
+        c.update_and_fetch(k, k)
+        c.trim(40)
+        return c
+
+    def test_extract_with_pending_right_padding(self):
+        # Both patched classes: the plain batch cache and the rotating
+        # (sliding-window) one. max_size=1024 keeps the rotating cache
+        # un-rotated, matching the production state (total length < window).
+        for batch_cls, single_cls, kwargs in (
+            (BatchKVCache, KVCache, {}),
+            (BatchRotatingKVCache, RotatingKVCache, {"max_size": 1024}),
+        ):
+            singles = [
+                self._restored_prefix_cache(single_cls, **kwargs) for _ in range(4)
+            ]
+            batch = batch_cls.merge(singles)
+
+            # One batched prefill chunk of the four remainders, padded to
+            # the longest (280): sequence 0 has 270 real tokens + 10 pad.
+            lengths = [270, 280, 272, 271]
+            S = max(lengths)
+            batch.prepare(lengths=lengths, right_padding=[S - l for l in lengths])
+            k = mx.random.normal((4, 2, S, 4))
+            batch.update_and_fetch(k, k)
+
+            # Extract in the pre-finalize window. Sequence 0 holds
+            # 52 (prefix) + 270 (real remainder) = 322 tokens; without the
+            # fix both assertions see 332 (322 + 10 pad) for both classes.
+            extracted = batch.extract(0)
+            self.assertEqual(extracted.keys.shape[2], 52 + 270)
+            self.assertEqual(extracted.offset, 52 + 270)
+
+            # After finalize() the padding is reconciled; extract() must
+            # give the same answer (this path was already correct, and
+            # pins that the fix did not change it).
+            batch.finalize()
+            extracted = batch.extract(0)
+            self.assertEqual(extracted.keys.shape[2], 52 + 270)
+            self.assertEqual(extracted.offset, 52 + 270)
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary

When the server batches several requests together, shorter rows get junk filler cells at the end to square off the rectangle (right padding), and a cleanup pass (`finalize()`) later shuffles each row so the junk sits where
the bookkeeping expects and each row's real-token count is correct again. Between processing and cleanup there is a window where the batch contains junk cells and the counts are temporarily off — by design, because `finalize()` is about to fix it.

The bug: `BatchKVCache.extract()` and `BatchRotatingKVCache.extract()` — which copy one request's row out of the batch to save as a prompt-cache entry — can run during that window. The saved copy then includes the junk filler cells and records the row length *counting* them ("this cache holds 332 tokens" when it's really 322 real ones plus 10 junk). This happens whenever `mlx_lm.server` stores a segment-boundary cache during a mixed-length batched prefill.

When a later request reuses that saved entry, every piece of bookkeeping that derives from the cache length — where new tokens get appended, how wide the attention mask should be — disagrees with the actual contents by
exactly the junk amount. That surfaces as `[broadcast_shapes]` crashes in `scaled_dot_product_attention` (mask width vs. key length differ by the pad amount), as livelocked generation, or quietest of all, as junk cells treated as real context. 

Possibly fixes #1384 where we are seeing Gemma garbage and crashes. Possibly fixes #1493, where the hang is on the same model family under exactly this workload. 

## Reproduction

Serve any model whose requests share long prompt prefixes with differing tails (we hit this with gemma-4-26b-a4b under 4 concurrent single-token-classification requests of unequal lengths; the server wedges
or crashes within a few hundred requests once prompt-cache restores begin). Unit-level, before this fix:

```python
batch = BatchKVCache.merge(four_caches_with_52_token_prefix)
batch.prepare(lengths=[270, 280, 272, 271], right_padding=[10, 0, 8, 9])
batch.update_and_fetch(k, v)          # padded chunk, S=280
batch.extract(0).offset               # 332 -- should be 322 (52 + 270)
```

## Fix

When snapshotting, cut off the junk cells and record the true count — i.e., `extract()` now produces exactly what it would have produced after `finalize()`: it subtracts the sequence's pending right padding from the slice end and (for the rotating cache) from the reported offset. Post-`finalize()` behavior is unchanged.

## Tests

`TestBatchCacheExtract.test_extract_with_pending_right_padding` covers both batch cache classes, pre- and post-finalize; it fails without the fix and passes with it. The full `tests/test_prompt_cache.py` suite passes (23 tests).

## Validation at scale

With this fix applied, our previously-crashing workload (three consecutive 4-way concurrent runs, ~650 prompt-cache stores against a gemma-4-26b-a4b server) completes with zero internally-inconsistent stored entries,
verified by per-layer instrumentation; unpatched, corrupted entries appear within the first dozen stores and the server crashes or hangs shortly after.

We also prototyped a follow-up that avoids `fetch_nearest_cache`'s per-fetch `copy.deepcopy` of the full entry; happy to open that separately if there's interest.
