### PR TITLE
Fix adapter_path lookup using aliased model_path in ModelProvider.load

### DIFF
--- a/mlx_lm/server.py
+++ b/mlx_lm/server.py
@@ -367,9 +367,9 @@ class ModelProvider:
             self.load("default_model", None, "default_model")
 
     def load(self, model_path, adapter_path=None, draft_model_path=None):
-        model_path = self._model_map.get(model_path, model_path)
         adapter_path = self._adapter_map.get(model_path, adapter_path)
         draft_model_path = self._draft_model_map.get(draft_model_path, draft_model_path)
+        model_path = self._model_map.get(model_path, model_path)
 
         model_key = (model_path, adapter_path, draft_model_path)
         if self.model_key != model_key:

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -1,10 +1,12 @@
 # Copyright © 2024 Apple Inc.
 
+import argparse
 import http
 import io
 import json
 import threading
 import unittest
+from unittest.mock import patch
 
 import mlx.core as mx
 import requests
@@ -14,6 +16,7 @@ from mlx_lm.models.cache import KVCache
 from mlx_lm.server import (
     APIHandler,
     LRUPromptCache,
+    ModelProvider,
     Response,
     ResponseGenerator,
     SamplingArguments,
@@ -732,6 +735,29 @@ class TestLRUPromptCache(unittest.TestCase):
         c, t = cache.fetch_nearest_cache(model, [3, 4])
         self.assertEqual(c, None)
         self.assertEqual(t, [3, 4])
+
+
+class TestModelProvider(unittest.TestCase):
+    """Regression test for https://github.com/ml-explore/mlx-lm/issues/1745"""
+
+    def test_load_resolves_adapter_for_default_model(self):
+        cli_args = argparse.Namespace(
+            model="mlx-community/base-model",
+            adapter_path="/path/to/adapters",
+            draft_model=None,
+            trust_remote_code=False,
+            use_default_chat_template=False,
+            chat_template=None,
+            pipeline=False,
+        )
+        provider = ModelProvider(cli_args)
+
+        with patch.object(provider, "_load") as mock_load:
+            provider.load("default_model")
+
+        mock_load.assert_called_once_with(
+            "mlx-community/base-model", "/path/to/adapters", None
+        )
 
 
 class TestMakeSampler(unittest.TestCase):


### PR DESCRIPTION
## Summary
- `ModelProvider.load` resolved `model_path` through `_model_map` before looking up `adapter_path` in `_adapter_map`, so adapters registered against a model alias (e.g. `default_model`) were never applied.
- Reorder so the adapter and draft-model lookups happen against the original `model_path` before it gets remapped.

Fixes #1745

## Test plan
- [x] Added `TestModelProvider.test_load_resolves_adapter_for_default_model` in `tests/test_server.py` covering the regression.
- [x] `python -m pytest tests/test_server.py`