### PR TITLE
Declare MLX norm convention in converted models

### DIFF
--- a/mlx_lm/utils.py
+++ b/mlx_lm/utils.py
@@ -57,6 +57,7 @@ MODEL_REMAPPING = {
 }
 
 MAX_FILE_SIZE_GB = 5
+MLX_NORM_CONVENTION = "mlx"
 
 
 def _parse_size(x):
@@ -797,7 +798,15 @@ def save_model(
         shard_name = shard_file_format.format(i + 1, shards_count)
         shard_path = save_path / shard_name
 
-        mx.save_safetensors(str(shard_path), shard, metadata={"format": "mlx"})
+        mx.save_safetensors(
+            str(shard_path),
+            shard,
+            metadata={
+                "format": "mlx",
+                # Norm weights are already in MLX runtime form.
+                "norm_convention": MLX_NORM_CONVENTION,
+            },
+        )
 
         for weight_name in shard.keys():
             index_data["weight_map"][weight_name] = shard_name
@@ -981,6 +990,9 @@ def save(
         src_path = hf_repo_to_path(hf_repo)
     else:
         hf_repo = None
+
+    # Converted weights are already in MLX runtime form.
+    config["norm_convention"] = MLX_NORM_CONVENTION
 
     dst_path = Path(dst_path)
     save_model(dst_path, model, donate_model=donate_model)

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -2,9 +2,11 @@
 
 import json
 import os
+import struct
 import tempfile
 import unittest
 from pathlib import Path
+from unittest import mock
 
 import mlx.core as mx
 import mlx.nn as nn
@@ -58,6 +60,32 @@ class TestUtils(unittest.TestCase):
         gb = sum(p.nbytes for _, p in weights) // 2**30
         shards = utils.make_shards(dict(weights), 1)
         self.assertTrue(gb <= len(shards) <= gb + 1)
+
+    def test_save_declares_mlx_norm_convention(self):
+        class Tokenizer:
+            def save_pretrained(self, path):
+                pass
+
+        source_path = Path(self.test_dir) / "source"
+        source_path.mkdir()
+        output_path = Path(self.test_dir) / "saved_model"
+
+        with mock.patch("mlx_lm.utils.create_model_card"):
+            utils.save(
+                output_path,
+                source_path,
+                nn.Linear(2, 2),
+                Tokenizer(),
+                {"model_type": "llama"},
+            )
+
+        with open(output_path / "config.json") as f:
+            self.assertEqual(json.load(f)["norm_convention"], "mlx")
+
+        with open(output_path / "model.safetensors", "rb") as f:
+            header_size = struct.unpack("<Q", f.read(8))[0]
+            metadata = json.loads(f.read(header_size))["__metadata__"]
+        self.assertEqual(metadata["norm_convention"], "mlx")
 
     def test_parse_size(self):
         self.assertEqual(utils._parse_size("1024"), 1024)


### PR DESCRIPTION
Fixes #1445

## Summary

- declare `norm_convention: "mlx"` in converted `config.json` files and safetensors metadata
- add a regression test that verifies both declarations

## Why

Converted MLX weights are already in MLX runtime form. Declaring that storage convention lets downstream runtimes avoid guessing whether an architecture-specific `1 + weight` RMSNorm adjustment is still required.

## Validation

```text
python -m unittest tests.test_utils.TestUtils.test_make_shards \
  tests.test_utils.TestUtils.test_save_declares_mlx_norm_convention
```

Result: 2 tests passed.

## Limitations

- Existing converted bundles are unchanged. They need to be reconverted or have equivalent metadata backfilled to carry this declaration.
- Downstream runtimes must honor the `norm_convention` field to benefit from it.
