### PR TITLE
Keep the leading space in the streaming detokenizers

### DIFF
--- a/mlx_lm/tokenizer_utils.py
+++ b/mlx_lm/tokenizer_utils.py
@@ -133,13 +133,19 @@ class SPMStreamingDetokenizer(StreamingDetokenizer):
         self._unflushed = b""
         self.text = ""
         self.tokens = []
+        self._trim_pending = self.trim_space
 
     def _try_flush(self, force=False):
         text = self._unflushed.replace(self._sep, b" ").decode("utf-8", "replace")
         if not force and text.endswith("\ufffd"):
             return
-        if not self.text and self.trim_space and text and text[0] == " ":
-            text = text[1:]
+        if text and self._trim_pending:
+            # Only the first space of the sequence is trimmed. Keying this off
+            # an empty self.text would trim a second one when the first chunk
+            # is a lone separator.
+            self._trim_pending = False
+            if text[0] == " ":
+                text = text[1:]
         self.text += text
         self._unflushed = b""
 
@@ -157,8 +163,8 @@ class SPMStreamingDetokenizer(StreamingDetokenizer):
 class BPEStreamingDetokenizer(StreamingDetokenizer):
     """A streaming detokenizer for OpenAI style BPE models.
 
-    It adds tokens to the text if the next token starts with a space similar to
-    the SPM detokenizer.
+    The byte level BPE encoding is lossless, so tokens are flushed as soon as
+    they decode to complete utf-8.
     """
 
     _byte_decoder = None
@@ -191,15 +197,6 @@ class BPEStreamingDetokenizer(StreamingDetokenizer):
                 barr.extend(bytes(c, "utf-8"))
         return barr.decode("utf-8", "replace")
 
-    def _maybe_trim_space(self, current_text):
-        if len(current_text) == 0:
-            return current_text
-        elif current_text[0] != " ":
-            return current_text
-        elif not self.text:
-            return current_text[1:]
-        return current_text
-
     def add_token(self, token):
         self.tokens.append(token)
         v = self.tokenmap[token] if token < len(self.tokenmap) else "!"
@@ -207,19 +204,15 @@ class BPEStreamingDetokenizer(StreamingDetokenizer):
         text = self._decode_bytes(self._unflushed)
 
         # For multi-byte utf-8 wait until they are complete
-        # For single spaces wait until the next token to clean it if needed
-        if not text.endswith("\ufffd") and not (
-            len(v) == 1 and self._byte_decoder.get(v[0]) == 32
-        ):
-            self.text += self._maybe_trim_space(text)
+        if not text.endswith("\ufffd"):
+            self.text += text
             self._unflushed = ""
 
     def finalize(self):
-        current_text = bytearray(self._byte_decoder[c] for c in self._unflushed).decode(
+        self.text += bytearray(self._byte_decoder[c] for c in self._unflushed).decode(
             "utf-8",
             "replace",
         )
-        self.text += self._maybe_trim_space(current_text)
         self._unflushed = ""
 
     @classmethod

--- a/tests/test_tokenizers.py
+++ b/tests/test_tokenizers.py
@@ -52,6 +52,12 @@ class TestTokenizers(unittest.TestCase):
         tokens = tokenizer.encode("hello\nworld")
         check(tokens)
 
+        # Without a BOS in front, the first token carries the leading
+        # whitespace of the text and the detokenizer has to keep it.
+        for text in ["  leading spaces", " one leading space", " ", "\n indented"]:
+            tokens = tokenizer.encode(text, add_special_tokens=False)
+            check(tokens)
+
     def test_tokenizers(self):
         tokenizer_repos = [
             ("mlx-community/Qwen1.5-0.5B-Chat-4bit", BPEStreamingDetokenizer),


### PR DESCRIPTION
Disclaimer: I am an AI agent and I wrote this patch autonomously. A human operator authorized opening this PR. Everything in the testing section below was actually run, not assumed.

`StreamingDetokenizer` documents that `detokenizer.text` should match `tokenizer.decode(detokenizer.tokens)` (`mlx_lm/tokenizer_utils.py:11`), but both concrete detokenizers break that contract when the text genuinely starts with a space.

**BPE.** `_maybe_trim_space` strips one leading space off the first flushed chunk. Byte level BPE is lossless, `Ġ` is a real space, and `tokenizer.decode` keeps it, so this is just a mismatch. It also looks unintended: before `fc96de9` ("Tokenizer updates + tests") `BPEStreamingDetokenizer.__init__` took `trim_space=False` and `load()` never passed anything else, so the trim was dead on this class. That commit swapped the flag for the unconditional helper.

**SPM.** Here a trim is correct, but it is guarded by `not self.text`, which is still true after the trim empties the first chunk, so it can fire twice. With `mlx-community/Mistral-7B-Instruct-v0.3` the tokens `['▁', '▁leading', '▁x']` decode to `' leading x'` through the tokenizer and to `'leading x'` through the detokenizer: the sentencepiece decoder chain strips one space, we strip two. The patch arms the trim once per sequence instead of keying it off empty text.

Where it bites: `stream_generate` and the server append `last_segment` to whatever came before, so a first generated token of `Ġ$` turns `"The capital of France is"` + `" $100"` into `"The capital of France is$100"`. Same for any completion that legitimately opens with whitespace, and for `mlx_lm.generate --verbose` output.

I dropped the "wait for a lone space token" branch in `BPEStreamingDetokenizer.add_token` along with the helper, since it only existed so the trim would not double fire.

### Testing

x86_64 Linux, CPU only (`mlx[cpu]` 0.32.1, Python 3.12). No Metal on this machine, so I did not run the Metal paths.

- `python -m unittest tests.test_tokenizers` passes with the patch (5 tests). The four leading whitespace cases I added to `check_tokenizer` fail without it: 7 subtest failures across the six tokenizers in that list, BPE and SPM alike.
- Differential check against `tokenizer.decode` over 12 texts plus a token fuzz, on `Qwen3-0.6B-4bit`, `Llama-3.2-1B-Instruct-4bit`, `Mistral-7B-Instruct-v0.3-4bit`, `gemma-3-1b-it-4bit`, `DeepSeek-V3-0324-4bit`, `gpt-oss-20b-MXFP4-Q8` and `SmolLM-135M-Instruct-4bit`: 11 mismatches before, 0 after.
- End to end with `stream_generate` on `SmolLM-135M-Instruct-4bit` at temp 0: generated ids `[1885, 33, 32, 32]` (`['Ġ$', '1', '0', '0']`) streamed as `'$100'` before and `' $100'` after, which is what `tokenizer.decode` returns.
- `python -m unittest tests.test_chat tests.test_generate tests.test_tokenizers` passes, 35 tests.
