### PR TITLE
Fix RWKV7 legacy checkpoint loading

### DIFF
--- a/mlx_lm/models/rwkv7.py
+++ b/mlx_lm/models/rwkv7.py
@@ -436,7 +436,14 @@ class Model(nn.Module):
         return self.model.layers
 
     def sanitize(self, weights):
-        for k, v in weights.items():
+        for k, v in list(weights.items()):
+            if k.endswith(".attn.x_x"):
+                prefix = k.removesuffix("x_x")
+                for name, value in zip(
+                    ("x_r", "x_w", "x_k", "x_v", "x_a", "x_g"), v
+                ):
+                    weights[f"{prefix}{name}"] = value[None, None, :]
+                del weights[k]
             if "k_k" in k or "k_a" in k or "g_norm" in k:
                 weights[k] = weights[k].reshape(
                     self.args.hidden_size // self.args.head_dim, self.args.head_dim

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -628,6 +628,77 @@ class TestModels(unittest.TestCase):
             model, args.model_type, args.vocab_size, args.num_hidden_layers
         )
 
+    def test_rwkv7_cached_generation_matches_full_prompt(self):
+        from mlx_lm.models import rwkv7
+
+        args = rwkv7.ModelArgs(
+            model_type="rwkv7",
+            vocab_size=128,
+            hidden_size=64,
+            intermediate_size=128,
+            norm_eps=1e-5,
+            head_dim=32,
+            num_hidden_layers=2,
+            a_low_rank_dim=16,
+            v_low_rank_dim=16,
+            gate_low_rank_dim=16,
+            decay_low_rank_dim=16,
+        )
+        model = rwkv7.Model(args)
+        inputs = mx.array([[1, 2, 3, 4], [5, 6, 7, 8]])
+
+        full_logits = model(inputs)
+        cache = model.make_cache()
+        cached_logits = mx.concatenate(
+            [
+                model(inputs[:, :2], cache=cache),
+                model(inputs[:, 2:3], cache=cache),
+                model(inputs[:, 3:], cache=cache),
+            ],
+            axis=1,
+        )
+        mx.eval(full_logits, cached_logits)
+
+        self.assertTrue(mx.allclose(full_logits, cached_logits, rtol=1e-5, atol=1e-5))
+        for layer_cache in cache:
+            self.assertEqual(layer_cache[0].shape, (2, 1, args.hidden_size))
+            self.assertEqual(
+                layer_cache[1].shape,
+                (
+                    2,
+                    args.hidden_size // args.head_dim,
+                    args.head_dim,
+                    args.head_dim,
+                ),
+            )
+            self.assertEqual(layer_cache[2].shape, (2, 1, args.hidden_size))
+
+    def test_rwkv7_sanitize_migrates_legacy_time_mix_weights(self):
+        from mlx_lm.models import rwkv7
+
+        args = rwkv7.ModelArgs(
+            model_type="rwkv7",
+            vocab_size=128,
+            hidden_size=64,
+            intermediate_size=128,
+            norm_eps=1e-5,
+            head_dim=32,
+            num_hidden_layers=2,
+            a_low_rank_dim=16,
+            v_low_rank_dim=16,
+            gate_low_rank_dim=16,
+            decay_low_rank_dim=16,
+        )
+        legacy_time_mix = mx.arange(6 * args.hidden_size).reshape(6, args.hidden_size)
+        weights = {"model.layers.0.attn.x_x": legacy_time_mix}
+        weights = rwkv7.Model(args).sanitize(weights)
+
+        self.assertNotIn("model.layers.0.attn.x_x", weights)
+        for index, name in enumerate(("x_r", "x_w", "x_k", "x_v", "x_a", "x_g")):
+            key = f"model.layers.0.attn.{name}"
+            self.assertEqual(weights[key].shape, (1, 1, args.hidden_size))
+            self.assertTrue(mx.array_equal(weights[key][0, 0], legacy_time_mix[index]))
+
     def test_qwen3_5_family_convert_then_load_norm_not_shift_twice(self):
         text_config = {
             "hidden_size": 8,


### PR DESCRIPTION
## Summary

Fix loading legacy RWKV-7 FLA checkpoints that store time-mix parameters in a
single `model.layers.*.attn.x_x` tensor.

`mlx_lm.models.rwkv7` expects the current six-parameter layout:
`x_r`, `x_w`, `x_k`, `x_v`, `x_a`, and `x_g`. The loader now splits the legacy
`[6, hidden_size]` tensor into these parameters and removes the legacy key
before strict weight loading.

## Validation

- Added a regression test for legacy `attn.x_x` migration.
- Added a batched cached-generation test asserting chunked generation matches a
  full forward pass.
- End-to-end validation with `RWKV/RWKV7-Goose-World3-1.5B-HF` on a
  three-token prompt loaded successfully and produced `(1, 3, 50304)` bfloat16
  logits.
- Compared those logits against an independent PyTorch reference implementation
  of the checkpoint equations: greedy argmax matched at every prompt position;
  mean absolute error was `0.0461` and maximum absolute error was `0.3125`.
  The remaining drift is consistent with bfloat16/fused-kernel accumulation.

```text
python -m unittest \
  tests.test_models.TestModels.test_rwkv7_cached_generation_matches_full_prompt \
  tests.test_models.TestModels.test_rwkv7_sanitize_migrates_legacy_time_mix_weights \
  tests.test_models.TestModels.test_all_models
```

All tests pass.
