### PR TITLE
fix(tool_parsers): strip trailing newline from GLM tool-call name

### DIFF
--- a/mlx_lm/tool_parsers/glm47.py
+++ b/mlx_lm/tool_parsers/glm47.py
@@ -218,7 +218,7 @@ def parse_tool_call(text: str, tools: list[Any] | None = None):
             return fallback
         return dict(name="unknown", arguments={"raw": text.strip()})
 
-    func_name = match.group(1)
+    func_name = match.group(1).strip()
     string_args = _get_string_arg_names(func_name, tools)
     arg_dct = {}
     for match in _func_arg_regex.finditer(text):


### PR DESCRIPTION
GLM templates emit `<tool_call>{name}\n<arg_key>…`, so `_func_name_regex` (`^(.*?)<arg_key>`) captures the function name with a trailing newline — e.g. `"create_file\n"`. Argument keys and values are already `.strip()`-ed, but the name is not, so OpenAI-compatible clients can't match it to a registered tool and tool calls silently fail.

Strip the captured name. Verified against GLM-4.5-Air served via `mlx_lm.server`: tool calls now match and dispatch correctly (previously the model fell back to describing the call in prose).
