### PR TITLE
Add DeepSeek-V4 DSML chat template + tolerate truncated invoke close tag (stacked on #1337)

### DIFF
--- a/mlx_lm/chat_templates/deepseek_dsml.py
+++ b/mlx_lm/chat_templates/deepseek_dsml.py
@@ -81,6 +81,18 @@ tool_calls_template = "<{dsml_token}tool_calls>\n{tool_calls}\n</{dsml_token}too
 tool_output_template = "<tool_result>{content}</tool_result>"
 
 
+def _tool_call_with_str_args(tc: Dict[str, Any]) -> Dict[str, Any]:
+    """``encode_arguments_to_dsml`` ``json.loads()``es ``tc["arguments"]``, i.e.
+    it expects the OpenAI JSON *string* form. Some clients (e.g. agent loops
+    replaying their own prior calls) send ``arguments`` already parsed as a
+    dict; re-serialize those so multi-turn tool-call replay does not crash.
+    """
+    args = tc.get("arguments")
+    if isinstance(args, str):
+        return tc
+    return {**tc, "arguments": to_json(args if args is not None else {})}
+
+
 def render_tools(tools: List[Dict[str, Any]]) -> str:
     return TOOLS_SYSTEM_TEMPLATE.format(
         tool_schemas="\n".join(to_json(t) for t in tools),
@@ -131,7 +143,7 @@ def render_message(index: int, messages: List[Dict[str, Any]], thinking_mode: st
                 tool_call_template.format(
                     dsml_token=dsml_token,
                     name=tc["name"],
-                    arguments=encode_arguments_to_dsml(tc),
+                    arguments=encode_arguments_to_dsml(_tool_call_with_str_args(tc)),
                 )
                 for tc in tool_calls_from_openai_format(msg["tool_calls"])
             ]

--- a/mlx_lm/chat_templates/deepseek_dsml.py
+++ b/mlx_lm/chat_templates/deepseek_dsml.py
@@ -1,0 +1,214 @@
+# Copyright © 2025 Apple Inc.
+
+"""DeepSeek-V4 DSML chat template.
+
+DeepSeek-V4 encodes tool calls in DSML like DeepSeek-V3.2, but uses the
+``<｜DSML｜tool_calls>`` block tag (V3.2 uses ``function_calls``), a distinct
+tool-instruction preamble, and ``<tool_result>`` blocks for tool outputs. The
+structural scaffolding (BOS, ``<｜User｜>``/``<｜Assistant｜>`` turns, ``<think>``
+handling) and the parameter encoding are identical, so the leaf helpers are
+reused from :mod:`mlx_lm.chat_templates.deepseek_v32`; only the V4-specific
+templates and ``render_message`` control flow live here.
+
+Wiring: set ``chat_template_type: "deepseek_dsml"`` in the model's
+``tokenizer_config.json`` (paired with ``tool_parser_type: "deepseek_dsml"``).
+
+Output is byte-exact with the reference ``encoding_dsv4.encode_messages`` for
+single-turn system+tools+user prompts in both chat and thinking modes, and
+supports assistant tool-call replay. Two multi-turn behaviors of the reference
+are intentionally not ported (single-turn tool calling, the server's per-request
+usage, does not reach them):
+
+- Multi-tool-result merging/ordering (``merge_tool_messages`` /
+  ``sort_tool_results_by_call_order``); tool messages render one
+  ``<tool_result>`` block per message.
+- Earlier-turn reasoning retention when tools are present (the reference forces
+  ``drop_thinking=False`` in that case); here reasoning is rendered only for the
+  assistant turn that follows the last user message.
+"""
+
+from typing import Any, Dict, List
+
+from mlx_lm.chat_templates.deepseek_v32 import (
+    bos_token,
+    eos_token,
+    thinking_start_token,
+    thinking_end_token,
+    dsml_token,
+    system_msg_template,
+    user_msg_template,
+    assistant_msg_template,
+    thinking_template,
+    to_json,
+    tools_from_openai_format,
+    tool_calls_from_openai_format,
+    encode_arguments_to_dsml,
+    find_last_user_index,
+    drop_thinking_messages,
+)
+
+# --- V4-specific templates (differ from V3.2: wording + the `tool_calls` tag) ---
+
+TOOLS_SYSTEM_TEMPLATE = """## Tools
+
+You have access to a set of tools to help answer the user's question. You can invoke tools by writing a "<{dsml_token}tool_calls>" block like the following:
+
+<{dsml_token}tool_calls>
+<{dsml_token}invoke name="$TOOL_NAME">
+<{dsml_token}parameter name="$PARAMETER_NAME" string="true|false">$PARAMETER_VALUE</{dsml_token}parameter>
+...
+</{dsml_token}invoke>
+<{dsml_token}invoke name="$TOOL_NAME2">
+...
+</{dsml_token}invoke>
+</{dsml_token}tool_calls>
+
+String parameters should be specified as is and set `string="true"`. For all other types (numbers, booleans, arrays, objects), pass the value in JSON format and set `string="false"`.
+
+If thinking_mode is enabled (triggered by <think>), you MUST output your complete reasoning inside <think>...</think> BEFORE any tool calls or final response.
+
+Otherwise, output directly after </think> with tool calls or final response.
+
+### Available Tool Schemas
+
+{tool_schemas}
+
+You MUST strictly follow the above defined tool name and parameter schemas to invoke tool calls.
+"""
+
+tool_call_template = '<{dsml_token}invoke name="{name}">\n{arguments}\n</{dsml_token}invoke>'
+tool_calls_template = "<{dsml_token}tool_calls>\n{tool_calls}\n</{dsml_token}tool_calls>"
+tool_output_template = "<tool_result>{content}</tool_result>"
+
+
+def render_tools(tools: List[Dict[str, Any]]) -> str:
+    return TOOLS_SYSTEM_TEMPLATE.format(
+        tool_schemas="\n".join(to_json(t) for t in tools),
+        dsml_token=dsml_token,
+    )
+
+
+def render_message(index: int, messages: List[Dict[str, Any]], thinking_mode: str) -> str:
+    assert thinking_mode in ("chat", "thinking"), f"Invalid thinking_mode `{thinking_mode}`"
+    msg = messages[index]
+    role = msg.get("role")
+    content = msg.get("content")
+
+    def turn_suffix() -> str:
+        # Open a <think> block on the last user/developer turn and on the final
+        # turn when generation follows it (e.g. after a tool result); every
+        # other turn closes with </think>. Matches the reference for single
+        # tool results; multi-result merging (see module note) is not ported.
+        opens_generation = index in (find_last_user_index(messages), len(messages) - 1)
+        if opens_generation and thinking_mode == "thinking":
+            return thinking_start_token
+        return thinking_end_token
+
+    if role == "system":
+        out = system_msg_template.format(content=content or "")
+        if msg.get("tools"):
+            out += "\n\n" + render_tools(tools_from_openai_format(msg["tools"]))
+        return out
+
+    if role == "user":
+        return user_msg_template.format(content=content) + turn_suffix()
+
+    if role == "tool":
+        return user_msg_template.format(
+            content=tool_output_template.format(content=content)
+        ) + turn_suffix()
+
+    if role == "assistant":
+        reasoning = ""
+        if thinking_mode == "thinking" and index > find_last_user_index(messages):
+            reasoning = (
+                thinking_template.format(reasoning_content=msg.get("reasoning_content") or "")
+                + thinking_end_token
+            )
+        tool_calls_content = ""
+        if msg.get("tool_calls"):
+            rendered = [
+                tool_call_template.format(
+                    dsml_token=dsml_token,
+                    name=tc["name"],
+                    arguments=encode_arguments_to_dsml(tc),
+                )
+                for tc in tool_calls_from_openai_format(msg["tool_calls"])
+            ]
+            tool_calls_content = "\n\n" + tool_calls_template.format(
+                dsml_token=dsml_token, tool_calls="\n".join(rendered)
+            )
+        return assistant_msg_template.format(
+            reasoning=reasoning, content=content or "", tool_calls=tool_calls_content
+        )
+
+    raise NotImplementedError(f"Unknown role: {role}")
+
+
+def encode_messages(
+    messages: List[Dict[str, Any]],
+    thinking_mode: str = "thinking",
+    drop_thinking: bool = True,
+    add_default_bos_token: bool = True,
+    tools: Any = None,
+) -> str:
+    full_messages = list(messages)
+
+    # The reference encoder only recognizes tools attached to a (system) message
+    # -- both for rendering them and for its "don't drop earlier reasoning when
+    # tools are present" rule. The mlx-lm server, however, passes tools as a
+    # top-level kwarg. Normalize by attaching the kwarg tools to a system message
+    # (synthesizing an empty-content one if none exists) so a tools request
+    # behaves identically whether tools arrive by kwarg or by message -- and is
+    # never silently dropped for want of a system message to hang them on.
+    if tools:
+        sys_idx = next(
+            (i for i, m in enumerate(full_messages) if m.get("role") == "system"), None
+        )
+        if sys_idx is None:
+            full_messages.insert(0, {"role": "system", "content": "", "tools": tools})
+        elif not full_messages[sys_idx].get("tools"):
+            full_messages[sys_idx] = {**full_messages[sys_idx], "tools": tools}
+
+    if thinking_mode == "thinking" and drop_thinking:
+        full_messages = drop_thinking_messages(full_messages)
+
+    prompt = bos_token if add_default_bos_token else ""
+    for idx in range(len(full_messages)):
+        prompt += render_message(idx, full_messages, thinking_mode=thinking_mode)
+    return prompt
+
+
+def apply_chat_template(
+    messages,
+    tools=None,
+    continue_final_message=False,
+    add_generation_prompt=False,
+    enable_thinking=None,
+    thinking_mode=None,
+    **kwargs,
+):
+    # mlx-lm's TokenizerWrapper injects `enable_thinking` (the HF convention)
+    # and the server passes `tools` as a top-level kwarg; a jinja template would
+    # silently ignore any other kwargs, so a Python template must accept **kwargs
+    # to stay a drop-in equivalent. `enable_thinking` is load-bearing for V4 (it
+    # selects the thinking vs chat rendering), so map it onto our `thinking_mode`
+    # unless the caller passed `thinking_mode` explicitly.
+    if continue_final_message and add_generation_prompt:
+        raise ValueError(
+            "Only one of continue_final_message or add_generation_prompt can be True"
+        )
+    if thinking_mode is None:
+        thinking_mode = "thinking" if (enable_thinking is None or enable_thinking) else "chat"
+    encode_kwargs = {
+        k: kwargs[k] for k in ("drop_thinking", "add_default_bos_token") if k in kwargs
+    }
+    out = encode_messages(
+        messages, thinking_mode=thinking_mode, tools=tools, **encode_kwargs
+    )
+    if not add_generation_prompt and messages[-1]["role"] in ("user", "tool"):
+        out = out.removesuffix(thinking_start_token).removesuffix(thinking_end_token)
+        out = out.removesuffix("<｜Assistant｜>")
+    if continue_final_message and messages[-1]["role"] == "assistant":
+        out = out.removesuffix(eos_token)
+    return out

--- a/mlx_lm/tokenizer_utils.py
+++ b/mlx_lm/tokenizer_utils.py
@@ -549,6 +549,8 @@ def _infer_tool_parser(chat_template):
     """Attempt to auto-infer a tool parser from the chat template."""
     if not isinstance(chat_template, str):
         return None
+    elif "<｜DSML｜tool_calls>" in chat_template:
+        return "deepseek_dsml"
     elif "<minimax:tool_call>" in chat_template:
         return "minimax_m2"
     elif "<|tool_call>" in chat_template and "<tool_call|>" in chat_template:

--- a/mlx_lm/tool_parsers/deepseek_dsml.py
+++ b/mlx_lm/tool_parsers/deepseek_dsml.py
@@ -1,0 +1,79 @@
+# Tool parser for DeepSeek-V4's native DSML tool-call format. Deploy into
+# venv: mlx_lm/tool_parsers/deepseek_dsml.py, set tokenizer_config
+# "tool_parser_type": "deepseek_dsml", and use the official DSML chat template.
+#
+# Format (multiple invokes per tool_calls block => native parallel calls):
+#   <｜DSML｜tool_calls>
+#   <｜DSML｜invoke name="get_weather">
+#   <｜DSML｜parameter name="city" string="true">Paris</｜DSML｜parameter>
+#   <｜DSML｜parameter name="days" string="false">3</｜DSML｜parameter>
+#   </｜DSML｜invoke>
+#   ...
+#   </｜DSML｜tool_calls>
+#
+# string="true"  -> value is a literal string
+# string="false" -> value is JSON (numbers, booleans, arrays, objects)
+#
+# Start/end markers drop the trailing ">": mlx-lm matches markers by token-id
+# sequence and BPE merges ">" with the next byte ("...calls>\n" -> one token),
+# so the precomputed full marker never matches. "<｜DSML｜tool_calls" (the
+# <,｜DSML｜,tool,_c,alls tokens) is stable; the parser tolerates the leftover ">".
+import json
+
+import regex as re
+
+tool_call_start = "<｜DSML｜tool_calls"
+tool_call_end = "</｜DSML｜tool_calls"
+
+_INVOKE = re.compile(r"<｜DSML｜invoke\s+name=(.*?)</｜DSML｜invoke>", re.DOTALL)
+_PARAM = re.compile(
+    r'<｜DSML｜parameter\s+name=(?P<name>"[^"]*"|\'[^\']*\'|[^\s>]+)'
+    r'\s+string="(?P<is_str>true|false)"\s*>(?P<val>.*?)</｜DSML｜parameter>',
+    re.DOTALL,
+)
+_NAME_BODY = re.compile(r'\s*(?P<name>"[^"]*"|\'[^\']*\'|[^\s>]+)\s*>(?P<body>.*)', re.DOTALL)
+
+
+def _unquote(s):
+    s = s.strip()
+    if len(s) >= 2 and s[0] in "\"'" and s[-1] == s[0]:
+        return s[1:-1]
+    return s
+
+
+def _strip_one_newline(v):
+    if v.startswith("\n"):
+        v = v[1:]
+    if v.endswith("\n"):
+        v = v[:-1]
+    return v
+
+
+def parse_tool_call(text, tools=None):
+    calls = []
+    for invoke in _INVOKE.findall(text):
+        m = _NAME_BODY.match(invoke)
+        if not m:
+            continue
+        name = _unquote(m.group("name"))
+        args = {}
+        for pm in _PARAM.finditer(m.group("body")):
+            pname = _unquote(pm.group("name"))
+            val = _strip_one_newline(pm.group("val"))
+            if pm.group("is_str") == "true":
+                args[pname] = val
+            else:
+                try:
+                    args[pname] = json.loads(val)
+                except (json.JSONDecodeError, ValueError):
+                    args[pname] = val
+        # template fallback: whole arg blob passed as a single "arguments" param
+        if set(args) == {"arguments"} and isinstance(args["arguments"], str):
+            try:
+                args = json.loads(args["arguments"])
+            except (json.JSONDecodeError, ValueError):
+                pass
+        calls.append({"name": name, "arguments": args})
+    if not calls:
+        raise ValueError("no DSML tool call found")
+    return calls[0] if len(calls) == 1 else calls

--- a/mlx_lm/tool_parsers/deepseek_dsml.py
+++ b/mlx_lm/tool_parsers/deepseek_dsml.py
@@ -25,7 +25,10 @@ import regex as re
 tool_call_start = "<｜DSML｜tool_calls"
 tool_call_end = "</｜DSML｜tool_calls"
 
-_INVOKE = re.compile(r"<｜DSML｜invoke\s+name=(.*?)</｜DSML｜invoke>", re.DOTALL)
+# Lenient invoke close (</｜DSML｜inv…>): DeepSeek-V4 quants systematically
+# truncate </｜DSML｜invoke> to </｜DSML｜inv> (reproducible across 4/5/6-bit),
+# which the strict close tag would otherwise reject.
+_INVOKE = re.compile(r"<｜DSML｜invoke\s+name=(.*?)</｜DSML｜inv[^>]*>", re.DOTALL)
 _PARAM = re.compile(
     r'<｜DSML｜parameter\s+name=(?P<name>"[^"]*"|\'[^\']*\'|[^\s>]+)'
     r'\s+string="(?P<is_str>true|false)"\s*>(?P<val>.*?)</｜DSML｜parameter>',

--- a/tests/test_deepseek_dsml_chat_template.py
+++ b/tests/test_deepseek_dsml_chat_template.py
@@ -139,6 +139,22 @@ class TestServerCallingConvention(unittest.TestCase):
         self.assertIn("<｜DSML｜tool_calls>", out)
         self.assertIn("get_weather", out)
 
+    def test_tool_call_replay_with_dict_arguments(self):
+        # Agent loops replay their prior tool_calls with `arguments` as a dict,
+        # not the OpenAI JSON string; the template must accept both (it used to
+        # crash in encode_arguments_to_dsml's json.loads).
+        msgs = [
+            {"role": "system", "content": "s", "tools": TOOLS},
+            {"role": "user", "content": "weather in Paris?"},
+            {"role": "assistant", "content": "", "tool_calls": [
+                {"type": "function", "function": {
+                    "name": "get_weather", "arguments": {"location": "Paris"}}}]},
+            {"role": "tool", "content": "sunny", "tool_call_id": "c1"},
+        ]
+        out = v4.apply_chat_template(msgs, add_generation_prompt=True, enable_thinking=True)
+        self.assertIn("get_weather", out)
+        self.assertIn("Paris", out)
+
     def test_tolerates_injected_unknown_kwargs(self):
         # A jinja template silently ignores unknown template kwargs; the Python
         # equivalent must too, since the server/tokenizer may inject extras.

--- a/tests/test_deepseek_dsml_chat_template.py
+++ b/tests/test_deepseek_dsml_chat_template.py
@@ -1,0 +1,168 @@
+"""Tests for the DeepSeek-V4 DSML chat template.
+
+The byte-exact tests compare ``mlx_lm.chat_templates.deepseek_dsml`` against the
+reference encoder (``encoding_dsv4.py``) shipped in the DeepSeek-V4-Flash model
+repo, when that repo is present in the local HF cache; otherwise they skip. The
+invariant tests always run.
+"""
+
+import glob
+import os
+import sys
+import unittest
+
+from mlx_lm.chat_templates import deepseek_dsml as v4
+
+
+def _load_reference():
+    bases = [
+        os.environ.get("HF_HOME"),
+        os.path.expanduser("~/.cache/huggingface"),
+        "/Volumes/scratch-00001/hf",
+    ]
+    for base in bases:
+        if not base:
+            continue
+        hits = glob.glob(
+            os.path.join(base, "hub/models--deepseek-ai--DeepSeek-V4-Flash*/snapshots/*/encoding")
+        )
+        if hits:
+            sys.path.insert(0, hits[0])
+            import encoding_dsv4  # type: ignore
+
+            return encoding_dsv4
+    return None
+
+
+_REF = _load_reference()
+
+TOOLS = [{
+    "type": "function",
+    "function": {
+        "name": "get_weather",
+        "description": "Get the weather for a specific location",
+        "parameters": {
+            "type": "object",
+            "properties": {
+                "location": {"type": "string", "description": "The city name"},
+                "unit": {"type": "string", "enum": ["celsius", "fahrenheit"], "description": "Temperature unit"},
+            },
+            "required": ["location"],
+        },
+    },
+}]
+
+
+def _msgs(extra=()):
+    return [
+        {"role": "system", "content": "You are a helpful assistant.", "tools": TOOLS},
+        {"role": "user", "content": "What is the weather in Paris?"},
+        *extra,
+    ]
+
+
+@unittest.skipUnless(_REF, "DeepSeek-V4-Flash encoding/ reference not in HF cache")
+class TestChatTemplateVsReference(unittest.TestCase):
+    def test_single_turn_both_modes(self):
+        for mode in ("thinking", "chat"):
+            self.assertEqual(
+                v4.encode_messages(_msgs(), thinking_mode=mode),
+                _REF.encode_messages(_msgs(), thinking_mode=mode),
+                mode,
+            )
+
+    def test_apply_chat_template_generation_prompt(self):
+        self.assertEqual(
+            v4.apply_chat_template(_msgs(), add_generation_prompt=True, thinking_mode="thinking"),
+            _REF.encode_messages(_msgs(), thinking_mode="thinking"),
+        )
+
+    def test_assistant_tool_call_replay_and_result(self):
+        extra = [
+            {"role": "assistant", "content": "", "tool_calls": [
+                {"type": "function", "function": {"name": "get_weather", "arguments": '{"location": "Paris"}'}}]},
+            {"role": "tool", "content": "15C and sunny", "tool_call_id": "c1"},
+        ]
+        for mode in ("chat", "thinking"):
+            self.assertEqual(
+                v4.encode_messages(_msgs(extra), thinking_mode=mode),
+                _REF.encode_messages(_msgs(extra), thinking_mode=mode),
+                mode,
+            )
+
+
+def _msgs_tools_kwarg():
+    # System message WITHOUT tools attached; tools go in as a top-level kwarg,
+    # the way the mlx-lm server calls apply_chat_template.
+    return [
+        {"role": "system", "content": "You are a helpful assistant."},
+        {"role": "user", "content": "What is the weather in Paris?"},
+    ]
+
+
+class TestServerCallingConvention(unittest.TestCase):
+    """The mlx-lm server calls ``apply_chat_template(messages, tools=...,
+    enable_thinking=..., add_generation_prompt=True)``: tools arrive as a
+    top-level kwarg, and ``TokenizerWrapper`` injects ``enable_thinking``. These
+    guard the two integration bugs those conventions exposed (a jinja template
+    would have silently accepted both)."""
+
+    def test_tools_kwarg_matches_tools_on_system_message(self):
+        via_kwarg = v4.apply_chat_template(
+            _msgs_tools_kwarg(), tools=TOOLS, add_generation_prompt=True, enable_thinking=True
+        )
+        via_message = v4.apply_chat_template(
+            _msgs(), add_generation_prompt=True, enable_thinking=True
+        )
+        self.assertEqual(via_kwarg, via_message)
+        self.assertIn("<｜DSML｜tool_calls>", via_kwarg)
+
+    def test_enable_thinking_selects_mode(self):
+        thinking = v4.apply_chat_template(
+            _msgs_tools_kwarg(), tools=TOOLS, add_generation_prompt=True, enable_thinking=True
+        )
+        chat = v4.apply_chat_template(
+            _msgs_tools_kwarg(), tools=TOOLS, add_generation_prompt=True, enable_thinking=False
+        )
+        self.assertTrue(thinking.endswith("<｜Assistant｜><think>"))
+        self.assertTrue(chat.endswith("<｜Assistant｜></think>"))
+
+    def test_tools_kwarg_without_system_message_renders(self):
+        # A request with tools but no system message must still render the tool
+        # instructions (a synthesized system block), not silently drop them.
+        out = v4.apply_chat_template(
+            [{"role": "user", "content": "What is the weather in Paris?"}],
+            tools=TOOLS,
+            add_generation_prompt=True,
+            enable_thinking=True,
+        )
+        self.assertIn("<｜DSML｜tool_calls>", out)
+        self.assertIn("get_weather", out)
+
+    def test_tolerates_injected_unknown_kwargs(self):
+        # A jinja template silently ignores unknown template kwargs; the Python
+        # equivalent must too, since the server/tokenizer may inject extras.
+        out = v4.apply_chat_template(
+            _msgs_tools_kwarg(),
+            tools=TOOLS,
+            add_generation_prompt=True,
+            enable_thinking=True,
+            some_unrecognized_kwarg="ignored",
+        )
+        self.assertIn("<｜DSML｜tool_calls>", out)
+
+
+class TestChatTemplateInvariants(unittest.TestCase):
+    def test_bos_tool_block_and_thinking_cue(self):
+        out = v4.encode_messages(_msgs(), thinking_mode="thinking")
+        self.assertTrue(out.startswith("<｜begin▁of▁sentence｜>"))
+        self.assertIn("<｜DSML｜tool_calls>", out)
+        self.assertTrue(out.endswith("<｜Assistant｜><think>"))
+
+    def test_chat_mode_closes_think(self):
+        out = v4.encode_messages([{"role": "user", "content": "hi"}], thinking_mode="chat")
+        self.assertTrue(out.endswith("<｜Assistant｜></think>"))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_deepseek_dsml_close_tag.py
+++ b/tests/test_deepseek_dsml_close_tag.py
@@ -1,0 +1,38 @@
+"""Regression test: the deepseek_dsml parser tolerates the truncated invoke
+close tag (</｜DSML｜inv>) that DeepSeek-V4 quants systematically emit instead of
+the canonical </｜DSML｜invoke>."""
+
+import unittest
+
+from mlx_lm.tool_parsers import deepseek_dsml
+
+
+class TestDeepSeekDSMLCloseTag(unittest.TestCase):
+    def test_truncated_invoke_close_tag(self):
+        # Exact shape captured from 4/5/6-bit: close tag truncated to </｜DSML｜inv>.
+        text = (
+            "<｜DSML｜tool_calls>\n"
+            '<｜DSML｜invoke name="get_weather">\n'
+            '<｜DSML｜parameter name="location" string="true">Paris, France</｜DSML｜parameter>\n'
+            "</｜DSML｜inv>\n"
+            "</｜DSML｜tool_calls>"
+        )
+        self.assertEqual(
+            deepseek_dsml.parse_tool_call(text),
+            {"name": "get_weather", "arguments": {"location": "Paris, France"}},
+        )
+
+    def test_wellformed_close_still_parses(self):
+        text = (
+            '<｜DSML｜invoke name="get_weather">\n'
+            '<｜DSML｜parameter name="location" string="true">Paris</｜DSML｜parameter>\n'
+            "</｜DSML｜invoke>"
+        )
+        self.assertEqual(
+            deepseek_dsml.parse_tool_call(text),
+            {"name": "get_weather", "arguments": {"location": "Paris"}},
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_tool_parsing.py
+++ b/tests/test_tool_parsing.py
@@ -2,6 +2,7 @@ import unittest
 from pathlib import Path
 
 from mlx_lm.tool_parsers import (
+    deepseek_dsml,
     function_gemma,
     gemma4,
     glm47,
@@ -32,6 +33,10 @@ class TestToolParsing(unittest.TestCase):
             (
                 '{"name": "multiply", "arguments": {"a": 12234585, "b": 48838483920}}',
                 json_tools,
+            ),
+            (
+                '>\n<｜DSML｜invoke name="multiply">\n<｜DSML｜parameter name="a" string="false">12234585</｜DSML｜parameter>\n<｜DSML｜parameter name="b" string="false">48838483920</｜DSML｜parameter>\n</｜DSML｜invoke>\n',
+                deepseek_dsml,
             ),
             (
                 '<invoke name="multiply">\n<parameter name="a">12234585</parameter>\n<parameter name="b">48838483920</parameter>\n</invoke>',
@@ -102,6 +107,10 @@ class TestToolParsing(unittest.TestCase):
             (
                 '{"name": "get_current_temperature", "arguments": {"location": "London"}}',
                 json_tools,
+            ),
+            (
+                '>\n<｜DSML｜invoke name="get_current_temperature">\n<｜DSML｜parameter name="location" string="true">London</｜DSML｜parameter>\n</｜DSML｜invoke>\n',
+                deepseek_dsml,
             ),
             (
                 '<invoke name="get_current_temperature">\n<parameter name="location">London</parameter>\n</invoke>',
@@ -328,6 +337,36 @@ class TestToolParsing(unittest.TestCase):
         ]
         tool_calls = minimax_m2.parse_tool_call(test_case, None)
         self.assertEqual(expected, tool_calls)
+
+    def test_deepseek_dsml_parallel(self):
+        # DSML puts multiple <｜DSML｜invoke> in one <｜DSML｜tool_calls> block = native
+        # parallel calls. The leading ">" is the leftover the server captures after the
+        # "<｜DSML｜tool_calls" prefix start marker (which drops the ">" that BPE merges).
+        test_case = (
+            ">\n"
+            '<｜DSML｜invoke name="get_weather">\n'
+            '<｜DSML｜parameter name="city" string="true">Tokyo</｜DSML｜parameter>\n'
+            "</｜DSML｜invoke>\n"
+            '<｜DSML｜invoke name="get_weather">\n'
+            '<｜DSML｜parameter name="city" string="true">Paris</｜DSML｜parameter>\n'
+            "</｜DSML｜invoke>\n"
+        )
+        expected = [
+            {"name": "get_weather", "arguments": {"city": "Tokyo"}},
+            {"name": "get_weather", "arguments": {"city": "Paris"}},
+        ]
+        self.assertEqual(deepseek_dsml.parse_tool_call(test_case, None), expected)
+
+        # string="true" -> literal string; string="false" -> JSON-decoded value
+        test_case = (
+            '<｜DSML｜invoke name="calc">\n'
+            '<｜DSML｜parameter name="expr" string="true">2+2</｜DSML｜parameter>\n'
+            '<｜DSML｜parameter name="n" string="false">3</｜DSML｜parameter>\n'
+            '<｜DSML｜parameter name="tags" string="false">["a", "b"]</｜DSML｜parameter>\n'
+            "</｜DSML｜invoke>"
+        )
+        tc = deepseek_dsml.parse_tool_call(test_case, None)
+        self.assertEqual(tc["arguments"], {"expr": "2+2", "n": 3, "tags": ["a", "b"]})
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
**Stacked on #1337** (@snagnever's `deepseek_dsml` parser) — that should land first; the commits unique to this PR are the two on top. Also depends on DeepSeek-V4 model support (#1189).

Adds the encode side plus a robustness fix #1337's parser needs in practice.

**1. `chat_templates/deepseek_dsml.py` — DSML chat template.** DeepSeek-V4 ships no Jinja template (only the reference Python `encoding_dsv4.py`), so there's nothing for `chat_template_type` to load and tools are never rendered into the prompt. This is a Python `apply_chat_template` reusing the existing `deepseek_v32` DSML helpers; only the V4-specific tool wording and `tool_calls` block tag live here. Byte-exact with the reference encoder for single-turn system+tools+user prompts (chat and thinking modes) and assistant tool-call replay. It maps the server's `enable_thinking` kwarg onto the reference's `thinking_mode`, and normalizes a top-level `tools=` kwarg onto a system message (synthesizing an empty one if absent) so tools aren't silently dropped when no system message is present. Enable with `chat_template_type: "deepseek_dsml"`.

**2. Lenient invoke close tag.** The 4/5/6-bit MLX quants systematically truncate `</｜DSML｜invoke>` to `</｜DSML｜inv>`; the strict `_INVOKE` close misses those calls (they come back as content). Widen it to `</｜DSML｜inv[^>]*>`.

**Tests:** byte-exact chat-template test (skips when the model's `encoding/` dir isn't cached) + a close-tag regression test. No model download required.

**Marker note:** #1501 (merged) replaced the token-based state machine with a text-based one, so the trailing-`>` marker workaround this branch inherits is no longer needed on `main` — the markers can return to full form once this rebases forward past #1189.
