### PR TITLE
Reject dynamic quantization targets at the BPW floor

### DIFF
--- a/mlx_lm/LEARNED_QUANTS.md
+++ b/mlx_lm/LEARNED_QUANTS.md
@@ -93,7 +93,8 @@ Some important options are:
 
 - `--target-bpw`: The target bits-per-weight. For a given set of quantization
   parameters only certain ranges are possible. For example, with the default
-  parameters a BPW in the range `[4.5, 5.5]` is achievable.
+  parameters the target must be greater than 4.5 BPW, since each 4-bit group
+  also stores a 16-bit scale and bias. Targets up to 5.5 BPW are achievable.
 - `--sensitivities`: A path to a precomputed sensitivities file.
 - `--low-bits`: The number of bits to use for the less sensitive layers.
 - `--high-bits`: The number of bits to use for the more sensitive layers.

--- a/mlx_lm/quant/dynamic_quant.py
+++ b/mlx_lm/quant/dynamic_quant.py
@@ -160,7 +160,13 @@ def main():
         help="Path to a pre-computed sensitivity JSON file.",
     )
     parser.add_argument(
-        "--target-bpw", type=float, default=5.0, help="Target bits per weight."
+        "--target-bpw",
+        type=float,
+        default=5.0,
+        help=(
+            "Target bits per weight. Must be greater than low-bits + "
+            "32 / low-group-size (4.5 with the defaults)."
+        ),
     )
     parser.add_argument("--low-bits", type=int, default=4)
     parser.add_argument("--low-group-size", type=int, default=64)
@@ -188,6 +194,18 @@ def main():
         help="Enable trusting remote code for tokenizer/model loading.",
     )
     args = parser.parse_args()
+
+    if args.low_group_size <= 0:
+        raise ValueError("--low-group-size must be positive.")
+    min_target_bpw = args.low_bits + 32 / args.low_group_size
+    if args.target_bpw <= min_target_bpw:
+        raise ValueError(
+            f"--target-bpw {args.target_bpw} is at or below the minimum "
+            f"({min_target_bpw:.4g}) expressible with --low-bits "
+            f"{args.low_bits} at group size {args.low_group_size}; the result "
+            f"would be uniform {args.low_bits}-bit quantization. Lower "
+            "--low-bits or raise the target."
+        )
 
     group = mx.distributed.init()
     model, tokenizer, config = load(

--- a/tests/test_dynamic_quant.py
+++ b/tests/test_dynamic_quant.py
@@ -1,0 +1,48 @@
+# Copyright © 2026 Apple Inc.
+
+import unittest
+from unittest.mock import patch
+
+from mlx_lm.quant.dynamic_quant import main
+
+
+class TestDynamicQuant(unittest.TestCase):
+
+    def test_target_bpw_at_low_precision_floor_fails_before_model_load(self):
+        cases = [
+            (["--target-bpw", "4.5"], 4.5),
+            (
+                [
+                    "--target-bpw",
+                    "4.0",
+                    "--low-bits",
+                    "3",
+                    "--low-group-size",
+                    "32",
+                ],
+                4.0,
+            ),
+        ]
+        for arguments, minimum in cases:
+            with self.subTest(arguments=arguments):
+                with patch("sys.argv", ["dynamic_quant.py", *arguments]):
+                    with patch("mlx_lm.quant.dynamic_quant.load") as load:
+                        with patch(
+                            "mlx_lm.quant.dynamic_quant.mx.distributed.init"
+                        ) as distributed_init:
+                            load.side_effect = AssertionError(
+                                "model loading should not be reached"
+                            )
+
+                            with self.assertRaisesRegex(
+                                ValueError,
+                                rf"is at or below the minimum \({minimum:.4g}\)",
+                            ):
+                                main()
+
+                            distributed_init.assert_not_called()
+                            load.assert_not_called()
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- reject `--target-bpw` values at or below the low-precision layout floor before distributed initialization, model loading, or calibration
- explain the computed lower bound in CLI help and the dynamic quantization guide
- cover the default and a custom low-bit/group-size configuration with a regression test

Fixes #1758.

## Root cause

Each quantized group stores a 16-bit scale and a 16-bit bias in addition to the packed weights. The low-precision floor is therefore:

```text
low_bits + 32 / low_group_size
```

With the defaults this is exactly 4.5 BPW. A target at or below that value leaves no room for a mixed-precision allocation, but the CLI previously completed model loading and calibration before silently producing an effectively uniform low-bit result.

The new check runs immediately after argument parsing and suggests lowering `--low-bits` or raising the target.

## Validation

- `python -m unittest tests.test_dynamic_quant -v`
- `pre-commit run --files mlx_lm/quant/dynamic_quant.py tests/test_dynamic_quant.py mlx_lm/LEARNED_QUANTS.md`
- CI-equivalent local suite on Apple Silicon with MLX 0.32.1 and the official test data: 213 tests passed, 1 skipped
- `mlx.launch --python .venv/bin/python -n 2 tests/model_parallel_tests.py`: passed on both ranks
