### PR TITLE
docs(dynamic_quant): document nondeterministic sensitivity computation

### DIFF
--- a/mlx_lm/quant/dynamic_quant.py
+++ b/mlx_lm/quant/dynamic_quant.py
@@ -46,6 +46,15 @@ def estimate_sensitivities(
     gradient_accum_dtype: mx.Dtype = mx.float32,
     gradient_checkpoint: bool = False,
 ):
+    """Estimate per-layer sensitivity to quantization.
+
+    Sensitivity = alignment between the gradient and (low_q - high_q) weight
+    difference, averaged over calibration batches.  The gradient computation
+    uses nondeterministic Metal reductions, so repeated calls with identical
+    inputs can produce slightly different values (median ~3%, max ~45%
+    relative difference observed).  The resulting bit allocation is therefore
+    not bit-reproducible across runs even with the same seed.
+    """
     def qdq(w, bits, group_size):
         w, s, b = mx.quantize(w, bits=bits, group_size=group_size)
         return mx.dequantize(w, scales=s, biases=b, bits=bits, group_size=group_size)
@@ -152,7 +161,19 @@ def main():
     parser.add_argument(
         "--mlx-path", default="mlx_model", help="Path to save the model"
     )
-    parser.add_argument("--seed", type=int, default=123)
+    parser.add_argument(
+        "--seed",
+        type=int,
+        default=123,
+        help=(
+            "Seed for the calibration sample draw. Fixes which data are"
+            " used but does not guarantee identical output: gradient"
+            " reductions in Metal are nondeterministic, so sensitivity"
+            " scores and the resulting bit allocation can vary between"
+            " runs. For method comparisons, build replicate runs and"
+            " treat the spread as a variance component."
+        ),
+    )
     parser.add_argument(
         "--sensitivities",
         type=str,


### PR DESCRIPTION
Fixes #1759

Body:
What

The --seed flag fixes the calibration sample draw, but gradient reductions in Metal are nondeterministic, so sensitivity scores and the resulting bit allocation can vary between runs even with the same seed. Three model families exhibit this (Qwen3-0.6B, Qwen2.5-1.5B, Llama-3.2-3B per the issue).

This PR documents the behavior in two places:

1. --seed help text — explains what the seed controls and doesn't control, and suggests replicate runs for method comparisons.
2. estimate_sensitivities docstring — notes the source of nondeterminism (Metal gradient reductions) and the observed variance (~3% median, ~45% max).

Why documentation and not a code fix

The nondeterminism enters at the kernel level: a single gradient computation on one identical batch, run twice in the same process, already returns slightly different values. This is the same class of nondeterminism as CUDA's non-deterministic atomicAdd. Fixing it requires deterministic reductions in mlx core, not in this repo.

The issue's suggestion #1 (document the behavior) turns a surprise into documented behavior. The suggested workaround (replicate runs, treat spread as variance) is included in the help text.

Testing

No behavioral change — only documentation. python -m mlx_lm.quant.dynamic_quant --help renders the new seed description correctly.

Fixes #1759.