### PR TITLE
cache.py: default trim() raises NotImplementedError instead of AttributeError (#1081)

### DIFF
--- a/mlx_lm/models/cache.py
+++ b/mlx_lm/models/cache.py
@@ -146,6 +146,23 @@ class _BaseCache:
     def is_trimmable(self):
         return False
 
+    def trim(self, n):
+        """
+        Trim ``n`` tokens off of the cache.
+
+        Any subclass that overrides ``is_trimmable()`` to return ``True``
+        must also override this method. Callers are expected to guard calls
+        to ``trim`` with ``is_trimmable()``, so reaching this default
+        implementation means that invariant was broken by a cache
+        subclass -- fail loudly instead of raising a generic
+        ``AttributeError`` deeper in the call stack.
+        """
+        raise NotImplementedError(
+            f"{type(self).__name__} does not implement trim() but reports "
+            "is_trimmable() == True. is_trimmable() must be overridden to "
+            "return False, or trim() must be implemented, for this class."
+        )
+
     def size(self):
         """
         Return the size (i.e. sequence length) of the cache.


### PR DESCRIPTION
Any subclass that overrides is_trimmable() to return True must also
override trim(); previously the base class had no trim() at all, so
that invariant being broken failed several frames away with a bare
AttributeError instead of failing loudly at the point of the bug.

---

Split out of #1766 per review feedback ("Please submit as separate PRs"). Full test suite (CPU backend, real model downloads, no mocks) passes for this change; see commit message for specifics.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
