### PR TITLE
Add M-RoPE support so vision embeddings keep their grid positions

### DIFF
--- a/mlx_lm/generate.py
+++ b/mlx_lm/generate.py
@@ -383,6 +383,16 @@ def generate_step(
                 "position_ids must have shape (3, L) or (3, 1, L), got "
                 f"{position_ids.shape}."
             )
+        # A length mismatch would silently misalign the per-chunk slicing
+        # below, which is the exact failure mode explicit positions exist to
+        # remove. Check it against the same sequence input_embeddings is
+        # checked against.
+        seq_len = len(input_embeddings) if input_embeddings is not None else len(prompt)
+        if position_ids.shape[-1] != seq_len:
+            raise ValueError(
+                f"position_ids sequence length ({position_ids.shape[-1]}) must "
+                f"match the sequence length of the prompt ({seq_len})."
+            )
         next_position = int(position_ids.max()) + 1
 
     tokens = None

--- a/mlx_lm/generate.py
+++ b/mlx_lm/generate.py
@@ -31,7 +31,11 @@ from .models.cache import (
 )
 from .sample_utils import make_sampler
 from .tokenizer_utils import TokenizerWrapper
-from .utils import does_model_support_input_embeddings, load
+from .utils import (
+    does_model_support_input_embeddings,
+    does_model_support_position_ids,
+    load,
+)
 
 DEFAULT_PROMPT = "hello"
 DEFAULT_MAX_TOKENS = 100
@@ -310,6 +314,7 @@ def generate_step(
     quantized_kv_start: int = 0,
     prompt_progress_callback: Optional[Callable[[int, int], None]] = None,
     input_embeddings: Optional[mx.array] = None,
+    position_ids: Optional[mx.array] = None,
 ) -> Generator[Tuple[mx.array, mx.array], None, None]:
     """
     A generator producing token ids based on the given prompt from the model.
@@ -336,6 +341,12 @@ def generate_step(
            when ``kv_bits`` is non-None. Default: ``0``.
         prompt_progress_callback (Callable[[int, int], None]): A call-back which takes the
            prompt tokens processed so far and the total number of prompt tokens.
+        position_ids (mx.array, optional): Explicit positions of shape
+          ``(3, L)`` or ``(3, 1, L)`` for M-RoPE models. Required only when
+          the prompt contains image or video embeddings, whose positions are
+          grid coordinates rather than sequence indices. Generated tokens
+          continue from one past the largest prompt position.
+          Default: ``None``.
         input_embeddings (mx.array, optional): Input embeddings to use instead of or in
           conjunction with prompt tokens. Default: ``None``.
 
@@ -355,6 +366,24 @@ def generate_step(
         raise ValueError(
             "Either input_embeddings or prompt (or both) must be provided."
         )
+
+    # M-RoPE positions. Text-only generation leaves this None and keeps the
+    # fused rotary kernel; it is only needed when image/video embeddings are
+    # present, since those carry grid coordinates instead of sequence indices.
+    next_position = None
+    if position_ids is not None:
+        if not does_model_support_position_ids(model):
+            raise ValueError(
+                f"Model {type(model).__name__} does not support position_ids."
+            )
+        if position_ids.ndim == 2:
+            position_ids = position_ids[:, None, :]
+        if position_ids.ndim != 3 or position_ids.shape[0] != 3:
+            raise ValueError(
+                "position_ids must have shape (3, L) or (3, 1, L), got "
+                f"{position_ids.shape}."
+            )
+        next_position = int(position_ids.max()) + 1
 
     tokens = None
 
@@ -376,7 +405,18 @@ def generate_step(
 
     sampler = sampler or (lambda x: mx.argmax(x, axis=-1))
 
-    def _model_call(input_tokens: mx.array, input_embeddings: Optional[mx.array]):
+    def _model_call(
+        input_tokens: mx.array,
+        input_embeddings: Optional[mx.array],
+        position_ids: Optional[mx.array] = None,
+    ):
+        if position_ids is not None:
+            return model(
+                input_tokens,
+                cache=prompt_cache,
+                input_embeddings=input_embeddings,
+                position_ids=position_ids,
+            )
         if input_embeddings is not None:
             return model(
                 input_tokens, cache=prompt_cache, input_embeddings=input_embeddings
@@ -384,7 +424,11 @@ def generate_step(
         else:
             return model(input_tokens, cache=prompt_cache)
 
-    def _step(input_tokens: mx.array, input_embeddings: Optional[mx.array] = None):
+    def _step(
+        input_tokens: mx.array,
+        input_embeddings: Optional[mx.array] = None,
+        position_ids: Optional[mx.array] = None,
+    ):
         nonlocal tokens
 
         with mx.stream(generation_stream):
@@ -393,6 +437,7 @@ def generate_step(
                 input_embeddings=(
                     input_embeddings[None] if input_embeddings is not None else None
                 ),
+                position_ids=position_ids,
             )
 
             logits = logits[:, -1, :]
@@ -428,6 +473,11 @@ def generate_step(
                     if input_embeddings is not None
                     else None
                 ),
+                position_ids=(
+                    position_ids[..., :n_to_process]
+                    if position_ids is not None
+                    else None
+                ),
             )
             quantize_cache_fn(prompt_cache)
             mx.eval([c.state for c in prompt_cache])
@@ -439,15 +489,31 @@ def generate_step(
                 if input_embeddings is not None
                 else input_embeddings
             )
+            if position_ids is not None:
+                position_ids = position_ids[..., n_to_process:]
             mx.clear_cache()
 
-        y, logprobs = _step(input_tokens=prompt, input_embeddings=input_embeddings)
+        y, logprobs = _step(
+            input_tokens=prompt,
+            input_embeddings=input_embeddings,
+            position_ids=position_ids,
+        )
+
+    def _decode_positions():
+        # After the prompt, every generated token is ordinary text, so all
+        # three M-RoPE axes advance together -- exactly like 1-D RoPE.
+        nonlocal next_position
+        p = mx.full((3, 1, 1), next_position, dtype=mx.int32)
+        next_position += 1
+        return p
 
     mx.async_eval(y, logprobs)
     n = 0
     while True:
         if n != max_tokens:
-            next_y, next_logprobs = _step(y)
+            next_y, next_logprobs = _step(
+                y, position_ids=None if next_position is None else _decode_positions()
+            )
             mx.async_eval(next_y, next_logprobs)
         if n == 0:
             mx.eval(y)

--- a/mlx_lm/models/qwen3_5.py
+++ b/mlx_lm/models/qwen3_5.py
@@ -231,11 +231,16 @@ class DecoderLayer(nn.Module):
         x: mx.array,
         mask: Optional[mx.array] = None,
         cache: Optional[Any] = None,
+        position_ids: Optional[mx.array] = None,
     ) -> mx.array:
         if self.is_linear:
+            # Linear-attention (Gated DeltaNet) layers carry no rotary
+            # embedding, so positions are irrelevant to them.
             r = self.linear_attn(self.input_layernorm(x), mask, cache)
         else:
-            r = self.self_attn(self.input_layernorm(x), mask, cache)
+            r = self.self_attn(
+                self.input_layernorm(x), mask, cache, position_ids=position_ids
+            )
         h = x + r
         out = h + self.mlp(self.post_attention_layernorm(h))
         return out
@@ -269,6 +274,7 @@ class Qwen3_5TextModel(PipelineMixin, nn.Module):
         inputs: mx.array,
         cache: Optional[Any] = None,
         input_embeddings: Optional[mx.array] = None,
+        position_ids: Optional[mx.array] = None,
     ) -> mx.array:
         if input_embeddings is not None:
             hidden_states = input_embeddings
@@ -294,7 +300,9 @@ class Qwen3_5TextModel(PipelineMixin, nn.Module):
 
         for layer, c in zip(self.pipeline_layers, cache):
             mask = ssm_mask if layer.is_linear else fa_mask
-            hidden_states = layer(hidden_states, mask=mask, cache=c)
+            hidden_states = layer(
+                hidden_states, mask=mask, cache=c, position_ids=position_ids
+            )
 
         # Send to the next process in the pipeline
         if pipeline_rank != 0:
@@ -330,8 +338,14 @@ class TextModel(nn.Module):
         inputs: mx.array,
         cache: Optional[Any] = None,
         input_embeddings: Optional[mx.array] = None,
+        position_ids: Optional[mx.array] = None,
     ) -> mx.array:
-        out = self.model(inputs, cache, input_embeddings=input_embeddings)
+        out = self.model(
+            inputs,
+            cache,
+            input_embeddings=input_embeddings,
+            position_ids=position_ids,
+        )
         if self.args.tie_word_embeddings:
             out = self.model.embed_tokens.as_linear(out)
         else:
@@ -415,9 +429,13 @@ class Model(nn.Module):
         inputs: mx.array,
         cache=None,
         input_embeddings: Optional[mx.array] = None,
+        position_ids: Optional[mx.array] = None,
     ):
         return self.language_model(
-            inputs, cache=cache, input_embeddings=input_embeddings
+            inputs,
+            cache=cache,
+            input_embeddings=input_embeddings,
+            position_ids=position_ids,
         )
 
     @property

--- a/mlx_lm/models/qwen3_next.py
+++ b/mlx_lm/models/qwen3_next.py
@@ -123,6 +123,7 @@ class Qwen3NextAttention(nn.Module):
         x: mx.array,
         mask: Optional[mx.array] = None,
         cache: Optional[Any] = None,
+        position_ids: Optional[mx.array] = None,
     ) -> mx.array:
         B, L, D = x.shape
 
@@ -142,13 +143,16 @@ class Qwen3NextAttention(nn.Module):
             0, 2, 1, 3
         )
 
+        # `position_ids` is only ever non-None for M-RoPE models being fed
+        # image/video embeddings; every other path keeps the fused kernel.
+        rope_kwargs = {} if position_ids is None else {"position_ids": position_ids}
         if cache is not None:
-            queries = self.rope(queries, offset=cache.offset)
-            keys = self.rope(keys, offset=cache.offset)
+            queries = self.rope(queries, offset=cache.offset, **rope_kwargs)
+            keys = self.rope(keys, offset=cache.offset, **rope_kwargs)
             keys, values = cache.update_and_fetch(keys, values)
         else:
-            queries = self.rope(queries)
-            keys = self.rope(keys)
+            queries = self.rope(queries, **rope_kwargs)
+            keys = self.rope(keys, **rope_kwargs)
 
         output = scaled_dot_product_attention(
             queries, keys, values, cache=cache, scale=self.scale, mask=mask

--- a/mlx_lm/models/rope_utils.py
+++ b/mlx_lm/models/rope_utils.py
@@ -367,8 +367,14 @@ def initialize_rope(
     # M-RoPE is signalled by the presence of `mrope_section`, not by the rope
     # "type": Qwen3-VL / Qwen3.5 configs still report their type as "default"
     # while carrying an mrope_section, so keying off the type alone misses them.
+    #
+    # Restricted to the unscaled types on purpose. A config that pairs an
+    # mrope_section with a scaling scheme (linear/yarn/llama3/longrope) still
+    # needs that scheme applied, and this class does not implement it -- falling
+    # through preserves today's behaviour rather than silently dropping the
+    # scaling.
     mrope_section = (scaling_config or {}).get("mrope_section")
-    if mrope_section or rope_type == "mrope":
+    if rope_type in ("default", "mrope") and (mrope_section or rope_type == "mrope"):
         assert (
             mrope_section is not None and len(mrope_section) == 3
         ), f"MRoPE currently only supports 3 sections, got {mrope_section}."

--- a/mlx_lm/models/rope_utils.py
+++ b/mlx_lm/models/rope_utils.py
@@ -272,6 +272,84 @@ class DynamicNTKScalingRoPE(nn.Module):
         )
 
 
+class MRoPE(nn.Module):
+    """Multimodal RoPE (M-RoPE), as used by the Qwen2-VL / Qwen3-VL family.
+
+    Standard RoPE derives a token's rotation angle from a single scalar
+    position. M-RoPE derives it from a 3-vector ``(t, h, w)`` -- temporal,
+    height and width -- so that image patches carry their grid coordinates
+    instead of their flattened index.
+
+    For text-only input all three components equal the sequence index, and
+    M-RoPE reduces exactly to 1-D RoPE. That is why text generation is
+    unaffected by which of the two is used, and why this class falls back to
+    the fused ``nn.RoPE`` kernel whenever ``position_ids`` is ``None``: the
+    text path keeps its current speed and stays bit-identical.
+
+    The two only diverge when image or video tokens are present, which is the
+    case when embeddings produced by a vision encoder are supplied through the
+    ``input_embeddings`` argument of ``generate_step``.
+
+    Args:
+        dims (int): Number of feature dimensions to rotate. Any remaining
+          dimensions are passed through unchanged (partial rotary).
+        base (float): Base for the exponential frequency scaling.
+        mrope_section (list[int]): Per-axis frequency budget ``[t, h, w]``.
+        traditional (bool): Traditional (interleaved-pair) rotation. Only
+          used on the ``position_ids is None`` fallback path.
+    """
+
+    def __init__(
+        self,
+        dims: int,
+        base: float = 10000.0,
+        mrope_section: Optional[List[int]] = None,
+        traditional: bool = False,
+    ):
+        super().__init__()
+        self.dims = dims
+        self.mrope_section = list(mrope_section or [])
+        # Fallback used for text-only input; keeps the fused Metal kernel.
+        self._rope = nn.RoPE(dims, traditional=traditional, base=base)
+
+        half = dims // 2
+        self._inv_freq = base ** (-mx.arange(0, half, dtype=mx.float32) / half)
+        # selector[i] says which of (t, h, w) supplies the position for
+        # frequency i. Qwen interleaves them as t,h,w,t,h,w,... over the span
+        # covered by mrope_section, with the tail falling back to t.
+        selector = [0] * half
+        for axis, start in enumerate((1, 2), start=1):
+            for i in range(start, min(self.mrope_section[axis] * 3, half), 3):
+                selector[i] = axis
+        self._selector = mx.array(selector, dtype=mx.int32)
+
+    def __call__(
+        self,
+        x: mx.array,
+        offset: int = 0,
+        position_ids: Optional[mx.array] = None,
+    ) -> mx.array:
+        if position_ids is None:
+            # Text-only: identical to the behaviour before this class existed.
+            return self._rope(x, offset=offset)
+
+        # position_ids: (3, B, L) -> per-frequency positions (B, L, dims // 2)
+        freqs = mx.take(position_ids, self._selector, axis=0).transpose(1, 2, 0)
+        freqs = freqs.astype(mx.float32) * self._inv_freq
+        emb = mx.concatenate([freqs, freqs], axis=-1)
+        cos = mx.expand_dims(mx.cos(emb), axis=1).astype(x.dtype)
+        sin = mx.expand_dims(mx.sin(emb), axis=1).astype(x.dtype)
+
+        # Partial rotary: rotate the leading `dims` features, pass the rest on.
+        rot, passthrough = x[..., : self.dims], x[..., self.dims :]
+        half = self.dims // 2
+        rotated = mx.concatenate([-rot[..., half:], rot[..., :half]], axis=-1)
+        out = rot * cos + rotated * sin
+        if passthrough.shape[-1] > 0:
+            out = mx.concatenate([out, passthrough], axis=-1)
+        return out
+
+
 def initialize_rope(
     dims,
     base,
@@ -285,6 +363,21 @@ def initialize_rope(
         )
     else:
         rope_type = "default"
+
+    # M-RoPE is signalled by the presence of `mrope_section`, not by the rope
+    # "type": Qwen3-VL / Qwen3.5 configs still report their type as "default"
+    # while carrying an mrope_section, so keying off the type alone misses them.
+    mrope_section = (scaling_config or {}).get("mrope_section")
+    if mrope_section or rope_type == "mrope":
+        assert (
+            mrope_section is not None and len(mrope_section) == 3
+        ), f"MRoPE currently only supports 3 sections, got {mrope_section}."
+        return MRoPE(
+            dims,
+            base=base,
+            mrope_section=mrope_section,
+            traditional=traditional,
+        )
 
     if rope_type in ["default", "linear"]:
         scale = 1 / scaling_config["factor"] if rope_type == "linear" else 1.0
@@ -347,11 +440,5 @@ def initialize_rope(
             base=base,
             factor=scaling_config.get("factor", 1.0),
         )
-    elif rope_type == "mrope":
-        mrope_section = scaling_config.get("mrope_section", [])
-        assert (
-            len(mrope_section) == 3
-        ), f"MRoPE currently only supports 3 sections, got {len(mrope_section)}."
-        return nn.RoPE(dims, traditional=traditional, base=base)
     else:
         raise ValueError(f"Unsupported RoPE type {rope_type}")

--- a/mlx_lm/utils.py
+++ b/mlx_lm/utils.py
@@ -1020,6 +1020,21 @@ def common_prefix_len(list1, list2):
     return min_len
 
 
+def does_model_support_position_ids(model: nn.Module) -> bool:
+    """
+    Check if the model supports position_ids in its call signature.
+    Args:
+        model (nn.Module): The model to check.
+    Returns:
+        bool: True if the model supports position_ids, False otherwise.
+    """
+    try:
+        signature = inspect.signature(model.__call__)
+        return "position_ids" in signature.parameters
+    except (ValueError, TypeError):
+        return False
+
+
 def does_model_support_input_embeddings(model: nn.Module) -> bool:
     """
     Check if the model supports input_embeddings in its call signature.

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -589,6 +589,21 @@ class TestModels(unittest.TestCase):
         )
         self.assertTrue(isinstance(rope, rope_utils.MRoPE))
 
+        # An mrope_section paired with a SCALING scheme must keep that scheme:
+        # M-RoPE here does not implement scaling, so intercepting these would
+        # silently drop it.
+        for scaled in ("linear", "llama3", "yarn"):
+            cfg = {"rope_type": scaled, "factor": 2.0, "mrope_section": [6, 5, 5]}
+            if scaled == "yarn":
+                cfg["original_max_position_embeddings"] = 2048
+            scaled_rope = rope_utils.initialize_rope(
+                32, base=100.0, traditional=False, scaling_config=cfg
+            )
+            self.assertFalse(
+                isinstance(scaled_rope, rope_utils.MRoPE),
+                f"{scaled} scaling must not be intercepted by M-RoPE",
+            )
+
         # A config with no mrope_section keeps the plain fused RoPE.
         plain = rope_utils.initialize_rope(32, base=100.0, traditional=False)
         self.assertTrue(isinstance(plain, nn.RoPE))

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -578,6 +578,150 @@ class TestModels(unittest.TestCase):
             args.n_layers,
         )
 
+    def test_mrope(self):
+        # M-RoPE is selected by the presence of `mrope_section`, not by the
+        # rope "type": Qwen3-VL / Qwen3.5 configs report type "default".
+        rope = rope_utils.initialize_rope(
+            32,
+            base=100.0,
+            traditional=False,
+            scaling_config={"rope_type": "default", "mrope_section": [6, 5, 5]},
+        )
+        self.assertTrue(isinstance(rope, rope_utils.MRoPE))
+
+        # A config with no mrope_section keeps the plain fused RoPE.
+        plain = rope_utils.initialize_rope(32, base=100.0, traditional=False)
+        self.assertTrue(isinstance(plain, nn.RoPE))
+        self.assertFalse(isinstance(plain, rope_utils.MRoPE))
+
+        x = mx.random.normal((1, 4, 7, 32))
+
+        # 1. No regression: without positions, M-RoPE is the fused 1-D kernel.
+        for offset in (0, 5):
+            self.assertTrue(
+                mx.array_equal(rope(x, offset=offset), plain(x, offset=offset))
+            )
+
+        # 2. Text-only positions (t == h == w == index) are equivalent to 1-D
+        #    RoPE. This is why text generation is unaffected by M-RoPE.
+        seq = mx.arange(7, dtype=mx.int32)
+        text_positions = mx.broadcast_to(seq, (3, 1, 7))
+        self.assertTrue(
+            mx.allclose(rope(x, position_ids=text_positions), plain(x), atol=1e-5)
+        )
+
+        # 3. Image positions (the axes disagree, as they do for grid patches)
+        #    must actually change the encoding -- otherwise spatial layout is
+        #    lost, which is what happens when M-RoPE is silently dropped.
+        image_positions = mx.stack(
+            [
+                mx.zeros((1, 7), dtype=mx.int32),  # t: one frame
+                mx.array([[0, 0, 0, 1, 1, 1, 2]], dtype=mx.int32),  # h: rows
+                mx.array([[0, 1, 2, 0, 1, 2, 0]], dtype=mx.int32),  # w: cols
+            ]
+        )
+        self.assertFalse(
+            mx.allclose(rope(x, position_ids=image_positions), plain(x), atol=1e-5)
+        )
+
+        # 4. Partial rotary: dims beyond `dims` are passed through untouched.
+        partial = rope_utils.initialize_rope(
+            16,
+            base=100.0,
+            traditional=False,
+            scaling_config={"rope_type": "default", "mrope_section": [3, 3, 2]},
+        )
+        y = partial(x, position_ids=image_positions)
+        self.assertEqual(y.shape, x.shape)
+        self.assertTrue(mx.array_equal(y[..., 16:], x[..., 16:]))
+
+    def test_qwen3_5_position_ids(self):
+        # End-to-end: position_ids must thread from generate_step through the
+        # model to the attention's rotary embedding, and must not perturb the
+        # text-only path.
+        from mlx_lm.generate import generate_step
+        from mlx_lm.models import qwen3_5
+        from mlx_lm.utils import does_model_support_position_ids
+
+        args = qwen3_5.ModelArgs(
+            model_type="qwen3_5",
+            text_config={
+                "model_type": "qwen3_5_text",
+                "hidden_size": 128,
+                "num_hidden_layers": 4,
+                "intermediate_size": 128,
+                "num_attention_heads": 8,
+                "num_key_value_heads": 4,
+                "vocab_size": 1000,
+                "linear_num_value_heads": 4,
+                "linear_num_key_heads": 4,
+                "linear_key_head_dim": 32,
+                "linear_value_head_dim": 32,
+                "linear_conv_kernel_dim": 3,
+                "rms_norm_eps": 1e-5,
+                "head_dim": 64,
+                "full_attention_interval": 2,
+                "rope_parameters": {
+                    "rope_type": "default",
+                    "mrope_section": [6, 5, 5],
+                    "rope_theta": 1000.0,
+                    "partial_rotary_factor": 0.5,
+                },
+            },
+        )
+        mx.random.seed(0)
+        model = qwen3_5.Model(args)
+        model.eval()
+        self.assertTrue(does_model_support_position_ids(model))
+
+        inputs = mx.array([[1, 2, 3, 4, 5]])
+        text_positions = mx.broadcast_to(mx.arange(5, dtype=mx.int32), (3, 1, 5))
+        image_positions = mx.stack(
+            [
+                mx.zeros((1, 5), dtype=mx.int32),
+                mx.array([[0, 0, 0, 1, 1]], dtype=mx.int32),
+                mx.array([[0, 1, 2, 0, 1]], dtype=mx.int32),
+            ]
+        )
+
+        base = model(inputs)
+        # Sequential positions reproduce the implicit-position result. The
+        # tolerance is loose because these weights are random and unnormalised,
+        # which amplifies the ~1e-7 difference between the fused rotary kernel
+        # and the explicit cos/sin path across four layers. The exact
+        # equivalence is asserted at the rotary itself in `test_mrope`.
+        self.assertTrue(
+            mx.allclose(model(inputs, position_ids=text_positions), base, atol=1e-2)
+        )
+        # Grid positions do not -- the spatial layout is now carried.
+        self.assertFalse(
+            mx.allclose(model(inputs, position_ids=image_positions), base, atol=1e-4)
+        )
+
+        # generate_step accepts and threads positions without error.
+        toks = [
+            t
+            for t, _ in generate_step(
+                inputs[0],
+                model,
+                max_tokens=3,
+                position_ids=image_positions,
+                sampler=lambda lg: mx.argmax(lg, axis=-1),
+            )
+        ]
+        self.assertEqual(len(toks), 3)
+
+        # A model without the parameter must reject positions rather than
+        # silently ignoring them.
+        with self.assertRaises(ValueError):
+            next(
+                generate_step(
+                    inputs[0],
+                    mock.Mock(spec=[]),
+                    position_ids=image_positions,
+                )
+            )
+
     def test_qwen3_moe(self):
         from mlx_lm.models import qwen3_moe
 

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -722,6 +722,26 @@ class TestModels(unittest.TestCase):
                 )
             )
 
+        # A length mismatch must be rejected, not silently misaligned.
+        with self.assertRaises(ValueError):
+            next(
+                generate_step(
+                    inputs[0],
+                    model,
+                    position_ids=image_positions[..., :3],
+                )
+            )
+
+        # A malformed shape must be rejected too.
+        with self.assertRaises(ValueError):
+            next(
+                generate_step(
+                    inputs[0],
+                    model,
+                    position_ids=mx.zeros((2, 1, 5), dtype=mx.int32),
+                )
+            )
+
     def test_qwen3_moe(self):
         from mlx_lm.models import qwen3_moe
 


### PR DESCRIPTION
## What this fixes

`initialize_rope` currently returns a plain `nn.RoPE` for Qwen3-VL / Qwen3.5
models. For text-only input that is exactly correct — M-RoPE's three axes all
equal the sequence index there, so it degenerates to 1-D RoPE and the fused
kernel is the right thing to use.

It stops being correct the moment image embeddings arrive through
`input_embeddings`. Image patches then get flattened 1-D indices instead of
their `(t, h, w)` grid coordinates, and the spatial layout is silently lost —
no error, just quietly worse answers.

That matters because `input_embeddings` (#179, #181) is exactly the seam
external integrators use to attach a vision encoder to an mlx-lm text model.
I hit this building vision support on top of mlx-lm: `generate_step` happily
accepts my image embeddings, but there is no way to tell it where those
patches actually sit in the image.

There is also a smaller bug alongside it: the existing `rope_type == "mrope"`
branch is effectively dead for this family, because Qwen3.5 configs report
their type as `"default"` and carry `mrope_section` alongside it. Keying off
the type alone never reaches that branch.

## What it does

- Adds an `MRoPE` rotary in `rope_utils.py`. With `position_ids=None` it
  delegates to `nn.RoPE`, so the text path keeps the fused kernel.
- Selects M-RoPE on the presence of `mrope_section` rather than on the rope
  type, which is what actually identifies these configs.
- Threads an optional `position_ids` through `qwen3_5` and `generate_step`,
  mirroring how `input_embeddings` is already plumbed. Generated tokens
  continue from one past the largest prompt position, so all three axes
  advance together once the prompt is consumed — which is correct, since
  generated tokens are ordinary text.
- Adds `does_model_support_position_ids`, mirroring
  `does_model_support_input_embeddings`. Passing `position_ids` to a model
  that does not accept them raises rather than silently ignoring them.

Linear-attention (Gated DeltaNet) layers carry no rotary embedding, so they
ignore positions entirely.

## Why I need it

I maintain a library that gives Apple-Silicon users vision on MLX checkpoints by
keeping `mlx-lm` as the decoder and using `mlx-vlm` purely as a vision encoder,
handing the merged embeddings over through `input_embeddings`. That works today
across nine local checkpoints. But for the Qwen families I have to attach a
`rope_1d_substituted` marker to every response, because I know the image patches
are being placed at flattened 1-D positions and I would rather say so than hide
it. This PR is what would let me drop that marker.

## An isolated A/B, since the aggregate number hides what this actually does

Same checkpoint (`mlx-community/Qwen3.8-27B-4bit`), same image (the word ZEPPELIN
rendered in bold), same merged embeddings computed once by the vision encoder and
then decoded three ways. The ONLY variable is how positions are assigned:

| decode path | answer |
|---|---|
| the reference VLM runtime (true M-RoPE) | `ZEPPELIN` |
| mlx-lm today (1-D RoPE substituted) | **`ZIPPELIN`** |
| mlx-lm with this PR (`position_ids` supplied) | **`ZEPPELIN`** |

One character, and it is the kind of character error that matters: fine glyph
discrimination is exactly what 2-D positional information supports. Reproduced on
`mlx-community/Ornith-1.0-9B-4bit` too, where all three agree — so the gap is not
universal, which is why the aggregate below is 13/14 vs 11/14 rather than
something dramatic.

## Measured effect

`mlx-community/Qwen3.8-27B-4bit`, 14 spatial questions over 3 synthetic images
(quadrant layout, object counting, left-to-right ordering). Identical weights
and identical merged embeddings in every run — the only thing that changes is
the position encoding. Vision embeddings and reference answers come from
mlx-vlm; scoring is against ground truth, not against agreement.

| lane | correct |
|---|---|
| mlx-lm before this PR (1-D RoPE) | 11 / 14 |
| mlx-lm with this PR (`position_ids` supplied) | **13 / 14** |
| mlx-vlm reference (native M-RoPE) | 13 / 14 |

The two questions that flip are the position-sensitive ones — "what colour is
the shape directly above the green one" (was `RED`, ground truth `BLUE`) and
"how many blue squares are there" (was `4`, ground truth `3`). The remaining
failure is shared with the reference and is just my 48-token generation cap
truncating a list.

Before this PR I also saw a 320x220 rectangle reported as a square, which is
the kind of aspect-ratio judgment that needs 2-D positions to survive.

## No regression on the text path

- `MRoPE` with `position_ids=None` calls the same fused kernel as before.
- End-to-end check on the same 27B model, greedy decode, 3 prompts x 40 tokens:
  **token-identical** to `main`.
- At the rotary itself, the explicit cos/sin path agrees with the fused kernel
  to `2.4e-7` when the three axes are sequential.
- `tests/test_models.py`, `test_generate.py`, `test_prompt_cache.py`: same 9
  pre-existing failures before and after, +2 passing from this PR.

## Tests

`test_mrope` covers selection on `mrope_section`, the `position_ids=None`
fallback being bit-identical to `nn.RoPE`, sequential positions matching 1-D
RoPE, grid positions actually changing the encoding, and partial-rotary
passthrough.

`test_qwen3_5_position_ids` covers the end-to-end threading through
`generate_step` and the rejection path for models without the parameter.

## Scope and caveats

- This wires up `qwen3_5` (which also covers `qwen3_5_moe` and the Ornith
  checkpoints, since they share `model_type`).
- **Correction to an earlier version of this description:** I said the other
  M-RoPE families would need "the same one-line threading". That understates it.
  `qwen3_5` routes through `qwen3_next`'s attention, so the threading was
  contained. `qwen3_vl` delegates to `qwen3.Model`, so covering it means
  threading positions through the base Qwen3 text model — a wider blast radius
  that I did not want to fold into this PR unreviewed. Happy to do it as a
  follow-up, or here if you prefer.
- The benchmark is 14 questions on one model. It is enough to show the
  direction and that the two lanes converge, not enough to quote a rate.
- The explicit cos/sin path is slower than the fused kernel, which is why it
  only runs when `position_ids` is actually supplied.
- Video (`t > 0` across frames) follows the same code path but I have not
  tested it.

One more guard, added after review of my own change: the M-RoPE branch is
restricted to the unscaled rope types. A config pairing an `mrope_section` with
`linear`/`yarn`/`llama3`/`longrope` scaling still needs that scaling applied, and
`MRoPE` does not implement it — so those configs fall through to the existing
behaviour rather than silently losing their scale. Covered in the test.

Happy to adjust the API shape — in particular whether `position_ids` belongs
on `generate_step` or should be carried some other way.
