### PR TITLE
Add tensor parallel sharding for Qwen3 MoE

### DIFF
--- a/mlx_lm/models/qwen3_moe.py
+++ b/mlx_lm/models/qwen3_moe.py
@@ -5,6 +5,7 @@ from typing import Any, Dict, List, Optional, Union
 
 import mlx.core as mx
 import mlx.nn as nn
+from mlx.nn.layers.distributed import shard_inplace, shard_linear, sum_gradients
 
 from .activations import swiglu
 from .base import BaseModelArgs, create_attention_mask, scaled_dot_product_attention
@@ -120,10 +121,15 @@ class Qwen3MoeSparseMoeBlock(nn.Module):
         self.gate = nn.Linear(dim, num_experts, bias=False)
         self.switch_mlp = SwitchGLU(dim, intermediate_size, num_experts)
 
+        self.sharding_group = None
+
     def __call__(
         self,
         x: mx.array,
     ) -> mx.array:
+        if self.sharding_group is not None:
+            x = sum_gradients(self.sharding_group)(x)
+
         gates = self.gate(x)
         gates = mx.softmax(gates, axis=-1, precise=True)
 
@@ -134,7 +140,10 @@ class Qwen3MoeSparseMoeBlock(nn.Module):
             scores /= mx.sum(scores, axis=-1, keepdims=True)
 
         y = self.switch_mlp(x, inds)
-        y = (y * scores[..., None]).sum(axis=-2)
+        y = (y * scores[..., None]).sum(axis=-2).astype(y.dtype)
+
+        if self.sharding_group is not None:
+            y = mx.distributed.all_sum(y, group=self.sharding_group)
 
         return y
 
@@ -244,6 +253,52 @@ class Model(nn.Module):
                     ]
                     weights[f"{prefix}.mlp.switch_mlp.{n}.weight"] = mx.stack(to_join)
         return weights
+
+    def shard(self, group: Optional[mx.distributed.Group] = None):
+        group = group or mx.distributed.init()
+        N = group.size()
+        for layer in self.model.layers:
+            # Shard the self attention
+            layer.self_attn.q_proj = shard_linear(
+                layer.self_attn.q_proj, "all-to-sharded", group=group
+            )
+            layer.self_attn.k_proj = shard_linear(
+                layer.self_attn.k_proj, "all-to-sharded", group=group
+            )
+            layer.self_attn.v_proj = shard_linear(
+                layer.self_attn.v_proj, "all-to-sharded", group=group
+            )
+            layer.self_attn.o_proj = shard_linear(
+                layer.self_attn.o_proj, "sharded-to-all", group=group
+            )
+            layer.self_attn.n_heads //= N
+            layer.self_attn.n_kv_heads //= N
+
+            # Shard the dense MLP layers
+            if isinstance(layer.mlp, MLP):
+                layer.mlp.gate_proj = shard_linear(
+                    layer.mlp.gate_proj, "all-to-sharded", group=group
+                )
+                layer.mlp.down_proj = shard_linear(
+                    layer.mlp.down_proj, "sharded-to-all", group=group
+                )
+                layer.mlp.up_proj = shard_linear(
+                    layer.mlp.up_proj, "all-to-sharded", group=group
+                )
+
+            # Shard the MoE. Shard in place since the MoE should be responsible
+            # for aggregating the results. The router (gate) stays replicated.
+            else:
+                layer.mlp.sharding_group = group
+                shard_inplace(
+                    layer.mlp.switch_mlp.gate_proj, "all-to-sharded", group=group
+                )
+                shard_inplace(
+                    layer.mlp.switch_mlp.down_proj, "sharded-to-all", group=group
+                )
+                shard_inplace(
+                    layer.mlp.switch_mlp.up_proj, "all-to-sharded", group=group
+                )
 
     @property
     def quant_predicate(self):

--- a/tests/model_parallel_tests.py
+++ b/tests/model_parallel_tests.py
@@ -94,6 +94,26 @@ class TestModelParallel(unittest.TestCase):
                 "tie_word_embeddings": False,
                 "num_nextn_predict_layers": 1,
             },
+            {
+                "model_type": "qwen3_moe",
+                "vocab_size": 128,
+                "hidden_size": 64,
+                "intermediate_size": 128,
+                "moe_intermediate_size": 32,
+                "num_hidden_layers": 4,
+                "num_attention_heads": 4,
+                "num_key_value_heads": 2,
+                "head_dim": 16,
+                "num_experts": 4,
+                "num_experts_per_tok": 2,
+                "decoder_sparse_step": 1,
+                "mlp_only_layers": [0],
+                "norm_topk_prob": True,
+                "rms_norm_eps": 1e-5,
+                "rope_theta": 10000.0,
+                "max_position_embeddings": 256,
+                "tie_word_embeddings": False,
+            },
         ]
         mx.random.seed(0)
         for config in test_configs:


### PR DESCRIPTION
Add tensor parallel sharding for Qwen3 MoE

## Problem

`qwen3_moe` has no `Model.shard()`, so Qwen3 MoE checkpoints (e.g.
Qwen3-30B-A3B, Qwen3-235B-A22B) cannot be tensor-parallel sharded across
multiple machines the way `glm4_moe`, `deepseek_v3`, and other MoE models
already can.

## Change

Follows the established `glm4_moe` pattern exactly:

- `Qwen3MoeSparseMoeBlock` gains a `sharding_group`; when set, the block
  applies `sum_gradients` on the input and `mx.distributed.all_sum` on the
  output. The router gate stays replicated. The expert-weighted sum gets
  `.astype(y.dtype)` for dtype parity with `glm4_moe`.
- `Model.shard(group)`: attention `q/k/v_proj` sharded all-to-sharded,
  `o_proj` sharded-to-all, with `n_heads` / `n_kv_heads` divided by the
  group size; dense-MLP layers (`mlp_only_layers` / `decoder_sparse_step`)
  sharded via `shard_linear`; MoE layers sharded in place on
  `switch_mlp.{gate,down,up}_proj` via `shard_inplace`.
- Adds a tiny `qwen3_moe` config (including a dense `mlp_only_layers=[0]`
  layer so both MLP branches are exercised) to
  `tests/model_parallel_tests.py::test_shard`.

## Verification

- `tests/model_parallel_tests.py`: 1 passed, 4 subtests passed (the new
  qwen3_moe subtest shards with a size-1 group and matches the unsharded
  output).
- `tests/test_models.py -k qwen3`: 3 passed.
- Hardware verification of the same change (originally applied on top of
  the 0.31.3 release): bit-exact vs unsharded at group size 1 (float and
  4-bit); max abs logit diff ~3e-8 at group size 2 on a local ring (float
  and 4-bit); sustained 2-node run of mlx-community/Qwen3-235B-A22B-4bit
  sharded across two Apple Silicon machines over RDMA (Thunderbolt 5),
  producing coherent generations.
- `black` / `isort --profile=black` clean.
