### PR TITLE
fix: wrap decode loops in generation_stream context for thread safety

### DIFF
--- a/mlx_lm/generate.py
+++ b/mlx_lm/generate.py
@@ -608,7 +608,9 @@ def speculative_generate_step(
                 num_draft = min(max_tokens - ntoks, num_draft_tokens)
                 draft_tokens = _draft_generate(draft_y, num_draft)
                 if prev_tokens is not None:
-                    prev_tokens = prev_tokens[: prev_tokens.size - y.size - num_draft + 1]
+                    prev_tokens = prev_tokens[
+                        : prev_tokens.size - y.size - num_draft + 1
+                    ]
                 y = mx.concatenate([y, draft_tokens])
                 tokens, logprobs = _step(model, model_cache, y, num_draft + 1)
                 mx.eval(tokens, draft_tokens)

--- a/mlx_lm/generate.py
+++ b/mlx_lm/generate.py
@@ -443,22 +443,23 @@ def generate_step(
 
         y, logprobs = _step(input_tokens=prompt, input_embeddings=input_embeddings)
 
-    mx.async_eval(y, logprobs)
-    n = 0
-    while True:
-        if n != max_tokens:
-            next_y, next_logprobs = _step(y)
-            mx.async_eval(next_y, next_logprobs)
-        if n == 0:
-            mx.eval(y)
-            prompt_progress_callback(total_prompt_tokens, total_prompt_tokens)
-        if n == max_tokens:
-            break
-        yield y.item(), logprobs
-        if n % 256 == 0:
-            mx.clear_cache()
-        y, logprobs = next_y, next_logprobs
-        n += 1
+    with mx.stream(generation_stream):
+        mx.async_eval(y, logprobs)
+        n = 0
+        while True:
+            if n != max_tokens:
+                next_y, next_logprobs = _step(y)
+                mx.async_eval(next_y, next_logprobs)
+            if n == 0:
+                mx.eval(y)
+                prompt_progress_callback(total_prompt_tokens, total_prompt_tokens)
+            if n == max_tokens:
+                break
+            yield y.item(), logprobs
+            if n % 256 == 0:
+                mx.clear_cache()
+            y, logprobs = next_y, next_logprobs
+            n += 1
 
 
 def speculative_generate_step(
@@ -595,54 +596,54 @@ def speculative_generate_step(
         draft_y = _prefill(draft_model, draft_cache, y)
         y = _prefill(model, model_cache, y)
 
-    ntoks = 0
-    # Set these so the finally block doesn't raise
-    num_draft = 0
-    n = 0
-    try:
-        while True:
-            num_draft = min(max_tokens - ntoks, num_draft_tokens)
-            draft_tokens = _draft_generate(draft_y, num_draft)
-            if prev_tokens is not None:
-                prev_tokens = prev_tokens[: prev_tokens.size - y.size - num_draft + 1]
-            y = mx.concatenate([y, draft_tokens])
-            tokens, logprobs = _step(model, model_cache, y, num_draft + 1)
-            mx.eval(tokens, draft_tokens)
-            draft_tokens = draft_tokens.tolist()
-            tokens = tokens.tolist()
-            n = 0
-            while n < num_draft:
-                tn, dtn, lpn = tokens[n], draft_tokens[n], logprobs[n]
-                if tn != dtn:
-                    break
-                n += 1
-                ntoks += 1
-                yield tn, lpn, True
+        ntoks = 0
+        # Set these so the finally block doesn't raise
+        num_draft = 0
+        n = 0
+        try:
+            while True:
+                num_draft = min(max_tokens - ntoks, num_draft_tokens)
+                draft_tokens = _draft_generate(draft_y, num_draft)
+                if prev_tokens is not None:
+                    prev_tokens = prev_tokens[: prev_tokens.size - y.size - num_draft + 1]
+                y = mx.concatenate([y, draft_tokens])
+                tokens, logprobs = _step(model, model_cache, y, num_draft + 1)
+                mx.eval(tokens, draft_tokens)
+                draft_tokens = draft_tokens.tolist()
+                tokens = tokens.tolist()
+                n = 0
+                while n < num_draft:
+                    tn, dtn, lpn = tokens[n], draft_tokens[n], logprobs[n]
+                    if tn != dtn:
+                        break
+                    n += 1
+                    ntoks += 1
+                    yield tn, lpn, True
+                    if ntoks == max_tokens:
+                        break
+                if ntoks < max_tokens:
+                    ntoks += 1
+                    yield tokens[n], logprobs[n], False
+
                 if ntoks == max_tokens:
                     break
-            if ntoks < max_tokens:
-                ntoks += 1
-                yield tokens[n], logprobs[n], False
 
-            if ntoks == max_tokens:
-                break
+                y = mx.array([tokens[n]], mx.uint32)
+                draft_y = y
 
-            y = mx.array([tokens[n]], mx.uint32)
-            draft_y = y
+                # If we accepted all the draft tokens, include the last
+                # draft token in the next draft step since it hasn't been
+                # processed yet by the draft model
+                if n == num_draft:
+                    draft_y = mx.concatenate(
+                        [mx.array(draft_tokens[-1:], mx.uint32), draft_y]
+                    )
 
-            # If we accepted all the draft tokens, include the last
-            # draft token in the next draft step since it hasn't been
-            # processed yet by the draft model
-            if n == num_draft:
-                draft_y = mx.concatenate(
-                    [mx.array(draft_tokens[-1:], mx.uint32), draft_y]
-                )
-
-            if prev_tokens is not None:
-                prev_tokens = prev_tokens[: -max(num_draft - n, 1)]
+                if prev_tokens is not None:
+                    prev_tokens = prev_tokens[: -max(num_draft - n, 1)]
+                _rewind_cache(num_draft, n)
+        finally:
             _rewind_cache(num_draft, n)
-    finally:
-        _rewind_cache(num_draft, n)
 
 
 def stream_generate(

--- a/tests/test_generate.py
+++ b/tests/test_generate.py
@@ -877,7 +877,6 @@ class TestGenerate(unittest.TestCase):
         self.assertIsNone(response.logprobs)
         self.assertIsNone(response.token_ids)
 
-
     def test_generate_step_worker_thread(self):
         """generate_step must not crash on a non-main thread.
 

--- a/tests/test_generate.py
+++ b/tests/test_generate.py
@@ -1,6 +1,8 @@
 # Copyright © 2024 Apple Inc.
 
+import concurrent.futures
 import random
+import threading
 import unittest
 from typing import List
 
@@ -13,6 +15,7 @@ from mlx_lm.generate import (
     batch_generate,
     generate,
     generate_step,
+    generation_stream,
     stream_generate,
 )
 from mlx_lm.models.cache import KVCache, RotatingKVCache
@@ -843,6 +846,58 @@ class TestGenerate(unittest.TestCase):
         )
         self.assertIsNone(response.logprobs)
         self.assertIsNone(response.token_ids)
+
+
+    def test_generate_step_worker_thread(self):
+        """generate_step must not crash on a non-main thread.
+
+        Servers like vllm-mlx run generation on worker threads.  The decode
+        loop in generate_step calls mx.async_eval which needs a valid stream.
+        Without the generation_stream context wrapping the decode loop, this
+        crashes with ``RuntimeError: There is no Stream(gpu, N) in current
+        thread`` because the thread-local default stream doesn't exist on the
+        worker.
+        """
+        import mlx_lm.generate as gen_mod
+
+        prompt = self.tokenizer.encode("hi")
+        prompt = mx.array(prompt)
+
+        def run_on_worker():
+            new_stream = mx.new_stream(mx.default_device())
+            mx.set_default_stream(new_stream)
+            gen_mod.generation_stream = new_stream
+
+            tokens = []
+            for token, _ in generate_step(prompt, self.model, max_tokens=3):
+                tokens.append(token)
+            return tokens
+
+        with concurrent.futures.ThreadPoolExecutor(max_workers=1) as pool:
+            future = pool.submit(run_on_worker)
+            tokens = future.result(timeout=30)
+        self.assertGreater(len(tokens), 0)
+
+    def test_stream_generate_worker_thread(self):
+        """stream_generate must not crash on a non-main thread."""
+        import mlx_lm.generate as gen_mod
+
+        def run_on_worker():
+            new_stream = mx.new_stream(mx.default_device())
+            mx.set_default_stream(new_stream)
+            gen_mod.generation_stream = new_stream
+
+            tokens = []
+            for response in stream_generate(
+                self.model, self.tokenizer, "hello", max_tokens=3
+            ):
+                tokens.append(response.token)
+            return tokens
+
+        with concurrent.futures.ThreadPoolExecutor(max_workers=1) as pool:
+            future = pool.submit(run_on_worker)
+            tokens = future.result(timeout=30)
+        self.assertGreater(len(tokens), 0)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

The decode loops in `generate_step` and `speculative_generate_step` run `mx.async_eval` **outside** the `with mx.stream(generation_stream):` context manager. On the main thread this works because the default stream happens to be valid, but on **worker threads** (as used by inference servers like [vllm-mlx](https://github.com/vllm-project/vllm-mlx)) the thread-local default stream does not exist, causing:

```
RuntimeError: There is no Stream(gpu, N) in current thread.
```

This makes **tool/function calling impossible** on any server that dispatches generation to worker threads, since the request crashes as soon as decoding begins. Non-tool chat works because it takes a different code path.

## Root cause

`generation_stream` is created with `mx.new_thread_local_stream()` at module import time (line 217). The `_step` function correctly uses `with mx.stream(generation_stream):`, but the surrounding decode loop — which calls `mx.async_eval(y, logprobs)`, `mx.eval(y)`, and `mx.clear_cache()` — runs **outside** that context. These calls fall back to the implicit default stream, which is stale/absent on worker threads.

vllm-mlx's `bind_generation_streams()` ([PR #411](https://github.com/vllm-project/vllm-mlx/pull/411)) attempted to fix this by rebinding `generation_stream` and calling `mx.set_default_stream()`, but `mx.async_eval` still crashes because the thread-local stream created by `mx.new_thread_local_stream` at import time doesn't exist in the worker thread.

## Fix

Wrap both decode loops in `with mx.stream(generation_stream):` so all MLX operations use the explicitly rebound stream:

- `generate_step`: lines 446–461 (the token-by-token decode loop)
- `speculative_generate_step`: lines 598–645 (the speculative decode loop)

## Tests

Two new tests run `generate_step` and `stream_generate` on a worker thread via `concurrent.futures.ThreadPoolExecutor`, rebinding the generation stream the same way a real server would. Without this fix they crash; with it they complete normally.

## Related

- vllm-project/vllm-mlx#407 — original report of the stream crash
- vllm-project/vllm-mlx#411 — partial fix (stream rebinding) that doesn't cover the decode loop