### PR TITLE
Make "state" of cache return full state

### DIFF
--- a/mlx_lm/models/afm7.py
+++ b/mlx_lm/models/afm7.py
@@ -358,7 +358,7 @@ class AFMModel(nn.Module):
         for layer, c in zip(self.layers, cache):
             h = layer(h, mask, cache=c)
 
-        keys, values = cache[-1].state
+        keys, values = cache[-1].keys_and_values()
         for layer in self.kv_reuse_layers:
             h = layer(h, keys, values, mask)
 

--- a/mlx_lm/models/cache.py
+++ b/mlx_lm/models/cache.py
@@ -52,12 +52,29 @@ def save_prompt_cache(
         metadata (Dict[str, str]): Optional metadata to save along with model
             state.
     """
-    metadata = {} if metadata is None else metadata
-    cache_data = [c.state for c in cache]
-    cache_info = [c.meta_state for c in cache]
-    cache_data = dict(tree_flatten(cache_data))
+    scalars = [""]  # must be non-empty otherwise tree_flatten drops it
+
+    # Convert scalars to mx.array so they can be serialized
+    def map_data(item):
+        i, data = item
+        if isinstance(data, mx.array):
+            return item
+        elif isinstance(data, (int, float, bool)):
+            scalars.append((i, "scalar"))
+            return (i, mx.array(data))
+        elif isinstance(data, str):
+            scalars.append((i, "string"))
+            return (i, mx.array([c for c in data.encode("utf-8")]))
+        elif data is None:
+            scalars.append((i, "none"))
+            return (i, mx.array([]))
+        else:
+            raise ValueError(f"Model state is not serializable: {data}")
+
+    cache_data = tree_flatten([c.state for c in cache])
+    cache_data = dict(map(map_data, cache_data))
     cache_classes = [type(c).__name__ for c in cache]
-    cache_metadata = [cache_info, metadata, cache_classes]
+    cache_metadata = [metadata or {}, cache_classes, scalars]
     cache_metadata = dict(tree_flatten(cache_metadata))
     mx.save_safetensors(file_name, cache_data, cache_metadata)
 
@@ -76,13 +93,20 @@ def load_prompt_cache(file_name, return_metadata=False):
             the metadata if requested.
     """
     arrays, cache_metadata = mx.load(file_name, return_metadata=True)
-    arrays = tree_unflatten(list(arrays.items()))
     cache_metadata = tree_unflatten(list(cache_metadata.items()))
-    info, metadata, classes = cache_metadata
-    cache = [
-        globals()[c].from_state(state, meta_state)
-        for c, state, meta_state in zip(classes, arrays, info)
-    ]
+    metadata, classes, scalars = cache_metadata
+    for pos, type in scalars[1:]:
+        array = arrays[pos]
+        if type == "scalar":
+            arrays[pos] = array.item()
+        elif type == "string":
+            arrays[pos] = "".join(chr(i) for i in array.tolist())
+        elif type == "none":
+            arrays[pos] = None
+        else:
+            raise ValueError(f"[load_prompt_cache] Unknown type {type}")
+    arrays = tree_unflatten(list(arrays.items()))
+    cache = [globals()[c].from_state(state) for c, state in zip(classes, arrays)]
     if return_metadata:
         return cache, metadata
     return cache
@@ -137,15 +161,6 @@ class _BaseCache:
         if v is not None and v:
             raise ValueError("This cache has no state but a state was set.")
 
-    @property
-    def meta_state(self):
-        return ""
-
-    @meta_state.setter
-    def meta_state(self, v):
-        if v is not None and v:
-            raise ValueError("This cache has no meta_state but a meta_state was set.")
-
     def is_trimmable(self):
         return False
 
@@ -170,11 +185,10 @@ class _BaseCache:
         raise NotImplementedError("Cache sub-class must implement this.")
 
     @classmethod
-    def from_state(cls, state, meta_state):
+    def from_state(cls, state):
         # Create an instance of cls without calling __init__
         obj = cls.__new__(cls)
         obj.state = state
-        obj.meta_state = meta_state
         return obj
 
 
@@ -199,7 +213,9 @@ class ConcatenateKVCache(_BaseCache):
             self.keys = mx.concatenate([self.keys, keys], axis=-2)
             self.values = mx.concatenate([self.values, values], axis=-2)
         self.offset = self.keys.shape[-2]
+        return self.keys_and_values()
 
+    def keys_and_values(self):
         return self.keys, self.values
 
     @property
@@ -283,10 +299,9 @@ class QuantizedKVCache(_BaseCache):
             self.keys[i][..., prev : self.offset, :] = keys[i]
             self.values[i][..., prev : self.offset, :] = values[i]
 
-        return tree_map(lambda x: x[..., : self.offset, :], (self.keys, self.values))
+        return self.keys_and_values()
 
-    @property
-    def state(self):
+    def keys_and_values(self):
         if self.offset == self.keys[0].shape[2]:
             return self.keys, self.values
         else:
@@ -294,17 +309,13 @@ class QuantizedKVCache(_BaseCache):
                 lambda x: x[..., : self.offset, :], (self.keys, self.values)
             )
 
+    @property
+    def state(self):
+        return self.keys, self.values, self.offset, self.group_size, self.bits
+
     @state.setter
     def state(self, v):
-        self.keys, self.values = v
-
-    @property
-    def meta_state(self):
-        return tuple(map(str, (self.offset, self.group_size, self.bits)))
-
-    @meta_state.setter
-    def meta_state(self, v):
-        self.offset, self.group_size, self.bits = map(int, v)
+        self.keys, self.values, self.offset, self.group_size, self.bits = v
 
     def is_trimmable(self):
         return True
@@ -355,25 +366,24 @@ class KVCache(_BaseCache):
         self.offset += keys.shape[2]
         self.keys[..., prev : self.offset, :] = keys
         self.values[..., prev : self.offset, :] = values
-        return self.keys[..., : self.offset, :], self.values[..., : self.offset, :]
+        return self.keys_and_values()
+
+    def keys_and_values(self):
+        if self.offset < self.keys.shape[2]:
+            return self.keys[..., : self.offset, :], self.values[..., : self.offset, :]
+        else:
+            return self.keys, self.values
 
     def size(self):
         return self.offset
 
     @property
     def state(self):
-        if self.offset == self.keys.shape[2]:
-            return self.keys, self.values
-        else:
-            return (
-                self.keys[..., : self.offset, :],
-                self.values[..., : self.offset, :],
-            )
+        return self.keys, self.values, self.offset
 
     @state.setter
     def state(self, v):
-        self.keys, self.values = v
-        self.offset = self.keys.shape[2]
+        self.keys, self.values, self.offset = v
 
     def is_trimmable(self):
         return True
@@ -507,40 +517,29 @@ class RotatingKVCache(_BaseCache):
         self.offset += S
         self._idx += S
 
-        # If the buffer is not full, slice off the end
-        if self.offset < self.max_size:
-            return self.keys[..., : self.offset, :], self.values[..., : self.offset, :]
-        return self.keys, self.values
+        return self.keys_and_values()
 
     def update_and_fetch(self, keys, values):
         if keys.shape[2] == 1:
             return self._update_in_place(keys, values)
         return self._update_concat(keys, values)
 
-    def size(self):
-        return min(self.offset, self.max_size)
-
-    @property
-    def state(self):
+    def keys_and_values(self):
         if self.offset < self.keys.shape[2]:
             return self.keys[..., : self.offset, :], self.values[..., : self.offset, :]
         else:
             return self.keys, self.values
 
-    @state.setter
-    def state(self, v):
-        self.keys, self.values = v
+    def size(self):
+        return min(self.offset, self.max_size)
 
     @property
-    def meta_state(self):
-        return tuple(map(str, (self.keep, self.max_size, self.offset, self._idx)))
+    def state(self):
+        return self.keys, self.values, self.offset, self.keep, self.max_size, self._idx
 
-    @meta_state.setter
-    def meta_state(self, v):
-        self.keep, self.max_size, self.offset, self._idx = map(
-            int,
-            v,
-        )
+    @state.setter
+    def state(self, v):
+        self.keys, self.values, self.offset, self.keep, self.max_size, self._idx = v
 
     def is_trimmable(self):
         return self.offset < self.max_size
@@ -595,16 +594,10 @@ class RotatingKVCache(_BaseCache):
 
 
 class ArraysCache(_BaseCache):
-    def __new__(cls, *args, **kwargs):
-        instance = super().__new__(cls)
-        instance.left_padding = None
-        instance.lengths = None
-        return instance
-
     def __init__(self, size, left_padding: Optional[List[int]] = None):
         self.cache = [None] * size
-        if left_padding:
-            self.left_padding = mx.array(left_padding)
+        self.left_padding = mx.array(left_padding) if left_padding else None
+        self.lengths = None
 
     @property
     def batch_size(self):
@@ -626,16 +619,11 @@ class ArraysCache(_BaseCache):
 
     @property
     def state(self):
-        # None can not be seralized so return empty array instead
-        left_padding = mx.array([]) if self.left_padding is None else self.left_padding
-        lengths = mx.array([]) if self.lengths is None else self.lengths
-        return self.cache, left_padding, lengths
+        return self.cache, self.left_padding, self.lengths
 
     @state.setter
     def state(self, v):
-        self.cache, left_padding, lengths = v
-        self.left_padding = left_padding if left_padding.size > 0 else None
-        self.lengths = lengths if lengths.size > 0 else None
+        self.cache, self.left_padding, self.lengths = v
 
     def filter(self, batch_indices):
         """
@@ -780,22 +768,19 @@ class ChunkedKVCache(_BaseCache):
         end = self.offset - self.start_position
         self.keys[..., prev:end, :] = keys
         self.values[..., prev:end, :] = values
+        return self.keys_and_values()
+
+    def keys_and_values(self):
+        end = self.offset - self.start_position
         return self.keys[..., :end, :], self.values[..., :end, :]
 
     @property
     def state(self):
-        if self.offset == self.keys.shape[2]:
-            return self.keys, self.values
-        else:
-            return (
-                self.keys[..., : self.offset, :],
-                self.values[..., : self.offset, :],
-            )
+        return self.keys, self.values, self.offset, self.chunk_size, self.start_position
 
     @state.setter
     def state(self, v):
-        self.keys, self.values = v
-        self.offset = self.keys.shape[2]
+        self.keys, self.values, self.offset, self.chunk_size, self.start_position = v
 
     def is_trimmable(self):
         return True
@@ -804,14 +789,6 @@ class ChunkedKVCache(_BaseCache):
         n = min(self.offset - self.start_position, n)
         self.offset -= n
         return n
-
-    @property
-    def meta_state(self):
-        return tuple(map(str, (self.chunk_size, self.start_position)))
-
-    @meta_state.setter
-    def meta_state(self, v):
-        self.chunk_size, self.start_position = map(int, v)
 
     def empty(self):
         return self.keys is None
@@ -840,24 +817,11 @@ class CacheList(_BaseCache):
 
     @property
     def state(self):
-        return [c.state for c in self.caches]
+        return [(c.state, type(c).__name__) for c in self.caches]
 
     @state.setter
     def state(self, v):
-        for c, s in zip(self.caches, v):
-            c.state = s
-
-    @property
-    def meta_state(self):
-        return (
-            [type(c).__name__ for c in self.caches],
-            [c.meta_state for c in self.caches],
-        )
-
-    @meta_state.setter
-    def meta_state(self, v):
-        for c, m in zip(self.caches, v[1]):
-            c.meta_state = m
+        self.caches = [globals()[c].from_state(s) for s, c in v]
 
     def filter(self, batch_indices):
         """
@@ -902,14 +866,6 @@ class CacheList(_BaseCache):
     @property
     def nbytes(self):
         return sum(c.nbytes for c in self.caches)
-
-    @classmethod
-    def from_state(cls, state, meta_state):
-        obj = cls.__new__(cls)
-        obj.caches = [
-            globals()[c].from_state(s, m) for s, c, m in zip(state, *meta_state)
-        ]
-        return obj
 
 
 def dynamic_roll(x, shifts, axis):
@@ -974,6 +930,9 @@ class BatchKVCache(_BaseCache):
         self._idx += keys.shape[2]
         self.keys[..., prev : self._idx, :] = keys
         self.values[..., prev : self._idx, :] = values
+        return self.keys_and_values()
+
+    def keys_and_values(self):
         return self.keys[..., : self._idx, :], self.values[..., : self._idx, :]
 
     def prepare(self, *, left_padding=None, lengths=None, right_padding=None):
@@ -1000,16 +959,11 @@ class BatchKVCache(_BaseCache):
 
     @property
     def state(self):
-        k, v = self.keys, self.values
-        if self._idx < k.shape[2]:
-            k = k[..., : self._idx, :]
-            v = v[..., : self._idx, :]
-        return k, v, self.offset, self.left_padding
+        return self.keys, self.values, self.offset, self.left_padding, self._idx
 
     @state.setter
     def state(self, v):
-        self.keys, self.values, self.offset, self.left_padding = v
-        self._idx = self.keys.shape[2]
+        self.keys, self.values, self.offset, self.left_padding, self._idx = v
 
     def is_trimmable(self):
         return True
@@ -1270,18 +1224,21 @@ class BatchRotatingKVCache(_BaseCache):
         # Make sure left_padding and offset are evaluated
         self.keys = mx.depends(self.keys, (self.left_padding, self.offset))
 
-        # If the buffer is not full, slice off the end
-        if self._offset < self.max_size:
-            return (
-                self.keys[..., : self._offset, :],
-                self.values[..., : self._offset, :],
-            )
-        return self.keys, self.values
+        return self.keys_and_values()
 
     def update_and_fetch(self, keys, values):
         if keys.shape[2] == 1:
             return self._update_in_place(keys, values)
         return self._update_concat(keys, values)
+
+    def keys_and_values(self):
+        if self._offset < self.keys.shape[2]:
+            return (
+                self.keys[..., : self._offset, :],
+                self.values[..., : self._offset, :],
+            )
+        else:
+            return self.keys, self.values
 
     def prepare(self, *, left_padding=None, lengths=None, right_padding=None):
         if left_padding is not None:
@@ -1307,26 +1264,29 @@ class BatchRotatingKVCache(_BaseCache):
 
     @property
     def state(self):
-        k, v = self.keys, self.values
-        if self._offset < k.shape[2]:
-            k, v = k[..., : self._offset, :], v[..., : self._offset, :]
-        return k, v, self.offset, self.left_padding
+        return (
+            self.keys,
+            self.values,
+            self.offset,
+            self.left_padding,
+            self.max_size,
+            self._offset,
+            self._idx,
+            self.rotated,
+        )
 
     @state.setter
     def state(self, v):
-        self.keys, self.values, self.offset, self.left_padding = v
-
-    @property
-    def meta_state(self):
-        return tuple(map(str, (self.max_size, self._offset, self._idx, self.rotated)))
-
-    @meta_state.setter
-    def meta_state(self, v):
-        self.max_size, self._offset, self._idx = map(
-            int,
-            v[:3],
-        )
-        self.rotated = bool(v[3])
+        (
+            self.keys,
+            self.values,
+            self.offset,
+            self.left_padding,
+            self.max_size,
+            self._offset,
+            self._idx,
+            self.rotated,
+        ) = v
 
     def is_trimmable(self):
         return self._offset < self.max_size

--- a/mlx_lm/models/cache.py
+++ b/mlx_lm/models/cache.py
@@ -64,7 +64,7 @@ def save_prompt_cache(
             return (i, mx.array(data))
         elif isinstance(data, str):
             scalars.append((i, "string"))
-            return (i, mx.array([c for c in data.encode("utf-8")]))
+            return (i, mx.array([ord(char) for char in data]))
         elif data is None:
             scalars.append((i, "none"))
             return (i, mx.array([]))

--- a/mlx_lm/models/gemma3n.py
+++ b/mlx_lm/models/gemma3n.py
@@ -130,7 +130,7 @@ class Gemma3nAttention(nn.Module):
         offset = 0
         if self.is_kv_shared_layer and cache is not None:
             # For shared layers, retrieve KV from the designated cache layer
-            keys, values = cache.state
+            keys, values = cache.keys_and_values()
             offset = cache.offset
 
         else:

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -358,7 +358,7 @@ class TestModels(unittest.TestCase):
         v = 1e-1 * mx.random.normal(shape=(B, n_kv_heads, L, D))
         k_up, v_up = cache.update_and_fetch(k, v)
         quant_cache = cache.to_quantized(group_size=32, bits=8)
-        qk_up, qv_up = quant_cache.state
+        qk_up, qv_up = quant_cache.keys_and_values()
 
         q = 1e-1 * mx.random.normal(shape=(B, n_q_heads, L, D))
 

--- a/tests/test_prompt_cache.py
+++ b/tests/test_prompt_cache.py
@@ -390,13 +390,19 @@ class TestPromptCache(unittest.TestCase):
             mx.random.normal(shape=(1, 2, 7, 4)), mx.random.normal(shape=(1, 2, 7, 4))
         )
 
+        def compare_keys_and_values(a, b):
+            ka, va = a.keys_and_values()
+            kb, vb = b.keys_and_values()
+            self.assertTrue(mx.array_equal(ka, kb))
+            self.assertTrue(mx.array_equal(va, vb))
+
         merged_cache = CacheList.merge((c1, c2))
         c1_ex = merged_cache.extract(0)
         self.assertTrue(mx.array_equal(c1_ex[0][0], c1[0][0]))
-        self.assertTrue(mx.array_equal(c1_ex[1].state[0], c1[1].state[0]))
+        compare_keys_and_values(c1_ex[1], c1[1])
         c2_ex = merged_cache.extract(1)
         self.assertTrue(mx.array_equal(c2_ex[0][0], c2[0][0]))
-        self.assertTrue(mx.array_equal(c2_ex[1].state[0], c2[1].state[0]))
+        compare_keys_and_values(c2_ex[1], c2[1])
 
     def test_make_mask_with_cache(self):
         # For 1 time step with no cache, don't need a mask
@@ -507,7 +513,7 @@ class TestPromptCache(unittest.TestCase):
         cache.filter([0, 1])
 
         # In this case filtering left shifts the cache so it has zero padding
-        self.assertEqual(cache.state[0].shape, (2, 1, 2, 8))
+        self.assertEqual(cache.keys_and_values()[0].shape, (2, 1, 2, 8))
 
         mask = cache.make_mask(1)
         self.assertEqual(mask[0].squeeze().tolist(), [True, True, True])
@@ -626,6 +632,8 @@ class TestPromptCache(unittest.TestCase):
         for c, lc in zip(cache, loaded_cache):
             self.assertTrue(mx.array_equal(c.left_padding, left_padding))
             self.assertTrue(mx.array_equal(lc.left_padding, left_padding))
+            if isinstance(c, BatchRotatingKVCache):
+                self.assertEqual(c.rotated, lc.rotated)
 
     def test_rotating_cache_updates(self):
         cache = RotatingKVCache(max_size=8)

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -617,7 +617,7 @@ class TestLRUPromptCache(unittest.TestCase):
         # lru cache
         tokens = tokens + [20] * 5
         c, t = cache.fetch_nearest_cache(model, tokens)
-        k, v = c[0].state
+        k, v = c[0].keys_and_values()
         self.assertTrue((k == v).all().item())
         self.assertTrue((k.flatten() == mx.arange(24)).all().item())
         self.assertEqual(t, [20] * 5)
@@ -632,7 +632,7 @@ class TestLRUPromptCache(unittest.TestCase):
         # Fetching a cache with a shared prefix doesn't remove it either
         tokens = tokens[:26] + [40] * 8
         c, t = cache.fetch_nearest_cache(model, tokens)
-        k, v = c[0].state
+        k, v = c[0].keys_and_values()
         self.assertTrue((k == v).all().item())
         self.assertTrue(
             (k.flatten() == mx.concatenate([mx.arange(24), mx.arange(2)])).all().item()


### PR DESCRIPTION
Make padded kv cache return raw keys/values/offset in `state`, so they would still be padded after restoration, which is required for optimized sdpa kernels to kick in.

A few more refactoring to make this happen:
* Make `load/save_prompt_cache` recognize scalars in cache state and do automatic serialization/deserialization, so it is possible to return scalars in `state` and get rid of `meta_state`.
* Add a `keys_and_values()` method to return sliced keys/values, instead of relying on internal state of `state` property.

As a side effect also fixes https://github.com/ml-explore/mlx-lm/issues/1250, fixes #1384.