### PR TITLE
Periodically evaluate cache state during decode (#1662)

### DIFF
--- a/mlx_lm/generate.py
+++ b/mlx_lm/generate.py
@@ -46,6 +46,13 @@ DEFAULT_SEED = None
 DEFAULT_MODEL = "mlx-community/Llama-3.2-3B-Instruct-4bit"
 DEFAULT_QUANTIZED_KV_START = 5000
 
+# How often (in decode steps) to materialize the KV cache state. Cache fields
+# that the sampled-token graph never reads accumulate one unevaluated in-place
+# update per step otherwise, pinning a Metal buffer each until the runtime's
+# buffer-count limit aborts the process (#1662). Chunked prefill already
+# evaluates cache state per chunk; decode needs the same, just less often.
+CACHE_STATE_EVAL_INTERVAL = 256
+
 
 def str2bool(string):
     return string.lower() not in ["false", "f"]
@@ -455,7 +462,8 @@ def generate_step(
         if n == max_tokens:
             break
         yield y.item(), logprobs
-        if n % 256 == 0:
+        if n % CACHE_STATE_EVAL_INTERVAL == 0:
+            mx.eval([c.state for c in prompt_cache])
             mx.clear_cache()
         y, logprobs = next_y, next_logprobs
         n += 1
@@ -1360,6 +1368,7 @@ class GenerationBatch:
 
         self._current_tokens = None
         self._current_logprobs = []
+        self._decode_steps = 0
         self._next_tokens = inputs
         self._next_logprobs = []
         self._token_context = [TokenBuffer(t) for t in tokens]
@@ -1448,7 +1457,13 @@ class GenerationBatch:
         # asynchronously
         self._next_tokens = sampled
         self._next_logprobs = list(logprobs)
-        mx.async_eval(self._next_tokens, self._next_logprobs, token_context)
+        self._decode_steps += 1
+        eval_targets = [self._next_tokens, self._next_logprobs, token_context]
+        if self._decode_steps % CACHE_STATE_EVAL_INTERVAL == 0:
+            # Fold the cache state into the eval already happening this step;
+            # see CACHE_STATE_EVAL_INTERVAL for why.
+            eval_targets.append([c.state for c in self.prompt_cache])
+        mx.async_eval(*eval_targets)
 
         # Eval the current tokens and current logprobs. After that also add
         # them to self.tokens so that it always represents the tokens contained


### PR DESCRIPTION
Fixes #1662.

## What

Cache fields that the sampled-token graph never reads accumulate one
unevaluated in-place update per decode step, each pinning a Metal buffer.
Long generations hit the runtime's buffer-count limit (`[metal::malloc]
Resource limit (499000) exceeded`) — ~11k generated tokens on a 43-layer
model — and #1662 reports the crash wedging the GPU driver hard enough to
panic the host. `deepseek_v4`-style attention (K==V, values discarded) is
the shipping trigger, but any cache field a model leaves unread has the
same failure mode.

Chunked prefill already materializes cache state once per chunk; decode
never did. This folds cache state into the evals both decode paths already
perform, every 256 steps (option 1 from the issue):

- `generate_step`: evaluate cache state on the existing `n % 256`
  maintenance branch, next to `clear_cache`.
- `GenerationBatch._step`: append cache state to the `async_eval` the step
  already issues — no extra synchronization.

The speculative path is left as-is: it trims the caches every iteration,
which bounds the chain. Same class of bug as #1632 (ArraysCache metadata),
one level down.

## Validation (M5 Max 128 GB)

- Greedy outputs unchanged through both paths across the interval boundary
  (Llama-3.2-1B, 600 tokens single + 400 tokens batched).
- DeepSeek-V4-Flash 2-bit (mlx-community OptiQ, served resident): without
  the patch, generation died deterministically at ~10-11k generated tokens
  per process (`[metal::malloc] Resource limit (499000) exceeded`, hit
  three times across two server front-ends). With the patch, a single
  15,000-token request completed with `finish_reason: length` and zero
  buffer-limit errors in the server log (1576 s, 9.5 tok/s).
- Throughput unchanged (the added evals ride existing sync points).

The #1662 author runs the call-site workaround in production and offered
to validate a library-side patch on the same workload.
