### PR TITLE
Proposal: Add --prefill-step-size also to mlx_lm.generate and mlx_lm.chat for speed/memory usage trade-off

### DIFF
--- a/README.md
+++ b/README.md
@@ -200,11 +200,18 @@ Face Space.
 
 - A rotating fixed-size key-value cache.
 - Prompt caching
+- A configurable prefill step size
 
 To use the rotating key-value cache pass the argument `--max-kv-size n` where
 `n` can be any integer. Smaller values like `512` will use very little RAM but
 result in worse quality. Larger values like `4096` or higher will use more RAM
 but have better quality.
+
+Long prompts are read in steps, and the step size sets how many prompt tokens
+are processed at once. Smaller steps use less peak memory while the prompt is
+read, at some cost to prompt processing speed. To change it pass
+`--prefill-step-size n`. The default is `2048`, and `mlx_lm.generate`,
+`mlx_lm.chat`, `mlx_lm.server` and `mlx_lm.benchmark` all accept it.
 
 Caching prompts can substantially speedup reusing the same long context with
 different queries. To cache a prompt use `mlx_lm.cache_prompt`. For example:

--- a/mlx_lm/chat.py
+++ b/mlx_lm/chat.py
@@ -16,6 +16,7 @@ DEFAULT_XTC_PROBABILITY = 0.0
 DEFAULT_XTC_THRESHOLD = 0.0
 DEFAULT_SEED = 0
 DEFAULT_MAX_TOKENS = 256
+DEFAULT_PREFILL_STEP_SIZE = 2048
 DEFAULT_MODEL = "mlx-community/Llama-3.2-3B-Instruct-4bit"
 
 
@@ -67,6 +68,13 @@ def setup_arg_parser():
         type=int,
         help="Set the maximum key-value cache size",
         default=None,
+    )
+    parser.add_argument(
+        "--prefill-step-size",
+        type=int,
+        default=DEFAULT_PREFILL_STEP_SIZE,
+        help="Number of prompt tokens to process at a time. Smaller values "
+        f"lower peak memory during prefill (default: {DEFAULT_PREFILL_STEP_SIZE})",
     )
     parser.add_argument(
         "--max-tokens",
@@ -154,6 +162,7 @@ def main():
                     ),
                 ),
                 prompt_cache=prompt_cache,
+                prefill_step_size=args.prefill_step_size,
             ):
                 ui.stream_token(response.text)
                 last_response = response

--- a/mlx_lm/generate.py
+++ b/mlx_lm/generate.py
@@ -45,6 +45,7 @@ DEFAULT_MIN_TOKENS_TO_KEEP = 1
 DEFAULT_SEED = None
 DEFAULT_MODEL = "mlx-community/Llama-3.2-3B-Instruct-4bit"
 DEFAULT_QUANTIZED_KV_START = 5000
+DEFAULT_PREFILL_STEP_SIZE = 2048
 
 
 def str2bool(string):
@@ -166,6 +167,13 @@ def setup_arg_parser():
         type=int,
         help="Set the maximum key-value cache size",
         default=None,
+    )
+    parser.add_argument(
+        "--prefill-step-size",
+        type=int,
+        default=DEFAULT_PREFILL_STEP_SIZE,
+        help="Number of prompt tokens to process at a time. Smaller values "
+        f"lower peak memory during prefill (default: {DEFAULT_PREFILL_STEP_SIZE})",
     )
     parser.add_argument(
         "--prompt-cache-file",
@@ -2175,6 +2183,7 @@ def main():
         verbose=args.verbose,
         sampler=sampler,
         max_kv_size=args.max_kv_size,
+        prefill_step_size=args.prefill_step_size,
         prompt_cache=prompt_cache if using_cache else None,
         kv_bits=args.kv_bits,
         kv_group_size=args.kv_group_size,

--- a/tests/test_chat.py
+++ b/tests/test_chat.py
@@ -2,7 +2,7 @@ import argparse
 import unittest
 from unittest.mock import MagicMock, patch
 
-from mlx_lm.chat import setup_arg_parser
+from mlx_lm.chat import DEFAULT_PREFILL_STEP_SIZE, setup_arg_parser
 
 
 class TestChat(unittest.TestCase):
@@ -17,6 +17,12 @@ class TestChat(unittest.TestCase):
         # Test with system prompt
         args = parser.parse_args(["--system-prompt", "You are a helpful assistant."])
         self.assertEqual(args.system_prompt, "You are a helpful assistant.")
+
+    def test_setup_arg_parser_prefill_step_size_default(self):
+        parser = setup_arg_parser()
+
+        args = parser.parse_args([])
+        self.assertEqual(args.prefill_step_size, DEFAULT_PREFILL_STEP_SIZE)
 
     def test_setup_arg_parser_all_args(self):
         parser = setup_arg_parser()
@@ -38,6 +44,8 @@ class TestChat(unittest.TestCase):
                 "42",
                 "--max-kv-size",
                 "1024",
+                "--prefill-step-size",
+                "512",
                 "--max-tokens",
                 "512",
                 "--system-prompt",
@@ -53,6 +61,7 @@ class TestChat(unittest.TestCase):
         self.assertEqual(args.xtc_threshold, 0.1)
         self.assertEqual(args.seed, 42)
         self.assertEqual(args.max_kv_size, 1024)
+        self.assertEqual(args.prefill_step_size, 512)
         self.assertEqual(args.max_tokens, 512)
         self.assertEqual(args.system_prompt, "You are a helpful assistant.")
 

--- a/tests/test_generate.py
+++ b/tests/test_generate.py
@@ -7,17 +7,30 @@ from typing import List
 import mlx.core as mx
 
 from mlx_lm.generate import (
+    DEFAULT_PREFILL_STEP_SIZE,
     BatchGenerator,
     GenerationResponse,
     StopSequenceMatcher,
     batch_generate,
     generate,
     generate_step,
+    setup_arg_parser,
     stream_generate,
 )
 from mlx_lm.models.cache import KVCache, RotatingKVCache
 from mlx_lm.sample_utils import make_logits_processors, make_sampler
 from mlx_lm.utils import load
+
+
+class TestGenerateArgs(unittest.TestCase):
+
+    def test_prefill_step_size_default(self):
+        args = setup_arg_parser().parse_args([])
+        self.assertEqual(args.prefill_step_size, DEFAULT_PREFILL_STEP_SIZE)
+
+    def test_prefill_step_size_override(self):
+        args = setup_arg_parser().parse_args(["--prefill-step-size", "512"])
+        self.assertEqual(args.prefill_step_size, 512)
 
 
 class TestGenerate(unittest.TestCase):


### PR DESCRIPTION
## Summary

`prefill_step_size` is the largest lever on peak memory during long-prompt prefill, but it is only reachable from the command line on two of the four entry points. #943 added `--prefill-step-size` to `mlx_lm.server` and
`mlx_lm.benchmark`. `mlx_lm.generate` and `mlx_lm.chat` still hardcode the 2048 default, so a user who runs either of those has no way to set it short of writing Python.

This adds the same flag to both, with the same name, type and default.

## Why it matters

Measured on an M5 Max 128 GB, mlx-lm 0.31.3, macOS 26.6.1, `mlx-community/Qwen3.8-27B-4bit`, at a full 128K context:

| prefill step size | peak GB | generation tok/s | prefill tok/s |
|---|---|---|---|
| 2048 (default) | 39.78 | 21.31 | 431.5 |
| 1024 | 32.26 | 21.37 | 438.1 |
| 512 | 28.54 | 21.40 | 438.9 |
| 256 | 26.52 | 21.29 | 418.5 |

Going from 2048 to 512 drops peak memory by 11.2 GB, or 28%, at a 128K context.

## Changes

- `mlx_lm/generate.py`: add `DEFAULT_PREFILL_STEP_SIZE`, add the
  `--prefill-step-size` argument, and pass it through to `generate`.
- `mlx_lm/chat.py`: same, passed through to `stream_generate`.
- `tests/test_generate.py`: parser tests for the default and an override.
- `tests/test_chat.py`: extend the existing all-args test and add a default test.
- `README.md`: document the flag under "Long Prompts and Generations".

No behaviour changes when the flag is not passed. Both entry points keep the existing 2048 default, and the plumbing is a keyword argument that `generate_step` already accepts.

## Verification

```
python -m unittest test_chat test_generate.TestGenerateArgs
Ran 7 tests in 0.014s
OK
```

Confirmed end to end that the value reaches `generate_step`: with `--prefill-step-size 8` it receives 8, and with the flag absent it receives 2048.
