### PR TITLE
Periodically evaluate cache state during decode (#1662)

### DIFF
--- a/mlx_lm/generate.py
+++ b/mlx_lm/generate.py
@@ -42,6 +42,13 @@ DEFAULT_MODEL = "mlx-community/Llama-3.2-3B-Instruct-4bit"
 DEFAULT_QUANTIZED_KV_START = 5000
 DEFAULT_PREFILL_STEP_SIZE = 2048
 
+# How often (in decode steps) to materialize the KV cache state. Cache fields
+# that the sampled-token graph never reads accumulate one unevaluated in-place
+# update per step otherwise, pinning a Metal buffer each until the runtime's
+# buffer-count limit aborts the process (#1662). Chunked prefill already
+# evaluates cache state per chunk; decode needs the same, just less often.
+CACHE_STATE_EVAL_INTERVAL = 256
+
 
 def str2bool(string):
     return string.lower() not in ["false", "f"]
@@ -458,7 +465,8 @@ def generate_step(
         if n == max_tokens:
             break
         yield y.item(), logprobs
-        if n % 256 == 0:
+        if n % CACHE_STATE_EVAL_INTERVAL == 0:
+            mx.eval([c.state for c in prompt_cache])
             mx.clear_cache()
         y, logprobs = next_y, next_logprobs
         n += 1
@@ -1325,6 +1333,7 @@ class GenerationBatch:
 
         self._current_tokens = None
         self._current_logprobs = []
+        self._decode_steps = 0
         self._next_tokens = inputs
         self._next_logprobs = []
         self._token_context = [TokenBuffer(t) for t in tokens]
@@ -1413,7 +1422,13 @@ class GenerationBatch:
         # asynchronously
         self._next_tokens = sampled
         self._next_logprobs = list(logprobs)
-        mx.async_eval(self._next_tokens, self._next_logprobs, token_context)
+        self._decode_steps += 1
+        eval_targets = [self._next_tokens, self._next_logprobs, token_context]
+        if self._decode_steps % CACHE_STATE_EVAL_INTERVAL == 0:
+            # Fold the cache state into the eval already happening this step;
+            # see CACHE_STATE_EVAL_INTERVAL for why.
+            eval_targets.append([c.state for c in self.prompt_cache])
+        mx.async_eval(*eval_targets)
 
         # Eval the current tokens and current logprobs. After that also add
         # them to self.tokens so that it always represents the tokens contained

--- a/mlx_lm/generate.py
+++ b/mlx_lm/generate.py
@@ -465,7 +465,10 @@ def generate_step(
         if n == max_tokens:
             break
         yield y.item(), logprobs
-        if n % CACHE_STATE_EVAL_INTERVAL == 0:
+        # Skip n == 0: the interval only needs to bound long generations,
+        # and evaluating this early perturbs kernel fusion for very short
+        # ones for no benefit.
+        if n > 0 and n % CACHE_STATE_EVAL_INTERVAL == 0:
             mx.eval([c.state for c in prompt_cache])
             mx.clear_cache()
         y, logprobs = next_y, next_logprobs

--- a/tests/test_decode_cache_state.py
+++ b/tests/test_decode_cache_state.py
@@ -1,0 +1,130 @@
+# Copyright © 2024 Apple Inc.
+
+"""Regression tests for #1662.
+
+A cache field the sampled-token graph never reads (e.g. K == V windowed
+attention that discards the ``values`` half, as in ``deepseek_v4``)
+accumulates one unevaluated in-place update per decode step. Nothing
+downstream forces it to materialize, so the lazy graph grows without bound
+and eventually exceeds the runtime's Metal buffer-count limit.
+
+Model-free, mirroring the issue's own minimal repro and the testing style of
+the accepted fix for the same bug class in #1632 (``mx.export_to_dot`` +
+edge count on the field that must not keep accumulating).
+"""
+
+import io
+import unittest
+
+import mlx.core as mx
+
+from mlx_lm.generate import (
+    CACHE_STATE_EVAL_INTERVAL,
+    GenerationBatch,
+    StopSequenceMatcher,
+    generate_step,
+)
+from mlx_lm.sample_utils import make_sampler
+
+
+class _EchoCache:
+    """Keys are read by the model below; values are written every step and
+    never read back -- the exact shape of the leak in #1662, without
+    needing deepseek_v4 (or any other model) to reproduce it.
+    """
+
+    def __init__(self):
+        self.keys = mx.zeros((1, 1, 1, 8), mx.float32)
+        self.values = mx.zeros((1, 1, 1, 8), mx.float32)
+        self.offset = 0
+
+    def update_and_fetch(self, keys, values):
+        self.keys = mx.concatenate([self.keys, keys], axis=2)[..., -8:, :]
+        self.values = mx.concatenate([self.values, values], axis=2)[..., -8:, :]
+        self.offset += 1
+        return self.keys, self.values
+
+    @property
+    def state(self):
+        return self.keys, self.values
+
+    @state.setter
+    def state(self, v):
+        self.keys, self.values = v
+
+    def to_quantized(self, **kwargs):
+        return self
+
+    def extract(self, idx):
+        return self
+
+    def filter(self, keep):
+        pass
+
+
+class _LeakyModel:
+    """Writes ``cache.values`` every step and never reads it back, same
+    shape as deepseek_v4's attention (K == V, values half discarded)."""
+
+    def __call__(self, tokens, cache=None):
+        row = mx.ones((1, 1, 1, 8), mx.float32) * tokens.sum()
+        keys, _ = cache[0].update_and_fetch(row, row)
+        return mx.broadcast_to(
+            keys.sum()[None, None, None], (tokens.shape[0], tokens.shape[1], 4)
+        )
+
+
+def _dead_chain_edges(array):
+    f = io.StringIO()
+    mx.export_to_dot(f, array)
+    f.seek(0)
+    return f.read().count("->")
+
+
+class TestDecodeCacheStateEval(unittest.TestCase):
+    def _run_generate_step(self, n_steps):
+        cache = [_EchoCache()]
+        for _ in generate_step(
+            mx.array([0]), _LeakyModel(), max_tokens=n_steps, prompt_cache=cache
+        ):
+            pass
+        return _dead_chain_edges(cache[0].values)
+
+    def test_generate_step_bounds_cache_graph(self):
+        # Compare two run lengths rather than assert an absolute edge count:
+        # mx.export_to_dot's edge-per-op cost is an implementation detail,
+        # but "does the graph keep growing with total steps" is not. Without
+        # the periodic cache-state eval, values never gets materialized and
+        # the chain grows linearly with n_steps; with it, it is bounded by
+        # CACHE_STATE_EVAL_INTERVAL regardless of how long generation runs.
+        short = self._run_generate_step(CACHE_STATE_EVAL_INTERVAL * 2)
+        long = self._run_generate_step(CACHE_STATE_EVAL_INTERVAL * 8)
+        self.assertLess(long, short * 2)
+
+    def _run_generation_batch(self, n_steps):
+        cache = [_EchoCache()]
+        sole_cache = cache[0]  # batch.filter() clears the list in place
+        batch = GenerationBatch(
+            model=_LeakyModel(),
+            uids=[0],
+            inputs=mx.array([0]),
+            prompt_cache=cache,
+            tokens=[[0]],
+            samplers=[None],
+            fallback_sampler=make_sampler(temp=0.0),
+            logits_processors=[None],
+            stop_matchers=[StopSequenceMatcher()],
+            max_tokens=[n_steps],
+        )
+        while batch.next():
+            pass
+        return _dead_chain_edges(sole_cache.values)
+
+    def test_generation_batch_bounds_cache_graph(self):
+        short = self._run_generation_batch(CACHE_STATE_EVAL_INTERVAL * 2)
+        long = self._run_generation_batch(CACHE_STATE_EVAL_INTERVAL * 8)
+        self.assertLess(long, short * 2)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Fixes #1662.

## What

Cache fields that the sampled-token graph never reads accumulate one
unevaluated in-place update per decode step, each pinning a Metal buffer.
Long generations hit the runtime's buffer-count limit (`[metal::malloc]
Resource limit (499000) exceeded`) — ~11k generated tokens on a 43-layer
model — and #1662 reports the crash wedging the GPU driver hard enough to
panic the host. `deepseek_v4`-style attention (K==V, values discarded) is
the shipping trigger, but any cache field a model leaves unread has the
same failure mode.

Chunked prefill already materializes cache state once per chunk; decode
never did. This folds cache state into the evals both decode paths already
perform, every 256 steps (option 1 from the issue):

- `generate_step`: evaluate cache state on the existing `n % 256`
  maintenance branch (skipping `n == 0`, which only perturbs very short
  generations for no benefit — the interval only needs to bound long ones).
- `GenerationBatch._step`: append cache state to the `async_eval` the step
  already issues — no extra synchronization.

The speculative path is left as-is: it trims the caches every iteration,
which bounds the chain. Same class of bug as #1632 (ArraysCache metadata),
one level down — `RotatingKVCache.state` already returns `(keys, values)`,
so this reuses the same "evaluate `.state`" contract rather than adding a
new one.

## Test

`tests/test_decode_cache_state.py` — model-free, mirroring the issue's own
minimal repro and the `mx.export_to_dot` style of #1632's regression test.
A fake cache writes `values` every step and never reads it back (the exact
K==V shape); a fake model drives it through both `generate_step` and
`GenerationBatch`. Assertion compares graph growth at 2x vs 8x the eval
interval rather than an absolute edge count (which is an `export_to_dot`
implementation detail): unpatched, the chain grows linearly with steps
(fails); patched, it's bounded by the interval regardless of run length.
Verified against unpatched `generate.py` that both tests fail with the
exact signature described in the issue (linear growth, no plateau).

## Validation (M5 Max 128 GB)

- New tests pass on the patched code, fail (linear-growth signature) with
  the periodic eval removed.
- DeepSeek-V4-Flash 2-bit (mlx-community OptiQ, served resident): without
  the patch, generation died deterministically at ~10-11k generated tokens
  per process (hit three times across two server front-ends). With the
  patch, a single 15,000-token request completed with `finish_reason:
  length` and zero buffer-limit errors in the server log (1576 s, 9.5 tok/s).
- Ran the full `tests/test_generate.py` + `tests/test_prompt_cache.py`
  suite before and after: same 8 pre-existing failures on unpatched `main`
  and on this branch, same tests, same outputs — confirmed environment-
  specific (this Mac's Metal/MLX build), not something this PR changes.
  No new failures.
