### PR TITLE
Fix unevaluated graph growing infinitely in deepseek

### DIFF
--- a/mlx_lm/models/deepseek_v32.py
+++ b/mlx_lm/models/deepseek_v32.py
@@ -98,7 +98,9 @@ class Indexer(nn.Module):
         k = self.rope(k, offset=offset)
 
         if cache is not None:
-            k, _ = cache.update_and_fetch(k, mx.zeros([b, 1, s, 0]))
+            k, _ = cache.update_and_fetch(k, k)
+            # Avoid unevaluated graph growing infinitely
+            cache.values = mx.zeros_like(cache.keys)
         if k.shape[2] <= self.index_topk:
             return None
         scores = q @ k.swapaxes(-1, -2)


### PR DESCRIPTION
Close https://github.com/ml-explore/mlx-lm/issues/1662

For models that discard the values of kv cache, the stored values in kv cache would become an unevaluated graph that keeps growing, and eventually throws after creating too much buffers.

The ideal fix would be making `update_and_fetch` accept `None` as values, but that would require a huge refactoring and complicates code a lot, especially impractical since there is only one model implementation doing this. It is also impossible to fix on MLX's side because we can not predict whether an array would be evaluated eventually.

So this PR just does a simple fix in the model implementation.