### PR TITLE
Return 503 from /health when the generation thread exits

### DIFF
--- a/mlx_lm/server.py
+++ b/mlx_lm/server.py
@@ -442,6 +442,10 @@ class ResponseGenerator:
     def join(self):
         self._generation_thread.join()
 
+    @property
+    def is_healthy(self):
+        return self._generation_thread.is_alive()
+
     def _log_cache_stats(self):
         n_sequences = len(self.prompt_cache)
         n_bytes = self.prompt_cache.nbytes
@@ -1615,10 +1619,14 @@ class APIHandler(BaseHTTPRequestHandler):
         """
         Handle a GET request for the /health endpoint.
         """
-        self._set_completion_headers(200)
+        is_healthy = self.response_generator.is_healthy
+        status_code = 200 if is_healthy else 503
+        status = "ok" if is_healthy else "unavailable"
+
+        self._set_completion_headers(status_code)
         self.end_headers()
 
-        self.wfile.write('{"status": "ok"}'.encode())
+        self.wfile.write(json.dumps({"status": status}).encode())
         self.wfile.flush()
 
     def handle_models_request(self):

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -388,6 +388,18 @@ class TestServer(unittest.TestCase):
         self.assertEqual(model["object"], "model")
         self.assertIn("created", model)
 
+    def test_health_endpoint(self):
+        url = f"http://localhost:{self.port}/health"
+
+        response = requests.get(url)
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.json(), {"status": "ok"})
+
+        self.response_generator.stop_and_join()
+        response = requests.get(url)
+        self.assertEqual(response.status_code, 503)
+        self.assertEqual(response.json(), {"status": "unavailable"})
+
 
 class TestServerWithDraftModel(unittest.TestCase):
     @classmethod


### PR DESCRIPTION
While building our agent infrastructure, we encountered an issue with an incorrect health endpoint status: it returned 200 even when the generation thread was dead.

This PR adds a small fix and tests covering the issue.

AI was used; the changes were reviewed and made deliberately.
