### PR TITLE
fix: handle single-quoted values with commas in pythonic tool parser

### DIFF
--- a/mlx_lm/tool_parsers/pythonic.py
+++ b/mlx_lm/tool_parsers/pythonic.py
@@ -14,7 +14,9 @@ Parses assistant responses containing tool calls in formats like:
 
 
 _tool_call_regex = re.compile(r"\[(\w+)\((.*?)\)\]", re.DOTALL)
-_tool_args_regex = re.compile(r"""(\w+)=(?:"([^"]*)"|'([^']*)'|([^,]+))(?:,\s*|$)""", re.DOTALL)
+_tool_args_regex = re.compile(
+    r"""(\w+)=(?:"([^"]*)"|'([^']*)'|([^,]+))(?:,\s*|$)""", re.DOTALL
+)
 
 
 def parse_tool_call(text: str, tools: Any | None = None):

--- a/mlx_lm/tool_parsers/pythonic.py
+++ b/mlx_lm/tool_parsers/pythonic.py
@@ -14,7 +14,7 @@ Parses assistant responses containing tool calls in formats like:
 
 
 _tool_call_regex = re.compile(r"\[(\w+)\((.*?)\)\]", re.DOTALL)
-_tool_args_regex = re.compile(r'(\w+)=(?:"([^"]*)"|([^,]+))(?:,\s*|$)', re.DOTALL)
+_tool_args_regex = re.compile(r"""(\w+)=(?:"([^"]*)"|'([^']*)'|([^,]+))(?:,\s*|$)""", re.DOTALL)
 
 
 def parse_tool_call(text: str, tools: Any | None = None):
@@ -30,8 +30,8 @@ def parse_tool_call(text: str, tools: Any | None = None):
         matches = _tool_args_regex.findall(args_str)
         for pair in matches:
             key = pair[0].strip()
-            # pair[1] is quoted value, pair[2] is unquoted value
-            value = pair[1] if pair[1] else pair[2].strip()
+            # pair[1] is double-quoted, pair[2] is single-quoted, pair[3] is unquoted
+            value = pair[1] if pair[1] else (pair[2] if pair[2] else pair[3].strip())
 
             # Try to parse the value using ast.literal_eval
             try:

--- a/mlx_lm/tool_parsers/pythonic.py
+++ b/mlx_lm/tool_parsers/pythonic.py
@@ -1,7 +1,7 @@
 # Copyright © 2026 Apple Inc.
 
 import ast
-from typing import Any, Dict, List
+from typing import Any
 
 import regex as re
 
@@ -42,7 +42,7 @@ def parse_tool_call(text: str, tools: Any | None = None):
 
             arguments[key] = value
 
-    return dict(name=func_name, arguments=arguments)
+    return {"name": func_name, "arguments": arguments}
 
 
 tool_call_start = "<|tool_call_start|>"

--- a/tests/test_tool_parsing.py
+++ b/tests/test_tool_parsing.py
@@ -154,6 +154,22 @@ class TestToolParsing(unittest.TestCase):
                 }
                 self.assertEqual(tool_call, expected)
 
+    def test_pythonic_single_quoted_args_with_commas(self):
+        # LFM2.5 emits single-quoted strings; embedded commas must not truncate
+        test_case = (
+            "[write(filePath='/tmp/hello.py', "
+            "content='# Hello, world!')]"
+        )
+        tool_call = pythonic.parse_tool_call(test_case, None)
+        self.assertEqual(tool_call["name"], "write")
+        self.assertEqual(tool_call["arguments"]["filePath"], "/tmp/hello.py")
+        self.assertEqual(tool_call["arguments"]["content"], "# Hello, world!")
+
+        # Double-quoted still works
+        test_case = '[search(query="hello, world")]'
+        tool_call = pythonic.parse_tool_call(test_case, None)
+        self.assertEqual(tool_call["arguments"]["query"], "hello, world")
+
     def test_qwen3_coder_single_quoted_params(self):
         tools = [
             {

--- a/tests/test_tool_parsing.py
+++ b/tests/test_tool_parsing.py
@@ -155,10 +155,7 @@ class TestToolParsing(unittest.TestCase):
 
     def test_pythonic_single_quoted_args_with_commas(self):
         # LFM2.5 emits single-quoted strings; embedded commas must not truncate
-        test_case = (
-            "[write(filePath='/tmp/hello.py', "
-            "content='# Hello, world!')]"
-        )
+        test_case = "[write(filePath='/tmp/hello.py', " "content='# Hello, world!')]"
         tool_call = pythonic.parse_tool_call(test_case, None)
         self.assertEqual(tool_call["name"], "write")
         self.assertEqual(tool_call["arguments"]["filePath"], "/tmp/hello.py")

--- a/tests/test_tool_parsing.py
+++ b/tests/test_tool_parsing.py
@@ -1,5 +1,4 @@
 import unittest
-from pathlib import Path
 
 from mlx_lm.tool_parsers import (
     function_gemma,


### PR DESCRIPTION
## Summary

The pythonic tool-call parser's regex only special-cases double-quoted values. Single-quoted values (which LFM2.5's chat template emits) fall into the `([^,]+)` branch, which truncates at the first embedded comma.

**Before:** `[write(filePath='/tmp/hello.py', content='# Hello, world!')]` parses `content` as `# Hello` (truncated at the comma).

**After:** The regex adds a `'([^']*)'` branch that handles single-quoted values as a third alternative, and the value-selection logic picks from the three groups (double-quoted, single-quoted, unquoted).

## Changes

- `mlx_lm/tool_parsers/pythonic.py`: added `'([^']*)'` to `_tool_args_regex`, updated group indexing
- `tests/test_tool_parsing.py`: added `test_pythonic_single_quoted_args_with_commas` with two cases (single-quoted with embedded comma + double-quoted regression)

## Tests

```
8 passed in 4.74s
```

Closes #1785.