### PR TITLE
fix: apply 1/sqrt(head_v_dim) readout scale in gated_delta_update

### DIFF
--- a/mlx_lm/models/gated_delta.py
+++ b/mlx_lm/models/gated_delta.py
@@ -610,5 +610,12 @@ def gated_delta_update(
         state = mx.zeros((B, Hv, Dv, Dk), dtype=mx.float32)
 
     if not use_kernel or mx.default_device() != mx.gpu or not mx.metal.is_available():
-        return gated_delta_ops(q, k, v, g, beta, state, mask)
-    return gated_delta_kernel(q, k, v, g, beta, state, mask)
+        y, state = gated_delta_ops(q, k, v, g, beta, state, mask)
+    else:
+        y, state = gated_delta_kernel(q, k, v, g, beta, state, mask)
+
+    # Readout scale: ggml GATED_DELTA_NET applies 1/sqrt(head_v_dim)
+    # unconditionally (ops.cpp:10824). Without it the raw delta output is
+    # ~1/head_v_dim^0.5 too large, compounding over layers.
+    y = y * (v.shape[-1] ** -0.5)
+    return y, state

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -3457,7 +3457,8 @@ class TestModels(unittest.TestCase):
             lower_bound=lower_bound,
         )
 
-        self.assertTrue(mx.allclose(output, expected))
+        # gated_delta_update applies 1/sqrt(head_v_dim) readout scale
+        self.assertTrue(mx.allclose(output, expected * (v.shape[-1] ** -0.5)))
         self.assertTrue(mx.allclose(state, expected_state))
 
     def test_gated_delta_precision(self):
@@ -3547,6 +3548,36 @@ class TestModels(unittest.TestCase):
                 y = y[:, s:e]
                 self.assertTrue(mx.allclose(y, y_gt, rtol=1e-4, atol=1e-4))
                 self.assertTrue(mx.allclose(st, st_gt, rtol=1e-4, atol=1e-3))
+
+    def test_gated_delta_readout_scale(self):
+        """gated_delta_update must scale output by 1/sqrt(head_v_dim)."""
+        mx.random.seed(0)
+        B, T = 1, 2
+        Hk, Hv, Dk, Dv = 2, 4, 16, 16
+
+        q = mx.random.normal(shape=(B, T, Hk, Dk))
+        k = mx.random.normal(shape=(B, T, Hk, Dk))
+        v = mx.random.normal(shape=(B, T, Hv, Dv))
+        a = mx.random.normal(shape=(B, T, Hv))
+        b = mx.random.normal(shape=(B, T, Hv))
+        A_log = mx.zeros((Hv,))
+        dt_bias = mx.zeros((Hv,))
+
+        # Raw (unscaled) output from the ops path
+        beta = mx.sigmoid(b)
+        g = mx.exp(-mx.exp(A_log.astype(mx.float32)) * nn.softplus(a + dt_bias))
+        state = mx.zeros((B, Hv, Dv, Dk), dtype=mx.float32)
+        y_raw, _ = gated_delta_ops(q, k, v, g, beta, state)
+
+        # Scaled output from gated_delta_update
+        y_scaled, _ = gated_delta_update(
+            q, k, v, a, b, A_log, dt_bias, use_kernel=False
+        )
+
+        scale = Dv**-0.5
+        self.assertTrue(mx.allclose(y_scaled, y_raw * scale, rtol=1e-5, atol=1e-6))
+        # Verify the scale is not identity
+        self.assertFalse(mx.allclose(y_scaled, y_raw, rtol=1e-2, atol=1e-3))
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## What

`gated_delta_update` omits the `1/sqrt(head_v_dim)` readout scale that the ggml reference applies unconditionally (`ops.cpp:10824`). For `head_v_dim=128` the output is ~11x too large, compounding over layers into incoherent generation.

## Fix

Scale output by `v.shape[-1] ** -0.5` inside `gated_delta_update`, after both kernel and ops paths. All four callers (qwen3_next, qwen3_5, kimi_linear, bailing_moe_v3) omit this scale, so applying it centrally is safe.

## Test

- New `test_gated_delta_readout_scale` asserts the scale is applied and is not identity.
- Updated `test_gated_delta_lower_bound` to account for the scale.
- All 5 `gated_delta` tests pass.

Fixes #1798