### PR TITLE
Fix MLA quantized-KV crash in deepseek_v3 and glm4_moe_lite

### DIFF
--- a/mlx_lm/models/base.py
+++ b/mlx_lm/models/base.py
@@ -90,11 +90,14 @@ def quantized_scaled_dot_product_attention(
             q_indices = mx.arange(kL - qL, kL)
             k_indices = mx.arange(kL)
             mask = q_indices[:, None] >= k_indices[None]
-        if n_repeats > 1 and mask.ndim >= 3:
-            if mask.shape[-3] == 1:
-                mask = mx.expand_dims(mask, -3)
-            else:
+        if n_repeats > 1 and 3 <= mask.ndim < scores.ndim:
+            if mask.shape[-3] == n_q_heads:
+                # Per-query-head mask (e.g. the absorbed-MLA pe_scores): split
+                # the head axis to match the scores' (n_kv_heads, n_repeats).
                 mask = mx.unflatten(mask, -3, (n_kv_heads, n_repeats))
+            else:
+                # Per-kv-head or broadcast mask: add the repeats axis.
+                mask = mx.expand_dims(mask, -3)
         if mask.dtype == mx.bool_:
             scores = mx.where(mask, scores, mx.finfo(scores.dtype).min)
         else:

--- a/mlx_lm/models/base.py
+++ b/mlx_lm/models/base.py
@@ -90,8 +90,11 @@ def quantized_scaled_dot_product_attention(
             q_indices = mx.arange(kL - qL, kL)
             k_indices = mx.arange(kL)
             mask = q_indices[:, None] >= k_indices[None]
-        if n_repeats > 1 and mask.ndim > 3:
-            mask = mx.expand_dims(mask, -3)
+        if n_repeats > 1 and mask.ndim >= 3:
+            if mask.shape[-3] == 1:
+                mask = mx.expand_dims(mask, -3)
+            else:
+                mask = mx.unflatten(mask, -3, (n_kv_heads, n_repeats))
         if mask.dtype == mx.bool_:
             scores = mx.where(mask, scores, mx.finfo(scores.dtype).min)
         else:

--- a/mlx_lm/models/deepseek_v3.py
+++ b/mlx_lm/models/deepseek_v3.py
@@ -144,7 +144,19 @@ class DeepseekV3Attention(nn.Module):
         if cache is not None:
             kv_latent, k_pe = cache.update_and_fetch(kv_latent, k_pe)
 
-        pe_scores = (q_pe * self.scale) @ k_pe.swapaxes(-1, -2)
+        # With a quantized cache the fetched entries are (packed, scales,
+        # biases) tuples.
+        quantized = isinstance(k_pe, (list, tuple))
+        if quantized:
+            pe_scores = mx.quantized_matmul(
+                q_pe * self.scale,
+                *k_pe,
+                transpose=True,
+                group_size=cache.group_size,
+                bits=cache.bits,
+            )
+        else:
+            pe_scores = (q_pe * self.scale) @ k_pe.swapaxes(-1, -2)
         if mask is not None:
             pe_scores = mx.where(
                 mask,
@@ -155,12 +167,19 @@ class DeepseekV3Attention(nn.Module):
         if L == 1:
             q_nope = self.embed_q(q_nope)
             k = v = kv_latent
+            sdpa_cache = cache
         else:
-            k = self.embed_q(kv_latent, transpose=False)
-            v = self.unembed_out(kv_latent)
+            lat = kv_latent
+            if quantized:
+                # Chunked prefill over an already-quantized cache: fall back
+                # to float latents for the absorbed projections.
+                lat = mx.dequantize(*lat, group_size=cache.group_size, bits=cache.bits)
+            k = self.embed_q(lat, transpose=False)
+            v = self.unembed_out(lat)
+            sdpa_cache = None if quantized else cache
 
         output = scaled_dot_product_attention(
-            q_nope, k, v, cache=cache, scale=self.scale, mask=pe_scores
+            q_nope, k, v, cache=sdpa_cache, scale=self.scale, mask=pe_scores
         )
         if L == 1:
             output = self.unembed_out(output)

--- a/mlx_lm/models/glm4_moe_lite.py
+++ b/mlx_lm/models/glm4_moe_lite.py
@@ -150,7 +150,19 @@ class Glm4MoeLiteAttention(nn.Module):
         if cache is not None:
             kv_latent, k_pe = cache.update_and_fetch(kv_latent, k_pe)
 
-        pe_scores = (q_pe * self.scale) @ k_pe.swapaxes(-1, -2)
+        # With a quantized cache the fetched entries are (packed, scales,
+        # biases) tuples.
+        quantized = isinstance(k_pe, (list, tuple))
+        if quantized:
+            pe_scores = mx.quantized_matmul(
+                q_pe * self.scale,
+                *k_pe,
+                transpose=True,
+                group_size=cache.group_size,
+                bits=cache.bits,
+            )
+        else:
+            pe_scores = (q_pe * self.scale) @ k_pe.swapaxes(-1, -2)
         if mask is not None:
             pe_scores = mx.where(
                 mask,
@@ -161,11 +173,19 @@ class Glm4MoeLiteAttention(nn.Module):
         if L == 1:
             q_nope = self.embed_q(q_nope)
             k = v = kv_latent
+            sdpa_cache = cache
         else:
-            k = self.embed_q(kv_latent, transpose=False)
-            v = self.unembed_out(kv_latent)
+            lat = kv_latent
+            if quantized:
+                # Chunked prefill over an already-quantized cache: fall back
+                # to float latents for the absorbed projections.
+                lat = mx.dequantize(*lat, group_size=cache.group_size, bits=cache.bits)
+            k = self.embed_q(lat, transpose=False)
+            v = self.unembed_out(lat)
+            sdpa_cache = None if quantized else cache
+
         output = scaled_dot_product_attention(
-            q_nope, k, v, cache=cache, scale=self.scale, mask=pe_scores
+            q_nope, k, v, cache=sdpa_cache, scale=self.scale, mask=pe_scores
         )
         if L == 1:
             output = self.unembed_out(output)

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -3251,6 +3251,36 @@ class TestModels(unittest.TestCase):
                 self.assertTrue(mx.allclose(y, y_gt, rtol=1e-4, atol=1e-4))
                 self.assertTrue(mx.allclose(st, st_gt, rtol=1e-4, atol=1e-3))
 
+    def test_quantized_sdpa_gqa_float_mask(self):
+        # Per-head float masks (e.g. the absorbed-MLA pe_scores) must be
+        # unflattened to (B, n_kv_heads, n_repeats, L, S) for GQA, not
+        # expanded on the kv axis.
+        from mlx_lm.models.base import quantized_scaled_dot_product_attention
+
+        B, n_q, n_kv, L, S, D = 1, 8, 2, 4, 64, 64
+        group_size, bits = 64, 8
+        mx.random.seed(0)
+        q = mx.random.normal((B, n_q, L, D))
+        k = mx.random.normal((B, n_kv, S, D))
+        v = mx.random.normal((B, n_kv, S, D))
+        mask = 0.1 * mx.random.normal((B, n_q, L, S))
+
+        q_k = mx.quantize(k, group_size=group_size, bits=bits)
+        q_v = mx.quantize(v, group_size=group_size, bits=bits)
+        out = quantized_scaled_dot_product_attention(
+            q, q_k, q_v, scale=1.0, mask=mask, group_size=group_size, bits=bits
+        )
+        self.assertEqual(out.shape, (B, n_q, L, D))
+
+        kd = mx.dequantize(*q_k, group_size=group_size, bits=bits)
+        vd = mx.dequantize(*q_v, group_size=group_size, bits=bits)
+        n_repeats = n_q // n_kv
+        kd = mx.repeat(kd, n_repeats, axis=1)
+        vd = mx.repeat(vd, n_repeats, axis=1)
+        scores = q @ kd.swapaxes(-1, -2) + mask
+        ref = mx.softmax(scores, axis=-1, precise=True) @ vd
+        self.assertTrue(mx.allclose(out, ref, rtol=1e-3, atol=1e-3))
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -9,7 +9,12 @@ from mlx.utils import tree_flatten, tree_map
 
 from mlx_lm.models import rope_utils
 from mlx_lm.models.base import create_causal_mask, scaled_dot_product_attention
-from mlx_lm.models.cache import KVCache, RotatingKVCache, make_prompt_cache
+from mlx_lm.models.cache import (
+    KVCache,
+    QuantizedKVCache,
+    RotatingKVCache,
+    make_prompt_cache,
+)
 from mlx_lm.models.gated_delta import (
     gated_delta_kernel,
     gated_delta_ops,
@@ -3252,34 +3257,115 @@ class TestModels(unittest.TestCase):
                 self.assertTrue(mx.allclose(st, st_gt, rtol=1e-4, atol=1e-3))
 
     def test_quantized_sdpa_gqa_float_mask(self):
-        # Per-head float masks (e.g. the absorbed-MLA pe_scores) must be
-        # unflattened to (B, n_kv_heads, n_repeats, L, S) for GQA, not
-        # expanded on the kv axis.
+        # Float masks under GQA: a per-query-head mask (e.g. the absorbed-MLA
+        # pe_scores) must be unflattened to (B, n_kv_heads, n_repeats, L, S),
+        # while per-kv-head, broadcast and already-full-rank masks must be left
+        # broadcastable. B > 1 so a full-rank mask can't pass by accident.
         from mlx_lm.models.base import quantized_scaled_dot_product_attention
 
-        B, n_q, n_kv, L, S, D = 1, 8, 2, 4, 64, 64
+        B, n_q, n_kv, L, S, D = 2, 8, 2, 4, 64, 64
         group_size, bits = 64, 8
+        n_repeats = n_q // n_kv
         mx.random.seed(0)
         q = mx.random.normal((B, n_q, L, D))
         k = mx.random.normal((B, n_kv, S, D))
         v = mx.random.normal((B, n_kv, S, D))
-        mask = 0.1 * mx.random.normal((B, n_q, L, S))
-
         q_k = mx.quantize(k, group_size=group_size, bits=bits)
         q_v = mx.quantize(v, group_size=group_size, bits=bits)
-        out = quantized_scaled_dot_product_attention(
-            q, q_k, q_v, scale=1.0, mask=mask, group_size=group_size, bits=bits
-        )
-        self.assertEqual(out.shape, (B, n_q, L, D))
 
-        kd = mx.dequantize(*q_k, group_size=group_size, bits=bits)
-        vd = mx.dequantize(*q_v, group_size=group_size, bits=bits)
-        n_repeats = n_q // n_kv
-        kd = mx.repeat(kd, n_repeats, axis=1)
-        vd = mx.repeat(vd, n_repeats, axis=1)
-        scores = q @ kd.swapaxes(-1, -2) + mask
-        ref = mx.softmax(scores, axis=-1, precise=True) @ vd
-        self.assertTrue(mx.allclose(out, ref, rtol=1e-3, atol=1e-3))
+        kd = mx.repeat(
+            mx.dequantize(*q_k, group_size=group_size, bits=bits), n_repeats, axis=1
+        )
+        vd = mx.repeat(
+            mx.dequantize(*q_v, group_size=group_size, bits=bits), n_repeats, axis=1
+        )
+
+        per_q = 0.1 * mx.random.normal((B, n_q, L, S))
+        masks = {
+            "per query head": per_q,
+            "per kv head": 0.1 * mx.random.normal((B, n_kv, L, S)),
+            "broadcast": 0.1 * mx.random.normal((B, 1, L, S)),
+            "full rank": per_q.reshape(B, n_kv, n_repeats, L, S),
+            "no heads": 0.1 * mx.random.normal((L, S)),
+        }
+        for name, mask in masks.items():
+            with self.subTest(mask=name):
+                out = quantized_scaled_dot_product_attention(
+                    q, q_k, q_v, scale=1.0, mask=mask, group_size=group_size, bits=bits
+                )
+                self.assertEqual(out.shape, (B, n_q, L, D))
+
+                ref_mask = mask
+                if ref_mask.ndim == 5:
+                    ref_mask = ref_mask.reshape(B, n_q, L, S)
+                elif ref_mask.ndim == 4 and 1 < ref_mask.shape[-3] < n_q:
+                    ref_mask = mx.repeat(ref_mask, n_q // ref_mask.shape[-3], axis=-3)
+                scores = q @ kd.swapaxes(-1, -2) + ref_mask
+                ref = mx.softmax(scores, axis=-1, precise=True) @ vd
+                self.assertTrue(mx.allclose(out, ref, rtol=1e-2, atol=1e-2))
+
+    def test_mla_quantized_cache(self):
+        # Absorbed-MLA attention fetches (packed, scales, biases) tuples from a
+        # quantized cache. Exercise the L == 1 decode path and a multi-token
+        # chunk over an already-quantized cache.
+        from mlx_lm.models import glm4_moe_lite
+
+        args = glm4_moe_lite.ModelArgs.from_dict(
+            {
+                "model_type": "glm4_moe_lite",
+                "vocab_size": 128,
+                "hidden_size": 128,
+                "intermediate_size": 128,
+                "moe_intermediate_size": 32,
+                "num_hidden_layers": 2,
+                "num_attention_heads": 4,
+                "num_key_value_heads": 4,
+                "n_shared_experts": 1,
+                "n_routed_experts": 4,
+                "routed_scaling_factor": 1.0,
+                "kv_lora_rank": 64,
+                "q_lora_rank": 64,
+                "qk_rope_head_dim": 32,
+                "qk_nope_head_dim": 32,
+                "v_head_dim": 32,
+                "topk_method": "noaux_tc",
+                "scoring_func": "sigmoid",
+                "norm_topk_prob": True,
+                "n_group": 1,
+                "topk_group": 1,
+                "num_experts_per_tok": 2,
+                "moe_layer_freq": 1,
+                "first_k_dense_replace": 1,
+                "max_position_embeddings": 256,
+                "rms_norm_eps": 1e-5,
+                "rope_theta": 1000,
+                "rope_scaling": None,
+                "attention_bias": False,
+                "partial_rotary_factor": 1.0,
+                "tie_word_embeddings": False,
+                "num_nextn_predict_layers": 1,
+            }
+        )
+        mx.random.seed(0)
+        model = glm4_moe_lite.Model(args)
+        model.eval()
+
+        def run(make_cache):
+            mx.random.seed(1)
+            cache = [make_cache() for _ in range(len(model.layers))]
+            outs = [model(mx.random.randint(0, 128, (1, 17)), cache=cache)[:, -1:]]
+            for _ in range(3):
+                outs.append(model(mx.random.randint(0, 128, (1, 1)), cache=cache))
+            outs.append(model(mx.random.randint(0, 128, (1, 9)), cache=cache))
+            return mx.concatenate(outs, axis=1).astype(mx.float32)
+
+        ref = run(KVCache)
+        out = run(lambda: QuantizedKVCache(group_size=32, bits=8))
+        self.assertEqual(out.shape, ref.shape)
+        self.assertTrue(
+            mx.array_equal(mx.argmax(out, axis=-1), mx.argmax(ref, axis=-1))
+        )
+        self.assertLess(mx.max(mx.abs(out - ref)).item(), 0.1)
 
 
 if __name__ == "__main__":

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -3263,46 +3263,57 @@ class TestModels(unittest.TestCase):
         # broadcastable. B > 1 so a full-rank mask can't pass by accident.
         from mlx_lm.models.base import quantized_scaled_dot_product_attention
 
-        B, n_q, n_kv, L, S, D = 2, 8, 2, 4, 64, 64
         group_size, bits = 64, 8
-        n_repeats = n_q // n_kv
-        mx.random.seed(0)
-        q = mx.random.normal((B, n_q, L, D))
-        k = mx.random.normal((B, n_kv, S, D))
-        v = mx.random.normal((B, n_kv, S, D))
-        q_k = mx.quantize(k, group_size=group_size, bits=bits)
-        q_v = mx.quantize(v, group_size=group_size, bits=bits)
+        # A plain GQA shape, then the absorbed-MLA decode shape: one kv head,
+        # so every query head is a repeat.
+        shapes = ((2, 8, 2, 4, 64, 64), (2, 64, 1, 1, 512, 64))
+        for B, n_q, n_kv, L, S, D in shapes:
+            n_repeats = n_q // n_kv
+            mx.random.seed(0)
+            q = mx.random.normal((B, n_q, L, D))
+            k = mx.random.normal((B, n_kv, S, D))
+            v = mx.random.normal((B, n_kv, S, D))
+            q_k = mx.quantize(k, group_size=group_size, bits=bits)
+            q_v = mx.quantize(v, group_size=group_size, bits=bits)
 
-        kd = mx.repeat(
-            mx.dequantize(*q_k, group_size=group_size, bits=bits), n_repeats, axis=1
-        )
-        vd = mx.repeat(
-            mx.dequantize(*q_v, group_size=group_size, bits=bits), n_repeats, axis=1
-        )
+            kd = mx.repeat(
+                mx.dequantize(*q_k, group_size=group_size, bits=bits), n_repeats, axis=1
+            )
+            vd = mx.repeat(
+                mx.dequantize(*q_v, group_size=group_size, bits=bits), n_repeats, axis=1
+            )
 
-        per_q = 0.1 * mx.random.normal((B, n_q, L, S))
-        masks = {
-            "per query head": per_q,
-            "per kv head": 0.1 * mx.random.normal((B, n_kv, L, S)),
-            "broadcast": 0.1 * mx.random.normal((B, 1, L, S)),
-            "full rank": per_q.reshape(B, n_kv, n_repeats, L, S),
-            "no heads": 0.1 * mx.random.normal((L, S)),
-        }
-        for name, mask in masks.items():
-            with self.subTest(mask=name):
-                out = quantized_scaled_dot_product_attention(
-                    q, q_k, q_v, scale=1.0, mask=mask, group_size=group_size, bits=bits
-                )
-                self.assertEqual(out.shape, (B, n_q, L, D))
+            per_q = 0.1 * mx.random.normal((B, n_q, L, S))
+            masks = {
+                "per query head": per_q,
+                "per kv head": 0.1 * mx.random.normal((B, n_kv, L, S)),
+                "broadcast": 0.1 * mx.random.normal((B, 1, L, S)),
+                "full rank": per_q.reshape(B, n_kv, n_repeats, L, S),
+                "no heads": 0.1 * mx.random.normal((L, S)),
+            }
+            for name, mask in masks.items():
+                with self.subTest(heads=(n_q, n_kv), mask=name):
+                    out = quantized_scaled_dot_product_attention(
+                        q,
+                        q_k,
+                        q_v,
+                        scale=1.0,
+                        mask=mask,
+                        group_size=group_size,
+                        bits=bits,
+                    )
+                    self.assertEqual(out.shape, (B, n_q, L, D))
 
-                ref_mask = mask
-                if ref_mask.ndim == 5:
-                    ref_mask = ref_mask.reshape(B, n_q, L, S)
-                elif ref_mask.ndim == 4 and 1 < ref_mask.shape[-3] < n_q:
-                    ref_mask = mx.repeat(ref_mask, n_q // ref_mask.shape[-3], axis=-3)
-                scores = q @ kd.swapaxes(-1, -2) + ref_mask
-                ref = mx.softmax(scores, axis=-1, precise=True) @ vd
-                self.assertTrue(mx.allclose(out, ref, rtol=1e-2, atol=1e-2))
+                    ref_mask = mask
+                    if ref_mask.ndim == 5:
+                        ref_mask = ref_mask.reshape(B, n_q, L, S)
+                    elif ref_mask.ndim == 4 and 1 < ref_mask.shape[-3] < n_q:
+                        ref_mask = mx.repeat(
+                            ref_mask, n_q // ref_mask.shape[-3], axis=-3
+                        )
+                    scores = q @ kd.swapaxes(-1, -2) + ref_mask
+                    ref = mx.softmax(scores, axis=-1, precise=True) @ vd
+                    self.assertTrue(mx.allclose(out, ref, rtol=1e-2, atol=1e-2))
 
     def test_mla_quantized_cache(self):
         # Absorbed-MLA attention fetches (packed, scales, biases) tuples from a


### PR DESCRIPTION
File "mlx_lm/models/deepseek_v3.py", line 147, in __call__
    pe_scores = (q_pe * self.scale) @ k_pe.swapaxes(-1, -2)
  AttributeError: 'tuple' object has no attribute 'swapaxes'

  main @ 96830a6:  FAILED (errors=5)
    ValueError: [broadcast_shapes] (2,2,4,4,64) and (2,2,4,1,4,64) cannot be broadcast
    ValueError: [reshape] Cannot reshape array of size 524288 into shape (2,64,1,64)
  this branch:     Ran 84 tests — OK (skipped=1)
  pre-commit:      black Passed, isort Passed

  Moonlight-16B-A3B-Instruct-4bit, M3 Max, wikitext-2 ppl @ 1k tokens
  fp16 6.64 · kv8 6.65 · kv4 6.80 · kv3 7.62   (--kv-bits 8 greedy output identical to fp16)

  The MLA path treats the cache output as an array, but a quantized cache returns a three-element tuple.
  
  The previous rank check applied the mask to the wrong head axis when multiple query heads share a KV head.


 
- ☑️ I understand it is strictly prohibited to use AI to write PR description
- AI usage disclosure: 
  - Claude Code wrote the patch (deepseek_v3.py, glm4_moe_lite.py, base.py, the two tests)
  - it ran the test runs and the ppl measurements on my M3 Max; every number in the PR is its tool output
  - it merged current main into the branch and pushed the branch to my fork
  - i reviewed the diff, understand it, and own it
  - the PR text is my writing
 