### PR TITLE
Add pipeline parallelism for Qwen3 MoE

### DIFF
--- a/mlx_lm/models/qwen3_moe.py
+++ b/mlx_lm/models/qwen3_moe.py
@@ -9,6 +9,7 @@ from mlx.nn.layers.distributed import shard_inplace, shard_linear, sum_gradients
 
 from .activations import swiglu
 from .base import BaseModelArgs, create_attention_mask, scaled_dot_product_attention
+from .pipeline import PipelineMixin
 from .switch_layers import SwitchGLU
 
 
@@ -181,7 +182,7 @@ class Qwen3MoeDecoderLayer(nn.Module):
         return out
 
 
-class Qwen3MoeModel(nn.Module):
+class Qwen3MoeModel(PipelineMixin, nn.Module):
     def __init__(self, args: ModelArgs):
         super().__init__()
         self.args = args
@@ -206,13 +207,30 @@ class Qwen3MoeModel(nn.Module):
         else:
             h = self.embed_tokens(inputs)
 
+        pipeline_rank = self.pipeline_rank
+        pipeline_size = self.pipeline_size
+
         if cache is None:
-            cache = [None] * len(self.layers)
+            cache = [None] * len(self.pipeline_layers)
 
         mask = create_attention_mask(h, cache[0])
 
-        for layer, c in zip(self.layers, cache):
+        # Receive from the previous process in the pipeline
+        if pipeline_rank < pipeline_size - 1:
+            h = mx.distributed.recv_like(h, (pipeline_rank + 1))
+
+        for layer, c in zip(self.pipeline_layers, cache):
             h = layer(h, mask, c)
+
+        # Send to the next process in the pipeline
+        if pipeline_rank != 0:
+            h = mx.distributed.send(h, (pipeline_rank - 1) % pipeline_size)
+            if cache[-1] is not None:
+                cache[-1].keys = mx.depends(cache[-1].keys, h)
+
+        # Broadcast h while keeping it in the graph
+        if pipeline_size > 1:
+            h = mx.distributed.all_gather(h)[: h.shape[0]]
 
         return self.norm(h)
 
@@ -312,4 +330,4 @@ class Model(nn.Module):
 
     @property
     def layers(self):
-        return self.model.layers
+        return self.model.pipeline_layers

--- a/tests/model_parallel_tests.py
+++ b/tests/model_parallel_tests.py
@@ -129,6 +129,43 @@ class TestModelParallel(unittest.TestCase):
                 out = model(x)
                 self.assertTrue(mx.allclose(expected, out, rtol=1e-3, atol=1e-3))
 
+    def test_pipeline(self):
+        test_configs = [
+            {
+                "model_type": "qwen3_moe",
+                "vocab_size": 128,
+                "hidden_size": 64,
+                "intermediate_size": 128,
+                "moe_intermediate_size": 32,
+                "num_hidden_layers": 4,
+                "num_attention_heads": 4,
+                "num_key_value_heads": 2,
+                "head_dim": 16,
+                "num_experts": 4,
+                "num_experts_per_tok": 2,
+                "decoder_sparse_step": 1,
+                "mlp_only_layers": [0],
+                "norm_topk_prob": True,
+                "rms_norm_eps": 1e-5,
+                "rope_theta": 10000.0,
+                "max_position_embeddings": 256,
+                "tie_word_embeddings": False,
+            },
+        ]
+        mx.random.seed(0)
+        for config in test_configs:
+            model_type = config["model_type"]
+            with self.subTest(f"Testing {model_type}", model_type=model_type):
+                arch = importlib.import_module(f"mlx_lm.models.{model_type}")
+                args = arch.ModelArgs.from_dict(config)
+                model = arch.Model(args)
+                vocab_size = args.vocab_size
+                x = mx.random.randint(0, vocab_size, shape=(32, 4))
+                expected = model(x)
+                model.model.pipeline(mx.distributed.init())
+                out = model(x)
+                self.assertTrue(mx.allclose(expected, out, rtol=1e-3, atol=1e-3))
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Problem

`qwen3_moe` has no pipeline support, so Qwen3 MoE checkpoints cannot be
split layer-wise across machines the way `glm4_moe`, `deepseek_v3`, and
other MoE models already can via `PipelineMixin`. (Companion to the
tensor-parallel `shard()` added in #1774; this adds the pipeline axis.)

## Change

Follows the established `glm4_moe` / `deepseek_v3` pattern exactly:

- `Qwen3MoeModel` mixes in `PipelineMixin` and its `__call__` gains the
  standard pipeline plumbing: `recv_like` from the previous rank, run
  `pipeline_layers`, `send` to the next rank with the `mx.depends` tie on
  the last cache, and the final `all_gather` broadcast. With
  `pipeline_size == 1` (the default) every branch is skipped and behavior
  is unchanged.
- `Model.layers` returns `self.model.pipeline_layers` (as in `glm4_moe`).
- Adds `tests/model_parallel_tests.py::test_pipeline`, a structural test
  in the style of the existing `test_shard`: a tiny `qwen3_moe` config is
  pipelined on a size-1 group and must match the un-pipelined output.

## Verification

Rebased onto current `main` (which already includes #1774 and #1787):

- `tests/model_parallel_tests.py`: 2 passed, 5 subtests passed.
- `tests/test_models.py -k qwen3`: 3 passed.
- Multi-node hardware verification (2 Apple Silicon MacBooks over an RDMA
  JACCL ring, Thunderbolt 5), `Qwen3-235B-A22B` 4-bit, greedy, identical
  prompt: 2-node **pipeline 28.41 tok/s decode, TTFT 7.23 s** vs 2-node
  tensor-parallel sharding 24.56 tok/s / TTFT 11.91 s (+16% decode,
  -39% TTFT); generated text checked coherent and consistent between the
  two modes.
- `black` / `isort --profile=black` clean.
