### PR TITLE
Feat/server kv cache quant partial

### DIFF
--- a/mlx_lm/generate.py
+++ b/mlx_lm/generate.py
@@ -292,7 +292,12 @@ def maybe_quantize_kv_cache(prompt_cache, quantized_kv_start, kv_group_size, kv_
         return
     for e, c in enumerate(prompt_cache):
         if hasattr(c, "to_quantized") and c.offset >= quantized_kv_start:
-            prompt_cache[e] = c.to_quantized(group_size=kv_group_size, bits=kv_bits)
+            try:
+                prompt_cache[e] = c.to_quantized(group_size=kv_group_size, bits=kv_bits)
+            except NotImplementedError:
+                # RotatingKVCache has no quantized variant, so a hybrid cache
+                # converts only in part. The caller reports the split.
+                pass
 
 
 def generate_step(

--- a/mlx_lm/server.py
+++ b/mlx_lm/server.py
@@ -918,9 +918,15 @@ class ResponseGenerator:
             ctx.prompt_cache_count = len(prompt) - len(rest)
             cache_key = prompt[:]
             if cache is None:
-                cache = make_prompt_cache(self.model_provider.model)
+                cache = make_prompt_cache(
+                    self.model_provider.model,
+                    max_kv_size=self.cli_args.max_kv_size,
+                )
                 if self.model_provider.draft_model is not None:
-                    cache += make_prompt_cache(self.model_provider.draft_model)
+                    cache += make_prompt_cache(
+                        self.model_provider.draft_model,
+                        max_kv_size=self.cli_args.max_kv_size,
+                    )
 
             # Process the prompt and generate tokens
             stop_state = stop_matcher.make_state()
@@ -1878,6 +1884,14 @@ def main():
         default=5000,
         help="When --kv-bits is set, begin quantizing the KV cache after "
         "this many tokens (default: 5000).",
+    )
+    parser.add_argument(
+        "--max-kv-size",
+        type=int,
+        default=None,
+        help="Maximum KV cache size in tokens; older entries are evicted "
+        "beyond this limit (uses a RotatingKVCache). Ignored for models that "
+        "provide their own make_cache (e.g. some hybrid architectures).",
     )
     args = parser.parse_args()
     if mx.metal.is_available():

--- a/mlx_lm/server.py
+++ b/mlx_lm/server.py
@@ -6,6 +6,7 @@ import logging
 import pickle
 import platform
 import socket
+import sys
 import time
 import uuid
 import warnings
@@ -15,7 +16,7 @@ from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
 from pathlib import Path
 from queue import Empty as QueueEmpty
 from queue import Queue
-from threading import Thread
+from threading import Event, Thread
 from typing import (
     Any,
     Callable,
@@ -489,6 +490,10 @@ class ResponseGenerator:
         self._is_distributed = mx.distributed.init().size() > 1
         self._rank = mx.distributed.init().rank()
         self._stop = False
+        # A rejected configuration surfaces on the generation thread. Record it
+        # so the failure does not leave the server up with a dead thread.
+        self.startup_error = None
+        self.startup_complete = Event()
         self._generation_thread = Thread(target=self._generate)
         self._generation_thread.start()
 
@@ -693,8 +698,14 @@ class ResponseGenerator:
         # synchronization messages.
         generation_stream = mx.default_stream(mx.default_device())
 
-        # Load the default model if it is given
-        self.model_provider.load_default()
+        # The load has to happen on this thread: MLX streams are thread-local.
+        try:
+            self.model_provider.load_default()
+        except ValueError as e:
+            self.startup_error = e
+            return
+        finally:
+            self.startup_complete.set()
 
         current_model = None
         current_sampling = None
@@ -1783,6 +1794,14 @@ def run(
     group = mx.distributed.init()
     prompt_cache = LRUPromptCache(model_provider.cli_args.prompt_cache_size)
     response_generator = ResponseGenerator(model_provider, prompt_cache)
+
+    if model_provider.cli_args.kv_bits is not None:
+        # A rejected request has to end the process. The generation thread
+        # cannot exit on its own, so requests would hang instead of failing.
+        response_generator.startup_complete.wait()
+        if response_generator.startup_error is not None:
+            logging.error(str(response_generator.startup_error))
+            sys.exit(1)
     if group.rank() == 0:
         _run_http_server(host, port, response_generator)
     else:

--- a/mlx_lm/server.py
+++ b/mlx_lm/server.py
@@ -619,6 +619,11 @@ class ResponseGenerator:
         return stop_matcher, text_sm
 
     def _is_batchable(self, args):
+        # The batched generator uses BatchKVCache, which has no quantized
+        # variant yet, so route through the single-sequence path (which does
+        # support KV quantization) whenever --kv-bits is requested.
+        if self.cli_args.kv_bits is not None:
+            return False
         return self.model_provider.is_batchable and args.seed is None
 
     def _generate(self):
@@ -931,6 +936,9 @@ class ResponseGenerator:
                 num_draft_tokens=args.num_draft_tokens,
                 prompt_progress_callback=progress,
                 prefill_step_size=self.cli_args.prefill_step_size,
+                kv_bits=self.cli_args.kv_bits,
+                kv_group_size=self.cli_args.kv_group_size,
+                quantized_kv_start=self.cli_args.quantized_kv_start,
             ):
                 finish_reason = gen.finish_reason
 
@@ -1849,6 +1857,27 @@ def main():
         "--pipeline",
         action="store_true",
         help="Use pipelining instead of tensor parallelism",
+    )
+    parser.add_argument(
+        "--kv-bits",
+        type=int,
+        default=None,
+        help="Number of bits for KV cache quantization. Defaults to no "
+        "quantization. Note: enabling this serves requests sequentially "
+        "(the batched path has no quantized cache yet).",
+    )
+    parser.add_argument(
+        "--kv-group-size",
+        type=int,
+        default=64,
+        help="Group size for KV cache quantization (default: 64).",
+    )
+    parser.add_argument(
+        "--quantized-kv-start",
+        type=int,
+        default=5000,
+        help="When --kv-bits is set, begin quantizing the KV cache after "
+        "this many tokens (default: 5000).",
     )
     args = parser.parse_args()
     if mx.metal.is_available():

--- a/mlx_lm/server.py
+++ b/mlx_lm/server.py
@@ -9,6 +9,7 @@ import socket
 import time
 import uuid
 import warnings
+from collections import Counter
 from dataclasses import dataclass
 from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
 from pathlib import Path
@@ -33,6 +34,7 @@ from huggingface_hub import scan_cache_dir
 
 from ._version import __version__
 from .generate import (
+    DEFAULT_QUANTIZED_KV_START,
     BatchGenerator,
     StopSequenceMatcher,
     TextStateMachine,
@@ -40,7 +42,7 @@ from .generate import (
     make_text_state_machine,
     stream_generate,
 )
-from .models.cache import LRUPromptCache, make_prompt_cache
+from .models.cache import CacheList, LRUPromptCache, make_prompt_cache
 from .sample_utils import make_logits_processors, make_sampler
 from .utils import _parse_size, load, sharded_load
 
@@ -271,6 +273,50 @@ class TimeBudget:
         raise StopIteration()
 
 
+def _check_kv_cache_quantizable(cache, kv_group_size, kv_bits, max_kv_size=None):
+    """
+    Raise if any KV cache entry cannot be quantized.
+
+    Converting an empty cache is free, so this tries the real conversion and
+    reports the reason the cache gives.
+    """
+    total = 0
+    unsupported = Counter()
+    for c in cache:
+        if isinstance(c, CacheList):
+            # maybe_quantize_kv_cache does not descend into CacheList, and must
+            # not: deepseek_v32 and longcat_flash read the fetched entries
+            # directly and fail on a quantized cache.
+            total += 1
+            unsupported[(type(c).__name__, "nested KV caches are not quantized")] += 1
+            continue
+        if not hasattr(c, "to_quantized"):
+            # Non-KV state, e.g. the ArraysCache of a Mamba layer, is not
+            # affected by --kv-bits.
+            continue
+        total += 1
+        try:
+            c.to_quantized(group_size=kv_group_size, bits=kv_bits)
+        except NotImplementedError as e:
+            unsupported[(type(c).__name__, str(e))] += 1
+
+    if not unsupported:
+        return
+
+    summary = ", ".join(
+        f"{n} x {name} ({reason})" for (name, reason), n in sorted(unsupported.items())
+    )
+    hint = "Serve without --kv-bits"
+    if max_kv_size is not None:
+        hint += ", or without --max-kv-size, which builds a RotatingKVCache"
+    raise ValueError(
+        f"--kv-bits {kv_bits} was requested but {sum(unsupported.values())} of "
+        f"{total} cache layers cannot be quantized: {summary}. Serving with only "
+        "the remaining layers quantized would ignore part of the request without "
+        f"reporting it. {hint}."
+    )
+
+
 class ModelProvider:
     def __init__(self, cli_args: argparse.Namespace):
         """Load models on demand and persist them across the whole process."""
@@ -354,6 +400,22 @@ class ModelProvider:
         is_batchable = is_batchable and all(
             hasattr(c, "merge") for c in make_prompt_cache(model)
         )
+
+        # Fail at load, not part-way through a request.
+        if self.cli_args.kv_bits is not None:
+            probe_cache = make_prompt_cache(
+                model, max_kv_size=self.cli_args.max_kv_size
+            )
+            if draft_model is not None:
+                probe_cache += make_prompt_cache(
+                    draft_model, max_kv_size=self.cli_args.max_kv_size
+                )
+            _check_kv_cache_quantizable(
+                probe_cache,
+                self.cli_args.kv_group_size,
+                self.cli_args.kv_bits,
+                max_kv_size=self.cli_args.max_kv_size,
+            )
 
         # Update the member variables
         self.model_key = (model_path, adapter_path, draft_model_path)
@@ -619,9 +681,8 @@ class ResponseGenerator:
         return stop_matcher, text_sm
 
     def _is_batchable(self, args):
-        # The batched generator uses BatchKVCache, which has no quantized
-        # variant yet, so route through the single-sequence path (which does
-        # support KV quantization) whenever --kv-bits is requested.
+        # BatchGenerator takes no kv_bits, so route through the single-sequence
+        # path, which can quantize.
         if self.cli_args.kv_bits is not None:
             return False
         return self.model_provider.is_batchable and args.seed is None
@@ -1881,9 +1942,9 @@ def main():
     parser.add_argument(
         "--quantized-kv-start",
         type=int,
-        default=5000,
+        default=DEFAULT_QUANTIZED_KV_START,
         help="When --kv-bits is set, begin quantizing the KV cache after "
-        "this many tokens (default: 5000).",
+        f"this many tokens (default: {DEFAULT_QUANTIZED_KV_START}).",
     )
     parser.add_argument(
         "--max-kv-size",

--- a/mlx_lm/server.py
+++ b/mlx_lm/server.py
@@ -276,28 +276,28 @@ class TimeBudget:
 
 def _check_kv_cache_quantizable(cache, kv_group_size, kv_bits, max_kv_size=None):
     """
-    Raise if any KV cache entry cannot be quantized.
+    Warn when only some KV cache entries can be quantized, and raise when none
+    can, because the request then has no effect.
 
     Converting an empty cache is free, so this tries the real conversion and
     reports the reason the cache gives.
     """
-    total = 0
+    quantizable = 0
     unsupported = Counter()
     for c in cache:
         if isinstance(c, CacheList):
             # maybe_quantize_kv_cache does not descend into CacheList, and must
             # not: deepseek_v32 and longcat_flash read the fetched entries
             # directly and fail on a quantized cache.
-            total += 1
             unsupported[(type(c).__name__, "nested KV caches are not quantized")] += 1
             continue
         if not hasattr(c, "to_quantized"):
             # Non-KV state, e.g. the ArraysCache of a Mamba layer, is not
             # affected by --kv-bits.
             continue
-        total += 1
         try:
             c.to_quantized(group_size=kv_group_size, bits=kv_bits)
+            quantizable += 1
         except NotImplementedError as e:
             unsupported[(type(c).__name__, str(e))] += 1
 
@@ -307,14 +307,24 @@ def _check_kv_cache_quantizable(cache, kv_group_size, kv_bits, max_kv_size=None)
     summary = ", ".join(
         f"{n} x {name} ({reason})" for (name, reason), n in sorted(unsupported.items())
     )
+    skipped = sum(unsupported.values())
+    total = quantizable + skipped
+
+    if quantizable:
+        logging.warning(
+            f"--kv-bits {kv_bits} applies to {quantizable} of {total} cache "
+            f"entries. {skipped} will stay unquantized: {summary}. On "
+            "sliding-window architectures these hold window-bounded state, while "
+            "the quantized entries grow with the context."
+        )
+        return
+
     hint = "Serve without --kv-bits"
     if max_kv_size is not None:
         hint += ", or without --max-kv-size, which builds a RotatingKVCache"
     raise ValueError(
-        f"--kv-bits {kv_bits} was requested but {sum(unsupported.values())} of "
-        f"{total} cache layers cannot be quantized: {summary}. Serving with only "
-        "the remaining layers quantized would ignore part of the request without "
-        f"reporting it. {hint}."
+        f"--kv-bits {kv_bits} cannot be applied to any of the {total} cache "
+        f"entries: {summary}. Serving would ignore the request entirely. {hint}."
     )
 
 
@@ -402,7 +412,7 @@ class ModelProvider:
             hasattr(c, "merge") for c in make_prompt_cache(model)
         )
 
-        # Fail at load, not part-way through a request.
+        # Report the split at load, not part-way through a request.
         if self.cli_args.kv_bits is not None:
             probe_cache = make_prompt_cache(
                 model, max_kv_size=self.cli_args.max_kv_size

--- a/tests/test_generate.py
+++ b/tests/test_generate.py
@@ -16,7 +16,13 @@ from mlx_lm.generate import (
     maybe_quantize_kv_cache,
     stream_generate,
 )
-from mlx_lm.models.cache import ArraysCache, CacheList, KVCache, RotatingKVCache
+from mlx_lm.models.cache import (
+    ArraysCache,
+    CacheList,
+    KVCache,
+    QuantizedKVCache,
+    RotatingKVCache,
+)
 from mlx_lm.sample_utils import make_logits_processors, make_sampler
 from mlx_lm.utils import load
 
@@ -819,6 +825,54 @@ class TestGenerate(unittest.TestCase):
 
         self.assertIsInstance(prompt_cache[0], CacheList)
         self.assertIs(prompt_cache[0].caches[1], inner)
+
+    def test_maybe_quantize_kv_cache_hybrid(self):
+        # A Gemma 4 style hybrid cache. RotatingKVCache has no quantized
+        # variant, so it must be left alone instead of aborting the request.
+        full = KVCache()
+        rotating = RotatingKVCache(max_size=8)
+        keys = mx.zeros((1, 1, 4, 64))
+        values = mx.zeros((1, 1, 4, 64))
+        full.update_and_fetch(keys, values)
+        rotating.update_and_fetch(keys, values)
+
+        prompt_cache = [full, rotating]
+        maybe_quantize_kv_cache(
+            prompt_cache, quantized_kv_start=0, kv_group_size=32, kv_bits=4
+        )
+
+        self.assertIsInstance(prompt_cache[0], QuantizedKVCache)
+        self.assertIsInstance(prompt_cache[1], RotatingKVCache)
+
+    def test_generate_step_with_hybrid_cache_and_kv_bits(self):
+        # maybe_quantize_kv_cache runs on every step, so a cache that cannot
+        # convert would abort mid-request, not at the start.
+        prompt_cache = [
+            KVCache() if i % 2 else RotatingKVCache(max_size=512)
+            for i in range(len(self.model.layers))
+        ]
+        prompt = mx.array(self.tokenizer.encode("hello"))
+
+        tokens = [
+            token
+            for token, _ in zip(
+                generate_step(
+                    prompt,
+                    self.model,
+                    prompt_cache=prompt_cache,
+                    kv_bits=8,
+                    quantized_kv_start=0,
+                ),
+                range(5),
+            )
+        ]
+
+        self.assertEqual(len(tokens), 5)
+        quantized = [c for c in prompt_cache if isinstance(c, QuantizedKVCache)]
+        rotating = [c for c in prompt_cache if isinstance(c, RotatingKVCache)]
+        self.assertEqual(len(quantized) + len(rotating), len(prompt_cache))
+        self.assertTrue(quantized)
+        self.assertTrue(rotating)
 
     def test_batch_generate_return_logprobs(self):
         """Test that batch_generate returns per-token logprobs when requested."""

--- a/tests/test_generate.py
+++ b/tests/test_generate.py
@@ -13,9 +13,10 @@ from mlx_lm.generate import (
     batch_generate,
     generate,
     generate_step,
+    maybe_quantize_kv_cache,
     stream_generate,
 )
-from mlx_lm.models.cache import KVCache, RotatingKVCache
+from mlx_lm.models.cache import ArraysCache, CacheList, KVCache, RotatingKVCache
 from mlx_lm.sample_utils import make_logits_processors, make_sampler
 from mlx_lm.utils import load
 
@@ -802,6 +803,22 @@ class TestGenerate(unittest.TestCase):
             if r.finish_reason is not None:
                 for cache in r.prompt_cache:
                     self.assertIsInstance(cache, KVCache)
+
+    def test_maybe_quantize_kv_cache_leaves_nested_caches_alone(self):
+        # CacheList must stay untouched: deepseek_v32 and longcat_flash read the
+        # fetched entries directly and fail on a quantized cache.
+        keys = mx.zeros((1, 1, 4, 64))
+        values = mx.zeros((1, 1, 4, 64))
+        inner = KVCache()
+        inner.update_and_fetch(keys, values)
+        prompt_cache = [CacheList(ArraysCache(size=2), inner)]
+
+        maybe_quantize_kv_cache(
+            prompt_cache, quantized_kv_start=0, kv_group_size=32, kv_bits=4
+        )
+
+        self.assertIsInstance(prompt_cache[0], CacheList)
+        self.assertIs(prompt_cache[0].caches[1], inner)
 
     def test_batch_generate_return_logprobs(self):
         """Test that batch_generate returns per-token logprobs when requested."""

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -4,26 +4,34 @@ import http
 import io
 import json
 import threading
+import types
 import unittest
 
 import mlx.core as mx
 import requests
 
 from mlx_lm.generate import TextStateMachine
-from mlx_lm.models.cache import KVCache
+from mlx_lm.models.cache import (
+    ArraysCache,
+    CacheList,
+    KVCache,
+    RotatingKVCache,
+    make_prompt_cache,
+)
 from mlx_lm.server import (
     APIHandler,
     LRUPromptCache,
     Response,
     ResponseGenerator,
     SamplingArguments,
+    _check_kv_cache_quantizable,
     _make_sampler,
 )
 from mlx_lm.utils import load
 
 
 class DummyModelProvider:
-    def __init__(self, with_draft=False):
+    def __init__(self, with_draft=False, kv_bits=None, max_kv_size=None):
         HF_MODEL_PATH = "mlx-community/Qwen1.5-0.5B-Chat-4bit"
         self.model, self.tokenizer = load(HF_MODEL_PATH)
         self.model_key = (HF_MODEL_PATH, None)
@@ -56,6 +64,10 @@ class DummyModelProvider:
                 "prompt_cache_bytes": 1 << 63,
                 "prompt_cache_total_bytes": None,
                 "allowed_origins": ["*"],
+                "kv_bits": kv_bits,
+                "kv_group_size": 64,
+                "quantized_kv_start": 0,
+                "max_kv_size": max_kv_size,
             },
         )
 
@@ -514,6 +526,95 @@ class TestServerWithDraftModel(unittest.TestCase):
         # Ensure both generated content
         self.assertIsNotNone(first_response_body["choices"][0]["message"]["content"])
         self.assertIsNotNone(second_response_body["choices"][0]["message"]["content"])
+
+
+class TestKVCacheQuantizable(unittest.TestCase):
+    def test_rejects_partly_quantizable_cache(self):
+        # Gemma 4 layout: the sliding-window layers cannot convert, so most of
+        # the request would be dropped without saying so (#1573).
+        cache = [KVCache()] + [RotatingKVCache(max_size=512) for _ in range(4)]
+        with self.assertRaises(ValueError) as ctx:
+            _check_kv_cache_quantizable(cache, 64, 8)
+        message = str(ctx.exception)
+        self.assertIn("4 of 5", message)
+        self.assertIn("RotatingKVCache", message)
+
+    def test_rejects_when_nothing_can_be_quantized(self):
+        cache = [RotatingKVCache(max_size=8, keep=4) for _ in range(2)]
+        with self.assertRaises(ValueError) as ctx:
+            _check_kv_cache_quantizable(cache, 64, 8)
+        message = str(ctx.exception)
+        self.assertIn("RotatingKVCache", message)
+        self.assertIn("2 of 2", message)
+        # The reason comes from the cache, not from a guess about the flag.
+        self.assertNotIn("--max-kv-size", message)
+
+    def test_rejects_nested_kv_caches(self):
+        # A CacheList model (falcon_h1, deepseek_v32, longcat_flash) ignores
+        # --kv-bits, because maybe_quantize_kv_cache does not descend into it.
+        cache = [CacheList(ArraysCache(size=2), KVCache()) for _ in range(3)]
+        with self.assertRaises(ValueError) as ctx:
+            _check_kv_cache_quantizable(cache, 64, 8)
+        self.assertIn("CacheList", str(ctx.exception))
+
+    def test_accepts_kv_cache(self):
+        _check_kv_cache_quantizable([KVCache() for _ in range(4)], 64, 8)
+
+    def test_ignores_non_kv_state(self):
+        # Recurrent state is not a KV cache, so this must be accepted.
+        _check_kv_cache_quantizable([KVCache(), ArraysCache(size=2)], 64, 8)
+
+    def test_rejects_max_kv_size_cache(self):
+        # max_kv_size builds RotatingKVCache(keep=4) for every layer, so
+        # nothing is quantizable.
+        model = types.SimpleNamespace(layers=[None] * 3)
+        cache = make_prompt_cache(model, max_kv_size=32)
+        with self.assertRaises(ValueError) as ctx:
+            _check_kv_cache_quantizable(cache, 64, 8, max_kv_size=32)
+        self.assertIn("--max-kv-size", str(ctx.exception))
+
+
+class TestServerWithKVCacheQuantization(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.response_generator = ResponseGenerator(
+            DummyModelProvider(kv_bits=8), LRUPromptCache()
+        )
+        cls.server_address = ("localhost", 0)
+        cls.httpd = http.server.HTTPServer(
+            cls.server_address,
+            lambda *args, **kwargs: APIHandler(cls.response_generator, *args, **kwargs),
+        )
+        cls.port = cls.httpd.server_port
+        cls.server_thread = threading.Thread(target=cls.httpd.serve_forever)
+        cls.server_thread.daemon = True
+        cls.server_thread.start()
+
+    @classmethod
+    def tearDownClass(cls):
+        cls.httpd.shutdown()
+        cls.httpd.server_close()
+        cls.server_thread.join()
+        cls.response_generator.stop_and_join()
+
+    def test_not_batchable_with_kv_bits(self):
+        args = types.SimpleNamespace(seed=None)
+        self.assertFalse(self.response_generator._is_batchable(args))
+
+    def test_handle_completions_with_kv_bits(self):
+        url = f"http://localhost:{self.port}/v1/completions"
+        response = requests.post(
+            url,
+            json={
+                "model": "default_model",
+                "prompt": "Once upon a time",
+                "max_tokens": 10,
+            },
+        )
+        self.assertEqual(response.status_code, 200)
+        response_body = json.loads(response.text)
+        self.assertIn("choices", response_body)
+        self.assertTrue(response_body["choices"][0]["text"])
 
 
 class TestKeepalive(unittest.TestCase):

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -6,6 +6,7 @@ import json
 import threading
 import types
 import unittest
+from unittest.mock import patch
 
 import mlx.core as mx
 import requests
@@ -26,6 +27,7 @@ from mlx_lm.server import (
     SamplingArguments,
     _check_kv_cache_quantizable,
     _make_sampler,
+    run,
 )
 from mlx_lm.utils import load
 
@@ -572,6 +574,58 @@ class TestKVCacheQuantizable(unittest.TestCase):
         with self.assertRaises(ValueError) as ctx:
             _check_kv_cache_quantizable(cache, 64, 8, max_kv_size=32)
         self.assertIn("--max-kv-size", str(ctx.exception))
+
+
+class TestKVQuantizationStartupRefusal(unittest.TestCase):
+    """The refusal has to end the process, not just the generation thread."""
+
+    def _provider(self, kv_bits):
+        return types.SimpleNamespace(
+            cli_args=types.SimpleNamespace(kv_bits=kv_bits, prompt_cache_size=1)
+        )
+
+    def test_generation_thread_records_the_error(self):
+        def load_default():
+            raise ValueError("cannot be applied to any of the 24 cache layers")
+
+        provider = self._provider(8)
+        provider.load_default = load_default
+        generator = ResponseGenerator(provider, LRUPromptCache(1))
+        self.addCleanup(generator.join)
+
+        self.assertTrue(generator.startup_complete.wait(timeout=30))
+        self.assertIsInstance(generator.startup_error, ValueError)
+        self.assertIn("cache layers", str(generator.startup_error))
+
+    def test_run_exits_when_startup_was_refused(self):
+        error = ValueError("cannot be applied to any of the 24 cache layers")
+        generator = types.SimpleNamespace(
+            startup_complete=threading.Event(), startup_error=error
+        )
+        generator.startup_complete.set()
+
+        with patch("mlx_lm.server.ResponseGenerator", return_value=generator):
+            with patch("mlx_lm.server._run_http_server") as serve:
+                with self.assertLogs(level="ERROR") as logs:
+                    with self.assertRaises(SystemExit) as ctx:
+                        run("127.0.0.1", 0, self._provider(8))
+
+        self.assertEqual(ctx.exception.code, 1)
+        self.assertIn("cache layers", "\n".join(logs.output))
+        serve.assert_not_called()
+
+    def test_run_does_not_wait_without_kv_bits(self):
+        # Nothing to validate, so startup must not block on the model load.
+        generator = types.SimpleNamespace(
+            startup_complete=threading.Event(), startup_error=None
+        )
+
+        with patch("mlx_lm.server.ResponseGenerator", return_value=generator):
+            with patch("mlx_lm.server._run_http_server") as serve:
+                run("127.0.0.1", 0, self._provider(None))
+
+        serve.assert_called_once()
+        self.assertFalse(generator.startup_complete.is_set())
 
 
 class TestServerWithKVCacheQuantization(unittest.TestCase):

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -531,14 +531,14 @@ class TestServerWithDraftModel(unittest.TestCase):
 
 
 class TestKVCacheQuantizable(unittest.TestCase):
-    def test_rejects_partly_quantizable_cache(self):
-        # Gemma 4 layout: the sliding-window layers cannot convert, so most of
-        # the request would be dropped without saying so (#1573).
+    def test_warns_and_serves_hybrid_cache(self):
+        # Gemma 4 layout: the sliding-window layers are window-bounded, while
+        # the layers that do convert grow with the context. Warn, do not refuse.
         cache = [KVCache()] + [RotatingKVCache(max_size=512) for _ in range(4)]
-        with self.assertRaises(ValueError) as ctx:
+        with self.assertLogs(level="WARNING") as logs:
             _check_kv_cache_quantizable(cache, 64, 8)
-        message = str(ctx.exception)
-        self.assertIn("4 of 5", message)
+        message = "\n".join(logs.output)
+        self.assertIn("1 of 5", message)
         self.assertIn("RotatingKVCache", message)
 
     def test_rejects_when_nothing_can_be_quantized(self):
@@ -547,7 +547,7 @@ class TestKVCacheQuantizable(unittest.TestCase):
             _check_kv_cache_quantizable(cache, 64, 8)
         message = str(ctx.exception)
         self.assertIn("RotatingKVCache", message)
-        self.assertIn("2 of 2", message)
+        self.assertIn("any of the 2 cache entries", message)
         # The reason comes from the cache, not from a guess about the flag.
         self.assertNotIn("--max-kv-size", message)
 
@@ -563,8 +563,9 @@ class TestKVCacheQuantizable(unittest.TestCase):
         _check_kv_cache_quantizable([KVCache() for _ in range(4)], 64, 8)
 
     def test_ignores_non_kv_state(self):
-        # Recurrent state is not a KV cache, so this must be accepted.
-        _check_kv_cache_quantizable([KVCache(), ArraysCache(size=2)], 64, 8)
+        # Recurrent state is not a KV cache, so this must not warn.
+        with self.assertNoLogs(level="WARNING"):
+            _check_kv_cache_quantizable([KVCache(), ArraysCache(size=2)], 64, 8)
 
     def test_rejects_max_kv_size_cache(self):
         # max_kv_size builds RotatingKVCache(keep=4) for every layer, so
@@ -586,7 +587,7 @@ class TestKVQuantizationStartupRefusal(unittest.TestCase):
 
     def test_generation_thread_records_the_error(self):
         def load_default():
-            raise ValueError("cannot be applied to any of the 24 cache layers")
+            raise ValueError("cannot be applied to any of the 24 cache entries")
 
         provider = self._provider(8)
         provider.load_default = load_default
@@ -595,10 +596,10 @@ class TestKVQuantizationStartupRefusal(unittest.TestCase):
 
         self.assertTrue(generator.startup_complete.wait(timeout=30))
         self.assertIsInstance(generator.startup_error, ValueError)
-        self.assertIn("cache layers", str(generator.startup_error))
+        self.assertIn("cache entries", str(generator.startup_error))
 
     def test_run_exits_when_startup_was_refused(self):
-        error = ValueError("cannot be applied to any of the 24 cache layers")
+        error = ValueError("cannot be applied to any of the 24 cache entries")
         generator = types.SimpleNamespace(
             startup_complete=threading.Event(), startup_error=error
         )
@@ -611,7 +612,7 @@ class TestKVQuantizationStartupRefusal(unittest.TestCase):
                         run("127.0.0.1", 0, self._provider(8))
 
         self.assertEqual(ctx.exception.code, 1)
-        self.assertIn("cache layers", "\n".join(logs.output))
+        self.assertIn("cache entries", "\n".join(logs.output))
         serve.assert_not_called()
 
     def test_run_does_not_wait_without_kv_bits(self):


### PR DESCRIPTION
# Problem

`mlx-lm`'s server has no way to enable KV cache quantization. The library supports it (`kv_bits`, `kv_group_size`, `quantized_kv_start`), but only through the Python API, so anyone running `mlx_lm.server` was stuck with an unquantized cache that grows linearly with context length. `max_kv_size` wasn't exposed either.

# Solution

Adds `--kv-bits`, `--kv-group-size`, `--quantized-kv-start`, and `--max-kv-size` to the server CLI and threads them through to generate.

Not every cache type supports quantization. Without a check, the server would start normally, quantize whatever layers happen to support it, and silently leave the rest alone. So model load now inspects the cache: if any layer can't be quantized with the requested settings, it logs which layers and how many, and the server exits with a non-zero code.

Noted that the model loads in a background thread. Raising there just kills the thread, and the main server keeps accepting connections that block forever waiting on a model that never arrives. The main thread now joins on the first load and exits if it failed.

Tradeoff: with `--kv-bits` set, requests are processed one at a time. The batched path doesn't support quantized caches yet. This is documented in the flag's help text.

- ☑️ I understand it is strictly prohibited to use AI to write PR description
- AI usage disclosure: 
I use AI as a helper but I do my judgment and apply as a human actor.