### PR TITLE
fix: plumb evaluate batch-size to generate_until, accept max_gen_toks

### DIFF
--- a/mlx_lm/evaluate.py
+++ b/mlx_lm/evaluate.py
@@ -343,7 +343,8 @@ class MLXLM(LM):
 
         # TODO consider multi-token, per-prompt stop conditions
         max_tokens = [
-            self._max_tokens or opt.get("max_gen_tokens", DEFAULT_MAX_TOKENS)
+            self._max_tokens
+            or opt.get("max_gen_tokens", opt.get("max_gen_toks", DEFAULT_MAX_TOKENS))
             for opt in options
         ]
 
@@ -354,6 +355,8 @@ class MLXLM(LM):
             max_tokens=max_tokens,
             verbose=True,
             sampler=self._sampler,
+            completion_batch_size=self._batch_size,
+            prefill_batch_size=max(self._batch_size // 2, 1),
         ).texts
 
         for e, (text, opt) in enumerate(zip(completions, options)):


### PR DESCRIPTION
Closes #1808.

## Bugs
Two bugs in `mlx_lm.evaluate` that make generative eval tasks unusable
on 16 GB Macs:

1. `generate_until` calls `batch_generate` without batch-size args, so
   `BatchGenerator`'s default `completion_batch_size=32` applies and
   every request decodes concurrently. The `--batch-size` flag was only
   used in the loglikelihood scoring loop.
2. `max_tokens` reads `opt.get("max_gen_tokens", ...)` but lm-eval
   passes the key `max_gen_toks`, so per-task generation caps are
   discarded and every request gets `DEFAULT_MAX_TOKENS = 8192`.

## What is the fix

- Pass `completion_batch_size=self._batch_size` and
  `prefill_batch_size=max(self._batch_size // 2, 1)` to `batch_generate`
- Accept `max_gen_toks` as a fallback key alongside `max_gen_tokens`

## Checks

- `pre-commit run --all-files` (black + isort) — clean