### PR TITLE
Fix tool name extraction in the qwen3_coder parser

### DIFF
--- a/mlx_lm/tool_parsers/qwen3_coder.py
+++ b/mlx_lm/tool_parsers/qwen3_coder.py
@@ -87,10 +87,12 @@ def _convert_param_value(param_value: str, param_name: str, param_config: dict) 
 
 
 def _parse_xml_function_call(function_call_str: str, tools: Optional[Any]):
-    end_index = function_call_str.index(">")
-    function_name = function_call_str[:end_index]
+    name_match = re.match(r"\s*([^\s<>]+)>?", function_call_str)
+    if name_match is None:
+        raise ValueError("No function name provided.")
+    function_name = name_match.group(1)
     param_config = _get_arguments_config(function_name, tools)
-    parameters = function_call_str[end_index + 1 :]
+    parameters = function_call_str[name_match.end() :]
     param_dict = {}
     for match_text in _parameter_regex.findall(parameters):
         idx = match_text.index(">")

--- a/tests/test_tool_parsing.py
+++ b/tests/test_tool_parsing.py
@@ -405,6 +405,24 @@ class TestToolParsing(unittest.TestCase):
         # parse_tool_call returns dict, not list
         self.assertEqual(tool_calls["arguments"]["msg"], "version 3.10.5-beta")
 
+    def test_qwen3_coder_missing_function_tag_close(self):
+        """Recover the function name when the model drops the ">" after it."""
+        tools = [
+            {
+                "type": "function",
+                "function": {
+                    "name": "get_current_time",
+                    "description": "Get the current time",
+                    "parameters": {"type": "object", "properties": {}},
+                },
+            }
+        ]
+        # Missing ">" after the name plus an orphan "</parameter>"
+        test_case = "<function=get_current_time\n</parameter>\n</function>"
+        tool_call = qwen3_coder.parse_tool_call(test_case, tools)
+        self.assertEqual(tool_call["name"], "get_current_time")
+        self.assertEqual(tool_call["arguments"], {})
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
The name was sliced at the first '>'. If the model drops the '>' after the name, the slice runs into the next tag and produces names like 'get_current_time\n</parameter', which clients reject as an unknown tool. 

I've been hitting this issue constantly with Qwen3.6-35B-A3B, Ornith-1.5 and Apodex-1.1.

The fix implemented here is to stop the name at the first whitespace or angle bracket instead.

- ☑️ I understand it is strictly prohibited to use AI to write PR description
- AI usage disclosure: Fable debugged this from OpenCode exits down to oMLX and mlx-ml. 