### PR TITLE
Fix/mlx_lm.evaluate ignoring max_gen_toks and --batch-size during generation

### DIFF
--- a/mlx_lm/evaluate.py
+++ b/mlx_lm/evaluate.py
@@ -342,8 +342,9 @@ class MLXLM(LM):
         ]
 
         # TODO consider multi-token, per-prompt stop conditions
+        # lm-eval names the per-task generation cap "max_gen_toks".
         max_tokens = [
-            self._max_tokens or opt.get("max_gen_tokens", DEFAULT_MAX_TOKENS)
+            self._max_tokens or opt.get("max_gen_toks", DEFAULT_MAX_TOKENS)
             for opt in options
         ]
 

--- a/mlx_lm/evaluate.py
+++ b/mlx_lm/evaluate.py
@@ -355,6 +355,8 @@ class MLXLM(LM):
             max_tokens=max_tokens,
             verbose=True,
             sampler=self._sampler,
+            prefill_batch_size=self._batch_size,
+            completion_batch_size=self._batch_size,
         ).texts
 
         for e, (text, opt) in enumerate(zip(completions, options)):
@@ -406,7 +408,13 @@ def main():
     parser.add_argument(
         "--output-dir", default=".", help="Output directory for result files."
     )
-    parser.add_argument("--batch-size", type=int, default=16, help="Batch size")
+    parser.add_argument(
+        "--batch-size",
+        type=int,
+        default=8,
+        help="Maximum number of sequences processed at once, both when "
+        "scoring and when generating.",
+    )
     parser.add_argument("--num-shots", type=int, default=None, help="Number of shots")
     parser.add_argument(
         "--max-tokens",

--- a/tests/test_evaluate.py
+++ b/tests/test_evaluate.py
@@ -16,6 +16,7 @@ class TestMLXLM(unittest.TestCase):
         self.mock_tokenizer.model_max_length = 2048
         self.mock_tokenizer.chat_template = None
         self.mock_tokenizer.encode = MagicMock(return_value=[1, 2, 3, 4])
+        self.mock_tokenizer.has_thinking = False
 
         with patch("mlx_lm.evaluate.load") as mock_load:
             mock_load.return_value = (self.mock_model, self.mock_tokenizer)
@@ -66,6 +67,35 @@ class TestMLXLM(unittest.TestCase):
         result = self.mlx_lm.generate_until([request])
 
         self.assertEqual(result, ["answer"])
+    def _make_lm(self, **kwargs):
+        with patch("mlx_lm.evaluate.load") as mock_load:
+            mock_load.return_value = (self.mock_model, self.mock_tokenizer)
+            return MLXLM("test_model", **kwargs)
+
+    def _run_generate_until(self, lm, options):
+        requests = [MagicMock(args=(f"prompt {i}", o)) for i, o in enumerate(options)]
+        with patch("mlx_lm.evaluate.batch_generate") as mock_generate:
+            mock_generate.return_value = MagicMock(texts=[""] * len(requests))
+            lm.generate_until(requests)
+        return mock_generate.call_args.kwargs
+
+    def test_generate_until_uses_task_max_gen_toks(self):
+        """lm-eval passes the per-task generation cap as `max_gen_toks`."""
+        lm = self._make_lm(max_tokens=None)
+        kwargs = self._run_generate_until(
+            lm,
+            [
+                {"until": ["\n\n"], "max_gen_toks": 10},
+                {"until": ["\n\n"], "max_gen_toks": 1024},
+            ],
+        )
+        self.assertEqual(kwargs["max_tokens"], [10, 1024])
+
+    def test_generate_until_max_tokens_overrides_task_default(self):
+        """--max-tokens takes precedence over task specific defaults."""
+        lm = self._make_lm(max_tokens=128)
+        kwargs = self._run_generate_until(lm, [{"until": ["\n\n"], "max_gen_toks": 10}])
+        self.assertEqual(kwargs["max_tokens"], [128])
 
 
 if __name__ == "__main__":

--- a/tests/test_evaluate.py
+++ b/tests/test_evaluate.py
@@ -67,6 +67,7 @@ class TestMLXLM(unittest.TestCase):
         result = self.mlx_lm.generate_until([request])
 
         self.assertEqual(result, ["answer"])
+
     def _make_lm(self, **kwargs):
         with patch("mlx_lm.evaluate.load") as mock_load:
             mock_load.return_value = (self.mock_model, self.mock_tokenizer)

--- a/tests/test_evaluate.py
+++ b/tests/test_evaluate.py
@@ -97,6 +97,13 @@ class TestMLXLM(unittest.TestCase):
         kwargs = self._run_generate_until(lm, [{"until": ["\n\n"], "max_gen_toks": 10}])
         self.assertEqual(kwargs["max_tokens"], [128])
 
+    def test_generate_until_respects_batch_size(self):
+        """--batch-size bounds generation, not just loglikelihood scoring."""
+        lm = self._make_lm(max_tokens=None, batch_size=4)
+        kwargs = self._run_generate_until(lm, [{"until": ["\n\n"]}] * 6)
+        self.assertEqual(kwargs["prefill_batch_size"], 4)
+        self.assertEqual(kwargs["completion_batch_size"], 4)
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
Fixes #1808

At `evaluate.py:346`, the code reads `max_gen_tokens`, while `lm-eval` emits `max_gen_toks`, so it falls back to 8192 tokens instead of applying `mmlu_pro`’s 2048-token limit. At `evaluate.py:350`, `--batch-size` is not passed to `batch_generate`, leaving `BatchGenerator`’s 8/32 defaults in effect; the flag is only read in the loglikelihood loop at `evaluate.py:303`.

```bash
mlx_lm.evaluate --model mlx-community/Qwen3-4B-Instruct-2507-4bit \
  --task mmlu_pro --limit 2 --batch-size 1
```

On main, this fails with `[METAL] Command buffer execution failed: Insufficient Memory (00000008:kIOGPUCommandBufferCallbackErrorOutOfMemory)`. Fixing the token key alone still crashes. With both fixes, peak memory is 3.44 GiB at batch size 1, 10.13 GiB at 4, and 16.97 GiB at the new default of 8.

Prefill memory is 5.41 / 8.21 / 9.49 GiB at batch sizes 4 / 8 / 16. Passing the old default of 16 into prefill would use 1.28 GiB more than 8, so the default moves to 8.

On 70 samples at batch size 1, the `mmlu_pro` exact-match score changes from 0.6143 to 0.5857. Ten completions exceed 2048 tokens, with a maximum of 5140, so the existing `BENCHMARKS.md` result produced under the 8192-token budget may decrease slightly when regenerated; `n=70` is small.

Three tests were added; two fail on main, while the `--max-tokens` precedence test already passes.

Per CONTRIBUTING: I directed the investigation, code, tests, and measurements using Claude Code; the runs were on my M4 Pro. I reviewed the diff, and I take responsibility for every line.
