### PR TITLE
fix: gate wired_limit on the active device

### DIFF
--- a/mlx_lm/generate.py
+++ b/mlx_lm/generate.py
@@ -1594,7 +1594,7 @@ class BatchGenerator:
         self._gen_tokens_counter = 0
         self._steps_counter = 0
 
-        if mx.metal.is_available():
+        if mx.metal.is_available() and mx.default_device() == mx.gpu:
             self._old_wired_limit = mx.set_wired_limit(
                 mx.device_info()["max_recommended_working_set_size"]
             )

--- a/mlx_lm/generate.py
+++ b/mlx_lm/generate.py
@@ -229,7 +229,7 @@ def wired_limit(model: nn.Module, streams: Optional[List[mx.Stream]] = None):
     async eval could be running pass in the streams to synchronize with prior
     to exiting the context manager.
     """
-    if not mx.metal.is_available():
+    if not mx.metal.is_available() or mx.default_device() != mx.gpu:
         try:
             yield
         finally:

--- a/mlx_lm/generate.py
+++ b/mlx_lm/generate.py
@@ -26,7 +26,11 @@ from .models.cache import (
 )
 from .sample_utils import make_sampler
 from .tokenizer_utils import TokenizerWrapper
-from .utils import does_model_support_input_embeddings, load
+from .utils import (
+    does_model_support_input_embeddings,
+    load,
+    maybe_set_recommended_wired_limit,
+)
 
 DEFAULT_PROMPT = "hello"
 DEFAULT_MAX_TOKENS = 100
@@ -229,35 +233,33 @@ def wired_limit(model: nn.Module, streams: Optional[List[mx.Stream]] = None):
     async eval could be running pass in the streams to synchronize with prior
     to exiting the context manager.
     """
-    if not mx.metal.is_available() or mx.default_device() != mx.gpu:
-        try:
-            yield
-        finally:
-            pass
-    else:
-        model_bytes = tree_reduce(
-            lambda acc, x: acc + x.nbytes if isinstance(x, mx.array) else acc, model, 0
+    old_limit = maybe_set_recommended_wired_limit()
+    if old_limit is None:
+        yield
+        return
+
+    model_bytes = tree_reduce(
+        lambda acc, x: acc + x.nbytes if isinstance(x, mx.array) else acc, model, 0
+    )
+    max_rec_size = mx.device_info()["max_recommended_working_set_size"]
+    if model_bytes > 0.9 * max_rec_size:
+        model_mb = model_bytes // 2**20
+        max_rec_mb = max_rec_size // 2**20
+        print(
+            f"[WARNING] Generating with a model that requires {model_mb} MB "
+            f"which is close to the maximum recommended size of {max_rec_mb} "
+            "MB. This can be slow. See the documentation for possible work-arounds: "
+            "https://github.com/ml-explore/mlx-lm/tree/main#large-models"
         )
-        max_rec_size = mx.device_info()["max_recommended_working_set_size"]
-        if model_bytes > 0.9 * max_rec_size:
-            model_mb = model_bytes // 2**20
-            max_rec_mb = max_rec_size // 2**20
-            print(
-                f"[WARNING] Generating with a model that requires {model_mb} MB "
-                f"which is close to the maximum recommended size of {max_rec_mb} "
-                "MB. This can be slow. See the documentation for possible work-arounds: "
-                "https://github.com/ml-explore/mlx-lm/tree/main#large-models"
-            )
-        old_limit = mx.set_wired_limit(max_rec_size)
-        try:
-            yield
-        finally:
-            if streams is not None:
-                for s in streams:
-                    mx.synchronize(s)
-            else:
-                mx.synchronize()
-            mx.set_wired_limit(old_limit)
+    try:
+        yield
+    finally:
+        if streams is not None:
+            for s in streams:
+                mx.synchronize(s)
+        else:
+            mx.synchronize()
+        mx.set_wired_limit(old_limit)
 
 
 @dataclass
@@ -1594,12 +1596,7 @@ class BatchGenerator:
         self._gen_tokens_counter = 0
         self._steps_counter = 0
 
-        if mx.metal.is_available() and mx.default_device() == mx.gpu:
-            self._old_wired_limit = mx.set_wired_limit(
-                mx.device_info()["max_recommended_working_set_size"]
-            )
-        else:
-            self._old_wired_limit = None
+        self._old_wired_limit = maybe_set_recommended_wired_limit()
 
     @property
     def stream(self):

--- a/mlx_lm/quant/dwq.py
+++ b/mlx_lm/quant/dwq.py
@@ -403,7 +403,7 @@ def main():
     if has_targets and model is not None:
         del model
 
-    if mx.metal.is_available():
+    if mx.metal.is_available() and mx.default_device() == mx.gpu:
         max_rec_size = mx.device_info()["max_recommended_working_set_size"]
         mx.set_wired_limit(max_rec_size)
 

--- a/mlx_lm/quant/dwq.py
+++ b/mlx_lm/quant/dwq.py
@@ -20,6 +20,7 @@ from mlx_lm.tuner.utils import print_trainable_parameters
 from mlx_lm.utils import (
     load,
     load_tokenizer,
+    maybe_set_recommended_wired_limit,
     quantize_model,
     save,
     sharded_load,
@@ -403,9 +404,7 @@ def main():
     if has_targets and model is not None:
         del model
 
-    if mx.metal.is_available() and mx.default_device() == mx.gpu:
-        max_rec_size = mx.device_info()["max_recommended_working_set_size"]
-        mx.set_wired_limit(max_rec_size)
+    _ = maybe_set_recommended_wired_limit()
 
     opt = optimizers.Adam(learning_rate=args.learning_rate, bias_correction=True)
     dwq_quantize(

--- a/mlx_lm/server.py
+++ b/mlx_lm/server.py
@@ -1854,7 +1854,7 @@ def main():
         help="Use pipelining instead of tensor parallelism",
     )
     args = parser.parse_args()
-    if mx.metal.is_available():
+    if mx.metal.is_available() and mx.default_device() == mx.gpu:
         wired_limit = mx.device_info()["max_recommended_working_set_size"]
         mx.set_wired_limit(wired_limit)
 

--- a/mlx_lm/server.py
+++ b/mlx_lm/server.py
@@ -42,7 +42,12 @@ from .generate import (
 )
 from .models.cache import LRUPromptCache, make_prompt_cache
 from .sample_utils import make_logits_processors, make_sampler
-from .utils import _parse_size, load, sharded_load
+from .utils import (
+    _parse_size,
+    load,
+    maybe_set_recommended_wired_limit,
+    sharded_load,
+)
 
 
 def get_system_fingerprint():
@@ -1854,9 +1859,7 @@ def main():
         help="Use pipelining instead of tensor parallelism",
     )
     args = parser.parse_args()
-    if mx.metal.is_available() and mx.default_device() == mx.gpu:
-        wired_limit = mx.device_info()["max_recommended_working_set_size"]
-        mx.set_wired_limit(wired_limit)
+    _ = maybe_set_recommended_wired_limit()
 
     logging.basicConfig(
         level=getattr(logging, args.log_level.upper(), None),

--- a/mlx_lm/tuner/losses.py
+++ b/mlx_lm/tuner/losses.py
@@ -3,9 +3,7 @@
 import mlx.core as mx
 import mlx.nn as nn
 
-
-def can_run_metal():
-    return mx.default_device() == mx.gpu and mx.metal.is_available()
+from ..utils import can_run_metal
 
 
 def _make_kl_forward_kernel():

--- a/mlx_lm/tuner/trainer.py
+++ b/mlx_lm/tuner/trainer.py
@@ -226,7 +226,7 @@ def train(
     iterate_batches: callable = iterate_batches,
     training_callback: TrainingCallback = None,
 ):
-    if mx.metal.is_available():
+    if mx.metal.is_available() and mx.default_device() == mx.gpu:
         mx.set_wired_limit(mx.device_info()["max_recommended_working_set_size"])
     world = mx.distributed.init()
     world_size = world.size()

--- a/mlx_lm/tuner/trainer.py
+++ b/mlx_lm/tuner/trainer.py
@@ -13,6 +13,7 @@ from mlx.nn.utils import average_gradients
 from mlx.utils import tree_flatten, tree_map
 
 from ..cli_ui import TrainUI, rprint
+from ..utils import maybe_set_recommended_wired_limit
 from .callbacks import TrainingCallback
 from .datasets import CacheDataset
 
@@ -226,8 +227,7 @@ def train(
     iterate_batches: callable = iterate_batches,
     training_callback: TrainingCallback = None,
 ):
-    if mx.metal.is_available() and mx.default_device() == mx.gpu:
-        mx.set_wired_limit(mx.device_info()["max_recommended_working_set_size"])
+    _ = maybe_set_recommended_wired_limit()
     world = mx.distributed.init()
     world_size = world.size()
     rank = world.rank()

--- a/mlx_lm/utils.py
+++ b/mlx_lm/utils.py
@@ -63,6 +63,22 @@ MODEL_ARCHITECTURE_REMAPPING = {
 MAX_FILE_SIZE_GB = 5
 
 
+def can_run_metal():
+    return mx.default_device() == mx.gpu and mx.metal.is_available()
+
+
+def maybe_set_recommended_wired_limit() -> Optional[int]:
+    """Set the wired limit to the recommended size.
+
+    Returns the previous limit, or ``None`` if the device reports no
+    recommended size.
+    """
+    max_rec_size = mx.device_info().get("max_recommended_working_set_size")
+    if max_rec_size is None:
+        return None
+    return mx.set_wired_limit(max_rec_size)
+
+
 def _parse_size(x):
     sizes = {"M": 10**6, "G": 10**9, "MB": 10**6, "GB": 10**9, "": 1}
     split = 0


### PR DESCRIPTION
`wired_limit()` and the other `set_wired_limit()` call sites gate on `mx.metal.is_available()`, but query `device_info()["max_recommended_working_set_size"]`, a GPU-only key. On Apple Silicon with `mx.set_default_device(mx.cpu)`, Metal is available but the key is missing, so generation dies with `KeyError`.

Gate on the active device instead, so the wired-limit path is skipped on CPU. Fixes #1813.
