### PR TITLE
Fix PipelineMixin dropping layers on uneven splits, add explicit per-rank splits

### DIFF
--- a/mlx_lm/models/ministral3.py
+++ b/mlx_lm/models/ministral3.py
@@ -174,8 +174,8 @@ class LanguageModel(PipelineMixin, nn.Module):
                 self.swa_idx = e
                 break
 
-    def pipeline(self, group):
-        super().pipeline(group)
+    def pipeline(self, group, split=None):
+        super().pipeline(group, split=split)
         self.fa_idx = None
         self.swa_idx = None
         for e, l in enumerate(self.pipeline_layers):

--- a/mlx_lm/models/pipeline.py
+++ b/mlx_lm/models/pipeline.py
@@ -15,17 +15,27 @@ class PipelineMixin:
     def pipeline_layers(self):
         return self.layers[self.start_idx : self.end_idx]
 
-    def pipeline(self, group):
+    def pipeline(self, group, split=None):
         # Split layers in reverse so rank=0 gets the last layers and
         # rank=pipeline_size-1 gets the first
         self.pipeline_rank = group.rank()
         self.pipeline_size = group.size()
-        layers_per_rank = len(self.layers) // self.pipeline_size
-        extra = len(self.layers) - layers_per_rank * self.pipeline_size
-        if self.pipeline_rank < extra:
-            layers_per_rank += 1
-        self.start_idx = (self.pipeline_size - self.pipeline_rank - 1) * layers_per_rank
-        self.end_idx = self.start_idx + layers_per_rank
+        if split is None:
+            # Even split; the low ranks get the extra layers.
+            base = len(self.layers) // self.pipeline_size
+            extra = len(self.layers) - base * self.pipeline_size
+            split = [base + (1 if r < extra else 0) for r in range(self.pipeline_size)]
+        if len(split) != self.pipeline_size:
+            raise ValueError(
+                f"split has {len(split)} entries for group size {self.pipeline_size}"
+            )
+        if any(s <= 0 for s in split) or sum(split) != len(self.layers):
+            raise ValueError(
+                f"split {split} must be positive and sum to {len(self.layers)} layers"
+            )
+        # Rank r runs the layers after the layers of ranks r+1 ... size-1.
+        self.start_idx = sum(split[self.pipeline_rank + 1 :])
+        self.end_idx = self.start_idx + split[self.pipeline_rank]
         self.layers = self.layers[: self.end_idx]
         # Keep the layer numbers the same for model loading
         self.layers[: self.start_idx] = [None] * self.start_idx

--- a/mlx_lm/models/pipeline.py
+++ b/mlx_lm/models/pipeline.py
@@ -22,8 +22,7 @@ class PipelineMixin:
         self.pipeline_size = group.size()
         if split is None:
             # Even split; the low ranks get the extra layers.
-            base = len(self.layers) // self.pipeline_size
-            extra = len(self.layers) - base * self.pipeline_size
+            base, extra = divmod(len(self.layers), self.pipeline_size)
             split = [base + (1 if r < extra else 0) for r in range(self.pipeline_size)]
         if len(split) != self.pipeline_size:
             raise ValueError(

--- a/mlx_lm/models/qwen3_5.py
+++ b/mlx_lm/models/qwen3_5.py
@@ -252,8 +252,8 @@ class Qwen3_5TextModel(PipelineMixin, nn.Module):
         self.ssm_idx = 0
         self.fa_idx = args.full_attention_interval - 1
 
-    def pipeline(self, group):
-        super().pipeline(group)
+    def pipeline(self, group, split=None):
+        super().pipeline(group, split=split)
         self.ssm_idx = None
         self.fa_idx = None
         for e, l in enumerate(self.pipeline_layers):

--- a/tests/model_parallel_tests.py
+++ b/tests/model_parallel_tests.py
@@ -166,6 +166,105 @@ class TestModelParallel(unittest.TestCase):
                 out = model(x)
                 self.assertTrue(mx.allclose(expected, out, rtol=1e-3, atol=1e-3))
 
+    def test_pipeline_layer_assignment(self):
+        from mlx_lm.models.pipeline import PipelineMixin
+
+        class Group:
+            def __init__(self, rank, size):
+                self._rank, self._size = rank, size
+
+            def rank(self):
+                return self._rank
+
+            def size(self):
+                return self._size
+
+        class Stage(PipelineMixin):
+            def __init__(self, num_layers):
+                super().__init__()
+                self.layers = list(range(num_layers))
+
+        def assignment(num_layers, size, split=None):
+            blocks = []
+            for rank in range(size):
+                stage = Stage(num_layers)
+                stage.pipeline(Group(rank, size), split=split)
+                blocks.append(stage.pipeline_layers)
+            return blocks
+
+        # Every layer must run on exactly one rank, also when the layer count
+        # does not divide evenly. The uneven cases dropped layers before.
+        for num_layers, size in [(4, 2), (7, 2), (10, 4), (48, 3), (62, 4), (5, 5)]:
+            blocks = assignment(num_layers, size)
+            assigned = sorted(l for block in blocks for l in block)
+            self.assertEqual(assigned, list(range(num_layers)), (num_layers, size))
+            # Stage order is reverse rank order: the last rank runs the first
+            # layers and rank 0 runs the last layers.
+            self.assertEqual(blocks[size - 1][0], 0)
+            self.assertEqual(blocks[0][-1], num_layers - 1)
+            for block in blocks:
+                self.assertEqual(block, list(range(block[0], block[-1] + 1)))
+
+        # An explicit split sets the layer count per rank.
+        blocks = assignment(4, 2, split=[1, 3])
+        self.assertEqual(blocks[0], [3])
+        self.assertEqual(blocks[1], [0, 1, 2])
+        blocks = assignment(10, 3, split=[2, 3, 5])
+        self.assertEqual([len(b) for b in blocks], [2, 3, 5])
+        self.assertEqual(sorted(l for b in blocks for l in b), list(range(10)))
+
+        # A bad split is an error, not a silent bad assignment.
+        with self.assertRaises(ValueError):
+            assignment(4, 2, split=[1, 1, 2])
+        with self.assertRaises(ValueError):
+            assignment(4, 2, split=[0, 4])
+        with self.assertRaises(ValueError):
+            assignment(4, 2, split=[2, 3])
+
+    def test_pipeline_uneven_model(self):
+        # 7 layers on 2 ranks: layer 3 ran on no rank before this fix.
+        config = {
+            "model_type": "qwen3_moe",
+            "vocab_size": 128,
+            "hidden_size": 64,
+            "intermediate_size": 128,
+            "moe_intermediate_size": 32,
+            "num_hidden_layers": 7,
+            "num_attention_heads": 4,
+            "num_key_value_heads": 2,
+            "head_dim": 16,
+            "num_experts": 4,
+            "num_experts_per_tok": 2,
+            "decoder_sparse_step": 1,
+            "mlp_only_layers": [0],
+            "norm_topk_prob": True,
+            "rms_norm_eps": 1e-5,
+            "rope_theta": 10000.0,
+            "max_position_embeddings": 256,
+            "tie_word_embeddings": False,
+        }
+
+        class Group:
+            def __init__(self, rank, size):
+                self._rank, self._size = rank, size
+
+            def rank(self):
+                return self._rank
+
+            def size(self):
+                return self._size
+
+        arch = importlib.import_module("mlx_lm.models.qwen3_moe")
+        args = arch.ModelArgs.from_dict(config)
+        assigned = []
+        for rank in range(2):
+            model = arch.Model(args)
+            model.model.pipeline(Group(rank, 2))
+            assigned.extend(
+                i for i, l in enumerate(model.model.layers) if l is not None
+            )
+        self.assertEqual(sorted(assigned), list(range(7)))
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/model_parallel_tests.py
+++ b/tests/model_parallel_tests.py
@@ -6,6 +6,25 @@ import unittest
 import mlx.core as mx
 
 import mlx_lm
+from mlx_lm.models import qwen3_moe
+from mlx_lm.models.pipeline import PipelineMixin
+
+
+class Group:
+    def __init__(self, rank, size):
+        self._rank, self._size = rank, size
+
+    def rank(self):
+        return self._rank
+
+    def size(self):
+        return self._size
+
+
+class Stage(PipelineMixin):
+    def __init__(self, num_layers):
+        super().__init__()
+        self.layers = list(range(num_layers))
 
 
 class TestModelParallel(unittest.TestCase):
@@ -167,23 +186,6 @@ class TestModelParallel(unittest.TestCase):
                 self.assertTrue(mx.allclose(expected, out, rtol=1e-3, atol=1e-3))
 
     def test_pipeline_layer_assignment(self):
-        from mlx_lm.models.pipeline import PipelineMixin
-
-        class Group:
-            def __init__(self, rank, size):
-                self._rank, self._size = rank, size
-
-            def rank(self):
-                return self._rank
-
-            def size(self):
-                return self._size
-
-        class Stage(PipelineMixin):
-            def __init__(self, num_layers):
-                super().__init__()
-                self.layers = list(range(num_layers))
-
         def assignment(num_layers, size, split=None):
             blocks = []
             for rank in range(size):
@@ -214,11 +216,11 @@ class TestModelParallel(unittest.TestCase):
         self.assertEqual(sorted(l for b in blocks for l in b), list(range(10)))
 
         # A bad split is an error, not a silent bad assignment.
-        with self.assertRaises(ValueError):
+        with self.assertRaisesRegex(ValueError, "3 entries for group size 2"):
             assignment(4, 2, split=[1, 1, 2])
-        with self.assertRaises(ValueError):
+        with self.assertRaisesRegex(ValueError, "positive and sum to 4 layers"):
             assignment(4, 2, split=[0, 4])
-        with self.assertRaises(ValueError):
+        with self.assertRaisesRegex(ValueError, "positive and sum to 4 layers"):
             assignment(4, 2, split=[2, 3])
 
     def test_pipeline_uneven_model(self):
@@ -244,22 +246,12 @@ class TestModelParallel(unittest.TestCase):
             "tie_word_embeddings": False,
         }
 
-        class Group:
-            def __init__(self, rank, size):
-                self._rank, self._size = rank, size
-
-            def rank(self):
-                return self._rank
-
-            def size(self):
-                return self._size
-
-        arch = importlib.import_module("mlx_lm.models.qwen3_moe")
-        args = arch.ModelArgs.from_dict(config)
+        size = 2
+        args = qwen3_moe.ModelArgs.from_dict(config)
         assigned = []
-        for rank in range(2):
-            model = arch.Model(args)
-            model.model.pipeline(Group(rank, 2))
+        for rank in range(size):
+            model = qwen3_moe.Model(args)
+            model.model.pipeline(Group(rank, size))
             assigned.extend(
                 i for i, l in enumerate(model.model.layers) if l is not None
             )


### PR DESCRIPTION
**Bug:** PipelineMixin.pipeline() assigns some layers to no rank whenever len(layers) % group.size() != 0. The per-rank count is adjusted, but start_idx still multiplies by this rank's own count. 7 layers / 2 ranks silently drops layer 3. 62/4 drops layers 30–31. Wrong output, no error.

**Fix:** Compute the per-rank counts once, then start_idx = sum(counts of ranks r+1…size-1). The divisible case produces the identical assignment.

**Feature:** Optional split=[...] - explicit per-rank layer counts for asymmetric machines. On my 2-Mac Thunderbolt/JACCL ring, an M4 Max and an M5 Max, an uneven 14/28 split put 50.2 GB on the busy dev machine vs 93.0 GB on the clean node, where TP needs 72.6 GB on each — it's what lets a smaller or loaded node participate at all; parity vs unpipelined < 1e-6 including cached decode. Measured with the same split logic in our own model port; this PR ports it to PipelineMixin

Tests: Assignment coverage over stub groups (every layer exactly once, contiguous, reverse-rank order) for 6 shapes; a real qwen3_moe 7-layer/2-rank regression (fails on current main); split semantics + three ValueError cases. model_parallel_tests.py 4 passed + 5 subtests with the change; the two new tests fail on current main. test_models.py -k qwen3 3 passed; black/isort clean.

- ☑️ I understand it is strictly prohibited to use AI to write PR descriptions

