### PR TITLE
fix: Speed up multi-token decode by computing the absorbed MLA threshold

### DIFF
--- a/mlx_lm/models/bailing_moe_v3.py
+++ b/mlx_lm/models/bailing_moe_v3.py
@@ -15,7 +15,7 @@ from .base import (
 )
 from .cache import ArraysCache, KVCache
 from .gated_delta import gated_delta_update
-from .mla import MultiLinear
+from .mla import MultiLinear, latent_length, max_absorbed_queries
 from .rope_utils import initialize_rope
 from .switch_layers import SwitchGLU
 
@@ -196,6 +196,11 @@ class BailingMLA(nn.Module):
             bias=False,
         )
         self.kv_a_layernorm = nn.RMSNorm(args.kv_lora_rank, eps=args.rms_norm_eps)
+        self._absorbed_dims = (
+            self.kv_lora_rank,
+            self.qk_nope_head_dim,
+            self.v_head_dim,
+        )
         self.embed_q = MultiLinear(
             args.qk_nope_head_dim, args.kv_lora_rank, args.num_attention_heads
         )
@@ -257,7 +262,10 @@ class BailingMLA(nn.Module):
                 mx.array(mx.finfo(pe_scores.dtype).min, pe_scores.dtype),
             )
 
-        if length == 1:
+        absorbed = length == 1 or length <= max_absorbed_queries(
+            *self._absorbed_dims, latent_length(kv_latent)
+        )
+        if absorbed:
             q_nope = self.embed_q(q_nope)
             keys = values = kv_latent
         else:
@@ -272,7 +280,7 @@ class BailingMLA(nn.Module):
             scale=self.scale,
             mask=pe_scores,
         )
-        if length == 1:
+        if absorbed:
             output = self.unembed_out(output)
 
         output = output.transpose(0, 2, 1, 3)

--- a/mlx_lm/models/deepseek_v3.py
+++ b/mlx_lm/models/deepseek_v3.py
@@ -11,7 +11,7 @@ from mlx.nn.layers.distributed import shard_inplace, shard_linear, sum_gradients
 
 from .activations import swiglu
 from .base import BaseModelArgs, create_attention_mask, scaled_dot_product_attention
-from .mla import MultiLinear
+from .mla import MultiLinear, latent_length, max_absorbed_queries
 from .pipeline import PipelineMixin
 from .rope_utils import initialize_rope
 from .switch_layers import SwitchGLU
@@ -86,6 +86,11 @@ class DeepseekV3Attention(nn.Module):
             bias=config.attention_bias,
         )
         self.kv_a_layernorm = nn.RMSNorm(self.kv_lora_rank, eps=1e-6)
+        self._absorbed_dims = (
+            self.kv_lora_rank,
+            self.qk_nope_head_dim,
+            self.v_head_dim,
+        )
         self.embed_q = MultiLinear(
             self.qk_nope_head_dim, self.kv_lora_rank, self.num_heads
         )
@@ -152,7 +157,10 @@ class DeepseekV3Attention(nn.Module):
                 mx.array(mx.finfo(pe_scores.dtype).min, pe_scores.dtype),
             )
 
-        if L == 1:
+        absorbed = L == 1 or L <= max_absorbed_queries(
+            *self._absorbed_dims, latent_length(kv_latent)
+        )
+        if absorbed:
             q_nope = self.embed_q(q_nope)
             k = v = kv_latent
         else:
@@ -162,7 +170,7 @@ class DeepseekV3Attention(nn.Module):
         output = scaled_dot_product_attention(
             q_nope, k, v, cache=cache, scale=self.scale, mask=pe_scores
         )
-        if L == 1:
+        if absorbed:
             output = self.unembed_out(output)
 
         output = output.transpose(0, 2, 1, 3).reshape(B, L, -1)

--- a/mlx_lm/models/deepseek_v32.py
+++ b/mlx_lm/models/deepseek_v32.py
@@ -11,7 +11,7 @@ from mlx.nn.layers.distributed import shard_inplace, shard_linear, sum_gradients
 from .activations import swiglu
 from .base import BaseModelArgs, create_attention_mask, scaled_dot_product_attention
 from .cache import CacheList, KVCache
-from .mla import MultiLinear
+from .mla import MultiLinear, latent_length, max_absorbed_queries
 from .rope_utils import initialize_rope
 from .switch_layers import SwitchGLU
 
@@ -147,6 +147,11 @@ class DeepseekV32Attention(nn.Module):
             bias=config.attention_bias,
         )
         self.kv_a_layernorm = nn.RMSNorm(self.kv_lora_rank, eps=1e-6)
+        self._absorbed_dims = (
+            self.kv_lora_rank,
+            self.qk_nope_head_dim,
+            self.v_head_dim,
+        )
         self.embed_q = MultiLinear(
             self.qk_nope_head_dim, self.kv_lora_rank, self.num_heads
         )
@@ -245,7 +250,10 @@ class DeepseekV32Attention(nn.Module):
                 mx.array(mx.finfo(pe_scores.dtype).min, pe_scores.dtype),
             )
 
-        if L == 1:
+        absorbed = L == 1 or L <= max_absorbed_queries(
+            *self._absorbed_dims, latent_length(kv_latent)
+        )
+        if absorbed:
             q_nope = self.embed_q(q_nope)
             k = v = kv_latent
         else:
@@ -255,7 +263,7 @@ class DeepseekV32Attention(nn.Module):
         output = scaled_dot_product_attention(
             q_nope, k, v, cache=cache, scale=self.scale, mask=pe_scores
         )
-        if L == 1:
+        if absorbed:
             output = self.unembed_out(output)
 
         output = output.transpose(0, 2, 1, 3).reshape(B, L, -1)

--- a/mlx_lm/models/glm4_moe_lite.py
+++ b/mlx_lm/models/glm4_moe_lite.py
@@ -10,7 +10,7 @@ from mlx.nn.layers.distributed import shard_inplace, shard_linear, sum_gradients
 
 from .activations import swiglu
 from .base import BaseModelArgs, create_attention_mask, scaled_dot_product_attention
-from .mla import MultiLinear
+from .mla import MultiLinear, latent_length, max_absorbed_queries
 from .pipeline import PipelineMixin
 from .rope_utils import initialize_rope
 from .switch_layers import SwitchGLU
@@ -92,6 +92,11 @@ class Glm4MoeLiteAttention(nn.Module):
         )
         self.kv_a_layernorm = nn.RMSNorm(self.kv_lora_rank, eps=config.rms_norm_eps)
         head_dim = self.qk_nope_head_dim + self.v_head_dim
+        self._absorbed_dims = (
+            self.kv_lora_rank,
+            self.qk_nope_head_dim,
+            self.v_head_dim,
+        )
         self.embed_q = MultiLinear(
             self.qk_nope_head_dim, self.kv_lora_rank, self.num_heads
         )
@@ -158,7 +163,10 @@ class Glm4MoeLiteAttention(nn.Module):
                 mx.array(mx.finfo(pe_scores.dtype).min, pe_scores.dtype),
             )
 
-        if L == 1:
+        absorbed = L == 1 or L <= max_absorbed_queries(
+            *self._absorbed_dims, latent_length(kv_latent)
+        )
+        if absorbed:
             q_nope = self.embed_q(q_nope)
             k = v = kv_latent
         else:
@@ -167,7 +175,7 @@ class Glm4MoeLiteAttention(nn.Module):
         output = scaled_dot_product_attention(
             q_nope, k, v, cache=cache, scale=self.scale, mask=pe_scores
         )
-        if L == 1:
+        if absorbed:
             output = self.unembed_out(output)
 
         output = output.transpose(0, 2, 1, 3).reshape(B, L, -1)

--- a/mlx_lm/models/kimi_k3.py
+++ b/mlx_lm/models/kimi_k3.py
@@ -18,7 +18,7 @@ from .base import (
 from .cache import ArraysCache, KVCache
 from .gated_delta import gated_delta_update
 from .kimi_linear import ShortConv1d
-from .mla import MultiLinear
+from .mla import MultiLinear, latent_length, max_absorbed_queries
 from .switch_layers import SwitchGLU
 
 
@@ -517,6 +517,11 @@ class KimiK3MLAAttention(nn.Module):
             hidden, self.kv_lora_rank + self.qk_rope_head_dim, bias=False
         )
         self.kv_a_layernorm = nn.RMSNorm(self.kv_lora_rank, eps=1e-6)
+        self._absorbed_dims = (
+            self.kv_lora_rank,
+            self.qk_nope_head_dim,
+            self.v_head_dim,
+        )
         self.embed_q = MultiLinear(
             self.qk_nope_head_dim, self.kv_lora_rank, self.num_heads
         )
@@ -562,7 +567,10 @@ class KimiK3MLAAttention(nn.Module):
                 mx.array(mx.finfo(pe_scores.dtype).min, pe_scores.dtype),
             )
 
-        if L == 1:
+        absorbed = L == 1 or L <= max_absorbed_queries(
+            *self._absorbed_dims, latent_length(kv_latent)
+        )
+        if absorbed:
             q_nope = self.embed_q(q_nope)
             k = v = kv_latent
         else:
@@ -573,7 +581,7 @@ class KimiK3MLAAttention(nn.Module):
             q_nope, k, v, cache=cache, scale=self.scale, mask=pe_scores
         )
 
-        if L == 1:
+        if absorbed:
             output = self.unembed_out(output)
 
         output = output.transpose(0, 2, 1, 3).reshape(B, L, -1)

--- a/mlx_lm/models/kimi_linear.py
+++ b/mlx_lm/models/kimi_linear.py
@@ -15,7 +15,7 @@ from .base import (
 )
 from .cache import ArraysCache, KVCache
 from .gated_delta import gated_delta_update
-from .mla import MultiLinear
+from .mla import MultiLinear, latent_length, max_absorbed_queries
 from .switch_layers import SwitchGLU
 
 
@@ -176,6 +176,11 @@ class KimiMLAAttention(nn.Module):
             bias=False,
         )
         self.kv_a_layernorm = nn.RMSNorm(args.kv_lora_rank, eps=args.rms_norm_eps)
+        self._absorbed_dims = (
+            self.kv_lora_rank,
+            self.qk_nope_head_dim,
+            self.v_head_dim,
+        )
         self.embed_q = MultiLinear(
             self.qk_nope_head_dim, args.kv_lora_rank, self.num_heads
         )
@@ -214,7 +219,10 @@ class KimiMLAAttention(nn.Module):
                 mx.array(mx.finfo(pe_scores.dtype).min, pe_scores.dtype),
             )
 
-        if L == 1:
+        absorbed = L == 1 or L <= max_absorbed_queries(
+            *self._absorbed_dims, latent_length(kv_latent)
+        )
+        if absorbed:
             q_nope = self.embed_q(q_nope)
             k = v = kv_latent
         else:
@@ -225,7 +233,7 @@ class KimiMLAAttention(nn.Module):
             q_nope, k, v, cache=cache, scale=self.scale, mask=pe_scores
         )
 
-        if L == 1:
+        if absorbed:
             output = self.unembed_out(output)
 
         output = output.transpose(0, 2, 1, 3).reshape(B, L, -1)

--- a/mlx_lm/models/longcat_flash.py
+++ b/mlx_lm/models/longcat_flash.py
@@ -9,7 +9,7 @@ from mlx.nn.layers.distributed import shard_inplace, shard_linear, sum_gradients
 from .activations import swiglu
 from .base import BaseModelArgs, create_attention_mask, scaled_dot_product_attention
 from .cache import CacheList, KVCache
-from .mla import MultiLinear
+from .mla import MultiLinear, latent_length, max_absorbed_queries
 from .rope_utils import initialize_rope
 from .switch_layers import SwitchGLU
 
@@ -81,6 +81,11 @@ class LongcatFlashMLA(nn.Module):
             bias=args.attention_bias,
         )
         self.kv_a_layernorm = nn.RMSNorm(self.kv_lora_rank)
+        self._absorbed_dims = (
+            self.kv_lora_rank,
+            self.qk_nope_head_dim,
+            self.v_head_dim,
+        )
         self.embed_q = MultiLinear(
             self.qk_nope_head_dim, self.kv_lora_rank, self.num_attention_heads
         )
@@ -162,7 +167,10 @@ class LongcatFlashMLA(nn.Module):
                 mx.array(mx.finfo(pe_scores.dtype).min, pe_scores.dtype),
             )
 
-        if L == 1:
+        absorbed = L == 1 or L <= max_absorbed_queries(
+            *self._absorbed_dims, latent_length(kv_latent)
+        )
+        if absorbed:
             q_nope = self.embed_q(q_nope)
             k = v = kv_latent
         else:
@@ -172,7 +180,7 @@ class LongcatFlashMLA(nn.Module):
         output = scaled_dot_product_attention(
             q_nope, k, v, cache=cache, scale=self.scale, mask=pe_scores
         )
-        if L == 1:
+        if absorbed:
             output = self.unembed_out(output)
 
         output = output.transpose(0, 2, 1, 3).reshape(B, L, -1)

--- a/mlx_lm/models/mla.py
+++ b/mlx_lm/models/mla.py
@@ -1,9 +1,46 @@
 # Copyright © 2026 Apple Inc.
 
 import math
+from typing import Optional
 
 import mlx.core as mx
 import mlx.nn as nn
+
+
+def max_absorbed_queries(
+    kv_lora_rank: int,
+    qk_nope_head_dim: int,
+    v_head_dim: int,
+    cache_len: Optional[int] = None,
+) -> int:
+    """Query count below which folding into the query beats materializing K/V.
+
+    Per head, with ``r = kv_lora_rank`` and ``d = qk_nope_head_dim +
+    v_head_dim``, the absorbed path costs ``L*r*d + 2*L*T*r`` and materializing
+    costs ``T*r*d + L*T*d``, where ``T`` is the post-update cache length. The
+    absorbed path wins while::
+
+        L < r*d / (r*d/T + 2*r - d)
+
+    With ``cache_len`` omitted this returns the ``T -> inf`` limit,
+    ``r*d / (2*r - d)``, which is the right answer once the cache is much
+    larger than the latent. Pass ``cache_len`` for the exact bound: on a cold
+    cache, where ``T == L``, it correctly falls below ``L``, because
+    materializing K and V is cheaper there for every current model.
+    """
+    d = qk_nope_head_dim + v_head_dim
+    denom = 2 * kv_lora_rank - d
+    if cache_len is not None and cache_len > 0:
+        denom += kv_lora_rank * d / cache_len
+    if denom <= 0:
+        return 1
+    return max(1, int(kv_lora_rank * d / denom))
+
+
+def latent_length(kv_latent) -> int:
+    """Length of the cached latent, tolerating the quantized 3-tuple form."""
+    arr = kv_latent[0] if isinstance(kv_latent, tuple) else kv_latent
+    return arr.shape[-2]
 
 
 class MultiLinear(nn.Module):

--- a/tests/test_absorbed_mla.py
+++ b/tests/test_absorbed_mla.py
@@ -1,0 +1,101 @@
+# Copyright © 2024 Apple Inc.
+import pathlib
+import re
+import unittest
+
+import mlx.core as mx
+
+from mlx_lm.models.mla import latent_length, max_absorbed_queries
+
+MODELS = [
+    "deepseek_v3",
+    "deepseek_v32",
+    "kimi_k3",
+    "kimi_linear",
+    "longcat_flash",
+    "glm4_moe_lite",
+    "bailing_moe_v3",
+]
+
+
+class TestMaxAbsorbedQueries(unittest.TestCase):
+    def test_asymptotic_limit(self):
+        # cache_len omitted -> the T -> inf answer
+        self.assertEqual(max_absorbed_queries(512, 128, 128), 170)
+        self.assertEqual(max_absorbed_queries(512, 192, 256), 398)
+
+    def test_cold_cache_rejects_the_absorbed_path(self):
+        # At T == L materializing is cheaper for every current model, so the
+        # threshold must fall below L rather than admit it.
+        for r, n, v in ((512, 128, 128), (512, 192, 256)):
+            for L in (2, 32, 64, 169, 398):
+                self.assertLess(
+                    max_absorbed_queries(r, n, v, cache_len=L),
+                    L,
+                    f"cold cache admitted L={L} for dims {(r, n, v)}",
+                )
+
+    def test_warm_cache_approaches_the_asymptote(self):
+        r, n, v = 512, 128, 128
+        limit = max_absorbed_queries(r, n, v)
+        self.assertEqual(max_absorbed_queries(r, n, v, cache_len=32768), limit - 1)
+        self.assertLess(max_absorbed_queries(r, n, v, cache_len=1024), limit)
+        seq = [max_absorbed_queries(r, n, v, cache_len=t) for t in (256, 1024, 8192)]
+        self.assertEqual(seq, sorted(seq))
+
+    def test_degenerate_dims_keep_the_decode_path(self):
+        self.assertEqual(max_absorbed_queries(64, 128, 128), 1)
+        self.assertGreaterEqual(max_absorbed_queries(1, 1, 1), 1)
+
+
+class TestLatentLength(unittest.TestCase):
+    def test_plain_array(self):
+        self.assertEqual(latent_length(mx.zeros((1, 1, 37, 8))), 37)
+
+    def test_quantized_tuple(self):
+        q = (mx.zeros((1, 1, 37, 2)), mx.zeros((1, 1, 37, 1)), mx.zeros((1, 1, 37, 1)))
+        self.assertEqual(latent_length(q), 37)
+
+
+class TestGatePairing(unittest.TestCase):
+    """Both gates must be driven by one boolean, so they cannot disagree."""
+
+    def test_one_decision_two_uses(self):
+        root = pathlib.Path(__file__).resolve().parents[1] / "mlx_lm" / "models"
+        decision = re.compile(
+            r"absorbed = (?:L|length) == 1 or (?:L|length) <= max_absorbed_queries\("
+        )
+        for m in MODELS:
+            src = (root / f"{m}.py").read_text()
+            with self.subTest(model=m):
+                self.assertEqual(
+                    len(decision.findall(src)),
+                    1,
+                    f"{m}: expected exactly one gate decision",
+                )
+                self.assertEqual(
+                    src.count("if absorbed:"),
+                    2,
+                    f"{m}: expected both gates to use that decision",
+                )
+
+
+class TestIndexerGateUnchanged(unittest.TestCase):
+    """The sparse top-k gather stays at L == 1.
+
+    It selects with ``topk_indices[:, :, 0, :]``, the first query's top-k, so
+    widening it would apply one query's selection to every query.
+    """
+
+    def test_first_query_gather_is_still_gated_on_one_query(self):
+        root = pathlib.Path(__file__).resolve().parents[1] / "mlx_lm" / "models"
+        src = (root / "deepseek_v32.py").read_text()
+        self.assertRegex(
+            src,
+            re.compile(r"if L == 1:\s*\n\s*idx = topk_indices"),
+            "deepseek_v32: the first-query top-k gather is no longer gated on L == 1",
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Speculative decoding on MLA models is currently slower than plain decoding: the absorbed path is gated on L == 1, so every verify step expands the entire cached latent instead. The cost grows with cache length, so it gets worse the longer you generate. Any step with L >= 2 pays it -- e.g. mlx-lm's draft-model speculation (and any multi-token forward pass).

The crossover between the two paths is a query count set by head geometry and the cache length: `L < r*d / (r*d/T + 2r - d)`, with `d = qk_nope_head_dim + v_head_dim`. For a long cache that tends to `r*d / (2r - d)`, 170 for DeepSeek V3 and 398 for GLM-4.7-Flash; on a cold cache, where T == L, it reverses and materialising always wins. This PR adds max_absorbed_queries and latent_length to models/mla.py so each model computes it from its own config and the current cache length. deepseek_v32's third guard, the sparse top-k gather, is deliberately left at L == 1 -- that branch is about correctness, not speed.

Single-token decode is within 2% across all models, because L=1 takes the same branch either way.

Example: on GLM-4.7-Flash with an 8K prompt, `mlx_lm.generate --draft-model` runs at 2.8 tok/s against 55.8 tok/s autoregressive. This change takes that to 14.7 tok/s (5.2×). Whether speculation then wins depends on draft cost (e.g. with a cheap draft head it does, with a same-architecture draft model it still loses).

Prior art: SGLang exposes `--speculative-attention-mode {prefill,decode}` to pick which path target-verify uses ([`server_args.py`](https://github.com/sgl-project/sglang/blob/main/python/sglang/srt/server_args.py#L2169), [`deepseek_v2.py`](https://github.com/sgl-project/sglang/blob/main/python/sglang/srt/models/deepseek_v2.py#L2033)); vLLM tracks the same problem class in [21984](https://github.com/vllm-project/vllm/issues/21984); the formula is from [Simon Dong's write-up](https://simondong1.github.io/mla-decoding.html).

## Results

M3 Max 128GB. Stock and patched are two checkouts of the same commit selected via `sys.path`, so nothing but the two guards differs -- no runtime patching.

### Verify-step cost (ms), stock → patched
| Model | Module | Threshold | cache 512 | cache 2048 | cache 8192 |
|---|---|---:|---:|---:|---:|
| GLM-4.7-Flash | `glm4_moe_lite` | 398 | 29.4 → 2.4 | 93.8 → 2.9 | **363.7 → 3.3** |
| Moonlight-16B-A3B | `deepseek_v3` | 170 | 6.6 → 2.3 | 21.7 → 2.4 | 83.0 → 2.5 |
| Kimi-Linear-48B | `kimi_linear` | 170 | 4.4 → 1.9 | 12.8 → 1.7 | 45.9 → 2.0 |

Marginal cost of the second token in a decode step -- what a verify pays. Stock grows with the cache, patched is flat. Kimi-Linear is per-step only: mlx-lm refuses speculative decoding on MLA hybrids (`ValueError: Speculative decoding requires a trimmable prompt cache (got {'ArraysCache'})`), since linear-attention state cannot be rewound on rejection.

### Where the paths cross

One GLM-4.7-Flash layer at cache 8192 with each branch forced:

| L | absorbed | materialised |
|---:|---:|---:|
| 1 | **0.5** | 7.3 |
| 398 | **16.0** | 16.9 |
| 512 | 19.9 | **18.6** |
| 2048 | 89.8 | **59.6** |

The empirical crossover is between 398 and 512 and the formula computes 379 at this cache length (398 in the limit), so it lands on the correct side with a small margin. Prefill steps are 512 or 2048, where materialised correctly wins -- prefill is unaffected.

### Downstream: MTPLX

MTPLX depends on mlx-lm and gets its MLA implementation from these files. Its tuner benchmarks autoregressive decode against each speculative depth and picks a winner.

| Context | Arm | AR | MTP D1 | vs AR | Verify | Acceptance |
|---|---|---:|---:|---:|---:|---:|
| ~700 tok | stock | 60.7 | 47.6 | 0.78× | 41.6 ms | — |
| ~700 tok | patched | 61.1 | 87.0 | **1.42×** | 20.1 ms | 90.3% |
| 2K–16K | stock | 47.8 | 7.1 | 0.15× | 413.9 ms | 72.1% |
| 2K–16K | patched | 47.7 | 64.4 | **1.35×** | **27.7 ms** | 73.8% |

Acceptance barely moves while verify cost falls 14.9×: the drafting was always fine but the verification was not. Every draft depth flips from losing to winning -- 0.83× / 0.82× / 0.64× at depths 1/2/3 becomes 1.39× / 1.15× / 1.06×.

### Tests

`test_models` covers all seven touched architectures: 85 OK on both arms. `test_generate` 30, `test_gated_delta` 8, `test_utils` 11, `test_losses` 4 -- all OK on both. `test_prompt_cache` (4 errors) and `test_sample_utils` (1 failure) are identical on both arms and reproduce on unmodified `main`.

`tests/test_absorbed_mla.py` is new: it covers the large-cache and cold-cache limits, the quantised latent form, that each of the seven models makes one gate decision used by both guards, and that deepseek_v32's indexer gate is untouched.

### Scope

Measured on `deepseek_v3`, `glm4_moe_lite` and `kimi_linear`. `kimi_k3`, `longcat_flash` and `bailing_moe_v3` share the same 512/128/128 head geometry and threshold of 170 but had no checkpoint small enough to run here. `deepseek_v32` is sparse, so its benefit is limited to caches below the top-k budget and neutral above (3.4× at 512, 0.99-1.02× at 2048/8192/32768 on the equivalent mlx-vlm model).

Outputs are not bit-identical: at 4-bit the two branches differ by 4.883e-04 max on values of scale ~0.1, against a bf16 ULP of ~2.44e-04 -- one to two units in the last place, and flat across L, so it is quantised-matmul ordering.


- ☑️ I understand it is strictly prohibited to use AI to write PR description
- AI usage disclosure: Claude Code (Opus 5) wrote the patch and the benchmark scripts. I reviewed the diff, ran every measurement myself on an M3 Max, and take responsibility for every line. This description is mine.