### PR TITLE
Fix quantized_kv_start default to match CLI (DEFAULT_QUANTIZED_KV_START)

### DIFF
--- a/mlx_lm/generate.py
+++ b/mlx_lm/generate.py
@@ -310,7 +310,7 @@ def generate_step(
     prefill_step_size: int = 2048,
     kv_bits: Optional[int] = None,
     kv_group_size: int = 64,
-    quantized_kv_start: int = 0,
+    quantized_kv_start: int = DEFAULT_QUANTIZED_KV_START,
     prompt_progress_callback: Optional[Callable[[int, int], None]] = None,
     input_embeddings: Optional[mx.array] = None,
 ) -> Generator[Tuple[mx.array, mx.array], None, None]:
@@ -336,7 +336,7 @@ def generate_step(
           None implies no cache quantization. Default: ``None``.
         kv_group_size (int): Group size for KV cache quantization. Default: ``64``.
         quantized_kv_start (int): Step to begin using a quantized KV cache.
-           when ``kv_bits`` is non-None. Default: ``0``.
+           when ``kv_bits`` is non-None. Default: ``5000``.
         prompt_progress_callback (Callable[[int, int], None]): A call-back which takes the
            prompt tokens processed so far and the total number of prompt tokens.
         input_embeddings (mx.array, optional): Input embeddings to use instead of or in
@@ -483,7 +483,7 @@ def speculative_generate_step(
     prefill_step_size: int = 512,
     kv_bits: Optional[int] = None,
     kv_group_size: int = 64,
-    quantized_kv_start: int = 0,
+    quantized_kv_start: int = DEFAULT_QUANTIZED_KV_START,
 ) -> Generator[Tuple[mx.array, mx.array, bool], None, None]:
     """
     A generator producing token ids based on the given prompt from the model.
@@ -508,7 +508,7 @@ def speculative_generate_step(
           None implies no cache quantization. Default: ``None``.
         kv_group_size (int): Group size for KV cache quantization. Default: ``64``.
         quantized_kv_start (int): Step to begin using a quantized KV cache.
-           when ``kv_bits`` is non-None. Default: ``0``.
+           when ``kv_bits`` is non-None. Default: ``5000``.
 
     Yields:
         Tuple[mx.array, mx.array, bool]: One token, a vector of log probabilities,


### PR DESCRIPTION
### Summary
Standardizes the default `quantized_kv_start` value across `mlx-lm` library entry points and the CLI, resolving an inconsistency where library calls defaulted to `0` while the CLI defaulted to `5000`.

Fixes #1651.

### Issue
Calling `mlx-lm` via Python vs. CLI yielded different output behavior when `kv_bits` was provided without an explicit `quantized_kv_start`:
* **Library API (`generate_step`, `speculative_generate_step`):** Defaulted to `0`, quantizing the cache starting from the very first token.
* **CLI (`mlx_lm.generate`, `mlx_lm.cache_prompt`):** Used `DEFAULT_QUANTIZED_KV_START = 5000`.

Quantizing from token 0 measurably degrades output quality on short generations, making this entry-point discrepancy unexpected.

### Solution
* Updated default argument values in `generate_step()` and `speculative_generate_step()` to use the existing `DEFAULT_QUANTIZED_KV_START` constant instead of hardcoded `0`.
* Updated corresponding docstrings to accurately reflect the default.
* Higher-level API wrappers (`stream_generate`, `generate`, `batch_generate`) automatically inherit this change as they forward `quantized_kv_start` via `**kwargs`.

### Testing & Verification
* **Manual Verification (Apple Silicon):** Confirmed via a live `generate_step(..., kv_bits=8)` run that quantization is now deferred to step 5000 by default.
* **Unit Tests:** Ran `python -m unittest discover tests` — all test results match baseline behavior on `main` (pre-existing unrelated test failures remain identical).