### PR TITLE
Fix evaluate post processing ordering bug

### DIFF
--- a/mlx_lm/evaluate.py
+++ b/mlx_lm/evaluate.py
@@ -359,7 +359,7 @@ class MLXLM(LM):
         for e, (text, opt) in enumerate(zip(completions, options)):
             completions[e] = _rstrip_until(text, opt["until"])
             if self.tokenizer.has_thinking:
-                completions[e] = _lstrip(text, self.tokenizer.think_end)
+                completions[e] = _lstrip(completions[e], self.tokenizer.think_end)
 
         # Gather the completions
         if group.size() > 1:

--- a/tests/test_evaluate.py
+++ b/tests/test_evaluate.py
@@ -54,6 +54,19 @@ class TestMLXLM(unittest.TestCase):
         self.assertEqual(len(call_args_list[1][0][0]), 2)  # Second batch: 2 items
         self.assertEqual(len(call_args_list[2][0][0]), 1)  # Third batch: 1 item
 
+    @patch("mlx_lm.evaluate.batch_generate")
+    def test_generate_strip_until_then_strip_thinking(self, mock_batch_generate):
+        self.mock_tokenizer.has_thinking = True
+        self.mock_tokenizer.think_end = "</think>"
+        mock_batch_generate.return_value.texts = [
+            "<think>scratch</think>answer STOP extra"
+        ]
+        request = MagicMock(args=("prompt", {"until": [" STOP"]}))
+
+        result = self.mlx_lm.generate_until([request])
+
+        self.assertEqual(result, ["answer"])
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
This PR is:

- To fix a post-processing ordering bug where thinking-strip reused the raw generated text.
- To add a focused regression test for the interaction between `until` and `think_end`.

Note: `generate_until()` first trims completions with `_rstrip_until(text, opt["until"])`. For thinking tokenizers, it then strips text through `tokenizer.think_end`. The previous code passed the original `text` into `_lstrip()`, which discarded the already-trimmed completion. That could reintroduce text after the stop sequence.


Before:
```
raw = "<think>scratch</think>answer STOP extra"
until = [" STOP"]
after until = "<think>scratch</think>answer"
final = "answer STOP extra"
```

After:
```
raw = "<think>scratch</think>answer STOP extra"
until = [" STOP"]
after until = "<think>scratch</think>answer"
final = "answer"
```


- ☑️ I understand it is strictly prohibited to use AI to write PR description

