### PR TITLE
Trimmable ArraysCache alternative

### DIFF
--- a/mlx_lm/generate.py
+++ b/mlx_lm/generate.py
@@ -530,8 +530,12 @@ def speculative_generate_step(
         model_cache = prompt_cache[: len(model.layers)]
         draft_cache = prompt_cache[len(model.layers) :]
 
-    if not can_trim_prompt_cache(model_cache):
-        types = {type(c).__name__ for c in model_cache if not c.is_trimmable()}
+    if not can_trim_prompt_cache(model_cache, num_draft_tokens):
+        types = {
+            type(c).__name__
+            for c in model_cache
+            if not c.is_trimmable(num_draft_tokens)
+        }
         raise ValueError(
             f"Speculative decoding requires a trimmable prompt cache " f"(got {types})."
         )

--- a/mlx_lm/models/cache.py
+++ b/mlx_lm/models/cache.py
@@ -112,11 +112,11 @@ def load_prompt_cache(file_name, return_metadata=False):
     return cache
 
 
-def can_trim_prompt_cache(cache: List[Any]) -> bool:
+def can_trim_prompt_cache(cache: List[Any], num_tokens: int = -1) -> bool:
     """
     Check if model's cache can be trimmed.
     """
-    return all(c.is_trimmable() for c in cache)
+    return all(c.is_trimmable(num_tokens) for c in cache)
 
 
 def trim_prompt_cache(cache: List[Any], num_tokens: int) -> List[Any]:
@@ -133,7 +133,7 @@ def trim_prompt_cache(cache: List[Any], num_tokens: int) -> List[Any]:
     Returns:
         (int): The number of tokens that were trimmed.
     """
-    if not can_trim_prompt_cache(cache) or len(cache) == 0:
+    if not can_trim_prompt_cache(cache, num_tokens) or len(cache) == 0:
         return 0
     return [c.trim(num_tokens) for c in cache][0]
 
@@ -161,7 +161,7 @@ class _BaseCache:
         if v is not None and v:
             raise ValueError("This cache has no state but a state was set.")
 
-    def is_trimmable(self):
+    def is_trimmable(self, n: int = -1):
         return False
 
     def size(self):
@@ -227,7 +227,7 @@ class ConcatenateKVCache(_BaseCache):
         self.keys, self.values = v
         self.offset = self.keys.shape[-2]
 
-    def is_trimmable(self):
+    def is_trimmable(self, n: int = -1):
         return True
 
     def trim(self, n):
@@ -317,7 +317,7 @@ class QuantizedKVCache(_BaseCache):
     def state(self, v):
         self.keys, self.values, self.offset, self.group_size, self.bits = v
 
-    def is_trimmable(self):
+    def is_trimmable(self, n: int = -1):
         return True
 
     def trim(self, n):
@@ -385,7 +385,7 @@ class KVCache(_BaseCache):
     def state(self, v):
         self.keys, self.values, self.offset = v
 
-    def is_trimmable(self):
+    def is_trimmable(self, n: int = -1):
         return True
 
     def trim(self, n):
@@ -541,7 +541,7 @@ class RotatingKVCache(_BaseCache):
     def state(self, v):
         self.keys, self.values, self.offset, self.keep, self.max_size, self._idx = v
 
-    def is_trimmable(self):
+    def is_trimmable(self, n: int = -1):
         return self.offset < self.max_size
 
     def trim(self, n):
@@ -593,6 +593,7 @@ class RotatingKVCache(_BaseCache):
         return self.keys.nbytes + self.values.nbytes
 
 
+# ArraysCache has been deprecated by RecurrentCache, no new code should use this.
 class ArraysCache(_BaseCache):
     def __init__(self, size, left_padding: Optional[List[int]] = None):
         self.cache = [None] * size
@@ -724,6 +725,312 @@ class ArraysCache(_BaseCache):
         return sum(c.nbytes for c in self.cache if c is not None)
 
 
+def dynamic_roll(x, shifts, axis):
+    n = x.shape[axis]
+    expand_shifts = (...,) + (None,) * (x.ndim - axis)
+    expand_indices = expand_shifts[:-1]
+    idx = (mx.arange(n)[expand_indices] - shifts[expand_shifts]) % n
+    rolled = mx.take_along_axis(x, idx, axis=axis)
+    return rolled
+
+
+class RecurrentCache(_BaseCache):
+    def __init__(self, *, conv_state_size=0, conv_kernel_size=4, max_size=1):
+        self.conv_states = [None] * conv_state_size
+        self.ssm_states = None
+        self.conv_kernel_size = conv_kernel_size
+        self.max_size = max_size
+        self.conv_offset = 0
+        self.ssm_offset = 0
+        self._right_padding = None
+
+    def __getitem__(self, idx: int):
+        if 0 <= idx < len(self.conv_states):
+            return self.conv_states[idx]
+        elif idx == -1 or idx == len(self.conv_states):
+            if self.ssm_states is not None:
+                return self.ssm_states[self.ssm_offset - 1]
+            else:
+                return None
+        else:
+            raise IndexError("Cache index out of bounds")
+
+    def update_conv_input(self, qkv: mx.array, idx=0):
+        B, S, D = qkv.shape
+        n_keep = self.conv_kernel_size - 1
+
+        conv_state = prev_conv_state = self.conv_states[idx]
+        if conv_state is None:
+            conv_state = mx.zeros(
+                (B, max(S, self.max_size) + n_keep, D),
+                dtype=qkv.dtype,
+            )
+            self.conv_offset = n_keep
+
+        # Enlarge to keep all of S for conv input
+        if S + n_keep > conv_state.shape[1]:
+            conv_state = mx.zeros((B, S + n_keep, D), dtype=qkv.dtype)
+            # Carry over
+            conv_state[:, : self.conv_offset, :] = prev_conv_state
+
+        # Rotate
+        overflow = self.conv_offset + S - conv_state.shape[1]
+        if overflow > 0:
+            overflow = min(self.conv_offset, overflow)
+            self.conv_offset -= overflow
+            conv_state = mx.roll(conv_state, -overflow, axis=1)
+
+        # Update
+        end = min(self.conv_offset + S, conv_state.shape[1])
+        conv_state[:, end - S : end, :] = qkv
+
+        # Slice to (S + n_keep) for conv input
+        conv_input = conv_state[:, end - S - n_keep : end, :]
+
+        # Slice to max_size for cache
+        if conv_state.shape[1] > self.max_size + n_keep:
+            conv_state = mx.contiguous(conv_state[:, -(self.max_size + n_keep) :, :])
+        self.conv_states[idx] = conv_state
+        self.conv_offset = min(end, self.max_size + n_keep)
+
+        return conv_input
+
+    def update_ssm_states(self, states: mx.array):
+        S, B, *rest = states.shape
+        if S > self.max_size:
+            states = states[-self.max_size :, ...]
+            S = self.max_size
+
+        if self.ssm_states is None:
+            self.ssm_states = mx.zeros((self.max_size, B, *rest), dtype=states.dtype)
+
+        # Rotate
+        overflow = self.ssm_offset + S - self.max_size
+        if overflow > 0:
+            self.ssm_offset -= overflow
+            self.ssm_states = mx.roll(self.ssm_states, -overflow, axis=0)
+
+        # Update
+        self.ssm_states[self.ssm_offset : self.ssm_offset + S, ...] = states
+
+        # Advance
+        self.ssm_offset += S
+
+    def prepare(self, right_padding: List[int] | None = None, **kwargs):
+        self._right_padding = mx.array(right_padding)
+
+    def finalize(self):
+        if self._right_padding is not None:
+            for i in range(len(self.conv_states)):
+                self.conv_states[i] = dynamic_roll(
+                    self.conv_states[i], self._right_padding, axis=1
+                )
+        self._right_padding = None
+
+    @property
+    def state(self):
+        return (
+            self.conv_states,
+            self.ssm_states,
+            self.conv_kernel_size,
+            self.max_size,
+            self.conv_offset,
+            self.ssm_offset,
+        )
+
+    @state.setter
+    def state(self, v):
+        (
+            self.conv_states,
+            self.ssm_states,
+            self.conv_kernel_size,
+            self.max_size,
+            self.conv_offset,
+            self.ssm_offset,
+        ) = v
+
+    def is_trimmable(self, n: int = -1):
+        if len(self.conv_states) > 0:
+            if self.conv_offset - n < self.conv_kernel_size - 1:
+                return False
+        if self.ssm_states is not None:
+            if n > self.ssm_offset:
+                return False
+        return True
+
+    def trim(self, n: int):
+        if len(self.conv_states) > 0:
+            if self.conv_offset - n < self.conv_kernel_size - 1:
+                raise ValueError("Trimming more conv states than available")
+            self.conv_offset -= n
+        if self.ssm_states is not None:
+            if n > self.ssm_offset:
+                raise ValueError("Trimming more ssm states than available")
+            self.ssm_offset -= n
+        return n
+
+    def make_mask(self, N: int):
+        return None
+
+    def filter(self, batch_indices):
+        """
+        In-place filter to keep just the given indices in the cache.
+        """
+        self.conv_states = [
+            c[batch_indices] if c is not None else None for c in self.conv_states
+        ]
+        self.ssm_states = self.ssm_states[:, batch_indices, ...]
+
+    def extend(self, other: "RecurrentCache"):
+        """
+        In-place extend this cache with the other cache.
+        """
+
+        def batch_size(cache):
+            for c in cache.conv_states:
+                if c is not None:
+                    return c.shape[0]
+            if cache.ssm_states is not None:
+                return cache.ssm_states.shape[1]
+            return 1
+
+        a_batch = batch_size(self)
+        b_batch = batch_size(other)
+
+        max_conv_offset = max(self.conv_offset, other.conv_offset)
+        max_ssm_offset = max(self.ssm_offset, other.ssm_offset)
+
+        # Pad the hidden states so they are right-aligned
+        def pad(x, left, right, axis):
+            if right < 0:
+                x = x[..., :right, :]
+                right = 0
+            if left != 0 or right != 0:
+                pad = [(0, 0)] * len(x.shape)
+                pad[axis] = (left, right)
+                x = mx.pad(x, pad)
+            return x
+
+        def pad_conv_states(a, b):
+            max_size = max(a.shape[1], b.shape[1])
+            left_a = max_conv_offset - self.conv_offset
+            left_b = max_conv_offset - other.conv_offset
+            right_a = max_size - a.shape[1] - left_a
+            right_b = max_size - b.shape[1] - left_b
+            a = pad(a, left_a, right_a, 1)
+            b = pad(b, left_b, right_b, 1)
+            return a, b
+
+        def pad_ssm_states(a, b):
+            max_size = max(a.shape[0], b.shape[0])
+            left_a = max_ssm_offset - self.ssm_offset
+            left_b = max_ssm_offset - other.ssm_offset
+            right_a = max_size - a.shape[0] - left_a
+            right_b = max_size - b.shape[0] - left_b
+            a = pad(a, left_a, right_a, 0)
+            b = pad(b, left_b, right_b, 0)
+            return a, b
+
+        # Concatenate on batch dim
+        def cat(a, b, pad_fun=None, axis=0):
+            shape = dtype = None
+            if a is not None:
+                shape = a.shape
+                dtype = a.dtype
+            if b is not None:
+                shape = b.shape
+                dtype = b.dtype
+
+            if shape is None:
+                return None
+
+            if a is None:
+                a = mx.zeros(shape[:axis] + (a_batch,) + shape[axis + 1 :], dtype=dtype)
+            if b is None:
+                b = mx.zeros(shape[:axis] + (b_batch,) + shape[axis + 1 :], dtype=dtype)
+            if pad_fun:
+                a, b = pad_fun(a, b)
+
+            return mx.concatenate([a, b], axis)
+
+        self.conv_states = [
+            cat(c, o, pad_conv_states)
+            for c, o in zip(self.conv_states, other.conv_states)
+        ]
+        self.ssm_states = cat(self.ssm_states, other.ssm_states, pad_ssm_states, axis=1)
+        self.max_size = max(self.max_size, other.max_size)
+        self.conv_offset = max_conv_offset
+        self.ssm_offset = max_ssm_offset
+
+    def extract(self, idx: int):
+        cache = RecurrentCache(
+            conv_state_size=len(self.conv_states),
+            conv_kernel_size=self.conv_kernel_size,
+            max_size=self.max_size,
+        )
+        cache.conv_states = [c[idx : idx + 1] for c in self.conv_states]
+        cache.ssm_states = mx.contiguous(self.ssm_states[:, idx : idx + 1, ...])
+        cache.conv_offset = self.conv_offset
+        cache.ssm_offset = self.ssm_offset
+        return cache
+
+    @classmethod
+    def merge(cls, caches: List["RecurrentCache"]):
+        max_size = max(c.max_size for c in caches)
+        cache = cls(
+            conv_state_size=len(caches[0].conv_states),
+            conv_kernel_size=caches[0].conv_kernel_size,
+            max_size=max_size,
+        )
+        cache.conv_offset = max(c.conv_offset for c in caches)
+        cache.ssm_offset = max(c.ssm_offset for c in caches)
+
+        # Merge conv states
+        for i in range(len(cache.conv_states)):
+            valid_states = [(c[i], c.conv_offset) for c in caches if c[i] is not None]
+            if len(valid_states) == 0:
+                continue
+            B = sum(s.shape[0] for s, _ in valid_states)
+            S = max_size + cache.conv_kernel_size - 1
+            D = valid_states[0][0].shape[2]
+            cache.conv_states[i] = mx.zeros((B, S, D), dtype=valid_states[0][0].dtype)
+            j = 0
+            for s, offset in valid_states:
+                B_s = s.shape[0]
+                target = slice(cache.conv_offset - offset, cache.conv_offset)
+                cache.conv_states[i][j : j + B_s, target, :] = s[:, :offset, :]
+                j += B_s
+
+        # Merge ssm states
+        valid_states = [
+            (c.ssm_states, c.ssm_offset) for c in caches if c.ssm_states is not None
+        ]
+        if len(valid_states) > 0:
+            B = sum(s.shape[1] for s, _ in valid_states)
+            rest = valid_states[0][0].shape[2:]
+            cache.ssm_states = mx.zeros(
+                (max_size, B, *rest), dtype=valid_states[0][0].dtype
+            )
+            j = 0
+            for s, offset in valid_states:
+                B_s = s.shape[1]
+                target = slice(cache.ssm_offset - offset, cache.ssm_offset)
+                cache.ssm_states[target, j : j + B_s, :] = s[:offset, :, :]
+                j += B_s
+
+        return cache
+
+    def empty(self):
+        empty_conv = all(c is None for c in self.conv_states)
+        return empty_conv and self.ssm_states is None
+
+    @property
+    def nbytes(self):
+        conv_nbytes = sum(c.nbytes for c in self.conv_states if c is not None)
+        ssm_nbytes = self.ssm_states.nbytes if self.ssm_states is not None else 0
+        return conv_nbytes + ssm_nbytes
+
+
 class ChunkedKVCache(_BaseCache):
     step = 256
 
@@ -782,7 +1089,7 @@ class ChunkedKVCache(_BaseCache):
     def state(self, v):
         self.keys, self.values, self.offset, self.chunk_size, self.start_position = v
 
-    def is_trimmable(self):
+    def is_trimmable(self, n: int = -1):
         return True
 
     def trim(self, n):
@@ -807,8 +1114,8 @@ class CacheList(_BaseCache):
     def __getitem__(self, idx):
         return self.caches[idx]
 
-    def is_trimmable(self):
-        return all(c.is_trimmable() for c in self.caches)
+    def is_trimmable(self, n: int = -1):
+        return all(c.is_trimmable(n) for c in self.caches)
 
     def trim(self, n):
         for c in self.caches:
@@ -866,15 +1173,6 @@ class CacheList(_BaseCache):
     @property
     def nbytes(self):
         return sum(c.nbytes for c in self.caches)
-
-
-def dynamic_roll(x, shifts, axis):
-    n = x.shape[axis]
-    expand_shifts = (...,) + (None,) * (x.ndim - axis)
-    expand_indices = expand_shifts[:-1]
-    idx = (mx.arange(n)[expand_indices] - shifts[expand_shifts]) % n
-    rolled = mx.take_along_axis(x, idx, axis=axis)
-    return rolled
 
 
 class BatchKVCache(_BaseCache):
@@ -965,7 +1263,7 @@ class BatchKVCache(_BaseCache):
     def state(self, v):
         self.keys, self.values, self.offset, self.left_padding, self._idx = v
 
-    def is_trimmable(self):
+    def is_trimmable(self, n: int = -1):
         return True
 
     def trim(self, n):
@@ -1288,7 +1586,7 @@ class BatchRotatingKVCache(_BaseCache):
             self.rotated,
         ) = v
 
-    def is_trimmable(self):
+    def is_trimmable(self, n: int = -1):
         return self._offset < self.max_size
 
     def trim(self, n):
@@ -1658,10 +1956,10 @@ class LRUPromptCache:
         short_length = len(result.shorter) if result.shorter is not None else 0
         if result.longer is not None and result.common_prefix > short_length:
             cache_entry = self._trie.get(result.model, result.longer)
-            if can_trim_prompt_cache(cache_entry.prompt_cache):
+            prefix = min(len(tokens) - 1, result.common_prefix)
+            num_to_trim = len(result.longer) - prefix
+            if can_trim_prompt_cache(cache_entry.prompt_cache, num_to_trim):
                 cache = copy.deepcopy(cache_entry.prompt_cache)
-                prefix = min(len(tokens) - 1, result.common_prefix)
-                num_to_trim = len(result.longer) - prefix
                 trim_prompt_cache(cache, num_to_trim)
                 return cache, tokens[prefix:]
 

--- a/mlx_lm/models/gated_delta.py
+++ b/mlx_lm/models/gated_delta.py
@@ -546,8 +546,9 @@ def gated_delta_ops(
     v: mx.array,
     g: mx.array,
     beta: mx.array,
-    state: Optional[mx.array] = None,
-    mask: Optional[mx.array] = None,
+    state: mx.array | None = None,
+    mask: mx.array | None = None,
+    return_num_states: int | None = None,
 ) -> Tuple[mx.array, mx.array]:
     """
     Ops-based reference implementation for prompt prefill (sequential loop).
@@ -561,7 +562,7 @@ def gated_delta_ops(
       - state: [B, Hv, Dv, Dk]
     Returns:
       - y: [B, T, Hv, Dv]
-      - state: [B, Hv, Dv, Dk]
+      - state: [B, Hv, Dv, Dk] or [T, B, Hv, Dv, Dk]
     """
     B, T, Hk, Dk = q.shape
     Hv, Dv = v.shape[-2:]
@@ -573,6 +574,7 @@ def gated_delta_ops(
         k = mx.repeat(k, repeat_factor, -2)
 
     ys = []
+    states = []
     for t in range(T):
         y, state = _gated_delta_step_ops(
             q[:, t],
@@ -584,8 +586,15 @@ def gated_delta_ops(
             None if mask is None else mask[:, t],
         )
         ys.append(y)
+        if return_num_states is not None:
+            states.append(state)
+            if len(states) > return_num_states:
+                states = states[-return_num_states:]
     y = mx.stack(ys, axis=1)
-    return y, state
+    if return_num_states is not None:
+        return y, mx.stack(states)
+    else:
+        return y, state
 
 
 def gated_delta_update(
@@ -600,6 +609,7 @@ def gated_delta_update(
     mask: Optional[mx.array] = None,
     use_kernel: bool = True,
     lower_bound: float | None = None,
+    return_num_states: int | None = None,
 ) -> Tuple[mx.array, mx.array]:
     """Gated delta rule recurrence.
 
@@ -619,10 +629,11 @@ def gated_delta_update(
 
     if (
         not use_kernel
+        or return_num_states is not None
         or mx.default_device() != mx.gpu
         or not mx.metal.is_available()
         or k.shape[-1] < 32
         or k.shape[-1] % 32 != 0
     ):
-        return gated_delta_ops(q, k, v, g, beta, state, mask)
+        return gated_delta_ops(q, k, v, g, beta, state, mask, return_num_states)
     return gated_delta_kernel(q, k, v, g, beta, state, mask)

--- a/mlx_lm/models/qwen3_5.py
+++ b/mlx_lm/models/qwen3_5.py
@@ -13,7 +13,7 @@ from .base import (
     create_attention_mask,
     create_ssm_mask,
 )
-from .cache import ArraysCache, KVCache
+from .cache import KVCache, RecurrentCache
 from .gated_delta import gated_delta_update
 from .pipeline import PipelineMixin
 from .qwen3_next import Qwen3NextAttention as Attention
@@ -134,7 +134,7 @@ class GatedDeltaNet(nn.Module):
         self,
         inputs: mx.array,
         mask: Optional[mx.array] = None,
-        cache: Optional[Any] = None,
+        cache: Optional[RecurrentCache] = None,
     ) -> mx.array:
         B, S, _ = inputs.shape
 
@@ -146,25 +146,17 @@ class GatedDeltaNet(nn.Module):
         b = self.in_proj_b(inputs)
         a = self.in_proj_a(inputs)
 
-        if cache is not None and cache[0] is not None:
-            conv_state = cache[0]
+        if mask is not None:
+            qkv = mx.where(mask[..., None], qkv, 0)
+
+        if cache is not None:
+            conv_input = cache.update_conv_input(qkv)
         else:
             conv_state = mx.zeros(
                 (B, self.conv_kernel_size - 1, self.conv_dim),
                 dtype=inputs.dtype,
             )
-
-        if mask is not None:
-            qkv = mx.where(mask[..., None], qkv, 0)
-        conv_input = mx.concatenate([conv_state, qkv], axis=1)
-        if cache is not None:
-            n_keep = self.conv_kernel_size - 1
-            if cache.lengths is not None:
-                ends = mx.clip(cache.lengths, 0, S)
-                positions = (ends[:, None] + mx.arange(n_keep))[..., None]
-                cache[0] = mx.take_along_axis(conv_input, positions, axis=1)
-            else:
-                cache[0] = mx.contiguous(conv_input[:, -n_keep:, :])
+            conv_input = mx.concatenate([conv_state, qkv], axis=1)
         conv_out = nn.silu(self.conv1d(conv_input))
 
         q, k, v = [
@@ -176,12 +168,11 @@ class GatedDeltaNet(nn.Module):
             )
         ]
 
-        state = cache[1] if cache else None
         inv_scale = k.shape[-1] ** -0.5
         q = (inv_scale**2) * mx.fast.rms_norm(q, None, 1e-6)
         k = inv_scale * mx.fast.rms_norm(k, None, 1e-6)
 
-        out, state = gated_delta_update(
+        out, states = gated_delta_update(
             q,
             k,
             v,
@@ -189,14 +180,14 @@ class GatedDeltaNet(nn.Module):
             b,
             self.A_log,
             self.dt_bias,
-            state,
+            cache[1] if cache is not None else None,
             mask,
             use_kernel=not self.training,
+            return_num_states=(None if cache is None else cache.max_size),
         )
 
         if cache is not None:
-            cache[1] = state
-            cache.advance(S)
+            cache.update_ssm_states(states)
 
         out = self.norm(out, z)
         out = self.out_proj(out.reshape(B, S, -1))
@@ -343,7 +334,18 @@ class TextModel(nn.Module):
         return self.model.pipeline_layers
 
     def make_cache(self):
-        return [ArraysCache(size=2) if l.is_linear else KVCache() for l in self.layers]
+        return [
+            (
+                RecurrentCache(
+                    conv_state_size=1,
+                    conv_kernel_size=self.args.linear_conv_kernel_dim,
+                    max_size=6,
+                )
+                if l.is_linear
+                else KVCache()
+            )
+            for l in self.layers
+        ]
 
     def sanitize(self, weights):
         has_unsanitized_conv1d = any(

--- a/tests/test_prompt_cache.py
+++ b/tests/test_prompt_cache.py
@@ -18,6 +18,7 @@ from mlx_lm.models.cache import (
     ChunkedKVCache,
     KVCache,
     QuantizedKVCache,
+    RecurrentCache,
     RotatingKVCache,
     load_prompt_cache,
     make_prompt_cache,
@@ -104,6 +105,7 @@ class TestPromptCache(unittest.TestCase):
 
         cache = [
             ArraysCache(size=2),
+            RecurrentCache(conv_state_size=1, max_size=4),
             KVCache(),
             RotatingKVCache(8),
             ArraysCache(size=2),
@@ -113,6 +115,9 @@ class TestPromptCache(unittest.TestCase):
             if isinstance(c, ArraysCache):
                 c[0] = mx.random.uniform(shape=(4, 4, 4))
                 c[1] = mx.random.uniform(shape=(4, 4, 4))
+            elif isinstance(c, RecurrentCache):
+                c.update_conv_input(mx.random.uniform(shape=(4, 4, 4)))
+                c.update_ssm_states(mx.random.uniform(shape=(4, 4, 1, 4, 4)))
             else:
                 x = mx.random.uniform(shape=(4, 4, 7, 4))
                 y = mx.random.uniform(shape=(4, 4, 7, 4))
@@ -122,6 +127,9 @@ class TestPromptCache(unittest.TestCase):
         loaded_cache = load_prompt_cache(cache_file)
         for c, lc in zip(cache, loaded_cache):
             if isinstance(c, ArraysCache):
+                self.assertTrue(mx.array_equal(c[0], lc[0]))
+                self.assertTrue(mx.array_equal(c[1], lc[1]))
+            elif isinstance(c, RecurrentCache):
                 self.assertTrue(mx.array_equal(c[0], lc[0]))
                 self.assertTrue(mx.array_equal(c[1], lc[1]))
             else:
@@ -138,6 +146,7 @@ class TestPromptCache(unittest.TestCase):
 
         cache = [
             ArraysCache(size=2),
+            RecurrentCache(conv_state_size=1, max_size=4),
             KVCache(),
             RotatingKVCache(8),
             ArraysCache(size=2),
@@ -147,6 +156,9 @@ class TestPromptCache(unittest.TestCase):
             if isinstance(c, ArraysCache):
                 c[0] = mx.random.uniform(shape=(4, 4, 4))
                 c[1] = mx.random.uniform(shape=(4, 4, 4))
+            elif isinstance(c, RecurrentCache):
+                c.update_conv_input(mx.random.uniform(shape=(4, 4, 4)))
+                c.update_ssm_states(mx.random.uniform(shape=(4, 4, 1, 4, 4)))
             else:
                 x = mx.random.uniform(shape=(4, 4, 7, 4))
                 y = mx.random.uniform(shape=(4, 4, 7, 4))
@@ -157,6 +169,9 @@ class TestPromptCache(unittest.TestCase):
         loaded_cache = load_prompt_cache(cache_file)
         for c, lc in zip(cache[0].caches, loaded_cache[0].caches):
             if isinstance(c, ArraysCache):
+                self.assertTrue(mx.array_equal(c[0], lc[0]))
+                self.assertTrue(mx.array_equal(c[1], lc[1]))
+            elif isinstance(c, RecurrentCache):
                 self.assertTrue(mx.array_equal(c[0], lc[0]))
                 self.assertTrue(mx.array_equal(c[1], lc[1]))
             else:
@@ -824,6 +839,280 @@ class TestPromptCache(unittest.TestCase):
         mask = create_attention_mask(h, c, window_size=4)
         expected = create_causal_mask(1, offset=32, window_size=4)
         self.assertTrue(mx.array_equal(mask, expected))
+
+
+class TestRecurrentCache(unittest.TestCase):
+    def test_nbytes(self):
+        S, D = 4, 16
+        n_keep = 3
+        c = RecurrentCache(conv_state_size=1, conv_kernel_size=n_keep + 1, max_size=S)
+
+        self.assertTrue(c.empty())
+        self.assertEqual(c.nbytes, 0)
+
+        x = mx.random.uniform(shape=(1, 1, D))
+        c.update_conv_input(x)
+        self.assertFalse(c.empty())
+        self.assertGreater(c.nbytes, x.nbytes)
+
+        old_size = c.nbytes
+        x = mx.random.uniform(shape=(1, 1, 1, D, D))
+        c.update_ssm_states(x)
+        self.assertGreater(c.nbytes, x.nbytes + old_size)
+
+    def test_update_conv_input(self):
+        S, D = 4, 16
+        n_keep = 3
+        c = RecurrentCache(conv_state_size=1, conv_kernel_size=n_keep + 1, max_size=S)
+
+        # Append single tokens within max size
+        states = [mx.random.uniform(shape=(1, 1, D)) for i in range(S)]
+        for x in states:
+            y = c.update_conv_input(x)
+        states = [mx.zeros((1, 1, D))] * n_keep + states
+        self.assertTrue(mx.array_equal(c[0], mx.concatenate(states, axis=1)))
+        input = states[-(x.shape[1] + n_keep) :]
+        self.assertTrue(mx.array_equal(y, mx.concatenate(input, axis=1)))
+
+        # Overflow by one
+        x = mx.random.uniform(shape=(1, 1, D))
+        y = c.update_conv_input(x)
+        states = states[1:] + [x]
+        self.assertTrue(mx.array_equal(c[0], mx.concatenate(states, axis=1)))
+        input = states[-(x.shape[1] + n_keep) :]
+        self.assertTrue(mx.array_equal(y, mx.concatenate(input, axis=1)))
+
+        # Overflow by multiple
+        x = mx.random.uniform(shape=(1, 2, D))
+        y = c.update_conv_input(x)
+        states = (states + mx.split(x, x.shape[1], 1))[-(S + n_keep) :]
+        self.assertTrue(mx.array_equal(c[0], mx.concatenate(states, axis=1)))
+        input = states[-(x.shape[1] + n_keep) :]
+        self.assertTrue(mx.array_equal(y, mx.concatenate(input, axis=1)))
+
+        # Overflow by max size
+        x = mx.random.uniform(shape=(1, S, D))
+        y = c.update_conv_input(x)
+        states = (states + mx.split(x, x.shape[1], 1))[-(S + n_keep) :]
+        self.assertTrue(mx.array_equal(c[0], mx.concatenate(states, axis=1)))
+        input = states[-(x.shape[1] + n_keep) :]
+        self.assertTrue(mx.array_equal(y, mx.concatenate(input, axis=1)))
+
+        # Overflow by more than max size
+        x = mx.random.uniform(shape=(1, S + 2, D))
+        y = c.update_conv_input(x)
+        full_states = states + mx.split(x, x.shape[1], 1)
+        states = full_states[-(S + n_keep) :]
+        self.assertTrue(mx.array_equal(c[0], mx.concatenate(states, axis=1)))
+        input = full_states[-(x.shape[1] + n_keep) :]
+        self.assertTrue(mx.array_equal(y, mx.concatenate(input, axis=1)))
+
+    def test_trim_conv_states(self):
+        S, D = 4, 16
+        n_keep = 3
+        c = RecurrentCache(conv_state_size=1, conv_kernel_size=n_keep + 1, max_size=S)
+
+        # Trim empty
+        with self.assertRaises(ValueError):
+            c.trim(1)
+
+        # Prefill
+        x = mx.random.uniform(shape=(1, S + n_keep, D))
+        c.update_conv_input(x)
+        states = mx.split(x, x.shape[1], 1)
+        self.assertTrue(mx.array_equal(c[0], x))
+
+        # Trim too much
+        with self.assertRaises(ValueError):
+            c.trim(S + 1)
+
+        # Trim one
+        c.trim(1)
+        x = mx.random.uniform(shape=(1, 1, D))
+        y = c.update_conv_input(x)
+        states = states[:-1] + [x]
+        input = states[-(x.shape[1] + n_keep) :]
+        self.assertTrue(mx.array_equal(y, mx.concatenate(input, axis=1)))
+
+        # Trim multiple
+        c.trim(3)
+        x = mx.random.uniform(shape=(1, 1, D))
+        y = c.update_conv_input(x)
+        states = states[:-3] + mx.split(x, x.shape[1], 1)
+        input = states[-(x.shape[1] + n_keep) :]
+        self.assertTrue(mx.array_equal(y, mx.concatenate(input, axis=1)))
+
+    def test_update_ssm_states(self):
+        S, H, D = 4, 2, 16
+        c = RecurrentCache(max_size=S)
+
+        # Append single tokens within max size
+        states = mx.random.uniform(shape=(S - 1, 1, H, D, D))
+        c.update_ssm_states(states)
+        self.assertTrue(mx.array_equal(c[0], states[-1]))
+
+        # Overflow
+        for T in (1, 2, S):
+            states = mx.random.uniform(shape=(T, 1, H, D, D))
+            c.update_ssm_states(states)
+            self.assertTrue(mx.array_equal(c[0], states[-1]))
+
+    def test_trim_ssm_states(self):
+        S, H, D = 4, 2, 16
+        c = RecurrentCache(max_size=S)
+
+        # Trim too much
+        states = mx.random.uniform(shape=(S, 1, H, D, D))
+        c.update_ssm_states(states)
+        with self.assertRaises(ValueError):
+            c.trim(S + 1)
+
+        # Trim one
+        c.trim(1)
+        self.assertTrue(mx.array_equal(c[0], states[-2]))
+
+        # Trim two
+        c.trim(2)
+        self.assertTrue(mx.array_equal(c[0], states[-4]))
+
+    def test_filter(self):
+        B, S, D = 8, 1, 2
+        n_keep = 3
+        c = RecurrentCache(conv_state_size=1, conv_kernel_size=n_keep + 1, max_size=S)
+
+        x = mx.random.uniform(shape=(B, 1, D))
+        c.update_conv_input(x)
+        y = mx.random.uniform(shape=(1, B, 1, D, D))
+        c.update_ssm_states(y)
+
+        batch_indices = [1, 2]
+        c.filter(batch_indices)
+        self.assertTrue(mx.array_equal(c[0][:, -1:, :], x[batch_indices, ...]))
+        self.assertTrue(mx.array_equal(c[1], y[0, batch_indices, ...]))
+
+    def test_extend(self):
+        S, D = 3, 2
+        n_keep = 2
+
+        def make_caches(B1, S1, B2, S2, max_size1=S, max_size2=S):
+            c1 = RecurrentCache(
+                conv_state_size=1, conv_kernel_size=n_keep + 1, max_size=max_size1
+            )
+            c2 = RecurrentCache(
+                conv_state_size=1, conv_kernel_size=n_keep + 1, max_size=max_size2
+            )
+            x1 = mx.random.uniform(shape=(B1, S1, D))
+            c1.update_conv_input(x1)
+            y1 = mx.random.uniform(shape=(S1, B1, 1, D, D))
+            c1.update_ssm_states(y1)
+            x2 = mx.random.uniform(shape=(B2, S2, D))
+            c2.update_conv_input(x2)
+            y2 = mx.random.uniform(shape=(S2, B2, 1, D, D))
+            c2.update_ssm_states(y2)
+            return c1, c2, x1, x2, y1, y2
+
+        # Different batch size, same sequance size
+        B1 = 2
+        B2 = 3
+        S1 = S2 = S + n_keep
+        c1, c2, x1, x2, y1, y2 = make_caches(B1, S1, B2, S2)
+        c1.extend(c2)
+        self.assertTrue(mx.array_equal(c1[0], mx.concatenate([x1, x2])))
+        self.assertTrue(mx.array_equal(c1[1], mx.concatenate([y1[-1], y2[-1]])))
+
+        # Different batch size, different sequance size
+        B1 = 2
+        B2 = 3
+        S1 = S + n_keep
+        S2 = S + n_keep + 2
+        c1, c2, x1, x2, y1, y2 = make_caches(
+            B1, S1, B2, S2, max_size1=S, max_size2=S + 2
+        )
+        c1.extend(c2)
+        x1 = mx.pad(x1, [(0, 0), (S2 - S1, 0), (0, 0)])
+        self.assertTrue(mx.array_equal(c1[0], mx.concatenate([x1, x2])))
+        self.assertTrue(mx.array_equal(c1[1], mx.concatenate([y1[-1], y2[-1]])))
+
+    def test_merge_extract(self):
+        D = 2
+        n_keep = 2
+        c1 = RecurrentCache(conv_state_size=1, conv_kernel_size=n_keep + 1, max_size=2)
+        c2 = RecurrentCache(conv_state_size=1, conv_kernel_size=n_keep + 1, max_size=4)
+        c3 = RecurrentCache.merge([c1, c2])
+        self.assertEqual(c3[0], None)
+        self.assertEqual(c3[1], None)
+
+        # Merge with empty
+        x1 = mx.random.uniform(shape=(1, 2, D))
+        c1.update_conv_input(x1)
+        y1 = mx.random.uniform(shape=(2, 1, 1, 1, D))
+        c1.update_ssm_states(y1)
+        c3 = RecurrentCache.merge([c1, c2])
+        self.assertTrue(mx.array_equal(c3[0][:, : c3.conv_offset, :], c1[0]))
+        self.assertTrue(mx.array_equal(c3[1], c1[1]))
+        c1_e = c3.extract(0)
+        self.assertTrue(mx.array_equal(c1_e[0][:, : c1_e.conv_offset, :], c1[0]))
+        self.assertTrue(mx.array_equal(c1_e[1], c1[1]))
+
+        # Merge with non-empty
+        x2 = mx.random.uniform(shape=(2, 3, D))
+        c2.update_conv_input(x2)
+        y2 = mx.random.uniform(shape=(3, 2, 1, 1, D))
+        c2.update_ssm_states(y2)
+        c3 = RecurrentCache.merge([c1, c2])
+        self.assertTrue(
+            mx.array_equal(
+                c3[0][:, c3.conv_offset - 3 : c3.conv_offset, :],
+                mx.concatenate([mx.pad(x1, [(0, 0), (1, 0), (0, 0)]), x2]),
+            )
+        )
+        self.assertTrue(mx.array_equal(c3[1], mx.concatenate([y1[-1], y2[-1]])))
+        c1_e = c3.extract(0)
+        self.assertTrue(
+            mx.array_equal(
+                c1_e[0][:, c1_e.conv_offset - 4 : c1_e.conv_offset, :],
+                c1[0],
+            )
+        )
+        self.assertTrue(mx.array_equal(c1_e[1], c1[1]))
+
+    def test_batch_prefill(self):
+        max_size = 3
+        n_keep = 2
+        c = RecurrentCache(
+            conv_state_size=1, conv_kernel_size=n_keep + 1, max_size=max_size
+        )
+
+        # Prepare data: batch of B with sequence length 1 to B
+        B, D = 4, 2
+        qkv = mx.random.uniform(shape=(B, B, D))
+        lengths = mx.arange(1, B + 1, dtype=mx.int32).tolist()
+        right_padding = [B - l for l in lengths]
+        for i, l in enumerate(lengths):
+            qkv[i, l:, :] = 0
+
+        c.prepare(lengths=lengths, right_padding=right_padding)
+
+        # Prefill half
+        M = 2
+        conv_inputs = c.update_conv_input(qkv[:, :M, :])
+        self.assertTrue(
+            mx.array_equal(
+                conv_inputs,
+                mx.concatenate([mx.zeros((B, n_keep, D)), qkv[:, :M, :]], axis=1),
+            )
+        )
+
+        # Prefill rest
+        conv_inputs = c.update_conv_input(qkv[:, M:, :])
+        self.assertTrue(mx.array_equal(conv_inputs, qkv[:, -M - n_keep :, :]))
+
+        # Right-aligned after prefilling
+        c.finalize()
+        expected = mx.zeros((B, max_size + n_keep, D))
+        for i, l in enumerate(lengths):
+            expected[i, -l:, :] = qkv[i, :l, :]
+        self.assertTrue(mx.array_equal(c[0], expected))
 
 
 if __name__ == "__main__":

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -94,7 +94,7 @@ class MockCache:
     def __eq__(self, other):
         return other.value == self.value
 
-    def is_trimmable(self):
+    def is_trimmable(self, n: int = -1):
         return self._is_trimmable
 
     def trim(self, n):


### PR DESCRIPTION
Refs #990

The `ArraysCache` only stores the last hidden states so it is not trimmable and does not work with speculative decoding like MTP.

This PR experiments with a new `RecurrentCache` implementation that, stores the hidden states in a temporal manner so we can roll back in speculative decoding. The downside is that the hidden states per token is much larger than traditional KV cache and the sequence length would be very limited, so it would not help much in the case of prefix prompt cache, but for speculative decoding we usually only draft 4~6 tokens and additional RAM usage would be quite small.

To try this branch:

```console
mlx_lm.generate --model mlx-community/Qwen3.8-27B-4bit --max-tokens 200 --prompt "Write a story about George Washington" --chat-template-config "{\"enable_thinking\": false}" --draft-model mlx-community/Qwen3.5-0.8B-4bit --num-draft-tokens 4
```