### PR TITLE
Read BatchKVCache left padding without a reduction kernel

### DIFF
--- a/mlx_lm/models/cache.py
+++ b/mlx_lm/models/cache.py
@@ -1033,7 +1033,8 @@ class BatchKVCache(_BaseCache):
         self.left_padding = self.left_padding[batch_indices]
 
         # Shift left to reduce padding
-        min_left_pad = self.left_padding.min().item()
+        mx.eval(self.left_padding)
+        min_left_pad = min(self.left_padding.tolist())
         if min_left_pad > 0:
             if self.keys is not None:
                 self.keys = self.keys[..., min_left_pad:, :]
@@ -1089,7 +1090,8 @@ class BatchKVCache(_BaseCache):
 
     def extract(self, idx):
         cache = KVCache()
-        padding = self.left_padding[idx].item()
+        mx.eval(self.left_padding)
+        padding = self.left_padding.tolist()[idx]
         cache.keys = mx.contiguous(self.keys[idx : idx + 1, :, padding : self._idx])
         cache.values = mx.contiguous(self.values[idx : idx + 1, :, padding : self._idx])
         cache.offset = cache.keys.shape[2]

--- a/mlx_lm/models/cache.py
+++ b/mlx_lm/models/cache.py
@@ -1033,7 +1033,6 @@ class BatchKVCache(_BaseCache):
         self.left_padding = self.left_padding[batch_indices]
 
         # Shift left to reduce padding
-        mx.eval(self.left_padding)
         min_left_pad = min(self.left_padding.tolist())
         if min_left_pad > 0:
             if self.keys is not None:


### PR DESCRIPTION
Move `min` to the CPU deliberately. `left_padding` is only ever written from Python ints, so `.min().item()` launched a reduction and blocked on it to recover a value the host already had: ~115us per call, once per layer, against ~1.3us for `.tolist()`. `BatchRotatingKVCache.extract` already reads it this way.

`mlx_lm.benchmark --model mlx-community/Qwen1.5-0.5B-Chat-4bit -p 512 -g 64 -b 32 -n 9`, mean of 9 trials on Apple M4 Max:

| | main | this PR |
|---|---|---|
| generation_tps | 2370.3 +/- 6.1 | 2645.5 +/- 19.7 (+11.6%) |

Larger still when sequences retire at different times, where `filter` runs repeatedly rather than once at teardown.

Previously part of the #1722
