### PR TITLE
Scatter the top-p keep mask instead of inverting the sort permutation

### DIFF
--- a/mlx_lm/sample_utils.py
+++ b/mlx_lm/sample_utils.py
@@ -212,7 +212,7 @@ def apply_top_p(logprobs: mx.array, top_p: float) -> mx.array:
     Returns:
         token selected based on the top-p criterion.
     """
-    # referenced implementation from https://github.com/huggingface/transformers/blob/main/src/transformers/generation/logits_process.py#L449-L460
+    # referenced implementation from https://github.com/huggingface/transformers/blob/main/src/transformers/generation/logits_process.py#L527-L539
     probs = mx.exp(logprobs)
     # sort in ascending order
     sorted_indices = mx.argsort(logprobs, axis=-1)
@@ -220,21 +220,12 @@ def apply_top_p(logprobs: mx.array, top_p: float) -> mx.array:
 
     cumulative_probs = mx.cumsum(sorted_probs, axis=-1)
 
-    # Rearrange cumulative probs back to original order
-    inverse_indices = mx.put_along_axis(
-        mx.zeros_like(sorted_indices),
-        sorted_indices,
-        mx.arange(sorted_indices.shape[-1], dtype=sorted_indices.dtype),
-        axis=-1,
+    # Scatter the keep mask back into vocabulary order.
+    sorted_keep = cumulative_probs > 1 - top_p
+    keep = mx.put_along_axis(
+        mx.zeros_like(sorted_keep), sorted_indices, sorted_keep, axis=-1
     )
-    cumulative_probs = mx.take_along_axis(cumulative_probs, inverse_indices, axis=-1)
-
-    # select tokens with cumulative probs below threshold
-    return mx.where(
-        cumulative_probs > 1 - top_p,
-        logprobs,
-        -float("inf"),
-    )
+    return mx.where(keep, logprobs, -float("inf"))
 
 
 @partial(mx.compile, inputs=mx.random.state, outputs=mx.random.state)


### PR DESCRIPTION
Compares against the threshold before scattering the mask back into vocabulary order, instead of gathering the cumulative probabilities first. Drops a full-vocabulary gather and the `mx.arange`. Bit-identical: a permutation commutes with an elementwise comparison.

Previously part of the #1722