### PR TITLE
Validate generation inputs instead of failing later or silently

### DIFF
--- a/mlx_lm/generate.py
+++ b/mlx_lm/generate.py
@@ -684,6 +684,11 @@ def stream_generate(
         GenerationResponse: An instance containing the generated text segment and
             associated metadata. See :class:`GenerationResponse` for details.
     """
+    if max_tokens == 0:
+        raise ValueError(
+            "Maximum number of tokens must be non-zero (use -1 for no limit)."
+        )
+
     if not isinstance(tokenizer, TokenizerWrapper):
         tokenizer = TokenizerWrapper(tokenizer)
 
@@ -874,6 +879,9 @@ def _build_trie(sequences):
         try:
             for tok in seq:
                 node = node.setdefault(tok, {})
+            if node is trie:
+                # An empty pattern would make the root match every token.
+                continue
             node["__match__"] = (tuple(seq), idx)
         except TypeError:
             node = node.setdefault(seq, {})
@@ -1669,22 +1677,38 @@ class BatchGenerator:
         ] = None,
         stop_matchers: Optional[List[StopSequenceMatcher]] = None,
     ):
-        uids = []
+        num_segments = len(segments)
 
-        max_tokens = max_tokens or [self.max_tokens] * len(segments)
+        max_tokens = max_tokens or [self.max_tokens] * num_segments
         all_tokens = all_tokens or [[] for _ in segments]
-        samplers = samplers or [None] * len(segments)
+        samplers = samplers or [None] * num_segments
         logits_processors = logits_processors or (
-            [self.logits_processors] * len(segments)
+            [self.logits_processors] * num_segments
         )
-        stop_matchers = stop_matchers or ([self._default_stop_matcher] * len(segments))
+        stop_matchers = stop_matchers or ([self._default_stop_matcher] * num_segments)
 
-        caches = caches or [None] * len(segments)
-        for i in range(len(segments)):
-            if caches[i] is None:
-                caches[i] = make_prompt_cache(self.model, self.max_kv_size)
+        caches = caches or [None] * num_segments
 
-        for seq, m, c, at, s, lp, sm in zip(
+        # Validate before touching any state: ``zip`` pairs up to the shortest.
+        opts = {
+            "max_tokens": max_tokens,
+            "caches": caches,
+            "all_tokens": all_tokens,
+            "samplers": samplers,
+            "logits_processors": logits_processors,
+            "stop_matchers": stop_matchers,
+        }
+        for k, v in opts.items():
+            if len(v) != num_segments:
+                raise ValueError(
+                    f"Option {k} must have one entry per segment: expected "
+                    f"{num_segments}, got {len(v)}."
+                )
+
+        uids = list(range(self._uid_count, self._uid_count + num_segments))
+        pending = []
+        for uid, seq, m, c, at, s, lp, sm in zip(
+            uids,
             segments,
             max_tokens,
             caches,
@@ -1693,15 +1717,20 @@ class BatchGenerator:
             logits_processors,
             stop_matchers,
         ):
-            seq = list(seq)
+            seq = [segment for segment in seq if segment]
+            if not seq:
+                raise ValueError(f"Sequence {uid} has an empty prompt.")
+            if m <= 0:
+                raise ValueError(f"Sequence {uid}'s max_tokens must be > 0.")
             if len(seq[-1]) != 1:
                 seq.append(seq[-1][-1:])
                 seq[-2] = seq[-2][:-1]
-            self._unprocessed_sequences.append(
-                (self._uid_count, seq, m, c, at, s, lp, sm)
-            )
-            uids.append(self._uid_count)
-            self._uid_count += 1
+            if c is None:
+                c = make_prompt_cache(self.model, self.max_kv_size)
+            pending.append((uid, seq, m, c, at, s, lp, sm))
+
+        self._unprocessed_sequences.extend(pending)
+        self._uid_count += num_segments
 
         return uids
 

--- a/tests/test_generate.py
+++ b/tests/test_generate.py
@@ -13,6 +13,7 @@ from mlx_lm.generate import (
     BatchGenerator,
     GenerationResponse,
     StopSequenceMatcher,
+    _build_trie,
     batch_generate,
     generate,
     generate_step,
@@ -949,6 +950,41 @@ class TestGenerate(unittest.TestCase):
             future = pool.submit(run_on_worker)
             tokens = future.result(timeout=30)
         self.assertGreater(len(tokens), 0)
+
+    def test_stream_generate_rejects_zero_max_tokens(self):
+        with self.assertRaises(ValueError):
+            next(stream_generate(self.model, self.tokenizer, "hello", max_tokens=0))
+
+        gen = stream_generate(self.model, self.tokenizer, "hello", max_tokens=-1)
+        self.assertIsNotNone(next(gen).token)
+        gen.close()
+
+    def test_insert_validates_atomically(self):
+        gen = BatchGenerator(self.model, max_tokens=2)
+        prompt = self.tokenizer.encode("hello")
+
+        # A short option list must raise, not drop the third prompt.
+        with self.assertRaises(ValueError) as ctx:
+            gen.insert([prompt, prompt, prompt], max_tokens=[2, 2])
+        self.assertIn("max_tokens", str(ctx.exception))
+
+        with self.assertRaises(ValueError):
+            gen.insert([prompt, prompt], max_tokens=[2, 0])
+        with self.assertRaises(ValueError):
+            gen.insert([[]])
+
+        # Nothing was enqueued and the uid counter did not advance.
+        self.assertEqual(len(gen._unprocessed_sequences), 0)
+        self.assertEqual(gen.insert([prompt]), [0])
+
+    def test_build_trie_ignores_empty_sequences(self):
+        trie = _build_trie([[], [7]])
+
+        state = trie
+        state, matched = StopSequenceMatcher.match(state, trie, 3)
+        self.assertFalse(matched)
+        state, matched = StopSequenceMatcher.match(state, trie, 7)
+        self.assertTrue(matched)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Addresses #1689. Supersedes #1681 (@Thump604), #1708 (@pierre427), #1668 (@kupilikula).

- `stream_generate(max_tokens=0)` raises instead of `UnboundLocalError`; `-1` stays unbounded.
- `insert_segments` requires one option entry per segment - `zip` paired up to the shortest and silently dropped trailing prompts.
- `insert_segments` rejects empty prompts and `max_tokens <= 0`, committing only once every sequence is built.
- `_build_trie` skips empty patterns, which otherwise make the root match every token.

Two calls to confirm: this reverses #1708 (it wanted an empty stream), and `max_tokens=-1` means unbounded in `generate_step` but "stop after one token" in `BatchGenerator` - rejected here rather than unified.

Previously part of #1722
