### PR TITLE
Make BatchGenerator.stats a window over monotonic counters

### DIFF
--- a/mlx_lm/generate.py
+++ b/mlx_lm/generate.py
@@ -8,7 +8,7 @@ import json
 import sys
 import time
 from collections import deque
-from dataclasses import dataclass
+from dataclasses import asdict, dataclass
 from typing import Any, Callable, Generator, List, Optional, Sequence, Tuple, Union
 
 import mlx.core as mx
@@ -16,6 +16,7 @@ import mlx.nn as nn
 from mlx.utils import tree_reduce
 from transformers import PreTrainedTokenizer
 
+from .generate_utils import BatchCounters, BatchReading, BatchStats
 from .models.cache import (
     QuantizedKVCache,
     TokenBuffer,
@@ -812,30 +813,6 @@ def _right_pad_prompts(prompts, max_length=None):
     return mx.array([p + [0] * (max_length - len(p)) for p in prompts])
 
 
-@dataclass
-class BatchStats:
-    """
-    An data object to hold generation stats.
-
-    Args:
-        prompt_tokens (int): The number of prompt tokens processed.
-        prompt_tps (float): The prompt processing tokens-per-second.
-        prompt_time (float): The time in seconds spent in prompt processing.
-        generation_tokens (int): The number of generated tokens.
-        generation_tps (float): The tokens-per-second for generation.
-        generation_time (float): The time in seconds spent in generation .
-        peak_memory (float): The peak memory used so far in GB.
-    """
-
-    prompt_tokens: int = 0
-    prompt_tps: float = 0
-    prompt_time: float = 0
-    generation_tokens: int = 0
-    generation_tps: float = 0
-    generation_time: float = 0
-    peak_memory: float = 0
-
-
 def _merge_caches(caches):
     batch_cache = []
 
@@ -1589,10 +1566,7 @@ class BatchGenerator:
         self._unprocessed_sequences = deque()
         self._currently_processing = []
 
-        self._prompt_tokens_counter = 0
-        self._prompt_time_counter = 0
-        self._gen_tokens_counter = 0
-        self._steps_counter = 0
+        self._counters = BatchCounters()
 
         if mx.metal.is_available():
             self._old_wired_limit = mx.set_wired_limit(
@@ -1615,25 +1589,19 @@ class BatchGenerator:
         self.close()
 
     @contextlib.contextmanager
-    def stats(self, stats=None):
-        stats = stats or BatchStats()
-        self._prompt_tokens_counter = 0
-        self._prompt_time_counter = 0
-        self._gen_tokens_counter = 0
-        tic = time.perf_counter()
+    def stats(self):
+        """The work this generator does while the block runs.
+
+        Readings are taken on entry and exit and subtracted, so nested windows
+        each report their own interval.
+        """
+        stats = BatchStats()
+        start = BatchReading(**asdict(self._counters))
         try:
             yield stats
         finally:
-            toc = time.perf_counter()
-            total_time = toc - tic
-            gen_time = total_time - self._prompt_time_counter
-            stats.prompt_tokens += self._prompt_tokens_counter
-            stats.prompt_time += self._prompt_time_counter
-            stats.prompt_tps = stats.prompt_tokens / stats.prompt_time
-            stats.generation_tokens += self._gen_tokens_counter
-            stats.generation_time += gen_time
-            stats.generation_tps = stats.generation_tokens / stats.generation_time
-            stats.peak_memory = max(stats.peak_memory, mx.get_peak_memory() / 1e9)
+            end = BatchReading(**asdict(self._counters))
+            stats += BatchReading.between(start, end)
 
     def insert(
         self,
@@ -1828,10 +1796,12 @@ class BatchGenerator:
 
         # Generate tokens first
         if len(self._generation_batch) > 0:
+            tic = time.perf_counter()
             generation_responses = self._generation_batch.next()
-            self._gen_tokens_counter += len(generation_responses)
-            self._steps_counter += 1
-            if self._steps_counter % 512 == 0:
+            self._counters.decode_time += time.perf_counter() - tic
+            self._counters.generation_tokens += len(generation_responses)
+            self._counters.generation_steps += 1
+            if self._counters.generation_steps % 512 == 0:
                 mx.clear_cache()
 
         # Exit early because we already have our hands full with decoding
@@ -1892,11 +1862,10 @@ class BatchGenerator:
             prompt_responses.append(response)
 
         # Process the prompts
-        self._prompt_tokens_counter += sum(len(p) for p in prompts)
+        self._counters.prompt_tokens += sum(len(p) for p in prompts)
         tic = time.perf_counter()
         self._prompt_batch.prompt(prompts)
-        toc = time.perf_counter()
-        self._prompt_time_counter += toc - tic
+        self._counters.prompt_time += time.perf_counter() - tic
 
         return prompt_responses, generation_responses
 

--- a/mlx_lm/generate.py
+++ b/mlx_lm/generate.py
@@ -16,7 +16,7 @@ import mlx.nn as nn
 from mlx.utils import tree_reduce
 from transformers import PreTrainedTokenizer
 
-from .generate_utils import BatchCounters, BatchReading, BatchStats
+from .generate_utils import BatchCounters, BatchCountersSnapshot, BatchStats
 from .models.cache import (
     QuantizedKVCache,
     TokenBuffer,
@@ -1596,12 +1596,12 @@ class BatchGenerator:
         each report their own interval.
         """
         stats = BatchStats()
-        start = BatchReading(**asdict(self._counters))
+        start = BatchCountersSnapshot(**asdict(self._counters))
         try:
             yield stats
         finally:
-            end = BatchReading(**asdict(self._counters))
-            stats += BatchReading.between(start, end)
+            end = BatchCountersSnapshot(**asdict(self._counters))
+            stats += BatchCountersSnapshot.between(start, end)
 
     def insert(
         self,

--- a/mlx_lm/generate_utils.py
+++ b/mlx_lm/generate_utils.py
@@ -5,7 +5,7 @@ from dataclasses import dataclass, field
 
 import mlx.core as mx
 
-__all__ = ["BatchCounters", "BatchReading", "BatchStats"]
+__all__ = ["BatchCounters", "BatchCountersSnapshot", "BatchStats"]
 
 
 def _peak_memory_gb() -> float:
@@ -54,7 +54,7 @@ class BatchCounters:
 
 
 @dataclass(kw_only=True, repr=True)
-class BatchReading(BatchCounters):
+class BatchCountersSnapshot(BatchCounters):
     """
     A generator's counters at a moment in time.
 
@@ -70,7 +70,9 @@ class BatchReading(BatchCounters):
     peak_memory: float = field(default_factory=_peak_memory_gb)
 
     @staticmethod
-    def between(start: "BatchReading", end: "BatchReading") -> "BatchStats":
+    def between(
+        start: "BatchCountersSnapshot", end: "BatchCountersSnapshot"
+    ) -> "BatchStats":
         """The work counted between two readings."""
         return BatchStats(
             prompt_tokens=end.prompt_tokens - start.prompt_tokens,
@@ -90,7 +92,7 @@ class BatchStats(BatchCounters):
     What a generator did over an interval.
 
     ``prompt_time``, ``decode_time`` and ``overhead_time`` partition
-    ``wall_time`` exactly. Use :obj:`BatchReading.between` to make one.
+    ``wall_time`` exactly. Use :obj:`BatchCountersSnapshot.between` to make one.
 
     Args:
         wall_time (float): The duration of the interval.

--- a/mlx_lm/generate_utils.py
+++ b/mlx_lm/generate_utils.py
@@ -1,0 +1,129 @@
+# Copyright © 2023-2024 Apple Inc.
+
+import time
+from dataclasses import dataclass, field
+
+import mlx.core as mx
+
+__all__ = ["BatchCounters", "BatchReading", "BatchStats"]
+
+
+def _peak_memory_gb() -> float:
+    return mx.get_peak_memory() / 1e9
+
+
+@dataclass(kw_only=True, repr=True)
+class BatchCounters:
+    """
+    The quantities a generator counts as it works.
+
+    None of them ever decrease, so the difference between two readings
+    describes the interval between them.
+
+    Args:
+        prompt_tokens (int): The number of prompt tokens processed.
+        prompt_time (float): The time in seconds spent in prompt processing.
+        generation_tokens (int): The number of generated tokens.
+        generation_steps (int): The number of decoding steps taken. One step
+            emits a token per decoding sequence, so this is at most
+            ``generation_tokens``.
+        decode_time (float): The time in seconds spent in the decode step.
+    """
+
+    prompt_tokens: int = 0
+    prompt_time: float = 0.0
+    generation_tokens: int = 0
+    generation_steps: int = 0
+    decode_time: float = 0.0
+
+    @property
+    def prompt_tps(self) -> float:
+        """The prompt processing tokens-per-second."""
+        return (
+            0.0 if self.prompt_time <= 0.0 else (self.prompt_tokens / self.prompt_time)
+        )
+
+    @property
+    def decode_tps(self) -> float:
+        """The tokens-per-second of the decode step, excluding caller-side work."""
+        return (
+            0.0
+            if self.decode_time <= 0.0
+            else (self.generation_tokens / self.decode_time)
+        )
+
+
+@dataclass(kw_only=True, repr=True)
+class BatchReading(BatchCounters):
+    """
+    A generator's counters at a moment in time.
+
+    Constructing one stamps it with the current time and peak memory.
+
+    Args:
+        measured_at (float): When the reading was taken. Defaults to now.
+        peak_memory (float): The process-wide peak memory in GB as of this
+            reading.
+    """
+
+    measured_at: float = field(default_factory=time.perf_counter)
+    peak_memory: float = field(default_factory=_peak_memory_gb)
+
+    @staticmethod
+    def between(start: "BatchReading", end: "BatchReading") -> "BatchStats":
+        """The work counted between two readings."""
+        return BatchStats(
+            prompt_tokens=end.prompt_tokens - start.prompt_tokens,
+            prompt_time=end.prompt_time - start.prompt_time,
+            generation_tokens=end.generation_tokens - start.generation_tokens,
+            generation_steps=end.generation_steps - start.generation_steps,
+            decode_time=end.decode_time - start.decode_time,
+            wall_time=end.measured_at - start.measured_at,
+            # A high-water mark rather than a total, so take the larger.
+            peak_memory=max(start.peak_memory, end.peak_memory),
+        )
+
+
+@dataclass(kw_only=True, repr=True)
+class BatchStats(BatchCounters):
+    """
+    What a generator did over an interval.
+
+    ``prompt_time``, ``decode_time`` and ``overhead_time`` partition
+    ``wall_time`` exactly. Use :obj:`BatchReading.between` to make one.
+
+    Args:
+        wall_time (float): The duration of the interval.
+        peak_memory (float): The process-wide peak memory in GB over the
+            interval.
+    """
+
+    wall_time: float = 0.0
+    peak_memory: float = 0.0
+
+    @property
+    def generation_time(self) -> float:
+        """The time in seconds spent generating, excluding prompt processing."""
+        return max(0.0, self.wall_time - self.prompt_time)
+
+    @property
+    def generation_tps(self) -> float:
+        """The tokens-per-second for generation."""
+        if self.generation_time <= 0:
+            return 0.0
+        return self.generation_tokens / self.generation_time
+
+    @property
+    def overhead_time(self) -> float:
+        """Interval time spent neither decoding nor processing prompts."""
+        return max(0.0, self.wall_time - self.prompt_time - self.decode_time)
+
+    def __iadd__(self, other: "BatchStats") -> "BatchStats":
+        self.prompt_tokens += other.prompt_tokens
+        self.prompt_time += other.prompt_time
+        self.generation_tokens += other.generation_tokens
+        self.generation_steps += other.generation_steps
+        self.decode_time += other.decode_time
+        self.wall_time += other.wall_time
+        self.peak_memory = max(self.peak_memory, other.peak_memory)
+        return self

--- a/tests/test_generate.py
+++ b/tests/test_generate.py
@@ -1003,6 +1003,52 @@ class TestGenerate(unittest.TestCase):
         self.assertEqual(len(tokens[uid_plain]), 3)
         self.assertEqual(tokens[uid_biased], [0, 0, 0])
 
+    def test_batch_stats_empty_window(self):
+        gen = BatchGenerator(self.model)
+        with gen.stats() as stats:
+            pass
+
+        self.assertEqual(stats.prompt_tps, 0.0)
+        self.assertEqual(stats.generation_tps, 0.0)
+        self.assertEqual(stats.decode_tps, 0.0)
+
+    def test_batch_stats_windows_nest(self):
+        gen = BatchGenerator(self.model, max_tokens=2)
+        prompt = self.tokenizer.encode("hello world")
+
+        with gen.stats() as outer:
+            gen.insert([prompt])
+            while gen.next_generated():
+                pass
+
+            with gen.stats() as inner:
+                gen.insert([prompt])
+                while gen.next_generated():
+                    pass
+
+        self.assertGreater(inner.generation_tokens, 0)
+        self.assertEqual(outer.generation_tokens, 2 * inner.generation_tokens)
+        self.assertGreater(inner.prompt_tokens, 0)
+        self.assertEqual(outer.prompt_tokens, 2 * inner.prompt_tokens)
+        self.assertGreaterEqual(outer.wall_time, inner.wall_time)
+
+    def test_batch_stats_time_partitions(self):
+        gen = BatchGenerator(self.model, max_tokens=3)
+
+        with gen.stats() as stats:
+            gen.insert([self.tokenizer.encode("hello world")])
+            while gen.next_generated():
+                pass
+
+        self.assertGreater(stats.prompt_time, 0.0)
+        self.assertGreater(stats.decode_time, 0.0)
+        self.assertGreaterEqual(stats.overhead_time, 0.0)
+        self.assertAlmostEqual(
+            stats.prompt_time + stats.decode_time + stats.overhead_time,
+            stats.wall_time,
+            places=6,
+        )
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
Supersedes #1645 (@th4ruka).

`stats()` divided by `prompt_time` unguarded, so an empty window raised ZeroDivisionError, and it reset the generator's counters on entry, so a second window stole the first one's work. Counters are now monotonic and `stats()` diffs entry against exit. Types move to `mlx_lm/generate_utils.py`, still exported from `mlx_lm.generate`.

Breaking: `stats()` drops its accumulator argument, and `prompt_tps`, `generation_tps` and `generation_time` become read-only properties. Can keep them assignable if you prefer.

Previously part of the #1722
