### PR TITLE
Adding kv cache quantization to server

### DIFF
--- a/mlx_lm/SERVER.md
+++ b/mlx_lm/SERVER.md
@@ -41,6 +41,35 @@ curl localhost:8080/v1/chat/completions \
    }'
 ```
 
+### KV Cache Quantization
+
+Use `--kv-bits` to quantize the KV cache. This saves memory on long-context
+generations. For example:
+
+```shell
+mlx_lm.server --model <path_to_model_or_hf_repo> --kv-bits 4
+```
+
+Use `--kv-group-size` to set the group size, and `--quantized-kv-start` to set
+the step at which quantization starts. The first steps stay unquantized to keep
+the accuracy of the prompt processing.
+
+These options are set at startup. You cannot set them per request.
+
+Also decrease `--prefill-step-size` when you use `--kv-bits`. Attention on a
+quantized cache is not fused, so it keeps a score matrix of
+`prefill_step_size x context_length`. With the default step size of 2048, this
+matrix can be larger than the memory that the quantized cache saves. A step
+size of 512 or less keeps the matrix small:
+
+```shell
+mlx_lm.server --model <path_to_model_or_hf_repo> --kv-bits 4 --prefill-step-size 512
+```
+
+> [!NOTE]
+> A quantized KV cache does not support batching. The server processes requests
+> one at a time when you set `--kv-bits`.
+
 ### Request Fields
 
 - `messages`: An array of message objects representing the conversation

--- a/mlx_lm/SERVER.md
+++ b/mlx_lm/SERVER.md
@@ -30,6 +30,26 @@ To see a full list of options run:
 mlx_lm.server --help
 ```
 
+### KV Cache Quantization
+
+Use `--kv-bits` to quantize the KV cache and save memory on long-context
+generations:
+
+```shell
+mlx_lm.server --model <path_to_model_or_hf_repo> --kv-bits 4 --prefill-step-size 512
+```
+
+Attention on a quantized cache is not fused, so it keeps a score matrix of
+`prefill_step_size x context_length`. Decrease `--prefill-step-size`, or the
+matrix can be larger than the memory that the quantized cache saves.
+
+Use `--kv-group-size` for the group size and `--quantized-kv-start` for the
+token position at which quantization starts (default `5000`).
+
+> [!NOTE]
+> A quantized KV cache does not support batching. The server processes requests
+> one at a time when you set `--kv-bits`.
+
 You can make a request to the model by running:
 
 ```shell
@@ -40,35 +60,6 @@ curl localhost:8080/v1/chat/completions \
      "temperature": 0.7
    }'
 ```
-
-### KV Cache Quantization
-
-Use `--kv-bits` to quantize the KV cache. This saves memory on long-context
-generations. For example:
-
-```shell
-mlx_lm.server --model <path_to_model_or_hf_repo> --kv-bits 4
-```
-
-Use `--kv-group-size` to set the group size, and `--quantized-kv-start` to set
-the step at which quantization starts. The first steps stay unquantized to keep
-the accuracy of the prompt processing.
-
-These options are set at startup. You cannot set them per request.
-
-Also decrease `--prefill-step-size` when you use `--kv-bits`. Attention on a
-quantized cache is not fused, so it keeps a score matrix of
-`prefill_step_size x context_length`. With the default step size of 2048, this
-matrix can be larger than the memory that the quantized cache saves. A step
-size of 512 or less keeps the matrix small:
-
-```shell
-mlx_lm.server --model <path_to_model_or_hf_repo> --kv-bits 4 --prefill-step-size 512
-```
-
-> [!NOTE]
-> A quantized KV cache does not support batching. The server processes requests
-> one at a time when you set `--kv-bits`.
 
 ### Request Fields
 

--- a/mlx_lm/server.py
+++ b/mlx_lm/server.py
@@ -33,6 +33,7 @@ from huggingface_hub import scan_cache_dir
 
 from ._version import __version__
 from .generate import (
+    DEFAULT_QUANTIZED_KV_START,
     BatchGenerator,
     StopSequenceMatcher,
     TextStateMachine,
@@ -418,6 +419,15 @@ def _format_top_logprobs(logprobs, top_n, tokenizer) -> Tuple[Dict[str, Any]]:
 
 class ResponseGenerator:
     def __init__(self, model_provider: ModelProvider, prompt_cache: LRUPromptCache):
+        if (
+            model_provider.cli_args.kv_bits is not None
+            and model_provider.cli_args.decode_concurrency > 1
+        ):
+            logging.warning(
+                "A quantized KV cache does not support batching. "
+                "The server processes requests one at a time."
+            )
+
         self.model_provider = model_provider
         self.prompt_cache = prompt_cache
         self.requests = Queue()
@@ -619,7 +629,11 @@ class ResponseGenerator:
         return stop_matcher, text_sm
 
     def _is_batchable(self, args):
-        return self.model_provider.is_batchable and args.seed is None
+        return (
+            self.model_provider.is_batchable
+            and args.seed is None
+            and self.cli_args.kv_bits is None
+        )
 
     def _generate(self):
         # Local thread stream that we 'll pass to the BatchGenerator to make
@@ -931,6 +945,9 @@ class ResponseGenerator:
                 num_draft_tokens=args.num_draft_tokens,
                 prompt_progress_callback=progress,
                 prefill_step_size=self.cli_args.prefill_step_size,
+                kv_bits=self.cli_args.kv_bits,
+                kv_group_size=self.cli_args.kv_group_size,
+                quantized_kv_start=self.cli_args.quantized_kv_start,
             ):
                 finish_reason = gen.finish_reason
 
@@ -1847,6 +1864,28 @@ def main():
         "--prompt-cache-bytes",
         type=_parse_size,
         help="Maximum size in bytes of the KV caches",
+    )
+    parser.add_argument(
+        "--kv-bits",
+        type=int,
+        default=None,
+        help="Number of bits for KV cache quantization. Defaults to no "
+        "quantization. Batching is not supported with a quantized KV cache, "
+        "so requests are served one at a time when this is set. Also decrease "
+        "--prefill-step-size to keep the peak memory low.",
+    )
+    parser.add_argument(
+        "--kv-group-size",
+        type=int,
+        default=64,
+        help="Group size for KV cache quantization",
+    )
+    parser.add_argument(
+        "--quantized-kv-start",
+        type=int,
+        default=DEFAULT_QUANTIZED_KV_START,
+        help="When --kv-bits is set, start quantizing the KV cache "
+        "from this step onwards",
     )
     parser.add_argument(
         "--pipeline",

--- a/mlx_lm/server.py
+++ b/mlx_lm/server.py
@@ -426,15 +426,6 @@ def _format_top_logprobs(logprobs, top_n, tokenizer) -> Tuple[Dict[str, Any]]:
 
 class ResponseGenerator:
     def __init__(self, model_provider: ModelProvider, prompt_cache: LRUPromptCache):
-        if (
-            model_provider.cli_args.kv_bits is not None
-            and model_provider.cli_args.decode_concurrency > 1
-        ):
-            logging.warning(
-                "A quantized KV cache does not support batching. "
-                "The server processes requests one at a time."
-            )
-
         self.model_provider = model_provider
         self.prompt_cache = prompt_cache
         self.requests = Queue()
@@ -1887,23 +1878,22 @@ def main():
         "--kv-bits",
         type=int,
         default=None,
-        help="Number of bits for KV cache quantization. Defaults to no "
-        "quantization. Batching is not supported with a quantized KV cache, "
-        "so requests are served one at a time when this is set. Also decrease "
-        "--prefill-step-size to keep the peak memory low.",
+        help="Number of bits for KV cache quantization (e.g., 4 or 8). "
+        "Reduces memory usage for long contexts. Disables batching, so "
+        "requests are served one at a time. Default: None (full precision)",
     )
     parser.add_argument(
         "--kv-group-size",
         type=int,
         default=64,
-        help="Group size for KV cache quantization",
+        help="Group size for KV cache quantization (default: 64)",
     )
     parser.add_argument(
         "--quantized-kv-start",
         type=int,
         default=DEFAULT_QUANTIZED_KV_START,
-        help="When --kv-bits is set, start quantizing the KV cache "
-        "from this step onwards",
+        help="Token position to start KV cache quantization "
+        f"(default: {DEFAULT_QUANTIZED_KV_START})",
     )
     parser.add_argument(
         "--pipeline",

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -10,7 +10,7 @@ import mlx.core as mx
 import requests
 
 from mlx_lm.generate import TextStateMachine
-from mlx_lm.models.cache import KVCache
+from mlx_lm.models.cache import KVCache, QuantizedKVCache
 from mlx_lm.server import (
     APIHandler,
     LRUPromptCache,
@@ -23,7 +23,7 @@ from mlx_lm.utils import load
 
 
 class DummyModelProvider:
-    def __init__(self, with_draft=False):
+    def __init__(self, with_draft=False, kv_bits=None, quantized_kv_start=0):
         HF_MODEL_PATH = "mlx-community/Qwen1.5-0.5B-Chat-4bit"
         self.model, self.tokenizer = load(HF_MODEL_PATH)
         self.model_key = (HF_MODEL_PATH, None)
@@ -56,6 +56,9 @@ class DummyModelProvider:
                 "prompt_cache_bytes": 1 << 63,
                 "prompt_cache_total_bytes": None,
                 "allowed_origins": ["*"],
+                "kv_bits": kv_bits,
+                "kv_group_size": 64,
+                "quantized_kv_start": quantized_kv_start,
             },
         )
 
@@ -515,6 +518,63 @@ class TestServerWithDraftModel(unittest.TestCase):
         # Ensure both generated content
         self.assertIsNotNone(first_response_body["choices"][0]["message"]["content"])
         self.assertIsNotNone(second_response_body["choices"][0]["message"]["content"])
+
+
+class TestServerKVCacheQuantization(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.model_provider = DummyModelProvider(kv_bits=4, quantized_kv_start=0)
+        cls.prompt_cache = LRUPromptCache()
+        cls.response_generator = ResponseGenerator(cls.model_provider, cls.prompt_cache)
+        cls.httpd = http.server.HTTPServer(
+            ("localhost", 0),
+            lambda *args, **kwargs: APIHandler(cls.response_generator, *args, **kwargs),
+        )
+        cls.port = cls.httpd.server_port
+        cls.server_thread = threading.Thread(target=cls.httpd.serve_forever)
+        cls.server_thread.daemon = True
+        cls.server_thread.start()
+
+    @classmethod
+    def tearDownClass(cls):
+        cls.httpd.shutdown()
+        cls.httpd.server_close()
+        cls.server_thread.join()
+        cls.response_generator.stop_and_join()
+
+    def test_quantized_kv_disables_batching(self):
+        args = type("args", (object,), {"seed": None})
+        self.assertFalse(self.response_generator._is_batchable(args))
+
+    def test_completion_quantizes_the_cache(self):
+        url = f"http://localhost:{self.port}/v1/completions"
+        prompt = "Once upon a time"
+        response = requests.post(
+            url,
+            json={"model": "default_model", "prompt": prompt, "max_tokens": 8},
+        )
+        self.assertIn("choices", json.loads(response.text))
+
+        tokens = self.model_provider.tokenizer.encode(prompt)
+        cache, _ = self.prompt_cache.fetch_nearest_cache(
+            self.model_provider.model_key, tokens
+        )
+        self.assertIsNotNone(cache)
+        for c in cache:
+            self.assertIsInstance(c, QuantizedKVCache)
+            self.assertEqual(c.bits, 4)
+            self.assertEqual(c.group_size, 64)
+
+
+class TestServerWithoutKVCacheQuantization(unittest.TestCase):
+    def test_batching_stays_enabled(self):
+        prompt_cache = LRUPromptCache()
+        response_generator = ResponseGenerator(DummyModelProvider(), prompt_cache)
+        try:
+            args = type("args", (object,), {"seed": None})
+            self.assertTrue(response_generator._is_batchable(args))
+        finally:
+            response_generator.stop_and_join()
 
 
 class TestKeepalive(unittest.TestCase):


### PR DESCRIPTION
## Overview
Addresses lack of kv cache functionality in server by mirroring implementation in `generate.py`. 

Closes #1308 
Closes #1043 
Closes #615

As per the CONTRIBUTORS.md file here are the required bits of info:
### Related PRs
#934  (closed due to capacity - not merged)
#1804 (does not contain memory benchmarks or server md docs but broader scoped to include additional server changes - not reviewed)

### Testing
The added tests fail against the current main branch but pass with this code change as expected and specified in CONTRIBUTORS.md
`python -m unittest tests.test_server`

### Memory benchmarks
No regression vs main:
| prefill | cache type | cache | peak (main) | peak (branch) | Δ |
|---------|------------|-------|-------------|---------------|-----|
| 2048    | `KVCache`  | 786.6 MB | 1877.5 MB | 1877.5 MB | 0.0 |
| 512     | `KVCache`  | 786.6 MB | 1877.5 MB | 1877.5 MB | 0.0 |

Memory savings with this quantization implementation:
| prefill | cache (fp16) | cache (4-bit) | peak (fp16) | peak (4-bit) | Δ peak |
|---------|--------------|---------------|-------------|--------------|--------|
| 2048    | 786.6 MB | 226.5 MB | 1877.5 MB | 2126.2 MB | +13.2% |
| 1024    | 786.6 MB | 226.5 MB | 1877.5 MB | 1561.6 MB | −16.8% |
| 512     | 786.6 MB | 226.5 MB | 1877.5 MB | 1427.2 MB | −24.0% |
| 256     | 786.6 MB | 226.5 MB | 1877.5 MB | 1385.8 MB | −26.2% |

Code:
```
import argparse
import mlx.core as mx
from mlx_lm.generate import stream_generate
from mlx_lm.models.cache import make_prompt_cache
from mlx_lm.utils import load

parser = argparse.ArgumentParser()
parser.add_argument("--model", default="mlx-community/Qwen1.5-0.5B-Chat-4bit")
parser.add_argument("--kv-bits", type=int, default=None)
parser.add_argument("--kv-group-size", type=int, default=64)
parser.add_argument("--quantized-kv-start", type=int, default=0)
parser.add_argument("--prefill-step-size", type=int, default=2048)
parser.add_argument("--repeats", type=int, default=800)
args = parser.parse_args()

model, tokenizer = load(args.model)
prompt = "The quick brown fox jumps over the lazy dog. " * args.repeats

cache = make_prompt_cache(model)
mx.clear_cache()
mx.reset_peak_memory()

for _ in stream_generate(
    model,
    tokenizer,
    prompt,
    max_tokens=8,
    prompt_cache=cache,
    kv_bits=args.kv_bits,
    kv_group_size=args.kv_group_size,
    quantized_kv_start=args.quantized_kv_start,
    prefill_step_size=args.prefill_step_size,
):
    pass

cache_mb = sum(c.nbytes for c in cache) / 1e6
print(
    f"kv_bits={args.kv_bits}\tprefill={args.prefill_step_size}\t"
    f"tokens={len(tokenizer.encode(prompt))}\t"
    f"cache={cache_mb:.1f}MB\tpeak={mx.get_peak_memory() / 1e6:.1f}MB"
)
```



- ☑️ I understand it is strictly prohibited to use AI to write PR description
- AI usage disclosure: 
AI was used in the code writing but all ideas, planning, review, and documentation here were done by me.