### PR TITLE
Fix undefined variable error in fully truncated branch

### DIFF
--- a/mlx_lm/evaluate.py
+++ b/mlx_lm/evaluate.py
@@ -208,8 +208,8 @@ class MLXLM(LM):
             # If the entire prompt got truncated ignore the question
             if prefix_l == 0:
                 long_completions += 1
-                all_scores.extend([-float("inf")] * len(rs))
-                all_is_greedy.extend([False] * len(rs))
+                scores.extend([-float("inf")] * len(rs))
+                is_greedy.extend([False] * len(rs))
                 continue
 
             # model scoring, returns num_requests x (logp, is_greedy, length).

--- a/tests/test_evaluate.py
+++ b/tests/test_evaluate.py
@@ -67,6 +67,28 @@ class TestMLXLM(unittest.TestCase):
 
         self.assertEqual(result, ["answer"])
 
+    def test_loglikelihood_returns_negative_infinity_when_context_is_fully_truncated(
+        self,
+    ):
+        # Make the continuation too long for the scoring window, so all context
+        # tokens are truncated and the request is skipped.
+        self.mlx_lm._max_tokens = 1
+        self.mlx_lm._tokenize = MagicMock(
+            side_effect=[
+                [[1, 2]],  # Context tokens.
+                [[1, 2, 3, 4]],  # Context + continuation tokens.
+            ]
+        )
+        self.mlx_lm._process_prompt = MagicMock()
+        self.mlx_lm._score_fn = MagicMock()
+        request = MagicMock(args=("context", " continuation"))
+
+        result = self.mlx_lm.loglikelihood([request])
+
+        self.assertEqual(result, [(-float("inf"), False)])
+        self.mlx_lm._process_prompt.assert_not_called()
+        self.mlx_lm._score_fn.assert_not_called()
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
This PR is:

- To fix a `loglikelihood()` crash when long continuations cause all context tokens to be truncated.
- To add a regression test for the skipped-request path that returns `(-inf, False)`.


Normal case:
```
[ context tokens ][ continuation tokens ]
        ↓ truncate old context if needed
[ ...context tokens left ][ continuation tokens ]
```

Fully truncated case:
```
[ context tokens ][ very long continuation tokens ]
        ↓ keep continuation intact, truncate old context
[ ][ very long continuation tokens ]

prefix_l == 0
# and in that if-branch, the old code used undefined names there: `all_scores` and `all_is_greedy`
```


Before:
<img width="1052" height="408" alt="Screenshot 2026-09-03 at 10 53 49 PM" src="https://github.com/user-attachments/assets/fa96a01a-e112-4222-a4e8-bde048203ac7" />


After:
<img width="1052" height="229" alt="Screenshot 2026-09-03 at 10 51 36 PM" src="https://github.com/user-attachments/assets/aff28e48-1dad-4388-813a-6b61c1b27279" />


- ☑️ I understand it is strictly prohibited to use AI to write PR description
