### PR TITLE
Granite nvfp4 underflow fix

### DIFF
--- a/mlx_lm/models/granite.py
+++ b/mlx_lm/models/granite.py
@@ -200,10 +200,14 @@ class Model(nn.Module):
     @property
     def quant_predicate(self):
         def predicate(path, _):
-            # o_proj's block absmax can be small enough that low-bit fp
-            # quant modes (e.g. nvfp4) underflow their scale encoding,
-            # corrupting dequantization. Keep it safe at 8 bits.
-            if path.endswith("self_attn.o_proj"):
+            # o_proj, down_proj, and lm_head run small enough in block absmax
+            # that low-bit fp quant modes (e.g. nvfp4) underflow their scale
+            # encoding, corrupting dequantization. Keep them safe at 8 bits.
+            if (
+                path.endswith("self_attn.o_proj")
+                or path.endswith("mlp.down_proj")
+                or path == "lm_head"
+            ):
                 return {"group_size": 64, "bits": 8}
             return True
 

--- a/mlx_lm/models/granite.py
+++ b/mlx_lm/models/granite.py
@@ -196,3 +196,15 @@ class Model(nn.Module):
         if self.args.tie_word_embeddings:
             weights.pop("lm_head.weight", None)
         return weights
+
+    @property
+    def quant_predicate(self):
+        def predicate(path, _):
+            # o_proj's block absmax can be small enough that low-bit fp
+            # quant modes (e.g. nvfp4) underflow their scale encoding,
+            # corrupting dequantization. Keep it safe at 8 bits.
+            if path.endswith("self_attn.o_proj"):
+                return {"group_size": 64, "bits": 8}
+            return True
+
+        return predicate

--- a/mlx_lm/models/granitemoe.py
+++ b/mlx_lm/models/granitemoe.py
@@ -224,7 +224,12 @@ class Model(nn.Module):
     @property
     def quant_predicate(self):
         def predicate(path, _):
-            if path.endswith("block_sparse_moe.router.layer"):
+            if (
+                path.endswith("block_sparse_moe.router.layer")
+                or path.endswith("self_attn.o_proj")
+                or path.endswith("mlp.down_proj")
+                or path == "lm_head"
+            ):
                 return {"group_size": 64, "bits": 8}
             return True
 

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -1017,7 +1017,7 @@ class TestModels(unittest.TestCase):
         )
         self.assertEqual(config["quantization"]["bits"], 4)
 
-    def test_granite_o_proj_quantizes_to_8bit(self):
+    def test_granite_sensitive_projections_quantize_to_8bit(self):
         from mlx_lm.models import granite
         from mlx_lm.utils import quantize_model
 
@@ -1038,6 +1038,7 @@ class TestModels(unittest.TestCase):
             attention_bias=False,
             mlp_bias=False,
             rope_theta=10000.0,
+            tie_word_embeddings=False,
         )
         model = granite.Model(args)
         model, config = quantize_model(
@@ -1049,13 +1050,18 @@ class TestModels(unittest.TestCase):
         )
 
         layer = model.model.layers[0]
-        self.assertIsInstance(layer.self_attn.o_proj, nn.QuantizedLinear)
-        self.assertEqual(layer.self_attn.o_proj.bits, 8)
+        for sensitive in (layer.self_attn.o_proj, layer.mlp.down_proj, model.lm_head):
+            self.assertIsInstance(sensitive, nn.QuantizedLinear)
+            self.assertEqual(sensitive.bits, 8)
         self.assertIsInstance(layer.self_attn.q_proj, nn.QuantizedLinear)
         self.assertEqual(layer.self_attn.q_proj.bits, 4)
         self.assertEqual(
             config["quantization"]["model.layers.0.self_attn.o_proj"]["bits"], 8
         )
+        self.assertEqual(
+            config["quantization"]["model.layers.0.mlp.down_proj"]["bits"], 8
+        )
+        self.assertEqual(config["quantization"]["lm_head"]["bits"], 8)
         self.assertEqual(config["quantization"]["bits"], 4)
 
     def test_qwen2_moe(self):

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -1017,6 +1017,47 @@ class TestModels(unittest.TestCase):
         )
         self.assertEqual(config["quantization"]["bits"], 4)
 
+    def test_granite_o_proj_quantizes_to_8bit(self):
+        from mlx_lm.models import granite
+        from mlx_lm.utils import quantize_model
+
+        args = granite.ModelArgs(
+            model_type="granite",
+            hidden_size=64,
+            num_hidden_layers=1,
+            intermediate_size=128,
+            num_attention_heads=4,
+            rms_norm_eps=1e-5,
+            vocab_size=64,
+            logits_scaling=1.0,
+            attention_multiplier=0.015625,
+            embedding_multiplier=1.0,
+            residual_multiplier=1.0,
+            max_position_embeddings=2048,
+            num_key_value_heads=2,
+            attention_bias=False,
+            mlp_bias=False,
+            rope_theta=10000.0,
+        )
+        model = granite.Model(args)
+        model, config = quantize_model(
+            model,
+            {"model_type": "granite"},
+            group_size=16,
+            bits=4,
+            mode="nvfp4",
+        )
+
+        layer = model.model.layers[0]
+        self.assertIsInstance(layer.self_attn.o_proj, nn.QuantizedLinear)
+        self.assertEqual(layer.self_attn.o_proj.bits, 8)
+        self.assertIsInstance(layer.self_attn.q_proj, nn.QuantizedLinear)
+        self.assertEqual(layer.self_attn.q_proj.bits, 4)
+        self.assertEqual(
+            config["quantization"]["model.layers.0.self_attn.o_proj"]["bits"], 8
+        )
+        self.assertEqual(config["quantization"]["bits"], 4)
+
     def test_qwen2_moe(self):
         from mlx_lm.models import qwen2_moe
 


### PR DESCRIPTION
## Description

This PR fixes underflows in the recent IBM Granite 4.2 models (https://huggingface.co/collections/ibm-granite/granite-42-language-models) and existing GraniteMoE models (eg https://huggingface.co/ibm-granite/granite-3.1-3b-a800m-instruct) when quantizing to `nvfp4`.

## Details

I found these issues while adding MLX support to Ollama (https://github.com/ollama/ollama/pull/17972) and verified that they also existed in native `mlx-lm`. The fix is to protect several key tensors from quantization below 8-bit.

## Open Questions

It looks like there's no way to differentiate between target quants when applying the precision guards. In testing, the `int4` quants work smoothly without these guards, so it appears to be unique to `nvfp4`, but it seems to be better to protect here for all sub-8-bit quants. Does this sound like the right choice?

## Testing

### GraniteForCausalLM (dense)

**Baseline NVFP4**

```sh
$ uv run mlx_lm generate --model ./granite-4.2-3b-mlx-nvfp4-baseline/ --prompt "Tell me a short story"
==========
-fore-fore-fore-fore-fore-fore-fore-fore-fore-fore-fore-fore-fore-fore-fore-fore-fore-fore-fore-fore-fore-fore-fore-fore-fore-fore-fore-fore-fore-fore-fore-fore-fore-fore-fore-fore-fore-fore-fore-fore-fore-fore-fore-fore-fore-fore-fore-fore-fore-fore
==========
Prompt: 20 tokens, 254.589 tokens-per-sec
Generation: 100 tokens, 146.458 tokens-per-sec
Peak memory: 2.177 GB
```

**Branch NVFP4**

```sh
$ uv run mlx_lm generate --model ./granite-4.2-3b-mlx-nvfp4-branch/ --prompt "Tell me a short story"
==========
Okay, the user asked for a short story. They probably wants something quick and engaging—maybe for a break, or to unwind. I'll keep it under 200 words, vivid but simple, with a gentle twist. No need for complex details; just a warm, memorable moment.

I'll craft a tiny story about a quiet place, a small kindness, ending softly. That should feel satisfying without being long.
</think>
The rain had stopped an hour ago, leaving the streets
==========
Prompt: 20 tokens, 223.821 tokens-per-sec
Generation: 100 tokens, 116.476 tokens-per-sec
Peak memory: 2.856 GB
```

### GraniteMoeForCausalLM (MoE)

**NOTE**: The existing 3.1 MoE models don't exhibit the underflow errors in baseline, but a private internal model does:

**Baseline NVFP4**

```sh
uv run mlx_lm generate --model ./sample-moe-mlx-nvfp4-baseline/ --prompt "Tell me a short story"
==========

...
<many many newlines>
...
==========
Prompt: 20 tokens, 201.232 tokens-per-sec
Generation: 100 tokens, 136.240 tokens-per-sec
Peak memory: 12.427 GB
```

**Branch NVFP4**

```sh
uv run mlx_lm generate --model ./sample-moe-mlx-nvfp4-branch/ --prompt "Tell me a short story"
==========
The user wants a short story. I need to come up with a concept, a plot, and a resolution.

**Concept Brainstorming:**
1.  *Sci-Fi:* A robot learning to paint. (A bit cliché, but effective).
2.  *Fantasy:* A wizard's last spell. (Classic, but maybe too generic).
3.  *Mystery:* A detective finds a clue in an old attic. (Good for tension).
==========
Prompt: 20 tokens, 180.196 tokens-per-sec
Generation: 100 tokens, 124.404 tokens-per-sec
Peak memory: 16.126 GB
```

## AI Usage

- ☑️ I understand it is strictly prohibited to use AI to write PR description
- AI usage disclosure: This PR was created using Claude Code. All commits were manually authored and reviewed.

<details>
<summary>git-ai-stats</summary>

```sh
╔══════════════════════════════════════════════════════════╗
║           GIT AI USAGE ANALYSIS                          ║
╚══════════════════════════════════════════════════════════╝

📊 COMMITS BY AGENT

--- Aggregate ---
Commits                        |      Count
---------------------------------------------
Claude + Sonnet 5              |          2
none                           |          1
---------------------------------------------
TOTAL                          |          3

📊 COMMITS BY USAGE TYPE

--- Aggregate ---
Commits                        |      Count
---------------------------------------------
none                           |          1
draft                          |          0
full                           |          2
---------------------------------------------
TOTAL                          |          3

📈 LINES OF CODE BY AGENT

--- Aggregate ---
Agent                     |    Commits |  Additions |  Deletions
------------------------------------------------------------
Claude + Sonnet 5         |          2 |         70 |          7
none                      |          1 |          6 |          1
------------------------------------------------------------
TOTAL                     |          3 |         76 |          8

📈 LINES OF CODE BY USAGE TYPE

--- Aggregate ---
Usage Type           |    Commits |  Additions |  Deletions
-------------------------------------------------------
none                 |          1 |          6 |          1
draft                |          0 |          0 |          0
full                 |          2 |         70 |          7
-------------------------------------------------------
TOTAL                |          3 |         76 |          8
```

</details>
