### PR TITLE
Return 503 from mlx_lm.server when the generation thread dies

### DIFF
--- a/mlx_lm/server.py
+++ b/mlx_lm/server.py
@@ -14,7 +14,7 @@ from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
 from pathlib import Path
 from queue import Empty as QueueEmpty
 from queue import Queue
-from threading import Thread
+from threading import Lock, Thread
 from typing import (
     Any,
     Callable,
@@ -428,6 +428,7 @@ class ResponseGenerator:
         self._rank = mx.distributed.init().rank()
         self._stop = False
         self._generation_failed = False
+        self._generation_lock = Lock()
         self._generation_thread = Thread(target=self._run_generate)
         self._generation_thread.start()
 
@@ -436,16 +437,18 @@ class ResponseGenerator:
             self._generate()
         except Exception:
             logging.exception("mlx_lm.server generation thread died")
-            self._generation_failed = True
-            try:
-                while True:
-                    rqueue, _, _ = self.requests.get_nowait()
-                    rqueue.put(RuntimeError("generation thread died"))
-            except QueueEmpty:
-                pass
+            with self._generation_lock:
+                self._generation_failed = True
+                try:
+                    while True:
+                        rqueue, _, _ = self.requests.get_nowait()
+                        rqueue.put(RuntimeError("generation thread died"))
+                except QueueEmpty:
+                    pass
 
     def generation_available(self):
-        return self._generation_thread.is_alive() and not self._generation_failed
+        with self._generation_lock:
+            return self._generation_thread.is_alive() and not self._generation_failed
 
     def stop_and_join(self):
         self._stop = True
@@ -995,10 +998,11 @@ class ResponseGenerator:
         generation_args: GenerationArguments,
         progress_callback: Optional[Callable[[int, int], None]] = None,
     ):
-        if not self.generation_available():
-            raise RuntimeError("generation thread died")
         response_queue = Queue()
-        self.requests.put((response_queue, request, generation_args))
+        with self._generation_lock:
+            if not (self._generation_thread.is_alive() and not self._generation_failed):
+                raise RuntimeError("generation thread died")
+            self.requests.put((response_queue, request, generation_args))
 
         def _inner():
             while True:

--- a/mlx_lm/server.py
+++ b/mlx_lm/server.py
@@ -427,8 +427,25 @@ class ResponseGenerator:
         self._is_distributed = mx.distributed.init().size() > 1
         self._rank = mx.distributed.init().rank()
         self._stop = False
-        self._generation_thread = Thread(target=self._generate)
+        self._generation_failed = False
+        self._generation_thread = Thread(target=self._run_generate)
         self._generation_thread.start()
+
+    def _run_generate(self):
+        try:
+            self._generate()
+        except Exception:
+            logging.exception("mlx_lm.server generation thread died")
+            self._generation_failed = True
+            try:
+                while True:
+                    rqueue, _, _ = self.requests.get_nowait()
+                    rqueue.put(RuntimeError("generation thread died"))
+            except QueueEmpty:
+                pass
+
+    def generation_available(self):
+        return self._generation_thread.is_alive() and not self._generation_failed
 
     def stop_and_join(self):
         self._stop = True
@@ -978,6 +995,8 @@ class ResponseGenerator:
         generation_args: GenerationArguments,
         progress_callback: Optional[Callable[[int, int], None]] = None,
     ):
+        if not self.generation_available():
+            raise RuntimeError("generation thread died")
         response_queue = Queue()
         self.requests.put((response_queue, request, generation_args))
 
@@ -1603,6 +1622,12 @@ class APIHandler(BaseHTTPRequestHandler):
         """
         Handle a GET request for the /health endpoint.
         """
+        if not self.response_generator.generation_available():
+            self._set_completion_headers(503)
+            self.end_headers()
+            self.wfile.write('{"status": "generation_unavailable"}'.encode())
+            self.wfile.flush()
+            return
         self._set_completion_headers(200)
         self.end_headers()
 
@@ -1613,6 +1638,14 @@ class APIHandler(BaseHTTPRequestHandler):
         """
         Handle a GET request for the /v1/models endpoint.
         """
+        if not self.response_generator.generation_available():
+            self._set_completion_headers(503)
+            self.end_headers()
+            self.wfile.write(
+                '{"error": {"message": "generation thread died", "type": "server_error"}}'.encode()
+            )
+            self.wfile.flush()
+            return
         self._set_completion_headers(200)
         self.end_headers()
 

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -774,6 +774,8 @@ class TestGenerationThreadDeath(unittest.TestCase):
         time.sleep(0.05)
         self.assertTrue(rg._generation_failed)
         self.assertFalse(rg.generation_available())
+        with self.assertRaisesRegex(RuntimeError, "generation thread died"):
+            rg.generate(None, None)
 
 
 if __name__ == "__main__":

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -761,5 +761,20 @@ class TestMakeSampler(unittest.TestCase):
         self.assertEqual(token.shape, (1,))
 
 
+class TestGenerationThreadDeath(unittest.TestCase):
+    def test_generation_unavailable_after_thread_crash(self):
+        import time
+
+        class BoomProvider:
+            def load_default(self):
+                raise RuntimeError("simulated generate crash")
+
+        rg = ResponseGenerator(BoomProvider(), LRUPromptCache())
+        rg.join()
+        time.sleep(0.05)
+        self.assertTrue(rg._generation_failed)
+        self.assertFalse(rg.generation_available())
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
Fixes #1505

If `_generate` dies, the HTTP server kept answering `/health` and `/v1/models` with 200 while every completion waited forever on the dead thread.

Wrap the generation thread, mark it failed, fail queued requests, reject new `generate()` calls, and return 503 from `/health` and `/v1/models`. Test crashes `load_default` and checks `generation_available()` is false.