### PR TITLE
Clear model and prompt cache in generation thread

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -26,7 +26,7 @@ jobs:
   mac_build_and_test:
     name: macOS
     if: github.repository == 'ml-explore/mlx-lm'
-    runs-on: [self-hosted, macos]
+    runs-on: 'macos-26-xlarge'
     steps:
       - uses: actions/checkout@v7
       - uses: astral-sh/setup-uv@v8.2.0

--- a/mlx_lm/server.py
+++ b/mlx_lm/server.py
@@ -1,6 +1,7 @@
 # Copyright © 2023-2024 Apple Inc.
 
 import argparse
+import gc
 import json
 import logging
 import pickle
@@ -864,6 +865,12 @@ class ResponseGenerator:
                         # It may have already been removed during
                         # generation
                         batch_results.pop(uid, None)
+
+        # Make sure the model and prompt cache are destroyed in the generation
+        # thread under same stream.
+        del self.model_provider
+        del self.prompt_cache
+        gc.collect()
 
     def _serve_single(self, request):
         rqueue, request, args = request

--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ sys.path.append(str(package_dir))
 
 from _version import __version__
 
-MIN_MLX_VERSION = "0.32.1"
+MIN_MLX_VERSION = "0.32.2"
 
 setup(
     name="mlx-lm",


### PR DESCRIPTION
Without explicit clean up the members would be cleared in the main thread along with the object itself, where the streams used by the arrays would no longer exist.

Also switch to hosted mac runner for CI which is not throttled.