### PR TITLE
Don't delete model provider, reset it instead

### DIFF
--- a/mlx_lm/server.py
+++ b/mlx_lm/server.py
@@ -304,6 +304,13 @@ class ModelProvider:
         if cli_args.chat_template:
             self._tokenizer_config["chat_template"] = cli_args.chat_template
 
+    def reset(self) -> None:
+        self.model_key = None
+        self.model = None
+        self.tokenizer = None
+        self.draft_model = None
+        self.is_batchable = False
+
     def _load(self, model_path, adapter_path=None, draft_model_path=None):
         if self.is_distributed and (
             adapter_path is not None or draft_model_path is not None
@@ -313,10 +320,7 @@ class ModelProvider:
             )
 
         # Remove the old model if it exists.
-        self.model_key = None
-        self.model = None
-        self.tokenizer = None
-        self.draft_model = None
+        self.reset()
 
         # Load the model and tokenizer
         if self.is_distributed:
@@ -868,7 +872,7 @@ class ResponseGenerator:
 
         # Make sure the model and prompt cache are destroyed in the generation
         # thread under same stream.
-        del self.model_provider
+        self.model_provider.reset()
         del self.prompt_cache
         gc.collect()
 

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -72,6 +72,13 @@ class DummyModelProvider:
     def load_default(self):
         return self.load("default_model", None, "default_model")
 
+    def reset(self) -> None:
+        self.model_key = None
+        self.model = None
+        self.tokenizer = None
+        self.draft_model = None
+        self.is_batchable = False
+
 
 class MockCache:
     def __init__(self, value, is_trimmable: bool = True):
@@ -320,6 +327,18 @@ class TestServer(unittest.TestCase):
         response_body = response.text
         self.assertIn("id", response_body)
         self.assertIn("choices", response_body)
+
+    def test_generation_thread_exit_releases_model(self):
+        response_generator = ResponseGenerator(DummyModelProvider(), LRUPromptCache())
+        provider = response_generator.model_provider
+        response_generator.stop_and_join()
+
+        # The weights are dropped even though this frame still holds the
+        # provider, and the args survive for request handler threads.
+        self.assertIsNone(provider.model)
+        self.assertIsNone(provider.tokenizer)
+        self.assertFalse(provider.is_batchable)
+        self.assertIsNotNone(response_generator.cli_args.allowed_origins)
 
     def test_make_state_machine_empty_tool_call_end(self):
         class FakeTokenizer:


### PR DESCRIPTION
The `del` causes troubles in, e.g., #1791, because the attribute is not present and we'd still want to set the headers for liveness check, etc.

Related: #1839 

- ☑️ I understand it is strictly prohibited to use AI to write PR description
- AI usage disclosure: debugging
