### PR TITLE
Rebind BatchKVCache offset instead of mutating in place.

### DIFF
--- a/mlx_lm/models/cache.py
+++ b/mlx_lm/models/cache.py
@@ -967,7 +967,7 @@ class BatchKVCache(_BaseCache):
             else:
                 self.keys, self.values = new_k, new_v
 
-        self.offset += keys.shape[2]
+        self.offset = self.offset + keys.shape[2]
         self._idx += keys.shape[2]
         self.keys[..., prev : self._idx, :] = keys
         self.values[..., prev : self._idx, :] = values
@@ -981,7 +981,7 @@ class BatchKVCache(_BaseCache):
                 )
             left_padding = mx.array(left_padding)
             self.left_padding += left_padding
-            self.offset -= left_padding
+            self.offset = self.offset - left_padding
 
         if right_padding is not None and max(right_padding) > 0:
             self._right_padding = mx.array(right_padding)
@@ -991,7 +991,7 @@ class BatchKVCache(_BaseCache):
             padding = self._right_padding
             self.keys = dynamic_roll(self.keys, padding[:, None], axis=2)
             self.values = dynamic_roll(self.values, padding[:, None], axis=2)
-            self.offset -= padding
+            self.offset = self.offset - padding
             self.left_padding += padding
             self._right_padding = None
 
@@ -1014,7 +1014,7 @@ class BatchKVCache(_BaseCache):
     def trim(self, n):
         n = min(self._idx, n)
         self._idx -= n
-        self.offset -= n
+        self.offset = self.offset - n
         return n
 
     def make_mask(self, N: int, return_array: bool = False, **kwargs):
@@ -1198,7 +1198,7 @@ class BatchRotatingKVCache(_BaseCache):
                 self.keys = dynamic_roll(self.keys, roll[:, None], axis=2)
                 self.values = dynamic_roll(self.values, roll[:, None], axis=2)
                 self.left_padding += roll
-                self.offset -= roll
+                self.offset = self.offset - roll
 
             # The largest size is self.max_size + S - 1 to ensure
             # every token gets at least self.max_size context
@@ -1207,7 +1207,7 @@ class BatchRotatingKVCache(_BaseCache):
                 self.left_padding -= trim_size
             self.keys = self._trim(trim_size, self.keys, keys)
             self.values = self._trim(trim_size, self.values, values)
-        self.offset += keys.shape[2]
+        self.offset = self.offset + keys.shape[2]
         self._offset += keys.shape[2]
         self._idx = self.keys.shape[2]
 
@@ -1261,7 +1261,7 @@ class BatchRotatingKVCache(_BaseCache):
         self.keys[..., self._idx : self._idx + S, :] = keys
         self.values[..., self._idx : self._idx + S, :] = values
         self._offset += S
-        self.offset += S
+        self.offset = self.offset + S
         self._idx += S
 
         # Make sure left_padding and offset are evaluated
@@ -1288,7 +1288,7 @@ class BatchRotatingKVCache(_BaseCache):
                 )
             left_padding = mx.array(left_padding)
             self.left_padding += left_padding
-            self.offset -= left_padding
+            self.offset = self.offset - left_padding
 
         if right_padding is not None and max(right_padding) > 0:
             self._lengths = mx.array(lengths) + self.offset
@@ -1299,7 +1299,7 @@ class BatchRotatingKVCache(_BaseCache):
             self.keys = dynamic_roll(self.keys, roll[:, None], axis=2)
             self.values = dynamic_roll(self.values, roll[:, None], axis=2)
             self.left_padding += roll
-            self.offset -= roll
+            self.offset = self.offset - roll
             self._lengths = None
 
     @property
@@ -1332,7 +1332,7 @@ class BatchRotatingKVCache(_BaseCache):
         n = min(self._offset, n)
         self._offset -= n
         self._idx -= n
-        self.offset -= n
+        self.offset = self.offset - n
         return n
 
     def to_quantized(self, group_size: int = 64, bits: int = 4) -> QuantizedKVCache:

--- a/tests/test_prompt_cache.py
+++ b/tests/test_prompt_cache.py
@@ -513,6 +513,16 @@ class TestPromptCache(unittest.TestCase):
         self.assertEqual(mask[0].squeeze().tolist(), [True, True, True])
         self.assertEqual(mask[1].squeeze().tolist(), [False, True, True])
 
+    def test_batch_kv_cache_offset_not_mutated_in_place(self):
+        cache = BatchKVCache(left_padding=[0])
+        captured = cache.offset
+        k, v = mx.zeros((1, 1, 4, 8)), mx.zeros((1, 1, 4, 8))
+        cache.update_and_fetch(k, v)
+        # Capturing offset before update_and_fetch must keep the pre-update
+        # value. In-place mx.array += would corrupt RoPE in gemma3n (#1806).
+        self.assertEqual(int(captured.item()), 0)
+        self.assertEqual(int(cache.offset.item()), 4)
+
         # Test extension
         cache_a = BatchKVCache(left_padding=[2, 1, 2])
         cache_b = BatchKVCache(left_padding=[3, 0])


### PR DESCRIPTION
mx.array += updates the existing handle, so a model that captures cache.offset before update_and_fetch (gemma3n) RoPEs at the new value. Assign a new array so the captured handle stays frozen.

Fixes #1806

- ☑️ I understand it is strictly prohibited to use AI to write PR description
- AI usage disclosure: 
