### PR TITLE
feat: Add query-free KV cache compression (KeyDiff)

### DIFF
--- a/mlx_lm/generate.py
+++ b/mlx_lm/generate.py
@@ -21,6 +21,7 @@ from .models.cache import (
     QuantizedKVCache,
     TokenBuffer,
     can_trim_prompt_cache,
+    compress_prompt_cache,
     load_prompt_cache,
     make_prompt_cache,
     trim_prompt_cache,
@@ -313,6 +314,7 @@ def generate_step(
     kv_bits: Optional[int] = None,
     kv_group_size: int = 64,
     quantized_kv_start: int = 0,
+    compression_ratio: Optional[float] = None,
     prompt_progress_callback: Optional[Callable[[int, int], None]] = None,
     input_embeddings: Optional[mx.array] = None,
 ) -> Generator[Tuple[mx.array, mx.array], None, None]:
@@ -339,6 +341,10 @@ def generate_step(
         kv_group_size (int): Group size for KV cache quantization. Default: ``64``.
         quantized_kv_start (int): Step to begin using a quantized KV cache.
            when ``kv_bits`` is non-None. Default: ``0``.
+        compression_ratio (float, optional): Fraction of KV cache tokens to
+           evict after prefill using importance-based compression. E.g. ``0.5``
+           keeps the 50% most distinctive tokens. Default: ``None`` (no
+           compression).
         prompt_progress_callback (Callable[[int, int], None]): A call-back which takes the
            prompt tokens processed so far and the total number of prompt tokens.
         input_embeddings (mx.array, optional): Input embeddings to use instead of or in
@@ -368,6 +374,7 @@ def generate_step(
         prompt_cache = make_prompt_cache(
             model,
             max_kv_size=max_kv_size,
+            compression_ratio=compression_ratio,
         )
 
     prompt_progress_callback = prompt_progress_callback or (lambda *_: None)
@@ -449,6 +456,12 @@ def generate_step(
                 if input_embeddings is not None
                 else input_embeddings
             )
+            mx.clear_cache()
+
+        # Compress the KV cache if using CompressedKVCache
+        if compression_ratio is not None and compression_ratio > 0.0:
+            compress_prompt_cache(prompt_cache)
+            mx.eval([c.state for c in prompt_cache])
             mx.clear_cache()
 
         y, logprobs = _step(input_tokens=prompt, input_embeddings=input_embeddings)

--- a/mlx_lm/models/cache.py
+++ b/mlx_lm/models/cache.py
@@ -15,6 +15,7 @@ from .base import create_causal_mask
 def make_prompt_cache(
     model: nn.Module,
     max_kv_size: Optional[int] = None,
+    compression_ratio: Optional[float] = None,
 ) -> List[Any]:
     """
     Construct the model's cache for use in generation.
@@ -27,6 +28,10 @@ def make_prompt_cache(
         max_kv_size (Optional[int]): If provided and the model does not have a
             ``make_cache`` method, a ``RotatingKVCache`` is used with a maximum
             size of ``max_kv_size``
+        compression_ratio (Optional[float]): If provided and the model does not
+            have a ``make_cache`` method, a ``CompressedKVCache`` is used that
+            compresses the KV cache after prefill by evicting this fraction of
+            tokens. E.g. ``0.5`` keeps the 50% most distinctive tokens.
     """
     if hasattr(model, "make_cache"):
         return model.make_cache()
@@ -36,8 +41,19 @@ def make_prompt_cache(
         return [
             RotatingKVCache(max_size=max_kv_size, keep=4) for _ in range(num_layers)
         ]
+    elif compression_ratio is not None and compression_ratio > 0.0:
+        return [
+            CompressedKVCache(compression_ratio=compression_ratio)
+            for _ in range(num_layers)
+        ]
     else:
         return [KVCache() for _ in range(num_layers)]
+
+
+def compress_prompt_cache(cache: List[Any]) -> None:
+    for c in cache:
+        if hasattr(c, "compress"):
+            c.compress()
 
 
 def save_prompt_cache(file_name: str, cache: List[Any], metadata: Dict[str, str] = {}):
@@ -405,6 +421,76 @@ class KVCache(_BaseCache):
         if self.keys is None:
             return 0
         return self.keys.nbytes + self.values.nbytes
+
+
+class CompressedKVCache(KVCache):
+    """KV cache with post-prefill compression using the KeyDiff algorithm.
+
+    Based on KeyDiffPress from `kvpress <https://github.com/NVIDIA/kvpress>`_.
+
+    Args:
+        compression_ratio (float): Fraction of tokens to evict. Default: ``0.0``.
+        n_sink (int): Number of initial tokens to always retain. Default: ``4``.
+    """
+
+    def __init__(self, compression_ratio: float = 0.0, n_sink: int = 4):
+        super().__init__()
+        self.compression_ratio = compression_ratio
+        self.n_sink = n_sink
+        self._compressed = False
+
+    def compress(self):
+        """Compress the cache in-place by evicting redundant tokens."""
+        if self._compressed or self.keys is None or self.compression_ratio <= 0.0:
+            return
+
+        keys = self.keys[..., : self.offset, :]
+        values = self.values[..., : self.offset, :]
+        S = keys.shape[2]
+
+        n_kept = max(int(S * (1.0 - self.compression_ratio)), self.n_sink + 1)
+        if n_kept >= S:
+            self._compressed = True
+            return
+
+        # Score by cosine dissimilarity to the mean key
+        key_norms = mx.linalg.norm(keys, axis=-1, keepdims=True)
+        norm_k = keys / (key_norms + 1e-8)
+        anchor = mx.mean(norm_k, axis=2, keepdims=True)
+        scores = -(norm_k * anchor).sum(axis=-1)
+
+        # Protect sink tokens
+        max_score = mx.max(scores)
+        scores = mx.concatenate(
+            [
+                mx.broadcast_to(max_score + 1, scores[..., : self.n_sink].shape),
+                scores[..., self.n_sink :],
+            ],
+            axis=-1,
+        )
+
+        # Keep the top-k most distinctive tokens in sequence order
+        neg_scores = -scores
+        indices = mx.argpartition(neg_scores, kth=n_kept - 1, axis=-1)[..., :n_kept]
+        indices = mx.sort(indices, axis=-1)
+
+        idx_expanded = mx.expand_dims(indices, axis=-1)
+        self.keys = mx.take_along_axis(keys, idx_expanded, axis=2)
+        self.values = mx.take_along_axis(values, idx_expanded, axis=2)
+        self.offset = n_kept
+        self._compressed = True
+
+    @property
+    def meta_state(self):
+        return tuple(
+            map(str, (self.compression_ratio, self.n_sink, int(self._compressed)))
+        )
+
+    @meta_state.setter
+    def meta_state(self, v):
+        self.compression_ratio = float(v[0])
+        self.n_sink = int(v[1])
+        self._compressed = bool(int(v[2]))
 
 
 class RotatingKVCache(_BaseCache):

--- a/tests/test_kv_press.py
+++ b/tests/test_kv_press.py
@@ -1,0 +1,242 @@
+# Copyright © 2024 Apple Inc.
+
+import os
+import tempfile
+import unittest
+
+import mlx.core as mx
+
+from mlx_lm.models.cache import (
+    CompressedKVCache,
+    KVCache,
+    compress_prompt_cache,
+    load_prompt_cache,
+    make_prompt_cache,
+    save_prompt_cache,
+)
+
+
+class TestCompressedKVCache(unittest.TestCase):
+
+    def _make_cache_with_data(
+        self,
+        compression_ratio=0.5,
+        n_sink=4,
+        seq_len=100,
+        batch=1,
+        n_heads=8,
+        head_dim=16,
+    ):
+        cache = CompressedKVCache(compression_ratio=compression_ratio, n_sink=n_sink)
+        keys = mx.random.normal(shape=(batch, n_heads, seq_len, head_dim))
+        values = mx.random.normal(shape=(batch, n_heads, seq_len, head_dim))
+        cache.update_and_fetch(keys, values)
+        mx.eval(cache.keys, cache.values)
+        return cache, keys, values
+
+    def test_compression_reduces_sequence_length(self):
+        cache, _, _ = self._make_cache_with_data(compression_ratio=0.5, seq_len=100)
+        self.assertEqual(cache.offset, 100)
+
+        cache.compress()
+        mx.eval(cache.keys, cache.values)
+
+        expected_kept = max(int(100 * 0.5), 4 + 1)
+        self.assertEqual(cache.offset, expected_kept)
+        self.assertEqual(cache.keys.shape[2], expected_kept)
+        self.assertEqual(cache.values.shape[2], expected_kept)
+
+    def test_output_shape_matches_expected(self):
+        B, H, D = 2, 4, 32
+        cache, _, _ = self._make_cache_with_data(
+            compression_ratio=0.4,
+            batch=B,
+            n_heads=H,
+            head_dim=D,
+            seq_len=200,
+        )
+        cache.compress()
+        mx.eval(cache.keys, cache.values)
+
+        n_kept = max(int(200 * 0.6), 4 + 1)
+        self.assertEqual(cache.keys.shape, (B, H, n_kept, D))
+        self.assertEqual(cache.values.shape, (B, H, n_kept, D))
+
+    def test_compression_is_idempotent(self):
+        cache, _, _ = self._make_cache_with_data(compression_ratio=0.5, seq_len=100)
+        cache.compress()
+        mx.eval(cache.keys, cache.values)
+        first_keys = cache.keys
+        first_offset = cache.offset
+
+        cache.compress()
+        mx.eval(cache.keys, cache.values)
+        self.assertEqual(cache.offset, first_offset)
+        self.assertTrue(mx.array_equal(cache.keys, first_keys))
+
+    def test_sink_tokens_always_retained(self):
+        n_sink = 4
+        cache, original_keys, original_values = self._make_cache_with_data(
+            compression_ratio=0.7,
+            n_sink=n_sink,
+            seq_len=100,
+        )
+        cache.compress()
+        mx.eval(cache.keys, cache.values)
+
+        compressed_sink_keys = cache.keys[..., :n_sink, :]
+        original_sink_keys = original_keys[..., :n_sink, :]
+        self.assertTrue(
+            mx.allclose(compressed_sink_keys, original_sink_keys, atol=1e-5),
+        )
+
+    def test_sequence_order_preserved(self):
+        cache = CompressedKVCache(compression_ratio=0.5, n_sink=2)
+        seq_len = 50
+        keys = mx.zeros((1, 1, seq_len, 4))
+        values = mx.zeros((1, 1, seq_len, 4))
+        for i in range(seq_len):
+            keys = keys.at[0, 0, i, 0].add(float(i))
+            values = values.at[0, 0, i, 0].add(float(i))
+        cache.update_and_fetch(keys, values)
+        mx.eval(cache.keys, cache.values)
+
+        cache.compress()
+        mx.eval(cache.keys, cache.values)
+
+        position_markers = cache.keys[0, 0, :, 0].tolist()
+        for i in range(len(position_markers) - 1):
+            self.assertLess(position_markers[i], position_markers[i + 1])
+
+    def test_zero_compression_ratio_is_noop(self):
+        cache, _, _ = self._make_cache_with_data(compression_ratio=0.0, seq_len=50)
+        cache.compress()
+        mx.eval(cache.keys)
+        self.assertEqual(cache.offset, 50)
+
+    def test_very_short_sequence_no_crash(self):
+        cache = CompressedKVCache(compression_ratio=0.5, n_sink=4)
+        keys = mx.random.normal(shape=(1, 4, 3, 16))
+        values = mx.random.normal(shape=(1, 4, 3, 16))
+        cache.update_and_fetch(keys, values)
+        mx.eval(cache.keys, cache.values)
+
+        cache.compress()
+        mx.eval(cache.keys, cache.values)
+        self.assertEqual(cache.offset, 3)
+
+    def test_empty_cache_compress_is_noop(self):
+        cache = CompressedKVCache(compression_ratio=0.5)
+        cache.compress()
+        self.assertTrue(cache.empty())
+
+    def test_compression_ratio_one_keeps_minimum(self):
+        n_sink = 4
+        cache, _, _ = self._make_cache_with_data(
+            compression_ratio=1.0,
+            n_sink=n_sink,
+            seq_len=100,
+        )
+        cache.compress()
+        mx.eval(cache.keys, cache.values)
+        self.assertEqual(cache.offset, n_sink + 1)
+
+    def test_update_after_compression(self):
+        cache, _, _ = self._make_cache_with_data(compression_ratio=0.5, seq_len=100)
+        cache.compress()
+        mx.eval(cache.keys, cache.values)
+        compressed_offset = cache.offset
+
+        for _ in range(10):
+            new_k = mx.random.normal(shape=(1, 8, 1, 16))
+            new_v = mx.random.normal(shape=(1, 8, 1, 16))
+            k_out, v_out = cache.update_and_fetch(new_k, new_v)
+            mx.eval(k_out, v_out)
+
+        self.assertEqual(cache.offset, compressed_offset + 10)
+        self.assertEqual(k_out.shape[2], compressed_offset + 10)
+
+    def test_trim_after_compression(self):
+        cache, _, _ = self._make_cache_with_data(compression_ratio=0.5, seq_len=100)
+        cache.compress()
+        mx.eval(cache.keys, cache.values)
+        pre_trim = cache.offset
+
+        trimmed = cache.trim(5)
+        self.assertEqual(trimmed, 5)
+        self.assertEqual(cache.offset, pre_trim - 5)
+
+    def test_save_load_compressed_cache(self):
+        cache, _, _ = self._make_cache_with_data(compression_ratio=0.5, seq_len=100)
+        cache.compress()
+        mx.eval(cache.keys, cache.values)
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            path = os.path.join(tmpdir, "compressed_cache.safetensors")
+            save_prompt_cache(path, [cache])
+            loaded = load_prompt_cache(path)
+
+        lc = loaded[0]
+        self.assertIsInstance(lc, CompressedKVCache)
+        self.assertEqual(lc.offset, cache.offset)
+        self.assertAlmostEqual(lc.compression_ratio, cache.compression_ratio)
+        self.assertEqual(lc.n_sink, cache.n_sink)
+        self.assertEqual(lc._compressed, cache._compressed)
+        self.assertTrue(mx.array_equal(lc.keys, cache.keys))
+        self.assertTrue(mx.array_equal(lc.values, cache.values))
+
+    def test_compress_prompt_cache_utility(self):
+        caches = []
+        for _ in range(4):
+            c = CompressedKVCache(compression_ratio=0.5)
+            keys = mx.random.normal(shape=(1, 4, 80, 16))
+            values = mx.random.normal(shape=(1, 4, 80, 16))
+            c.update_and_fetch(keys, values)
+            mx.eval(c.keys, c.values)
+            caches.append(c)
+
+        compress_prompt_cache(caches)
+        mx.eval([c.state for c in caches])
+
+        for c in caches:
+            expected = max(int(80 * 0.5), 4 + 1)
+            self.assertEqual(c.offset, expected)
+
+    def test_compress_prompt_cache_ignores_regular_kvcache(self):
+        kv = KVCache()
+        keys = mx.random.normal(shape=(1, 4, 80, 16))
+        values = mx.random.normal(shape=(1, 4, 80, 16))
+        kv.update_and_fetch(keys, values)
+        mx.eval(kv.keys, kv.values)
+
+        compress_prompt_cache([kv])
+        self.assertEqual(kv.offset, 80)
+
+    def test_make_prompt_cache_with_compression_ratio(self):
+
+        class FakeModel:
+            def __init__(self, n_layers):
+                self.layers = [None] * n_layers
+
+        model = FakeModel(4)
+        cache = make_prompt_cache(model, compression_ratio=0.3)
+        self.assertEqual(len(cache), 4)
+        for c in cache:
+            self.assertIsInstance(c, CompressedKVCache)
+            self.assertAlmostEqual(c.compression_ratio, 0.3)
+
+    def test_make_prompt_cache_without_compression_returns_kvcache(self):
+
+        class FakeModel:
+            def __init__(self, n_layers):
+                self.layers = [None] * n_layers
+
+        model = FakeModel(4)
+        cache = make_prompt_cache(model)
+        for c in cache:
+            self.assertIsInstance(c, KVCache)
+            self.assertNotIsInstance(c, CompressedKVCache)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
### Description

This PR introduces an importance-based token eviction strategy for the KV cache to significantly reduce memory footprint and generation time for long contexts, without requiring changes to model architectures.

We implement the **KeyDiff** algorithm (originally from [NVIDIA kvpress](https://github.com/NVIDIA/kvpress)), which is purely query-free. It scores each cached token by computing the cosine dissimilarity between its key vector and the mean key vector (anchor). Distinctive tokens are retained, while redundant tokens are evicted after the prefill phase.

**Key Features:**
- **`CompressedKVCache`**: A drop-in subclass of `KVCache` that implements a one-shot `compress()` method.
- **Model Agnostic**: Requires zero changes to model attention files (`llama.py`, `qwen.py`, etc.) because it doesn't rely on attention weights.
- **Backwards Compatible**: By default, `compression_ratio=0.0`. When set to 0, it operates exactly like a regular `KVCache` with no overhead.
- **Attention Sinks**: The first `n_sink=4` tokens are always protected from eviction.

### Usage

```python
from mlx_lm import generate, load

model, tokenizer = load("mlx-community/Meta-Llama-3-8B-Instruct-4bit")
prompt = "Your very long prompt here..."

# Evicts the 50% most redundant tokens from the KV cache immediately after prefill
generate(model, tokenizer, prompt, compression_ratio=0.5, verbose=True)
```

### Testing
- Added `tests/test_kv_press.py` with 16 comprehensive unit tests covering idempotency, sequence order preservation, edge cases (short sequences, zero compression, multi-batch), and serialization round-tripping.
- All existing tests in `test_prompt_cache.py` pass without regressions.
- Code is formatted and passes `pre-commit run --all-files`.
