### PR TITLE
Build the streaming detokenizer once per tokenizer, not once per generation

### DIFF
--- a/mlx_lm/tokenizer_utils.py
+++ b/mlx_lm/tokenizer_utils.py
@@ -1,3 +1,4 @@
+import copy
 import importlib
 import json
 import warnings
@@ -451,8 +452,22 @@ class TokenizerWrapper:
     def detokenizer(self):
         """
         Get a stateful streaming detokenizer.
+
+        The detokenizer's per-stream state is exactly what ``reset()``
+        installs; everything else it holds (the id-to-token map, the byte
+        decoder) is derived from the tokenizer and immutable. Building one
+        prototype per wrapper and handing out shallow copies keeps every
+        stream independent while materialising the vocabulary only once --
+        rebuilding it per call costs O(vocab) on the first token of every
+        generation.
         """
-        return self._detokenizer_class(self)
+        prototype = self.__dict__.get("_detokenizer_prototype")
+        if prototype is None:
+            prototype = self._detokenizer_class(self)
+            self.__dict__["_detokenizer_prototype"] = prototype
+        detokenizer = copy.copy(prototype)
+        detokenizer.reset()
+        return detokenizer
 
     def __getattr__(self, attr):
         if attr == "detokenizer":

--- a/tests/test_tokenizers.py
+++ b/tests/test_tokenizers.py
@@ -72,6 +72,63 @@ class TestTokenizers(unittest.TestCase):
         tokenizer._detokenizer = NaiveStreamingDetokenizer(tokenizer)
         self.check_tokenizer(tokenizer)
 
+    def test_detokenizer_not_rebuilt_per_access(self):
+        """Accessing .detokenizer must not re-read the vocabulary.
+
+        The detokenizer is handed out per stream, but everything it holds
+        besides the state ``reset()`` installs is immutable and derived from
+        the tokenizer. Rebuilding it per access costs O(vocab) on the first
+        token of every generation.
+        """
+        tokenizer = load_tokenizer("mlx-community/Qwen1.5-0.5B-Chat-4bit")
+        inner = tokenizer._tokenizer
+        original_get_vocab = type(inner).get_vocab
+        calls = []
+
+        def counting_get_vocab(self, *args, **kwargs):
+            calls.append(1)
+            return original_get_vocab(self, *args, **kwargs)
+
+        type(inner).get_vocab = counting_get_vocab
+        try:
+            tokenizer.detokenizer
+            after_first = len(calls)
+            for _ in range(9):
+                tokenizer.detokenizer
+            self.assertEqual(len(calls), after_first)
+        finally:
+            type(inner).get_vocab = original_get_vocab
+
+    def test_detokenizers_are_independent(self):
+        """Two detokenizers share the token map but never each other's state."""
+        tokenizer = load_tokenizer("mlx-community/Qwen1.5-0.5B-Chat-4bit")
+        first, second = tokenizer.detokenizer, tokenizer.detokenizer
+        self.assertIsNot(first, second)
+        # `assertIs` would dump the whole vocabulary into the failure message.
+        self.assertTrue(
+            first.tokenmap is second.tokenmap,
+            "the immutable token map should be shared between detokenizers",
+        )
+
+        a_tokens = tokenizer.encode("hello\nworld")
+        b_tokens = tokenizer.encode('{"a":3.5}')
+        first.reset()
+        second.reset()
+        a_text = b_text = ""
+        for i in range(max(len(a_tokens), len(b_tokens))):
+            if i < len(a_tokens):
+                first.add_token(a_tokens[i])
+                a_text += first.last_segment
+            if i < len(b_tokens):
+                second.add_token(b_tokens[i])
+                b_text += second.last_segment
+        first.finalize()
+        second.finalize()
+        a_text += first.last_segment
+        b_text += second.last_segment
+        self.assertEqual(a_text, tokenizer.decode(a_tokens))
+        self.assertEqual(b_text, tokenizer.decode(b_tokens))
+
     def test_special_tokens(self):
         tokenizer_repo = "mlx-community/DeepSeek-Coder-V2-Lite-Instruct-4bit-mlx"
         tokenizer = load_tokenizer(tokenizer_repo)


### PR DESCRIPTION
Closes the TTFT regression reported in #1435.

`TokenizerWrapper.detokenizer` builds a fresh detokenizer on every access, and both `BPEStreamingDetokenizer.__init__` and `SPMStreamingDetokenizer.__init__` construct a full id-to-token map from `tokenizer.vocab` — a `get_vocab()` passthrough that materialises the whole vocabulary, referenced twice per constructor.

`generate.py:697` takes `tokenizer.detokenizer` once per `stream_generate` call, so every generation pays O(vocab) before its first token. On a 151,669-entry vocabulary that is ~51 ms, independent of model size — which is why #1435 saw a constant offset rather than a proportional slowdown.

Handing out a per-stream detokenizer is the right design: `offset`, `_unflushed`, `text` and `tokens` are genuinely per-sequence. What did not need rebuilding is the immutable part. This builds one prototype per wrapper and returns shallow copies, so streams stay independent and the vocabulary is read once.

## Measured

Apple M5, `mlx==0.31.2`:

| | before | after |
|---|---:|---:|
| `.detokenizer`, median of subsequent accesses (Qwen1.5-0.5B) | 57.9 ms | **0.001 ms** |
| `get_vocab()` calls over 20 accesses | 40 | **2** |
| TTFT, Qwen3-0.6B-4bit, median of 12 | 83.7 ms | **32.1 ms** |

`mlx-lm==0.27.1` measures 34.8 ms on the same bench, so the gap closes fully. Generated text is byte-identical.

A version sweep with `mlx` pinned puts the whole step at 0.27.1 → 0.28.0, the release that introduced batch generation (#443, #430, #468); the reverse control, sweeping `mlx` with `mlx-lm` pinned, shows no step. Full bisect table and profile in [the issue comment](https://github.com/ml-explore/mlx-lm/issues/1435#issuecomment-5557959604).

## Tests

Two added, both failing without this change:

- `test_detokenizer_not_rebuilt_per_access` — repeated `.detokenizer` access must not call `get_vocab()` again.
- `test_detokenizers_are_independent` — two detokenizers driven interleaved share the token map and still produce correct, independent output.

Verified against `BPEStreamingDetokenizer` (Qwen1.5, Llama-3.2), `SPMStreamingDetokenizer` (Mistral-7B-Instruct-v0.3) and `NaiveStreamingDetokenizer`. `black` and `isort --profile=black` are clean.

## Pre-existing failure, unrelated to this PR

`test_tokenizers` fails on `Llama-3.2-1B-Instruct-4bit` and `Falcon3-7B-Instruct-4bit` with `'a,b' != 'a ,b'` on `transformers==5.16.1`, which now warns that `clean_up_tokenization_spaces=True` is destructive for BPE tokenizers. I confirmed this reproduces identically on unmodified `v0.31.3`, so it is not introduced here — but it does mean the file is not green on current `transformers`, and it may be worth a separate issue.

## Two things noticed while working on this, not changed here

- `tests/test_tokenizers.py` sets `tokenizer._detokenizer = NaiveStreamingDetokenizer(tokenizer)` and then calls `check_tokenizer`, which reads `tokenizer.detokenizer` — the property, which ignores `_detokenizer`. That subtest currently re-tests the BPE path rather than the naive one.
- `TokenizerWrapper.__getattr__` returns `self._detokenizer` for `attr == "detokenizer"`. Since the property shadows `__getattr__`, that branch is only reachable when the property itself raises `AttributeError`, in which case the original error is replaced by `'TokenizerWrapper' object has no attribute '_detokenizer'`. It cost me some time; happy to open a separate PR if you would like it removed.
