### PR TITLE
Fix padding-token inflation in batched perplexity evals

### DIFF
--- a/mlx_lm/evaluate.py
+++ b/mlx_lm/evaluate.py
@@ -303,7 +303,7 @@ class MLXLM(LM):
         for i in tqdm(range(0, len(inputs), self._batch_size)):
             batch = inputs[i : i + self._batch_size]
             scores, lengths, _ = self._score_fn(batch)
-            mask = mx.arange(scores.shape[-1]) < lengths[:, None]
+            mask = mx.arange(scores.shape[-1]) < lengths[:, None] - 1
             all_scores.extend((mask * scores).sum(axis=-1).tolist())
 
         return all_scores

--- a/tests/test_evaluate.py
+++ b/tests/test_evaluate.py
@@ -71,21 +71,22 @@ class TestMLXLM(unittest.TestCase):
                 logits = mx.arange(11, dtype=mx.float32)
                 return mx.broadcast_to(logits, (*inputs.shape, logits.shape[0]))
 
-        lm = MLXLM.__new__(MLXLM)
-        lm._model = Model()
-        lm.tokenizer = Tokenizer()
-        lm.use_chat_template = False
-        lm._batch_size = 2
+        def make_lm(batch_size):
+            with patch("mlx_lm.evaluate.load") as mock_load:
+                mock_load.return_value = (Model(), Tokenizer())
+                return MLXLM("test_model", batch_size=batch_size)
 
         # The first request is padded only when scored in a mixed-length batch.
         requests = [
             SimpleNamespace(args=("1 2 3 4",)),
             SimpleNamespace(args=("5 6 7 8 9 10",)),
         ]
-        batched_scores = lm.loglikelihood_rolling(requests)
+        batched_scores = make_lm(2).loglikelihood_rolling(requests)
 
-        lm._batch_size = 1
-        single_scores = [lm.loglikelihood_rolling([request])[0] for request in requests]
+        single_lm = make_lm(1)
+        single_scores = [
+            single_lm.loglikelihood_rolling([request])[0] for request in requests
+        ]
 
         self.assertAlmostEqual(batched_scores[0], single_scores[0])
         self.assertAlmostEqual(batched_scores[1], single_scores[1])

--- a/tests/test_evaluate.py
+++ b/tests/test_evaluate.py
@@ -1,6 +1,7 @@
 # Copyright © 2024 Apple Inc.
 
 import unittest
+from types import SimpleNamespace
 from unittest.mock import MagicMock, patch
 
 import mlx.core as mx
@@ -54,6 +55,40 @@ class TestMLXLM(unittest.TestCase):
         self.assertEqual(len(call_args_list[0][0][0]), 2)  # First batch: 2 items
         self.assertEqual(len(call_args_list[1][0][0]), 2)  # Second batch: 2 items
         self.assertEqual(len(call_args_list[2][0][0]), 1)  # Third batch: 1 item
+
+    def test_loglikelihood_rolling_mixed_lengths_is_independent_of_batch_size(self):
+        class Tokenizer:
+            chat_template = None
+
+            def encode(self, text, add_special_tokens=True):
+                return [int(token) for token in text.split()]
+
+        class Model:
+            def make_cache(self):
+                return []
+
+            def __call__(self, inputs, cache=None):
+                logits = mx.arange(11, dtype=mx.float32)
+                return mx.broadcast_to(logits, (*inputs.shape, logits.shape[0]))
+
+        lm = MLXLM.__new__(MLXLM)
+        lm._model = Model()
+        lm.tokenizer = Tokenizer()
+        lm.use_chat_template = False
+        lm._batch_size = 2
+
+        # The first request is padded only when scored in a mixed-length batch.
+        requests = [
+            SimpleNamespace(args=("1 2 3 4",)),
+            SimpleNamespace(args=("5 6 7 8 9 10",)),
+        ]
+        batched_scores = lm.loglikelihood_rolling(requests)
+
+        lm._batch_size = 1
+        single_scores = [lm.loglikelihood_rolling([request])[0] for request in requests]
+
+        self.assertAlmostEqual(batched_scores[0], single_scores[0])
+        self.assertAlmostEqual(batched_scores[1], single_scores[1])
 
     @patch("mlx_lm.evaluate.batch_generate")
     def test_generate_strip_until_then_strip_thinking(self, mock_batch_generate):


### PR DESCRIPTION
This PR is:
- to fix the padding-token log-probability being included in the score of shorter documents.
- to add a regression test that batches a short and a long document together and verifies that each result matches scoring the same document individually.

TLDR:
mlx_lm.evaluate reports different perplexity for the same model on the same data depending on --batch-size, because every document that isn't the longest in its batch gets one padding-token log-probability added to its score

####  How reproduce (change to different batch size):
```bash
$ mlx_lm.evaluate --model mlx-community/SmolLM2-135M-Instruct --tasks wikitext --batch-size 1 --no-apply-chat-template

$ mlx_lm.evaluate --model mlx-community/SmolLM2-135M-Instruct --tasks wikitext --batch-size 8 --no-apply-chat-template

$ mlx_lm.evaluate --model mlx-community/SmolLM2-135M-Instruct --tasks wikitext --batch-size 16 --no-apply-chat-template
```

#### Before-screenshot:
<img width="1054" height="984" alt="Screenshot 2026-09-07 at 10 35 55 AM" src="https://github.com/user-attachments/assets/753cdacf-dcf9-4038-99c4-90f425dad157" />

#### After-screenshot:

<img width="1052" height="968" alt="Screenshot 2026-09-07 at 10 27 16 AM" src="https://github.com/user-attachments/assets/df991103-e98e-4335-9ce9-2f72f20b280d" />



#### Evidence table:

| Version | Batch size | Word perplexity | Byte perplexity | Bits/byte |
|---|---:|---:|---:|---:|
| Before | 1 | 26.8173617726 | 1.8497836726 | 0.8873565612 |
| Before | 8 | 26.8773976779 | 1.8505573757 | 0.8879598664 |
| Before | 16 | 26.8815974797 | 1.8506114473 | 0.8880020201 |
| After | 1 | 26.8173617726 | 1.8497836726 | 0.8873565612 |
| After | 8 | 26.8168858929 | 1.8497775342 | 0.8873517736 |
| After | 16 | 26.8168858929 | 1.8497775342 | 0.8873517736 |


before the fix, bs=8 and bs=16 inflated Wikitext perplexity relative to bs=1; after the fix, batched scoring converges and no longer adds the padding-token score. However, after the fix, bs=1 is still off from bs=8/16 by about 0.00048 word perplexity, which is tiny compared with the previous ~0.06 drift.



- ☑️ I understand it is strictly prohibited to use AI to write PR description
