### PR TITLE
Fix config parsing for Nemotron-H checkpoints saved by transformers

### DIFF
--- a/mlx_lm/models/base.py
+++ b/mlx_lm/models/base.py
@@ -12,13 +12,19 @@ from mlx.utils import tree_map
 class BaseModelArgs:
     @classmethod
     def from_dict(cls, params):
-        return cls(
-            **{
-                k: v
-                for k, v in params.items()
-                if k in inspect.signature(cls).parameters
-            }
-        )
+        accepted = inspect.signature(cls).parameters
+        kwargs = {k: v for k, v in params.items() if k in accepted}
+        missing = [
+            name
+            for name, param in accepted.items()
+            if param.default is inspect.Parameter.empty and name not in kwargs
+        ]
+        if missing:
+            raise ValueError(
+                f"Config for model type '{params.get('model_type', 'unknown')}' is "
+                f"missing required key(s): {', '.join(missing)}."
+            )
+        return cls(**kwargs)
 
 
 def create_causal_mask(

--- a/mlx_lm/models/base.py
+++ b/mlx_lm/models/base.py
@@ -12,19 +12,13 @@ from mlx.utils import tree_map
 class BaseModelArgs:
     @classmethod
     def from_dict(cls, params):
-        accepted = inspect.signature(cls).parameters
-        kwargs = {k: v for k, v in params.items() if k in accepted}
-        missing = [
-            name
-            for name, param in accepted.items()
-            if param.default is inspect.Parameter.empty and name not in kwargs
-        ]
-        if missing:
-            raise ValueError(
-                f"Config for model type '{params.get('model_type', 'unknown')}' is "
-                f"missing required key(s): {', '.join(missing)}."
-            )
-        return cls(**kwargs)
+        return cls(
+            **{
+                k: v
+                for k, v in params.items()
+                if k in inspect.signature(cls).parameters
+            }
+        )
 
 
 def create_causal_mask(

--- a/mlx_lm/models/nemotron_h.py
+++ b/mlx_lm/models/nemotron_h.py
@@ -40,9 +40,9 @@ class ModelArgs(BaseModelArgs):
     use_conv_bias: bool
     hybrid_override_pattern: Optional[List[str]] = None
     layers_block_type: Optional[List[str]] = None
+    # Alias transformers exposes the list under.
     layer_types: Optional[List[str]] = None
-    # Derived from the block list when the config leaves it out, which is what
-    # transformers does: there the layer count is a property of layers_block_type.
+    # Omitted by transformers, which derives it from the block list.
     num_hidden_layers: Optional[int] = None
     head_dim: Optional[int] = None
     moe_intermediate_size: Optional[int] = None
@@ -59,17 +59,15 @@ class ModelArgs(BaseModelArgs):
     time_step_min: Optional[float] = None
     time_step_max: Optional[float] = None
 
-    # Map from layers_block_type names to single-char pattern codes. Both the
-    # current spelling and the legacy one are accepted, since a checkpoint may
-    # have been saved by either version of transformers.
     _block_type_to_char = {
-        "linear_attention": "M",
-        "mamba": "M",
-        "conv": "M",
         "full_attention": "*",
-        "attention": "*",
+        "linear_attention": "M",
         "moe": "E",
         "mlp": "-",
+        # legacy spellings, remapped since transformers 5.13
+        "attention": "*",
+        "mamba": "M",
+        "conv": "M",
     }
 
     def __post_init__(self):
@@ -89,8 +87,6 @@ class ModelArgs(BaseModelArgs):
                 self._block_type_to_char[t] for t in block_types
             ]
         if self.hybrid_override_pattern is not None:
-            # The block list is authoritative for the layer count; transformers
-            # treats num_hidden_layers as deprecated for this architecture.
             self.num_hidden_layers = len(self.hybrid_override_pattern)
         else:
             raise ValueError(

--- a/mlx_lm/models/nemotron_h.py
+++ b/mlx_lm/models/nemotron_h.py
@@ -25,7 +25,6 @@ class ModelArgs(BaseModelArgs):
     vocab_size: int
     hidden_size: int
     intermediate_size: int
-    num_hidden_layers: int
     max_position_embeddings: int
     num_attention_heads: int
     num_key_value_heads: int
@@ -42,6 +41,10 @@ class ModelArgs(BaseModelArgs):
     use_conv_bias: bool
     hybrid_override_pattern: Optional[List[str]] = None
     layers_block_type: Optional[List[str]] = None
+    layer_types: Optional[List[str]] = None
+    # Derived from the block list when the config leaves it out, which is what
+    # transformers does: there the layer count is a property of layers_block_type.
+    num_hidden_layers: Optional[int] = None
     head_dim: Optional[int] = None
     moe_intermediate_size: Optional[int] = None
     moe_shared_expert_intermediate_size: Optional[int] = None
@@ -57,20 +60,44 @@ class ModelArgs(BaseModelArgs):
     time_step_min: Optional[float] = None
     time_step_max: Optional[float] = None
 
-    # Map from layers_block_type names to single-char pattern codes
-    _block_type_to_char = {"mamba": "M", "attention": "*", "moe": "E", "mlp": "-"}
+    # Map from layers_block_type names to single-char pattern codes. Both the
+    # current spelling and the legacy one are accepted, since a checkpoint may
+    # have been saved by either version of transformers.
+    _block_type_to_char = {
+        "linear_attention": "M",
+        "mamba": "M",
+        "conv": "M",
+        "full_attention": "*",
+        "attention": "*",
+        "moe": "E",
+        "mlp": "-",
+    }
 
     def __post_init__(self):
         if self.time_step_limit is None:
             self.time_step_limit = (0.0, float("inf"))
 
         # Normalize to hybrid_override_pattern (single-char list)
-        if self.hybrid_override_pattern is None and self.layers_block_type is not None:
+        block_types = self.layers_block_type or self.layer_types
+        if self.hybrid_override_pattern is None and block_types is not None:
+            unknown = sorted(set(block_types) - self._block_type_to_char.keys())
+            if unknown:
+                raise ValueError(
+                    f"Unsupported layers_block_type {unknown}, expected any of "
+                    f"{sorted(self._block_type_to_char)}."
+                )
             self.hybrid_override_pattern = [
-                self._block_type_to_char[t] for t in self.layers_block_type
+                self._block_type_to_char[t] for t in block_types
             ]
         if self.hybrid_override_pattern is not None:
+            # The block list is authoritative for the layer count; transformers
+            # treats num_hidden_layers as deprecated for this architecture.
             self.num_hidden_layers = len(self.hybrid_override_pattern)
+        else:
+            raise ValueError(
+                "The config must have layers_block_type or hybrid_override_pattern "
+                "to describe the layer stack."
+            )
 
 
 class MambaRMSNormGated(nn.Module):

--- a/mlx_lm/utils.py
+++ b/mlx_lm/utils.py
@@ -304,9 +304,8 @@ def hf_repo_to_path(hf_repo):
     )
 
 
-# Recent versions of transformers keep config.json readable by every JSON
-# parser by tagging non-finite floats, e.g. {"__float__": "Infinity"} for inf.
-# Undo the tagging here or the value reaches the model as a dict.
+# transformers tags non-finite floats so config.json stays valid JSON, e.g.
+# {"__float__": "Infinity"}. Undo it or the value arrives as a dict.
 _FLOAT_TAG_KEY = "__float__"
 _FLOAT_TAGS = {
     "Infinity": float("inf"),

--- a/mlx_lm/utils.py
+++ b/mlx_lm/utils.py
@@ -5,6 +5,7 @@ import glob
 import importlib
 import inspect
 import json
+import math
 import os
 import resource
 import shutil
@@ -287,9 +288,43 @@ def hf_repo_to_path(hf_repo):
     )
 
 
+# Recent versions of transformers keep config.json readable by every JSON
+# parser by tagging non-finite floats, e.g. {"__float__": "Infinity"} for inf.
+# Undo the tagging here or the value reaches the model as a dict.
+_FLOAT_TAG_KEY = "__float__"
+_FLOAT_TAGS = {
+    "Infinity": float("inf"),
+    "-Infinity": float("-inf"),
+    "NaN": float("nan"),
+}
+
+
+def _decode_tagged_floats(obj: Any) -> Any:
+    if isinstance(obj, dict):
+        if set(obj) == {_FLOAT_TAG_KEY} and obj[_FLOAT_TAG_KEY] in _FLOAT_TAGS:
+            return _FLOAT_TAGS[obj[_FLOAT_TAG_KEY]]
+        return {k: _decode_tagged_floats(v) for k, v in obj.items()}
+    if isinstance(obj, list):
+        return [_decode_tagged_floats(v) for v in obj]
+    return obj
+
+
+def _encode_tagged_floats(obj: Any) -> Any:
+    """Tag non-finite floats again, so a saved config stays valid JSON."""
+    if isinstance(obj, float) and not math.isfinite(obj):
+        if math.isnan(obj):
+            return {_FLOAT_TAG_KEY: "NaN"}
+        return {_FLOAT_TAG_KEY: "Infinity" if obj > 0 else "-Infinity"}
+    if isinstance(obj, dict):
+        return {k: _encode_tagged_floats(v) for k, v in obj.items()}
+    if isinstance(obj, (list, tuple)):
+        return [_encode_tagged_floats(v) for v in obj]
+    return obj
+
+
 def load_config(model_path: Path) -> dict:
     with open(model_path / "config.json", "r") as f:
-        config = json.load(f)
+        config = _decode_tagged_floats(json.load(f))
 
     generation_config_file = model_path / "generation_config.json"
     if generation_config_file.exists():
@@ -978,7 +1013,7 @@ def save_config(
 
     # write the updated config to the config_path (if provided)
     with open(config_path, "w") as fid:
-        json.dump(config, fid, indent=4)
+        json.dump(_encode_tagged_floats(config), fid, indent=4)
 
 
 def save(

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -2004,6 +2004,8 @@ class TestModels(unittest.TestCase):
     def test_nemotron_h_layer_count_from_block_types(self):
         from mlx_lm.models import nemotron_h
 
+        # transformers derives the layer count from layers_block_type and omits
+        # num_hidden_layers, so recent checkpoints do not carry the key.
         config = {
             "model_type": "nemotron_h",
             "vocab_size": 1000,
@@ -2023,55 +2025,29 @@ class TestModels(unittest.TestCase):
             "layer_norm_epsilon": 1e-4,
             "use_bias": True,
             "use_conv_bias": True,
-            # transformers derives the layer count from this list and treats
-            # num_hidden_layers as deprecated, so recent checkpoints of this
-            # architecture do not carry the key at all.
-            "layers_block_type": [
-                "full_attention",
-                "linear_attention",
-                "mlp",
-                "linear_attention",
-            ],
+            "layers_block_type": ["full_attention", "linear_attention", "mlp", "moe"],
         }
-        expected_pattern = ["*", "M", "-", "M"]
+        expected = ["*", "M", "-", "E"]
 
         args = nemotron_h.ModelArgs.from_dict(config)
         self.assertEqual(args.num_hidden_layers, 4)
-        self.assertEqual(args.hybrid_override_pattern, expected_pattern)
-        model = nemotron_h.Model(args)
-        self.model_test_runner(model, args.model_type, config["vocab_size"], 4)
+        self.assertEqual(args.hybrid_override_pattern, expected)
 
-        # The legacy block-type spelling describes the same stack.
-        legacy = dict(config)
-        legacy["layers_block_type"] = ["attention", "mamba", "mlp", "mamba"]
+        # The legacy spellings describe the same stack.
+        legacy = dict(config, layers_block_type=["attention", "conv", "mlp", "moe"])
         self.assertEqual(
-            nemotron_h.ModelArgs.from_dict(legacy).hybrid_override_pattern,
-            expected_pattern,
+            nemotron_h.ModelArgs.from_dict(legacy).hybrid_override_pattern, expected
         )
-
-        # So does layer_types, the alias transformers exposes the list under.
-        aliased = {k: v for k, v in config.items() if k != "layers_block_type"}
-        aliased["layer_types"] = config["layers_block_type"]
+        legacy["layers_block_type"] = ["attention", "mamba", "mlp", "moe"]
         self.assertEqual(
-            nemotron_h.ModelArgs.from_dict(aliased).hybrid_override_pattern,
-            expected_pattern,
+            nemotron_h.ModelArgs.from_dict(legacy).hybrid_override_pattern, expected
         )
 
         # An unmappable block type is reported instead of raising a KeyError.
-        unknown = dict(config)
-        unknown["layers_block_type"] = ["sliding_attention"] * 4
+        unknown = dict(config, layers_block_type=["sliding_attention"] * 4)
         with self.assertRaises(ValueError) as raised:
             nemotron_h.ModelArgs.from_dict(unknown)
         self.assertIn("sliding_attention", str(raised.exception))
-
-    def test_model_args_reports_missing_config_keys(self):
-        from mlx_lm.models import llama
-
-        with self.assertRaises(ValueError) as raised:
-            llama.ModelArgs.from_dict({"model_type": "llama", "hidden_size": 128})
-        message = str(raised.exception)
-        self.assertIn("llama", message)
-        self.assertIn("num_hidden_layers", message)
 
     def test_phi3small(self):
         from mlx_lm.models import phi3small

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -1922,6 +1922,78 @@ class TestModels(unittest.TestCase):
             model, args.model_type, args.vocab_size, args.num_hidden_layers
         )
 
+    def test_nemotron_h_layer_count_from_block_types(self):
+        from mlx_lm.models import nemotron_h
+
+        config = {
+            "model_type": "nemotron_h",
+            "vocab_size": 1000,
+            "hidden_size": 128,
+            "intermediate_size": 128,
+            "max_position_embeddings": 1000,
+            "num_attention_heads": 8,
+            "num_key_value_heads": 4,
+            "attention_bias": False,
+            "mamba_num_heads": 8,
+            "mamba_head_dim": 64,
+            "mamba_proj_bias": False,
+            "ssm_state_size": 128,
+            "conv_kernel": 3,
+            "n_groups": 4,
+            "mlp_bias": False,
+            "layer_norm_epsilon": 1e-4,
+            "use_bias": True,
+            "use_conv_bias": True,
+            # transformers derives the layer count from this list and treats
+            # num_hidden_layers as deprecated, so recent checkpoints of this
+            # architecture do not carry the key at all.
+            "layers_block_type": [
+                "full_attention",
+                "linear_attention",
+                "mlp",
+                "linear_attention",
+            ],
+        }
+        expected_pattern = ["*", "M", "-", "M"]
+
+        args = nemotron_h.ModelArgs.from_dict(config)
+        self.assertEqual(args.num_hidden_layers, 4)
+        self.assertEqual(args.hybrid_override_pattern, expected_pattern)
+        model = nemotron_h.Model(args)
+        self.model_test_runner(model, args.model_type, config["vocab_size"], 4)
+
+        # The legacy block-type spelling describes the same stack.
+        legacy = dict(config)
+        legacy["layers_block_type"] = ["attention", "mamba", "mlp", "mamba"]
+        self.assertEqual(
+            nemotron_h.ModelArgs.from_dict(legacy).hybrid_override_pattern,
+            expected_pattern,
+        )
+
+        # So does layer_types, the alias transformers exposes the list under.
+        aliased = {k: v for k, v in config.items() if k != "layers_block_type"}
+        aliased["layer_types"] = config["layers_block_type"]
+        self.assertEqual(
+            nemotron_h.ModelArgs.from_dict(aliased).hybrid_override_pattern,
+            expected_pattern,
+        )
+
+        # An unmappable block type is reported instead of raising a KeyError.
+        unknown = dict(config)
+        unknown["layers_block_type"] = ["sliding_attention"] * 4
+        with self.assertRaises(ValueError) as raised:
+            nemotron_h.ModelArgs.from_dict(unknown)
+        self.assertIn("sliding_attention", str(raised.exception))
+
+    def test_model_args_reports_missing_config_keys(self):
+        from mlx_lm.models import llama
+
+        with self.assertRaises(ValueError) as raised:
+            llama.ModelArgs.from_dict({"model_type": "llama", "hidden_size": 128})
+        message = str(raised.exception)
+        self.assertIn("llama", message)
+        self.assertIn("num_hidden_layers", message)
+
     def test_phi3small(self):
         from mlx_lm.models import phi3small
 

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -41,6 +41,38 @@ class TestUtils(unittest.TestCase):
         p2 = model_lazy.layers[0].mlp.up_proj.weight
         self.assertTrue(mx.allclose(p1, p2))
 
+    def test_load_config_decodes_tagged_floats(self):
+        # transformers tags non-finite floats so that config.json stays valid
+        # JSON for every parser; the tag has to be undone on the way back in.
+        model_path = Path(self.test_dir) / "tagged-floats"
+        model_path.mkdir(exist_ok=True)
+        with open(model_path / "config.json", "w") as f:
+            json.dump(
+                {
+                    "model_type": "nemotron_h",
+                    "time_step_limit": [0.0, {"__float__": "Infinity"}],
+                    "nested": {"lower": {"__float__": "-Infinity"}},
+                    "not_a_tag": {"__float__": 3, "other": 4},
+                },
+                f,
+            )
+
+        config = utils.load_config(model_path)
+        self.assertEqual(config["time_step_limit"], [0.0, float("inf")])
+        self.assertEqual(config["nested"]["lower"], float("-inf"))
+        self.assertEqual(config["not_a_tag"], {"__float__": 3, "other": 4})
+
+        # Saving tags them again, so a converted model keeps a config.json that
+        # any JSON parser can read, and reading it back gives the same floats.
+        utils.save_config(config, model_path / "config.json")
+        with open(model_path / "config.json") as f:
+            self.assertEqual(
+                json.load(f)["time_step_limit"], [0.0, {"__float__": "Infinity"}]
+            )
+        self.assertEqual(
+            utils.load_config(model_path)["time_step_limit"], config["time_step_limit"]
+        )
+
     def test_make_shards(self):
         from mlx_lm.models import llama
 


### PR DESCRIPTION
Loading or converting a Nemotron-H checkpoint written by a recent transformers release fails in three separate places:

- `num_hidden_layers` is a property of `layers_block_type` in transformers, so it never appears in the saved config and ModelArgs raises "missing 1 required positional argument: 'num_hidden_layers'". Derive the layer count from the block list instead, accept `layer_types` as an alias for `layers_block_type`, map both the current and the legacy block-type spellings, and raise a listed-values error for unknown ones.

- transformers tags non-finite floats, e.g. `{"__float__": "Infinity"}`, so that config.json stays valid JSON for every parser. load_config passed the tag through untouched, so time_step_limit reached mx.clip as a dict. Decode the tags on load and re-encode them on save, which keeps a converted config readable by both libraries.

- A config missing a required key surfaced as a bare `__init__` `TypeError` naming only the first missing argument and no model type. Report the model type and every missing key instead.

Each new test fails on main with the corresponding error.

- ☑️ I understand it is strictly prohibited to use AI to write PR description
- AI usage disclosure: 
The patch was co-written with Claude Code under my directions. Manual reviews and live tests were performed. 