### PR TITLE
Add XVERSE model remapping to reuse LLaMA implementation

### DIFF
--- a/mlx_lm/utils.py
+++ b/mlx_lm/utils.py
@@ -53,6 +53,7 @@ MODEL_REMAPPING = {
     "qwen2_5_vl": "qwen2_vl",
     "minimax_m2": "minimax",
     "iquestcoder": "llama",
+    "xverse": "llama",
     "gemma4_unified": "gemma4",  # encoder-free multimodal variant; vision/audio weights stripped by sanitize()
 }
 


### PR DESCRIPTION
## Requirements

- ☑️ I understand it is strictly prohibited to use AI to write PR description
- AI usage disclosure: Claude Code was used to compare the XVERSE config and weights against `llama.py`, write the repacking and comparison scripts in the linked gist, repack the `.bin` weights to safetensors, run the conversion and generation checks, and upload the converted checkpoint to the Hub. I reviewed the one-line diff and checked the generated and comparison outputs myself.

## Model information

- Name: XVERSE-7B-Chat (the dense XVERSE-13B/65B variants use the same architecture family and are expected to work with this remap, but only XVERSE-7B-Chat was tested here; XVERSE-MoE-A4.2B is not covered)
- Homepage: https://huggingface.co/xverse/XVERSE-7B-Chat
- Reference implementation: https://huggingface.co/xverse/XVERSE-7B-Chat/blob/main/modeling_xverse.py — this is remote code shipped with the checkpoint, not an implementation in Transformers.

## Supported checkpoints

- https://huggingface.co/mlx-community/XVERSE-7B-Chat-4bit
- The upstream `xverse/XVERSE-7B-Chat` checkpoint also works after repacking its `.bin` weights to safetensors as shown in [this gist](https://gist.github.com/a1bhinav/b7272842e8f78113b362f64587dc097f).

## Verification

Run mlx-lm command:

```console
mlx_lm.generate --model mlx-community/XVERSE-7B-Chat-4bit -p "The secret to baking a good cake is" -m 1024
```

Output:

```text
==========
more than just following a recipe. It involves understanding the ingredients, their functions, and how they interact with each other. Here are some key points:

1. Understand your ingredients: Know the texture, flavor, and appearance of each ingredient. For example, butter should be soft and creamy, while baking soda should be free-flowing and not have any lumps.

2. Follow the recipe: A good recipe is the foundation of a good cake. Make sure to follow the recipe exactly as it is written. Any changes can greatly affect the outcome.

3. Preheat your oven: Properly preheating your oven is crucial for achieving the right baking temperature. This ensures your cake bakes evenly.

4. Use the right tools: High-quality baking tools can make a big difference. For example, using a silicone spatula to mix the batter can prevent scraping the bowl clean, and parchment paper can prevent sticking.

5. Beat the eggs and sugar: The process of beating eggs and sugar together until it's light and fluffy is crucial. This creates air pockets that help the cake rise.

6. Sift your dry ingredients: Sifting dry ingredients like flour and baking powder can help to ensure they're well mixed and free of lumps, which can affect the texture and rise of your cake.

7. Don't overmix: Overmixing can cause the cake to rise unevenly or collapse. Always mix until just combined, then stop.

8. Don't overbake: The cake is done when it's golden and springs back when touched lightly. Overbaking can cause the cake to be dry.

9. Cool it down: Let your cake cool in the pan for a bit before removing it to finish cooling on a wire rack. This allows the cake to set up and prevents it from sticking to the pan.

10. Test yourself: Before serving, take a small piece of the cake and taste it. If it's too sweet, add a bit more flour or reduce the sugar. If it's too dry, add a bit more milk or butter.

Remember, baking is an art and each batch can be different. Don't be discouraged if your first few cakes don't turn out perfectly. With practice, you'll get the hang of it!
==========
Prompt: 23 tokens, 212.933 tokens-per-sec
Generation: 692 tokens, 65.622 tokens-per-sec
Peak memory: 4.696 GB
```

## Reference output

I ran the upstream XVERSE-7B-Chat bf16 model on MPS using the chat-templated version of the same input passed to mlx-lm, rather than the literal `pipeline()` snippet below. The reproduction and comparison scripts are available in [this gist](https://gist.github.com/a1bhinav/b7272842e8f78113b362f64587dc097f).

```python
from transformers import pipeline

pipeline = pipeline(task="text-generation", model="xverse/XVERSE-7B-Chat")
response = pipeline("the secret to baking a good cake is", max_new_tokens=1024)
print(response[0]["generated_text"])
```

Output:

```text
not a secret at all. It mainly involves the right ingredients, the right technique, and the right tools. Here are the key steps:

1. Ingredients: Use high-quality, fresh ingredients. This includes flour, sugar, eggs, butter, and baking powder or soda. The fresher the ingredients, the better the cake will taste.

2. Measurements: Be precise when measuring your ingredients. A little too much or too little of any ingredient can greatly affect the outcome.

3. Mixing: Mix the ingredients together until the batter is smooth and uniform. Overmixing can cause the cake to be tough.
```

This reference run was capped at 200 generated tokens and stopped at the token limit rather than EOS.

## Why a remap is sufficient

XVERSE's dense models use the same architecture as the existing LLaMA implementation in mlx-lm. The XVERSE configuration fields map onto `llama.ModelArgs`, the model weight names match, and the XVERSE-specific `rotary_emb.inv_freq` tensors are already discarded by LLaMA's `sanitize()`. Because of that, supporting `model_type: xverse` only requires mapping it to the existing `llama` implementation rather than adding a new model file.

I also compared the upstream and MLX bf16 models directly:

```text
shapes: mlx (23, 100534) | hf (23, 100534)
max abs logit diff : 0.906250
mean abs logit diff: 0.038396
argmax agreement   : 22/23
  pos 22: mlx 112 ('m') vs hf 97795 ('not')
HF  top-5 @pos22: [(97795, 'not', 17.5), (112, 'm', 17.375), (52, '1', 16.625), (105, 'f', 16.375), (100, 'a', 15.875)]
MLX top-5 @pos22: [(97795, 'not', 17.375), (112, 'm', 17.375), (52, '1', 16.75), (105, 'f', 16.375), (100, 'a', 15.9375)]
HF  gap between its top-2 : 0.1250
MLX gap between its top-2 : 0.0000
```

The next-token argmax agrees at 22/23 positions. At position 22, HF gives `not` a logit of `17.5000` and `m` `17.3750`, while MLX rounds both to `17.3750`, producing a bf16 tie. Over a separate 200-token greedy comparison, the first 63 generated tokens matched exactly; the runs then split at token 63 (`" The"` versus `" This"`), with both continuations remaining coherent and later converging again.

There are two checkpoint-level caveats. The upstream XVERSE-7B-Chat repository publishes `.bin` weights rather than safetensors, so they need to be repacked before mlx-lm conversion, and its legacy `tokenizer.json` needs a compatibility fix for current tokenizers. Those changes, along with the chat template, belong to the checkpoint rather than mlx-lm.

No test is added for this change, matching the existing treatment of other pure model remaps.

Closes #1818