### PR TITLE
Update DeepSeek-V3.2 to use PipelineMixin

### DIFF
--- a/mlx_lm/models/deepseek_v32.py
+++ b/mlx_lm/models/deepseek_v32.py
@@ -12,6 +12,7 @@ from .activations import swiglu
 from .base import BaseModelArgs, create_attention_mask, scaled_dot_product_attention
 from .cache import CacheList, KVCache
 from .mla import MultiLinear
+from .pipeline import PipelineMixin
 from .rope_utils import initialize_rope
 from .switch_layers import SwitchGLU
 
@@ -412,7 +413,7 @@ class DeepseekV32DecoderLayer(nn.Module):
         return h + r
 
 
-class DeepseekV32Model(nn.Module):
+class DeepseekV32Model(PipelineMixin, nn.Module):
     def __init__(self, config: ModelArgs):
         super().__init__()
         self.vocab_size = config.vocab_size
@@ -421,28 +422,7 @@ class DeepseekV32Model(nn.Module):
             DeepseekV32DecoderLayer(config, idx)
             for idx in range(config.num_hidden_layers)
         ]
-        self.start_idx = 0
-        self.end_idx = len(self.layers)
-        self.num_layers = self.end_idx
-
         self.norm = nn.RMSNorm(config.hidden_size, eps=config.rms_norm_eps)
-        self.pipeline_rank = 0
-        self.pipeline_size = 1
-
-    def pipeline(self, group):
-        # Split layers in reverse so rank=0 gets the last layers and
-        # rank=pipeline_size-1 gets the first
-        self.pipeline_rank = group.rank()
-        self.pipeline_size = group.size()
-        layers_per_rank = len(self.layers) // self.pipeline_size
-        extra = len(self.layers) - layers_per_rank * self.pipeline_size
-        if self.pipeline_rank < extra:
-            layers_per_rank += 1
-        self.start_idx = (self.pipeline_size - self.pipeline_rank - 1) * layers_per_rank
-        self.end_idx = self.start_idx + layers_per_rank
-        self.layers = self.layers[: self.end_idx]
-        self.layers[: self.start_idx] = [None] * self.start_idx
-        self.num_layers = len(self.layers) - self.start_idx
 
     def __call__(
         self,
@@ -455,23 +435,22 @@ class DeepseekV32Model(nn.Module):
         pipeline_size = self.pipeline_size
 
         if cache is None:
-            cache = [None] * self.num_layers
+            cache = [None] * len(self.pipeline_layers)
         mask = create_attention_mask(
-            h, cache[0][0] if cache[0] else None, return_array=True
+            h, cache[0][0] if cache and cache[0] else None, return_array=True
         )
 
         # Receive from the previous process in the pipeline
-
         if pipeline_rank < pipeline_size - 1:
             h = mx.distributed.recv_like(h, (pipeline_rank + 1))
 
-        for i in range(self.num_layers):
-            h = self.layers[self.start_idx + i](h, mask, cache[i])
+        for layer, c in zip(self.pipeline_layers, cache):
+            h = layer(h, mask, c)
 
         # Send to the next process in the pipeline
         if pipeline_rank != 0:
             h = mx.distributed.send(h, (pipeline_rank - 1) % pipeline_size)
-            if cache[-1] is not None:
+            if cache and cache[-1] is not None:
                 cache[-1][0].keys = mx.depends(cache[-1][0].keys, h)
 
         # Broadcast h while keeping it in the graph
@@ -646,7 +625,7 @@ class Model(nn.Module):
 
     @property
     def layers(self):
-        return self.model.layers[self.model.start_idx : self.model.end_idx]
+        return self.model.pipeline_layers
 
     @property
     def cast_predicate(self):

--- a/mlx_lm/models/deepseek_v32.py
+++ b/mlx_lm/models/deepseek_v32.py
@@ -437,7 +437,7 @@ class DeepseekV32Model(PipelineMixin, nn.Module):
         if cache is None:
             cache = [None] * len(self.pipeline_layers)
         mask = create_attention_mask(
-            h, cache[0][0] if cache and cache[0] else None, return_array=True
+            h, cache[0][0] if cache[0] else None, return_array=True
         )
 
         # Receive from the previous process in the pipeline
@@ -450,7 +450,7 @@ class DeepseekV32Model(PipelineMixin, nn.Module):
         # Send to the next process in the pipeline
         if pipeline_rank != 0:
             h = mx.distributed.send(h, (pipeline_rank - 1) % pipeline_size)
-            if cache and cache[-1] is not None:
+            if cache[-1] is not None:
                 cache[-1][0].keys = mx.depends(cache[-1][0].keys, h)
 
         # Broadcast h while keeping it in the graph

--- a/mlx_lm/models/qwen3_moe.py
+++ b/mlx_lm/models/qwen3_moe.py
@@ -260,9 +260,18 @@ class Model(nn.Module):
     def sanitize(self, weights):
         if self.args.tie_word_embeddings:
             weights.pop("lm_head.weight", None)
-        if "model.layers.0.mlp.experts.0.up_proj.weight" not in weights:
-            return weights
-        for l in range(self.args.num_hidden_layers):
+        # Presence-based, not a fixed layer-0 probe: under pipeline
+        # sharding, a rank only downloads its own local layers' weight
+        # files, so a raw (unstacked-experts) checkpoint may have no
+        # layer-0 key at all even though its own local layers still need
+        # stacking — a layer-0-only gate would skip them entirely.
+        local_moe_layers = sorted(
+            int(k.split(".")[2])
+            for k in weights
+            if k.startswith("model.layers.")
+            and k.endswith(".mlp.experts.0.up_proj.weight")
+        )
+        for l in local_moe_layers:
             prefix = f"model.layers.{l}"
             for n in ["up_proj", "down_proj", "gate_proj"]:
                 if f"{prefix}.mlp.experts.0.{n}.weight" in weights:

--- a/mlx_lm/models/qwen3_moe.py
+++ b/mlx_lm/models/qwen3_moe.py
@@ -260,18 +260,9 @@ class Model(nn.Module):
     def sanitize(self, weights):
         if self.args.tie_word_embeddings:
             weights.pop("lm_head.weight", None)
-        # Presence-based, not a fixed layer-0 probe: under pipeline
-        # sharding, a rank only downloads its own local layers' weight
-        # files, so a raw (unstacked-experts) checkpoint may have no
-        # layer-0 key at all even though its own local layers still need
-        # stacking — a layer-0-only gate would skip them entirely.
-        local_moe_layers = sorted(
-            int(k.split(".")[2])
-            for k in weights
-            if k.startswith("model.layers.")
-            and k.endswith(".mlp.experts.0.up_proj.weight")
-        )
-        for l in local_moe_layers:
+        if "model.layers.0.mlp.experts.0.up_proj.weight" not in weights:
+            return weights
+        for l in range(self.args.num_hidden_layers):
             prefix = f"model.layers.{l}"
             for n in ["up_proj", "down_proj", "gate_proj"]:
                 if f"{prefix}.mlp.experts.0.{n}.weight" in weights:

--- a/tests/model_parallel_tests.py
+++ b/tests/model_parallel_tests.py
@@ -5,7 +5,7 @@ import unittest
 
 import mlx.core as mx
 
-from mlx_lm.models import qwen3_moe
+from mlx_lm.models import deepseek_v32, qwen3_moe
 from mlx_lm.models.pipeline import PipelineMixin
 
 
@@ -169,6 +169,29 @@ class TestModelParallel(unittest.TestCase):
                 "max_position_embeddings": 256,
                 "tie_word_embeddings": False,
             },
+            {
+                "model_type": "deepseek_v32",
+                "vocab_size": 128,
+                "hidden_size": 64,
+                "index_head_dim": 16,
+                "index_n_heads": 2,
+                "index_topk": 4,
+                "intermediate_size": 128,
+                "moe_intermediate_size": 32,
+                "num_hidden_layers": 4,
+                "num_attention_heads": 4,
+                "num_key_value_heads": 4,
+                "n_shared_experts": 1,
+                "n_routed_experts": 4,
+                "kv_lora_rank": 8,
+                "q_lora_rank": 8,
+                "qk_rope_head_dim": 8,
+                "v_head_dim": 16,
+                "qk_nope_head_dim": 16,
+                "num_experts_per_tok": 2,
+                "first_k_dense_replace": 1,
+                "max_position_embeddings": 256,
+            },
         ]
         mx.random.seed(0)
         for config in test_configs:
@@ -246,15 +269,40 @@ class TestModelParallel(unittest.TestCase):
         }
 
         size = 2
-        args = qwen3_moe.ModelArgs.from_dict(config)
-        assigned = []
-        for rank in range(size):
-            model = qwen3_moe.Model(args)
-            model.model.pipeline(Group(rank, size))
-            assigned.extend(
-                i for i, l in enumerate(model.model.layers) if l is not None
-            )
-        self.assertEqual(sorted(assigned), list(range(7)))
+        dsv32_config = {
+            "model_type": "deepseek_v32",
+            "vocab_size": 128,
+            "hidden_size": 64,
+            "index_head_dim": 16,
+            "index_n_heads": 2,
+            "index_topk": 4,
+            "intermediate_size": 128,
+            "moe_intermediate_size": 32,
+            "num_hidden_layers": 7,
+            "num_attention_heads": 4,
+            "num_key_value_heads": 4,
+            "n_shared_experts": 1,
+            "n_routed_experts": 4,
+            "kv_lora_rank": 8,
+            "q_lora_rank": 8,
+            "qk_rope_head_dim": 8,
+            "v_head_dim": 16,
+            "qk_nope_head_dim": 16,
+            "num_experts_per_tok": 2,
+            "first_k_dense_replace": 1,
+            "max_position_embeddings": 256,
+        }
+        for arch, arch_config in ((qwen3_moe, config), (deepseek_v32, dsv32_config)):
+            with self.subTest(model_type=arch_config["model_type"]):
+                args = arch.ModelArgs.from_dict(arch_config)
+                assigned = []
+                for rank in range(size):
+                    model = arch.Model(args)
+                    model.model.pipeline(Group(rank, size))
+                    assigned.extend(
+                        i for i, l in enumerate(model.model.layers) if l is not None
+                    )
+                self.assertEqual(sorted(assigned), list(range(7)))
 
 
 if __name__ == "__main__":

--- a/tests/model_parallel_tests.py
+++ b/tests/model_parallel_tests.py
@@ -5,7 +5,7 @@ import unittest
 
 import mlx.core as mx
 
-from mlx_lm.models import deepseek_v32, qwen3_moe
+from mlx_lm.models import qwen3_moe
 from mlx_lm.models.pipeline import PipelineMixin
 
 
@@ -269,40 +269,15 @@ class TestModelParallel(unittest.TestCase):
         }
 
         size = 2
-        dsv32_config = {
-            "model_type": "deepseek_v32",
-            "vocab_size": 128,
-            "hidden_size": 64,
-            "index_head_dim": 16,
-            "index_n_heads": 2,
-            "index_topk": 4,
-            "intermediate_size": 128,
-            "moe_intermediate_size": 32,
-            "num_hidden_layers": 7,
-            "num_attention_heads": 4,
-            "num_key_value_heads": 4,
-            "n_shared_experts": 1,
-            "n_routed_experts": 4,
-            "kv_lora_rank": 8,
-            "q_lora_rank": 8,
-            "qk_rope_head_dim": 8,
-            "v_head_dim": 16,
-            "qk_nope_head_dim": 16,
-            "num_experts_per_tok": 2,
-            "first_k_dense_replace": 1,
-            "max_position_embeddings": 256,
-        }
-        for arch, arch_config in ((qwen3_moe, config), (deepseek_v32, dsv32_config)):
-            with self.subTest(model_type=arch_config["model_type"]):
-                args = arch.ModelArgs.from_dict(arch_config)
-                assigned = []
-                for rank in range(size):
-                    model = arch.Model(args)
-                    model.model.pipeline(Group(rank, size))
-                    assigned.extend(
-                        i for i, l in enumerate(model.model.layers) if l is not None
-                    )
-                self.assertEqual(sorted(assigned), list(range(7)))
+        args = qwen3_moe.ModelArgs.from_dict(config)
+        assigned = []
+        for rank in range(size):
+            model = qwen3_moe.Model(args)
+            model.model.pipeline(Group(rank, size))
+            assigned.extend(
+                i for i, l in enumerate(model.model.layers) if l is not None
+            )
+        self.assertEqual(sorted(assigned), list(range(7)))
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
- ☑️ I understand it is strictly prohibited to use AI to write PR description
- AI usage disclosure: AI was used to write the fix and the tests with some guidance from me. It went through many rounds of code reviews with a wide variety of agent frameworks and models to check for any issues with the core logic, styling, edge cases, etc.

The issue this is addressing:
deepseek_v32.py had its own independent pipeline implementation, duplicating logic that already existed in the shared PipelineMixin base class but not benefiting from bug fixes.

The solution:
Converted DeepseekV32Model to inherit PipelineMixin like every other pipeline-capable model so it benefits from the shared, tested pipeline logic (including uneven-split support) instead of maintaining another copy of similar code.

Note: an earlier version of this PR also fixed a layer-drop bug directly in pipeline.py's core split calculation, but that was independently fixed and merged upstream in https://github.com/ml-explore/mlx-lm/pull/1816 first so that part was dropped from this PR to avoid duplicating it.

I needed these fixes to get DeepSeek-V3.2-family models running correctly in pipeline mode on my 3-node cluster.