### PR TITLE
Add pipeline() support to Qwen2 and Qwen3-Next

### DIFF
--- a/mlx_lm/models/qwen2.py
+++ b/mlx_lm/models/qwen2.py
@@ -9,6 +9,7 @@ from mlx.nn.layers.distributed import shard_linear
 
 from .activations import swiglu
 from .base import BaseModelArgs, create_attention_mask, scaled_dot_product_attention
+from .pipeline import PipelineMixin
 from .rope_utils import initialize_rope
 
 
@@ -121,7 +122,7 @@ class TransformerBlock(nn.Module):
         return out
 
 
-class Qwen2Model(nn.Module):
+class Qwen2Model(PipelineMixin, nn.Module):
     def __init__(self, args: ModelArgs):
         super().__init__()
         self.args = args
@@ -145,12 +146,33 @@ class Qwen2Model(nn.Module):
         else:
             h = self.embed_tokens(inputs)
 
-        if cache is None:
-            cache = [None] * len(self.layers)
-        mask = create_attention_mask(h, cache[0])
+        pipeline_rank = self.pipeline_rank
+        pipeline_size = self.pipeline_size
 
-        for layer, c in zip(self.layers, cache):
+        if cache is None:
+            cache = [None] * len(self.pipeline_layers)
+        # Every layer is identical plain attention (no sliding-window or
+        # linear-attention layer types), so a single mask covers all of
+        # this rank's layers. cache can be empty if a rank ends up with
+        # zero local layers (e.g. more ranks than layers).
+        mask = create_attention_mask(h, cache[0] if cache else None)
+
+        # Receive from the previous process in the pipeline
+        if pipeline_rank < pipeline_size - 1:
+            h = mx.distributed.recv_like(h, (pipeline_rank + 1))
+
+        for layer, c in zip(self.pipeline_layers, cache):
             h = layer(h, mask, c)
+
+        # Send to the next process in the pipeline
+        if pipeline_rank != 0:
+            h = mx.distributed.send(h, (pipeline_rank - 1) % pipeline_size)
+            if cache and cache[-1] is not None:
+                cache[-1].keys = mx.depends(cache[-1].keys, h)
+
+        # Broadcast h while keeping it in the graph
+        if pipeline_size > 1:
+            h = mx.distributed.all_gather(h)[: h.shape[0]]
 
         return self.norm(h)
 
@@ -218,4 +240,4 @@ class Model(nn.Module):
 
     @property
     def layers(self):
-        return self.model.layers
+        return self.model.pipeline_layers

--- a/mlx_lm/models/qwen3_next.py
+++ b/mlx_lm/models/qwen3_next.py
@@ -494,27 +494,27 @@ class Model(nn.Module):
         return [ArraysCache(size=2) if l.is_linear else KVCache() for l in self.layers]
 
     def sanitize(self, weights):
-        # Presence-based, not a fixed layer-0 probe: under pipeline
-        # sharding, a rank only downloads its own local layers' weight
-        # files, so a raw (unstacked-experts) checkpoint may have no
-        # layer-0 key at all even though its own local layers still need
-        # stacking. Likewise, only stack the layers actually present
-        # locally — iterating every layer in the config would KeyError
-        # popping a layer this rank doesn't own.
-        local_moe_layers = sorted(
+        # Presence-based, not a fixed layer-0 probe: whether layer 0 is
+        # an MoE layer is config-driven (decoder_sparse_step,
+        # mlp_only_layers), so a layer-0-only gate would wrongly skip
+        # stacking for every layer on any config where it isn't. Also
+        # only stack the layers actually present in weights — iterating
+        # every layer in the config would KeyError popping a layer whose
+        # key isn't in weights at all.
+        moe_layers = sorted(
             int(k.split(".")[2])
             for k in weights
             if k.startswith("model.layers.")
             and k.endswith(".mlp.experts.0.up_proj.weight")
         )
-        if not local_moe_layers:
+        if not moe_layers:
             return weights
         weights = {key: value for key, value in weights.items() if "mtp." not in key}
 
         if self.args.tie_word_embeddings:
             weights.pop("lm_head.weight", None)
 
-        for l in local_moe_layers:
+        for l in moe_layers:
             prefix = f"model.layers.{l}.mlp"
             for n in ["up_proj", "down_proj", "gate_proj"]:
                 to_join = [

--- a/mlx_lm/models/qwen3_next.py
+++ b/mlx_lm/models/qwen3_next.py
@@ -19,6 +19,7 @@ from .base import (
 )
 from .cache import ArraysCache, KVCache
 from .gated_delta import gated_delta_update
+from .pipeline import PipelineMixin
 from .rope_utils import initialize_rope
 from .switch_layers import SwitchGLU
 
@@ -390,7 +391,7 @@ class Qwen3NextDecoderLayer(nn.Module):
         return out
 
 
-class Qwen3NextModel(nn.Module):
+class Qwen3NextModel(PipelineMixin, nn.Module):
     def __init__(self, args: ModelArgs):
         super().__init__()
         self.embed_tokens = nn.Embedding(args.vocab_size, args.hidden_size)
@@ -402,6 +403,18 @@ class Qwen3NextModel(nn.Module):
         self.ssm_idx = 0
         self.fa_idx = args.full_attention_interval - 1
 
+    def pipeline(self, group, split=None):
+        super().pipeline(group, split=split)
+        self.ssm_idx = None
+        self.fa_idx = None
+        for e, l in enumerate(self.pipeline_layers):
+            if self.ssm_idx is None and l.is_linear:
+                self.ssm_idx = e
+            elif self.fa_idx is None and not l.is_linear:
+                self.fa_idx = e
+            if self.ssm_idx is not None and self.fa_idx is not None:
+                break
+
     def __call__(
         self,
         inputs: mx.array,
@@ -409,15 +422,45 @@ class Qwen3NextModel(nn.Module):
     ) -> mx.array:
         hidden_states = self.embed_tokens(inputs)
 
+        pipeline_rank = self.pipeline_rank
+        pipeline_size = self.pipeline_size
+
         if cache is None:
-            cache = [None] * len(self.layers)
+            cache = [None] * len(self.pipeline_layers)
 
-        fa_mask = create_attention_mask(hidden_states, cache[self.fa_idx])
-        ssm_mask = create_ssm_mask(hidden_states, cache[self.ssm_idx])
+        fa_mask = None
+        ssm_mask = None
+        if self.fa_idx is not None:
+            fa_mask = create_attention_mask(hidden_states, cache[self.fa_idx])
+        if self.ssm_idx is not None:
+            ssm_mask = create_ssm_mask(hidden_states, cache[self.ssm_idx])
 
-        for layer, c in zip(self.layers, cache):
+        # Receive from the previous process in the pipeline
+        if pipeline_rank < pipeline_size - 1:
+            hidden_states = mx.distributed.recv_like(hidden_states, (pipeline_rank + 1))
+
+        for layer, c in zip(self.pipeline_layers, cache):
             mask = ssm_mask if layer.is_linear else fa_mask
             hidden_states = layer(hidden_states, mask=mask, cache=c)
+
+        # Send to the next process in the pipeline
+        if pipeline_rank != 0:
+            hidden_states = mx.distributed.send(
+                hidden_states, (pipeline_rank - 1) % pipeline_size
+            )
+            if cache and cache[-1] is not None:
+                # KVCache (full-attention) exposes .keys directly;
+                # ArraysCache (linear/GatedDeltaNet) is indexed instead.
+                if hasattr(cache[-1], "keys"):
+                    cache[-1].keys = mx.depends(cache[-1].keys, hidden_states)
+                else:
+                    cache[-1][0] = mx.depends(cache[-1][0], hidden_states)
+
+        # Broadcast h while keeping it in the graph
+        if pipeline_size > 1:
+            hidden_states = mx.distributed.all_gather(hidden_states)[
+                : hidden_states.shape[0]
+            ]
 
         return self.norm(hidden_states)
 
@@ -445,20 +488,33 @@ class Model(nn.Module):
 
     @property
     def layers(self):
-        return self.model.layers
+        return self.model.pipeline_layers
 
     def make_cache(self):
         return [ArraysCache(size=2) if l.is_linear else KVCache() for l in self.layers]
 
     def sanitize(self, weights):
-        if "model.layers.0.mlp.experts.0.up_proj.weight" not in weights:
+        # Presence-based, not a fixed layer-0 probe: under pipeline
+        # sharding, a rank only downloads its own local layers' weight
+        # files, so a raw (unstacked-experts) checkpoint may have no
+        # layer-0 key at all even though its own local layers still need
+        # stacking. Likewise, only stack the layers actually present
+        # locally — iterating every layer in the config would KeyError
+        # popping a layer this rank doesn't own.
+        local_moe_layers = sorted(
+            int(k.split(".")[2])
+            for k in weights
+            if k.startswith("model.layers.")
+            and k.endswith(".mlp.experts.0.up_proj.weight")
+        )
+        if not local_moe_layers:
             return weights
         weights = {key: value for key, value in weights.items() if "mtp." not in key}
 
         if self.args.tie_word_embeddings:
             weights.pop("lm_head.weight", None)
 
-        for l in range(self.args.num_hidden_layers):
+        for l in local_moe_layers:
             prefix = f"model.layers.{l}.mlp"
             for n in ["up_proj", "down_proj", "gate_proj"]:
                 to_join = [

--- a/tests/model_parallel_tests.py
+++ b/tests/model_parallel_tests.py
@@ -5,7 +5,7 @@ import unittest
 
 import mlx.core as mx
 
-from mlx_lm.models import qwen3_moe
+from mlx_lm.models import qwen2, qwen3_moe, qwen3_next
 from mlx_lm.models.pipeline import PipelineMixin
 
 
@@ -192,6 +192,45 @@ class TestModelParallel(unittest.TestCase):
                 "first_k_dense_replace": 1,
                 "max_position_embeddings": 256,
             },
+            {
+                "model_type": "qwen2",
+                "vocab_size": 128,
+                "hidden_size": 64,
+                "intermediate_size": 128,
+                "num_hidden_layers": 4,
+                "num_attention_heads": 4,
+                "num_key_value_heads": 2,
+                "rms_norm_eps": 1e-5,
+                "rope_theta": 10000.0,
+                "max_position_embeddings": 256,
+                "tie_word_embeddings": False,
+            },
+            {
+                "model_type": "qwen3_next",
+                "vocab_size": 128,
+                "hidden_size": 64,
+                "num_hidden_layers": 4,
+                "intermediate_size": 128,
+                "num_attention_heads": 4,
+                "num_key_value_heads": 2,
+                "head_dim": 16,
+                "linear_num_value_heads": 4,
+                "linear_num_key_heads": 2,
+                "linear_key_head_dim": 16,
+                "linear_value_head_dim": 16,
+                "linear_conv_kernel_dim": 4,
+                "num_experts": 4,
+                "num_experts_per_tok": 2,
+                "decoder_sparse_step": 1,
+                "shared_expert_intermediate_size": 32,
+                "mlp_only_layers": [0],
+                "moe_intermediate_size": 32,
+                "rms_norm_eps": 1e-5,
+                "rope_theta": 10000.0,
+                "partial_rotary_factor": 0.25,
+                "max_position_embeddings": 256,
+                "full_attention_interval": 4,
+            },
         ]
         mx.random.seed(0)
         for config in test_configs:
@@ -269,15 +308,74 @@ class TestModelParallel(unittest.TestCase):
         }
 
         size = 2
-        args = qwen3_moe.ModelArgs.from_dict(config)
-        assigned = []
-        for rank in range(size):
-            model = qwen3_moe.Model(args)
-            model.model.pipeline(Group(rank, size))
-            assigned.extend(
-                i for i, l in enumerate(model.model.layers) if l is not None
-            )
-        self.assertEqual(sorted(assigned), list(range(7)))
+        qwen2_config = {
+            "model_type": "qwen2",
+            "vocab_size": 128,
+            "hidden_size": 64,
+            "intermediate_size": 128,
+            "num_hidden_layers": 7,
+            "num_attention_heads": 4,
+            "num_key_value_heads": 2,
+            "rms_norm_eps": 1e-5,
+            "rope_theta": 10000.0,
+            "max_position_embeddings": 256,
+            "tie_word_embeddings": False,
+        }
+        qwen3_next_config = {
+            "model_type": "qwen3_next",
+            "vocab_size": 128,
+            "hidden_size": 64,
+            "num_hidden_layers": 7,
+            "intermediate_size": 128,
+            "num_attention_heads": 4,
+            "num_key_value_heads": 2,
+            "head_dim": 16,
+            "linear_num_value_heads": 4,
+            "linear_num_key_heads": 2,
+            "linear_key_head_dim": 16,
+            "linear_value_head_dim": 16,
+            "linear_conv_kernel_dim": 4,
+            "num_experts": 4,
+            "num_experts_per_tok": 2,
+            "decoder_sparse_step": 1,
+            "shared_expert_intermediate_size": 32,
+            "mlp_only_layers": [0],
+            "moe_intermediate_size": 32,
+            "rms_norm_eps": 1e-5,
+            "rope_theta": 10000.0,
+            "partial_rotary_factor": 0.25,
+            "max_position_embeddings": 256,
+            "full_attention_interval": 4,
+        }
+        for arch, arch_config in (
+            (qwen3_moe, config),
+            (qwen2, qwen2_config),
+            (qwen3_next, qwen3_next_config),
+        ):
+            with self.subTest(model_type=arch_config["model_type"]):
+                args = arch.ModelArgs.from_dict(arch_config)
+                assigned = []
+                for rank in range(size):
+                    model = arch.Model(args)
+                    model.model.pipeline(Group(rank, size))
+                    assigned.extend(
+                        i for i, l in enumerate(model.model.layers) if l is not None
+                    )
+                self.assertEqual(sorted(assigned), list(range(7)))
+
+        # Hybrid edge case: 7 layers on 2 ranks puts layers 0-2 (all linear,
+        # full_attention_interval=4) on the last rank; its rescan must leave
+        # fa_idx as None rather than pointing at a wrong layer. Rank 0 holds
+        # layers 3-6, so its full-attention layer sits at local index 0.
+        args = qwen3_next.ModelArgs.from_dict(qwen3_next_config)
+        model = qwen3_next.Model(args)
+        model.model.pipeline(Group(1, size))
+        self.assertIsNone(model.model.fa_idx)
+        self.assertEqual(model.model.ssm_idx, 0)
+        model = qwen3_next.Model(args)
+        model.model.pipeline(Group(0, size))
+        self.assertEqual(model.model.fa_idx, 0)
+        self.assertEqual(model.model.ssm_idx, 1)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
- ☑️ I understand it is strictly prohibited to use AI to write PR description
- AI usage disclosure: AI was used to write the fix and the tests with some guidance from me. It went through many rounds of code reviews with a wide variety of agent frameworks and models to check for any issues with the core logic, styling, edge cases, etc.

The issue this is addressing:
Pipeline parallelism wasn't supported for Qwen2 and Qwen3-Next model architectures. Attempting to use pipeline mode would result in it hanging after a "not supported" error happened on a background thread.

The solution:
Added support for pipeline parallelism for Qwen2 and Qwen3-Next model architectures. It follows the same pattern used for other models with similar structures.

I needed this change so I could properly use pipeline processing on my 3 node cluster with Qwen2 and Qwen3-Next models. I've been running it successfully for a while with great results.