### PR TITLE
Fix NameError in benchmark script

### DIFF
--- a/mlx_lm/benchmark.py
+++ b/mlx_lm/benchmark.py
@@ -125,7 +125,7 @@ def main():
     prompt = prompts[0]
 
     def single_bench():
-        for _ in stream_generate(
+        for _response in stream_generate(
             model,
             tokenizer,
             prompt,
@@ -133,7 +133,7 @@ def main():
             prefill_step_size=args.prefill_step_size,
         ):
             pass
-        return response
+        return _response
 
     def batch_bench():
         return batch_generate(


### PR DESCRIPTION
This PR is:
- to name error issue in the benchmark script (introduced from lint cleanup PR #1860 )
- to rename the loop variable to `_response` and the return to `return _response`

note: In Python, `_response` is still a normal variable. The leading underscore tells lint tools: "this variable is intentionally unused in the loop body” since we return it after the loop, it still carries the last streamed response.


Before:
<img width="1047" height="182" alt="Screenshot 2026-09-09 at 10 49 36 PM" src="https://github.com/user-attachments/assets/6f546e8e-28a9-418e-b194-f38a2960875e" />


After:
<img width="1053" height="102" alt="Screenshot 2026-09-09 at 10 49 41 PM" src="https://github.com/user-attachments/assets/262b45b5-1ec6-467e-a7f7-53fac6f3b456" />


- ☑️ I understand it is strictly prohibited to use AI to write PR description
