### PR TITLE
Parse gpt-oss's harmony channel format in non-streaming completions

### DIFF
--- a/mlx_lm/harmony.py
+++ b/mlx_lm/harmony.py
@@ -1,0 +1,75 @@
+"""Parsing for OpenAI's "harmony" multi-channel response format (gpt-oss).
+
+gpt-oss models separate internal reasoning from user-facing output with a
+small set of control tokens rather than a single <think>/</think> pair:
+
+    <|channel|>analysis<|message|>...internal reasoning...<|end|>
+    <|start|>assistant<|channel|>final<|message|>...user-facing answer...
+
+``<|channel|>`` is a single combined special token shared by every channel
+boundary; the channel name ("analysis", "commentary", or "final") is
+generated as ordinary text between ``<|channel|>`` and ``<|message|>``, and a
+``commentary`` channel may additionally carry a ``<|constrain|>FORMAT``
+segment (e.g. for a tool call's JSON payload). This does not fit the
+existing think-token detection in ``tokenizer_utils._infer_thinking``, which
+only matches a fixed single start/end token pair — see ``has_harmony_format``
+for the dedicated detection this module pairs with.
+
+Tracking: https://github.com/ml-explore/mlx-lm/issues/875 (channel token
+leakage into ``message.content``, reported against 0.30.6, reproduced here
+against 0.31.3 with mlx-community/gpt-oss-20b-MXFP4-Q8 via aider's
+whole-file-edit client).
+"""
+
+import re
+
+HARMONY_CONTROL_TOKENS = ("<|channel|>", "<|message|>", "<|start|>", "<|end|>")
+
+_SEGMENT_RE = re.compile(
+    r"<\|channel\|>(?P<name>[a-zA-Z_]+)"
+    r"(?:<\|constrain\|>(?P<fmt>[^<]*))?"
+    r"<\|message\|>(?P<body>.*?)"
+    r"(?=<\|end\|>|<\|return\|>|<\|start\|>|<\|channel\|>|\Z)",
+    re.DOTALL,
+)
+
+
+def parse_harmony_response(text: str) -> tuple[str, str]:
+    """Split harmony-formatted text into (content, reasoning).
+
+    Text with no channel markers at all is returned unchanged as content
+    with empty reasoning — a safe no-op when called on non-harmony output.
+    "analysis" channel bodies become reasoning; every other channel name
+    ("final", "commentary", or anything unrecognized) contributes to
+    content, concatenated in generation order — a commentary channel's
+    tool-call payload is kept in content rather than dropped, matching the
+    behavior requested in ml-explore/mlx-lm#875.
+
+    A response truncated mid-channel (e.g. hit the completion length cap
+    before a "final" channel ever started) correctly yields empty content
+    and a partial reasoning string, rather than raising or fabricating an
+    end marker that was never generated.
+    """
+    matches = list(_SEGMENT_RE.finditer(text))
+    if not matches:
+        return text, ""
+    content_parts = []
+    reasoning_parts = []
+    for m in matches:
+        (reasoning_parts if m.group("name") == "analysis" else content_parts).append(
+            m.group("body")
+        )
+    return "".join(content_parts), "".join(reasoning_parts)
+
+
+def has_harmony_format(tokenizer) -> bool:
+    """True if `tokenizer`'s vocabulary declares the full harmony control set.
+
+    Checked directly against the vocabulary rather than inferred from a
+    model-family name, so this activates only for a tokenizer that actually
+    has all four control tokens available — never a false positive for an
+    unrelated model that merely happens to use one of these token strings
+    for something else.
+    """
+    vocab = tokenizer.get_vocab()
+    return all(t in vocab for t in HARMONY_CONTROL_TOKENS)

--- a/mlx_lm/server.py
+++ b/mlx_lm/server.py
@@ -38,6 +38,7 @@ from .generate import (
     SequenceStateMachine,
     stream_generate,
 )
+from .harmony import has_harmony_format, parse_harmony_response
 from .models.cache import (
     LRUPromptCache,
     make_prompt_cache,
@@ -1295,6 +1296,24 @@ class APIHandler(BaseHTTPRequestHandler):
             dict: A dictionary containing the response, in the same format as
               OpenAI's API.
         """
+        # gpt-oss-family models emit OpenAI's "harmony" multi-channel format
+        # (<|channel|>NAME<|message|>BODY<|end|>...), which the reasoning-split
+        # state machine above never detects (it only matches a single fixed
+        # start/end token pair, e.g. <think>/</think> — harmony's <|channel|>
+        # is one token shared across every channel boundary, with the channel
+        # name generated as ordinary text). Unpatched, raw channel markers
+        # land verbatim in message.content. Only applied when NOT streaming:
+        # the harmony parser needs the fully-accumulated text to correctly
+        # attribute a channel's content, which only the non-streaming path
+        # ever has in `text`; streaming-safe incremental splitting is a
+        # follow-up. See mlx_lm.harmony and ml-explore/mlx-lm#875.
+        if not self.stream and text:
+            tokenizer = self.response_generator.model_provider.tokenizer
+            if tokenizer is not None and has_harmony_format(tokenizer):
+                text, harmony_reasoning = parse_harmony_response(text)
+                if harmony_reasoning:
+                    reasoning_text = (reasoning_text or "") + harmony_reasoning
+
         token_logprobs = token_logprobs or []
         top_logprobs = top_tokens or []
         tool_calls = tool_calls or []

--- a/tests/test_harmony.py
+++ b/tests/test_harmony.py
@@ -1,0 +1,104 @@
+# Copyright © 2026 Apple Inc.
+
+import unittest
+
+from mlx_lm.harmony import has_harmony_format, parse_harmony_response
+
+
+class _FakeTokenizer:
+    def __init__(self, vocab):
+        self._vocab = vocab
+
+    def get_vocab(self):
+        return self._vocab
+
+
+HARMONY_VOCAB = {
+    "<|channel|>": 200005,
+    "<|message|>": 200008,
+    "<|start|>": 200006,
+    "<|end|>": 200007,
+    "<|return|>": 200002,
+    "<|constrain|>": 200003,
+}
+
+
+class TestHasHarmonyFormat(unittest.TestCase):
+    def test_full_control_set_detected(self):
+        self.assertTrue(has_harmony_format(_FakeTokenizer(HARMONY_VOCAB)))
+
+    def test_plain_vocab_not_detected(self):
+        self.assertFalse(has_harmony_format(_FakeTokenizer({"hello": 1, "world": 2})))
+
+    def test_partial_control_set_not_detected(self):
+        # Missing <|end|> -- a tokenizer with only some of these strings
+        # (coincidentally, for something unrelated) must not false-positive.
+        partial = {k: v for k, v in HARMONY_VOCAB.items() if k != "<|end|>"}
+        self.assertFalse(has_harmony_format(_FakeTokenizer(partial)))
+
+
+class TestParseHarmonyResponse(unittest.TestCase):
+    def test_plain_text_passthrough(self):
+        text = "def f():\n    return 1"
+        content, reasoning = parse_harmony_response(text)
+        self.assertEqual(content, text)
+        self.assertEqual(reasoning, "")
+
+    def test_analysis_then_final_no_fence(self):
+        text = (
+            "<|channel|>analysis<|message|>Just provide function.<|end|>"
+            "<|start|>assistant<|channel|>final<|message|>"
+            "def square(n):\n    return n * n"
+        )
+        content, reasoning = parse_harmony_response(text)
+        self.assertEqual(content, "def square(n):\n    return n * n")
+        self.assertEqual(reasoning, "Just provide function.")
+        self.assertNotIn("<|", content)
+
+    def test_analysis_then_final_fenced(self):
+        text = (
+            "<|channel|>analysis<|message|>Reasoning about the discount "
+            "algorithm.<|end|><|start|>assistant<|channel|>final<|message|>"
+            "book_store.py\n```python\ndef total(basket):\n    return 0\n```"
+        )
+        content, reasoning = parse_harmony_response(text)
+        self.assertTrue(content.startswith("book_store.py"))
+        self.assertIn("discount algorithm", reasoning)
+        self.assertNotIn("<|", content)
+
+    def test_commentary_tool_call_kept_in_content(self):
+        # ml-explore/mlx-lm#875's own expected behavior: a commentary
+        # channel's tool-call payload belongs in content, not dropped.
+        text = (
+            "<|channel|>analysis<|message|>User wants Telegram message.<|end|>"
+            "<|start|>assistant<|channel|>commentary<|constrain|>json<|message|>"
+            "<send_telegram_message><chat_id>12345</chat_id></send_telegram_message>"
+        )
+        content, reasoning = parse_harmony_response(text)
+        self.assertEqual(
+            content,
+            "<send_telegram_message><chat_id>12345</chat_id></send_telegram_message>",
+        )
+        self.assertIn("Telegram", reasoning)
+
+    def test_truncated_mid_analysis_yields_empty_content(self):
+        # Generation hit the completion length cap before any "final"
+        # channel ever started -- must not fabricate content or raise.
+        text = "<|channel|>analysis<|message|>Still reasoning about the appro"
+        content, reasoning = parse_harmony_response(text)
+        self.assertEqual(content, "")
+        self.assertIn("Still reasoning", reasoning)
+
+    def test_multiple_analysis_segments_concatenate(self):
+        text = (
+            "<|channel|>analysis<|message|>First thought.<|end|>"
+            "<|start|>assistant<|channel|>analysis<|message|>Second thought.<|end|>"
+            "<|start|>assistant<|channel|>final<|message|>answer"
+        )
+        content, reasoning = parse_harmony_response(text)
+        self.assertEqual(content, "answer")
+        self.assertEqual(reasoning, "First thought.Second thought.")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

Fixes #875 (channel token leakage into `message.content` — the empty-string
`tool_call_start` bug and hallucinated tool execution reported in that same
issue are separate root causes in the tool-calling path and are not
addressed here).

`mlx_lm.server` has no protocol awareness of OpenAI's "harmony" multi-channel
response format used by gpt-oss models: `<|channel|>NAME<|message|>BODY<|end|>`
segments (`analysis`/`commentary`/`final`), with an optional
`<|constrain|>FORMAT` before a `commentary` channel's payload. The existing
reasoning-split state machine (`TokenizerWrapper._infer_thinking`) only
detects a fixed single start/end token pair (e.g. `<think>`/`</think>`),
which never matches gpt-oss's vocabulary — `<|channel|>` is one combined
token shared across every channel boundary, with the channel name generated
as ordinary text rather than a fixed control token. Every response currently
passes through unprocessed: raw channel markers land verbatim in
`message.content`.

I hit this reproducibly with `mlx-community/gpt-oss-20b-MXFP4-Q8` served via
`mlx_lm.server`, driven by aider's own benchmark harness (whole-file-edit
client, non-streaming). It breaks in two distinct ways, not just cosmetically:

1. When the final-channel answer isn't wrapped in a clean fence, a
   whole-format parser can misparse the harmony-marker-adjacent text as file
   content — observed: the client parsed
   `<|end|><|start|>assistant<|channel|>final<|message|>beer_song.py` as one
   garbled filename token, then wrote unrelated prompt text into the file.
2. Every multi-turn retry is a **guaranteed** failure once a prior turn's raw
   `<|channel|>`-tagged content is replayed back as conversation history:
   litellm's own gpt-oss format validator rejects it outright (`404
   NotFoundError: "You have passed a message containing <|channel|> tags in
   the content field..."`).

## What this does

- New `mlx_lm/harmony.py`:
  - `has_harmony_format(tokenizer)` detects the full control-token set
    (`<|channel|>`, `<|message|>`, `<|start|>`, `<|end|>`) directly against
    the vocabulary — never a model-name guess, so it only activates for a
    tokenizer that genuinely declares all four.
  - `parse_harmony_response(text)` splits channel segments into
    `(content, reasoning)`: `analysis` bodies become reasoning; every other
    channel (including a `commentary` channel's tool-call payload, matching
    this issue's own stated expected behavior) becomes content, concatenated
    in generation order. A response truncated mid-channel (hit the
    completion length cap before a `final` channel ever started) correctly
    yields empty content and a partial reasoning string, rather than raising
    or fabricating an end marker that was never generated.
- Hooked into `APIHandler.generate_response` — the single choke point where
  the fully-accumulated **non-streaming** text becomes `message.content`.
  Gated so it's a verified no-op for any tokenizer without the harmony
  control tokens, and for the streaming path, which never has the full text
  in one place — incremental harmony-aware splitting for streaming is a
  natural follow-up I didn't attempt here, since my own use case (and
  aider's benchmark harness in general) already runs `stream=False`.

## Testing

9 new unit tests in `tests/test_harmony.py`, all pure-Python (no model
download needed): detection (full/partial/absent control-token sets),
plain-text passthrough (no-op guarantee), unfenced and fenced final-channel
content, a commentary/tool-call channel, a response truncated mid-analysis,
and multiple analysis segments concatenating correctly.

Also manually verified against real captured `gpt-oss-20b` responses from a
live `mlx_lm.server` instance (not included in the test suite, since that
needs a live model) — before/after diffs of the exact leaking responses
described in #875, confirmed clean.

`black --check` passes on all three changed/added files.