### PR TITLE
Chunkwise-parallel gated delta rule for training

### DIFF
--- a/mlx_lm/models/gated_delta.py
+++ b/mlx_lm/models/gated_delta.py
@@ -548,6 +548,29 @@ def gated_delta_ops(
     mask: Optional[mx.array] = None,
 ) -> Tuple[mx.array, mx.array]:
     """
+    Ops-based gated delta rule, used whenever the Metal kernel is unavailable.
+
+    That includes every training step, since the kernel has no VJP. Scalar
+    gating without a mask takes the chunkwise-parallel path, which is
+    equivalent to the sequential recurrence but retains O(T / chunk) states
+    for autograd instead of one per timestep; everything else falls back to
+    :func:`gated_delta_sequential`.
+    """
+    if mask is None and g.ndim == 3:
+        return gated_delta_chunkwise(q, k, v, g, beta, state)
+    return gated_delta_sequential(q, k, v, g, beta, state, mask)
+
+
+def gated_delta_sequential(
+    q: mx.array,
+    k: mx.array,
+    v: mx.array,
+    g: mx.array,
+    beta: mx.array,
+    state: Optional[mx.array] = None,
+    mask: Optional[mx.array] = None,
+) -> Tuple[mx.array, mx.array]:
+    """
     Ops-based reference implementation for prompt prefill (sequential loop).
     Supports both scalar and vectorized gating.
 
@@ -584,6 +607,127 @@ def gated_delta_ops(
         ys.append(y)
     y = mx.stack(ys, axis=1)
     return y, state
+
+
+def _unit_tri_inv(m: mx.array) -> mx.array:
+    """Inverse of a unit lower-triangular matrix, built from matmuls.
+
+    ``mx.linalg.tri_inv`` is CPU-only and has no VJP, so it cannot appear in a
+    training graph. The 2x2 block identity
+
+        [A 0; C B]^-1 = [A^-1 0; -B^-1 C A^-1, B^-1]
+
+    gives the inverse in log2(n) levels of batched matmuls, which autodiff
+    handles natively and which parallelizes over the batch.
+    """
+    n = m.shape[-1]
+    if n == 1:
+        return mx.ones_like(m)
+    h = n // 2
+    a, c, b = m[..., :h, :h], m[..., h:, :h], m[..., h:, h:]
+    a_inv, b_inv = _unit_tri_inv(a), _unit_tri_inv(b)
+    lower = -(b_inv @ c @ a_inv)
+    zeros = mx.zeros_like(mx.swapaxes(lower, -1, -2))
+    return mx.concatenate(
+        [
+            mx.concatenate([a_inv, zeros], axis=-1),
+            mx.concatenate([lower, b_inv], axis=-1),
+        ],
+        axis=-2,
+    )
+
+
+def gated_delta_chunkwise(
+    q: mx.array,
+    k: mx.array,
+    v: mx.array,
+    g: mx.array,
+    beta: mx.array,
+    state: Optional[mx.array] = None,
+    mask: Optional[mx.array] = None,
+    chunk_size: int = 64,
+) -> Tuple[mx.array, mx.array]:
+    """Chunkwise-parallel gated delta rule, for training.
+
+    Equivalent to :func:`gated_delta_ops` but splits the sequence into chunks of
+    ``chunk_size`` and evaluates each chunk with matmuls, so autograd retains
+    O(T / chunk_size) states instead of one per timestep.
+
+    Writing the recurrence as ``S_t = g_t S_{t-1} + u_t k_t^T`` with
+    ``u_t = b_t (v_t - g_t S_{t-1} k_t)`` telescopes within a chunk::
+
+        S_j = G_j S_0 + sum_{i<=j} (G_j / G_i) u_i k_i^T,  G_j = prod_{m<=j} g_m
+
+    and the ``u_i`` satisfy a unit lower-triangular system solved once per
+    chunk. Quantities are carried as ratios ``G_j / G_i`` (bounded by 1 for
+    i <= j) rather than as ``G_j``, which underflows on strongly decaying heads
+    and sends the intermediate writes to infinity.
+
+    Scalar gating only; vectorized gating and masks fall back to the caller.
+
+    Shapes match :func:`gated_delta_ops`.
+    """
+    B, T, Hk, Dk = q.shape
+    Hv, Dv = v.shape[-2:]
+    out_dtype = q.dtype
+    if state is None:
+        state = mx.zeros((B, Hv, Dv, Dk), dtype=mx.float32)
+
+    if (repeat_factor := Hv // Hk) > 1:
+        q = mx.repeat(q, repeat_factor, -2)
+        k = mx.repeat(k, repeat_factor, -2)
+
+    # [B, T, H, D] -> [B, H, T, D]; accumulate in fp32 as the kernels do
+    q, k, v = (mx.swapaxes(x, 1, 2).astype(mx.float32) for x in (q, k, v))
+    g = mx.swapaxes(g, 1, 2).astype(mx.float32)
+    beta = mx.swapaxes(beta, 1, 2).astype(mx.float32)
+
+    pad = (-T) % chunk_size
+    if pad:
+        # padding must neither decay the state (g = 1) nor write to it (beta = 0)
+        widths = [(0, 0), (0, 0), (0, pad), (0, 0)]
+        q, k, v = (mx.pad(x, widths) for x in (q, k, v))
+        g = mx.pad(g, widths[:3], constant_values=1.0)
+        beta = mx.pad(beta, widths[:3])
+
+    T_pad = q.shape[2]
+    n_chunks = T_pad // chunk_size
+    shape = (B, Hv, n_chunks, chunk_size)
+    q, k, v = (x.reshape(*shape, -1) for x in (q, k, v))
+    g, beta = g.reshape(shape), beta.reshape(shape)
+
+    cumulative = mx.cumsum(mx.log(mx.maximum(g, 1e-30)), axis=-1)
+    causal = mx.tril(mx.ones((chunk_size, chunk_size), dtype=mx.bool_))
+    strict = mx.tril(mx.ones((chunk_size, chunk_size), dtype=mx.bool_), -1)
+    eye = mx.eye(chunk_size, dtype=mx.float32)
+
+    # ratios[j, i] = G_j / G_i for i <= j, zero above the diagonal
+    deltas = cumulative[..., :, None] - cumulative[..., None, :]
+    ratios = mx.where(causal, mx.exp(mx.where(causal, deltas, -1e30)), 0.0)
+    gammas = mx.exp(cumulative)
+
+    ys = []
+    s = state.astype(mx.float32)
+    for c in range(n_chunks):
+        q_c, k_c, v_c = q[:, :, c], k[:, :, c], v[:, :, c]
+        beta_c, gamma_c, ratio_c = beta[:, :, c], gammas[:, :, c], ratios[:, :, c]
+        k_t = mx.swapaxes(k_c, -1, -2)
+
+        system = eye + mx.where(strict, beta_c[..., :, None] * (k_c @ k_t) * ratio_c, 0.0)
+        u = _unit_tri_inv(system) @ (
+            beta_c[..., None] * (v_c - gamma_c[..., None] * (k_c @ mx.swapaxes(s, -1, -2)))
+        )
+
+        attn = mx.where(causal, (q_c @ k_t) * ratio_c, 0.0)
+        ys.append(gamma_c[..., None] * (q_c @ mx.swapaxes(s, -1, -2)) + attn @ u)
+
+        tail = ratio_c[..., -1, :]  # G_C / G_i
+        s = gamma_c[..., -1, None, None] * s + mx.swapaxes(tail[..., None] * u, -1, -2) @ k_c
+
+    y = mx.stack(ys, axis=2).reshape(B, Hv, T_pad, Dv)
+    if pad:
+        y = y[:, :, :T]
+    return mx.swapaxes(y, 1, 2).astype(out_dtype), s
 
 
 def gated_delta_update(

--- a/tests/test_gated_delta.py
+++ b/tests/test_gated_delta.py
@@ -6,10 +6,11 @@ import mlx.core as mx
 
 import mlx_lm.models.gated_delta as gated_delta
 from mlx_lm.models.gated_delta import (
+    gated_delta_chunkwise,
     gated_delta_kernel,
     gated_delta_kernel_unpacked,
     gated_delta_kernel_xtree,
-    gated_delta_ops,
+    gated_delta_sequential,
 )
 
 
@@ -90,7 +91,7 @@ class TestGatedDelta(unittest.TestCase):
 
         q, k, v, g, beta, state = self._inputs(1, 64, 16, 32, 128, 128, mx.bfloat16)
         y_p, s_p = gated_delta_kernel(q, k, v, g, beta, state, None)
-        y_r, s_r = gated_delta_ops(q, k, v, g, beta, state, None)
+        y_r, s_r = gated_delta_sequential(q, k, v, g, beta, state, None)
         mx.eval(y_p, s_p, y_r, s_r)
         self.assertLess(_rel_l2(y_p, y_r), 2e-3)
         self.assertLess(_rel_l2(s_p, s_r), 2e-3)
@@ -116,7 +117,7 @@ class TestGatedDelta(unittest.TestCase):
         q, k, v, g, beta, state = self._inputs(2, 33, 8, 16, 128, 128, mx.bfloat16)
         mask = mx.arange(33)[None] < mx.array([[29], [17]])
         y_k, s_k = gated_delta_kernel(q, k, v, g, beta, state, mask)
-        y_r, s_r = gated_delta_ops(q, k, v, g, beta, state, mask)
+        y_r, s_r = gated_delta_sequential(q, k, v, g, beta, state, mask)
         mx.eval(y_k, s_k, y_r, s_r)
         # Outputs at padded positions are unspecified (the kernel zeros
         # them, the ops reference does not); compare valid positions only.
@@ -133,7 +134,7 @@ class TestGatedDelta(unittest.TestCase):
         g = mx.exp(-mx.random.uniform(shape=(1, 65, 8, 128)) * 0.2).astype(mx.float32)
         mx.eval(g)
         y_k, s_k = gated_delta_kernel(q, k, v, g, beta, state, None)
-        y_r, s_r = gated_delta_ops(q, k, v, g, beta, state, None)
+        y_r, s_r = gated_delta_sequential(q, k, v, g, beta, state, None)
         mx.eval(y_k, s_k, y_r, s_r)
         self.assertLess(_rel_l2(y_k, y_r), 2e-3)
         self.assertLess(_rel_l2(s_k, s_r), 2e-3)
@@ -143,7 +144,7 @@ class TestGatedDelta(unittest.TestCase):
             raise unittest.SkipTest("gated delta kernels are GPU only")
         q, k, v, g, beta, state = self._inputs(1, 65, 4, 8, 64, 64, mx.bfloat16)
         y_k, s_k = gated_delta_kernel(q, k, v, g, beta, state, None)
-        y_r, s_r = gated_delta_ops(q, k, v, g, beta, state, None)
+        y_r, s_r = gated_delta_sequential(q, k, v, g, beta, state, None)
         mx.eval(y_k, s_k, y_r, s_r)
         self.assertLess(_rel_l2(y_k, y_r), 2e-3)
         self.assertLess(_rel_l2(s_k, s_r), 2e-3)
@@ -168,6 +169,61 @@ class TestGatedDelta(unittest.TestCase):
         mx.eval(y_p, s_p, y_u, s_u)
         self.assertTrue(mx.array_equal(y_p, y_u))
         self.assertTrue(mx.array_equal(s_p, s_u))
+
+
+class TestGatedDeltaChunkwise(unittest.TestCase):
+    """The chunkwise training path must agree with the sequential reference."""
+
+    def _inputs(self, B, T, Hk, Hv, Dk, Dv, decay, dtype=mx.float32):
+        mx.random.seed(7)
+        q = _normed((B, T, Hk, Dk), Dk, dtype)
+        k = _normed((B, T, Hk, Dk), Dk, dtype)
+        v = mx.random.normal((B, T, Hv, Dv)).astype(dtype)
+        g = mx.exp(-mx.random.uniform(shape=(B, T, Hv)) * decay).astype(mx.float32)
+        beta = mx.random.uniform(shape=(B, T, Hv)).astype(dtype)
+        state = (mx.random.normal((B, Hv, Dv, Dk)) * 0.3).astype(mx.float32)
+        mx.eval(q, k, v, g, beta, state)
+        return q, k, v, g, beta, state
+
+    def test_matches_ops(self):
+        # decay 0.2 is the mild regime the kernels are tested at; 4.0 drives the
+        # cumulative products small, where dividing by them would overflow.
+        for decay in (0.2, 4.0):
+            for T, chunk in ((128, 64), (96, 64), (64, 16)):  # 96 exercises padding
+                args = self._inputs(1, T, 8, 16, 64, 64, decay)
+                y_ref, s_ref = gated_delta_sequential(*args, None)
+                y, s = gated_delta_chunkwise(*args, None, chunk_size=chunk)
+                mx.eval(y_ref, s_ref, y, s)
+                self.assertLess(_rel_l2(y, y_ref), 1e-5, f"decay={decay} T={T}")
+                self.assertLess(_rel_l2(s, s_ref), 1e-5, f"decay={decay} T={T}")
+
+    def test_grouped_query_heads(self):
+        args = self._inputs(2, 64, 4, 16, 64, 64, 0.5)  # Hv // Hk == 4
+        y_ref, s_ref = gated_delta_sequential(*args, None)
+        y, s = gated_delta_chunkwise(*args, None, chunk_size=32)
+        mx.eval(y_ref, s_ref, y, s)
+        self.assertLess(_rel_l2(y, y_ref), 1e-5)
+        self.assertLess(_rel_l2(s, s_ref), 1e-5)
+
+    def test_gradients_match_ops(self):
+        q, k, v, g, beta, state = self._inputs(1, 64, 2, 4, 32, 32, 0.5)
+        w = mx.random.normal((1, 64, 4, 32))
+
+        def make(fn, **kwargs):
+            def loss(q, k, v, g, beta):
+                y, s = fn(q, k, v, g, beta, state, None, **kwargs)
+                return (y * w).sum() + (s * s).sum()
+
+            return loss
+
+        argnums = (0, 1, 2, 3, 4)
+        ref = mx.grad(make(gated_delta_sequential), argnums=argnums)(q, k, v, g, beta)
+        got = mx.grad(make(gated_delta_chunkwise, chunk_size=16), argnums=argnums)(
+            q, k, v, g, beta
+        )
+        mx.eval(ref, got)
+        for a, b in zip(ref, got):
+            self.assertLess(_rel_l2(b, a), 1e-4)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Problem

The gated delta layers fall back to `gated_delta_ops` whenever the Metal kernel is unavailable, and that includes **every training step** — `use_kernel=not self.training`, because the kernel has no VJP. `gated_delta_ops` is a sequential loop over timesteps, so autograd retains one state per token.

Measured on one layer (Hk=16, Hv=32, Dk=Dv=128), forward and backward, M4 Pro:

| seq | peak memory | time |
|---:|---:|---:|
| 512 | 4.29 GB | 0.36 s |
| 1024 | 10.18 GB | 1.16 s |
| 2048 | 31.44 GB | 4.20 s |
| 4096 | 108.33 GB | 39.02 s |

About 8 MB per token per layer, growing linearly, and superlinear in time. Five model families route through this during training: `qwen3_5`, `qwen3_next`, `kimi_k3`, `kimi_linear`, `bailing_moe_v3`.

## Change

`gated_delta_ops` becomes a thin dispatcher: scalar gating without a mask takes a new `gated_delta_chunkwise`, everything else goes to `gated_delta_sequential`, which is the existing loop under a name that says what it is. The existing kernel tests now compare against `gated_delta_sequential` so they keep testing what they tested before.

`gated_delta_chunkwise` is the chunkwise parallel form of the gated delta rule ([arXiv:2406.06484](https://arxiv.org/abs/2406.06484), [arXiv:2412.06464](https://arxiv.org/abs/2412.06464)). Splitting the sequence into chunks of 64 and solving one unit lower-triangular system per chunk keeps `O(T / chunk)` states instead of `O(T)` and replaces the per-step loop with matmuls.

Same setup, with the new path:

| seq | peak memory | time | vs sequential |
|---:|---:|---:|---|
| 512 | 0.33 GB | 0.04 s | 13x mem, 10x speed |
| 1024 | 0.97 GB | 0.09 s | 10x mem, 12x speed |
| 2048 | 1.74 GB | 0.23 s | 18x mem, 19x speed |
| 4096 | 4.73 GB | 0.60 s | **23x mem, 65x speed** |

Inference is untouched: that path uses the Metal kernel and never reaches this code.

## Scope

The dispatch prefers the chunkwise path only for scalar gating without a mask. Vectorized gating (`g.ndim == 4`) and masked sequences continue to use the reference loop, so the change cannot alter results for cases it does not cover.

## Two implementation notes

`mx.linalg.tri_inv` is CPU-only and has no VJP, so it cannot appear in a training graph. The unit-triangular inverse is instead built from matmuls by 2x2 block recursion in log2(n) levels, which autodiff handles natively and which parallelizes across the batch — for the batched 64x64 case here that also measured faster than the LAPACK path (5.9 ms vs 7.4 ms for 1024 matrices, before counting the device round trip).

The textbook derivation divides by the cumulative decay `G_j`, which underflows and sends the intermediate writes to infinity on strongly decaying heads. This implementation carries bounded ratios `G_j / G_i` (at most 1 for `i <= j`) instead. The tests cover that regime explicitly.

## Testing

`tests/test_gated_delta.py` adds a `TestGatedDeltaChunkwise` case covering:

- agreement with `gated_delta_ops` at mild (0.2) and strong (4.0) decay
- sequence lengths that are and are not a multiple of the chunk size
- grouped-query heads (`Hv // Hk == 4`)
- gradients through all five inputs

Outputs match to ~1e-6 relative in fp32 and gradients to ~1e-4. The existing kernel tests pass unchanged (11 passed, 32 subtests).

Verified to merge cleanly into current `main`, and the merged tree passes the suite (training dispatch agrees with the kernel to 1.5e-6).
