### PR TITLE
Bound ArraysCache metadata evaluation during batched decoding

### DIFF
--- a/mlx_lm/models/cache.py
+++ b/mlx_lm/models/cache.py
@@ -683,6 +683,14 @@ class ArraysCache(_BaseCache):
             self.lengths -= N
         if self.left_padding is not None:
             self.left_padding -= N
+        metadata = tuple(
+            value for value in (self.lengths, self.left_padding) if value is not None
+        )
+        if metadata:
+            for index, value in enumerate(self.cache):
+                if value is not None:
+                    self.cache[index] = mx.depends(value, metadata)
+                    break
 
     def make_mask(self, N: int):
         if self.left_padding is not None:

--- a/tests/test_arrays_cache.py
+++ b/tests/test_arrays_cache.py
@@ -1,0 +1,40 @@
+# Copyright © 2026 Mark Smeltzer
+
+import pathlib
+import tempfile
+import unittest
+
+import mlx.core as mx
+
+from mlx_lm.models.cache import ArraysCache
+
+
+class TestArraysCache(unittest.TestCase):
+    def test_advance_bounds_metadata_graph(self):
+        cache = ArraysCache(2, left_padding=[2])
+        cache.prepare(lengths=[3])
+        cache[0] = mx.array([0])
+        cache[1] = mx.array([0])
+
+        for _ in range(256):
+            cache[0] = cache[0] + 1
+            cache.advance(1)
+            mx.eval(cache[0])
+
+        with tempfile.TemporaryDirectory() as directory:
+            for name, metadata in (
+                ("lengths", cache.lengths),
+                ("left-padding", cache.left_padding),
+            ):
+                graph_path = pathlib.Path(directory, f"arrays-cache-{name}.dot")
+                mx.export_to_dot(str(graph_path), metadata)
+                edge_count = graph_path.read_text(encoding="utf-8").count("->")
+                self.assertLessEqual(edge_count, 8, f"{name} graph has {edge_count} edges")
+
+        self.assertEqual(cache[0].item(), 256)
+        self.assertEqual(cache.lengths.item(), 3 - 256)
+        self.assertEqual(cache.left_padding.item(), 2 - 256)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
# Bound ArraysCache metadata evaluation during batched decoding
## Summary

This proposal binds `ArraysCache` length and left-padding metadata to a populated
cache-state tensor through `mx.depends`. It targets a lazy-evaluation gap in batch
generation: callers can evaluate token and logprob outputs without evaluating
every recurrent layer's complete cache state, allowing otherwise unused metadata
graphs to grow with the number of decode steps.

The mechanism has been tested in a pinned MLX-LM fork used by EXO. A minimal
upstream branch and a red/green comparison against current MLX-LM `main` have not
yet been prepared. The results below describe that tested candidate, not an
already-qualified upstream patch.

**Related issue:** [#1871](https://github.com/ml-explore/mlx-lm/issues/1871)

## Model Lineage and Architecture Context

The investigation began while enabling two exact model artifacts:

| Artifact | Tested revision |
| --- | --- |
| `mlx-community/Qwen3.8-27B-8bit` | `815b83c0df8ffd1d1b5244cf75fd6ef14fca9ef9` |
| `mlx-community/Qwen3.8-27B-bf16` | `6f265714824f3c38d4452baa1628aef3d9b9aae9` |

Their configuration selects `model_type: qwen3_5` and
`Qwen3_5ForConditionalGeneration`. The advertised Qwen3.8 name does not imply
that this patch introduces a new MLX-LM architecture implementation.

| Architecture context | Cache behavior relevant to this investigation |
| --- | --- |
| Ordinary `qwen3` full-attention models | Attention consumes cached keys and values directly. |
| Qwen3-Next | An earlier example of hybrid recurrent/attention execution; hybrid caching is not unique to Qwen3.8. |
| These Qwen3.8-27B artifacts, using `qwen3_5` | 64 text layers: 48 GatedDeltaNet linear/recurrent layers with `ArraysCache(size=2)` and 16 full-attention layers with `KVCache`. |

This is implementation and architecture lineage, not a claim that these weights
were directly derived from any particular earlier checkpoint. The important
difference from ordinary full-attention Qwen3 is the recurrent cache: convolution
history and recurrent state are consumed by the layer, but their associated
padding and length metadata need not all be consumed by the batch output graph.

The proposed patch does not change layer counts, attention or recurrent math,
weights, quantization, model registration, tensor sharding, or distributed
transport. The 4-bit artifact was not tested and is outside this qualification.
This is a decoding metadata-lifetime correction, not a training-time
GatedDeltaNet optimization or a general fix for every form of recurrent-state retention.

## Observed Failure and Mechanism

During the retained Q8 incident, two of four EXO workers failed approximately
264 seconds into sustained generation with:

```text
[metal::malloc] Resource limit (499000) exceeded
```

The exception surfaced at `mx.async_eval` in EXO's batch-generation step while
evaluating token and logprob outputs. This is a Metal resource-object limit,
not necessarily exhaustion of physical RAM. No equivalent historical BF16
crash was captured.

`ArraysCache.advance()` decrements sequence-length and left-padding arrays.
Because MLX evaluation is lazy, repeated decrements can retain an increasingly
large computation graph when those arrays are not evaluated. The hybrid model
uses a shared recurrent-layer mask derived from a representative cache, so that
mask does not necessarily consume every layer's metadata. EXO's tested batch
step evaluates output tensors, not every cache's complete `state`.

In the reviewed pinned path, `ArraysCache.merge()` introduces `left_padding`
even for a single sequence. On the typical unpadded single-sequence path, that
metadata survives into decoding. The issue therefore is not limited to requests
that an application would describe as unequal-length padded batches.

The focused graph reproduction demonstrates metadata growth and its correction.
The source path, sustained-run results and related reports support the proposed
connection to the historical crash; a complete trace attributing all retained
Metal objects to these arrays was not captured.

## Proposed Correction

After advancing the metadata, collect non-null `lengths` and `left_padding` and
attach them as dependencies of the first populated cache-state tensor using
`mx.depends`. On the reviewed Qwen path, both cache slots have been written before
`advance()`; the first slot is convolution state consumed in the next decode step.
That consumption brings metadata evaluation into the state dependency graph,
with a bounded one-step lag instead of indefinite retention.

This keeps evaluation responsibility inside the cache rather than requiring
every batch caller to explicitly evaluate all metadata. Empty metadata is a
no-op. The change is adapted from the `advance()` portion of
[Pierre Lamy's commit bb615eb](https://github.com/pierre427/mlx-lm/commit/bb615ebdb5aff33eb931ac0627cae142bd7adbaa);
its separate `extract()` change is not included.

The adaptation is not claimed as a new invention. Relevant history includes
[PR #1632](https://github.com/ml-explore/mlx-lm/pull/1632),
[issue #1641](https://github.com/ml-explore/mlx-lm/issues/1641),
[PR #1642](https://github.com/ml-explore/mlx-lm/pull/1642), and the implicit-evaluation
precedent in [PR #960](https://github.com/ml-explore/mlx-lm/pull/960).
Exposing metadata through `cache.state` helps callers that evaluate that property;
it does not by itself cover callers that omit it. The active batch-path report
[issue #1845](https://github.com/ml-explore/mlx-lm/issues/1845) proposes a different
deferred-integer approach. Comparison and coordination remain pending; this
draft does not assert that `mx.depends` is the only viable correction.

## Reproduction and Results

The retained component regression uses real `ArraysCache`, initializes both
state tensors, advances metadata for 256 steps, and evaluates `cache[0]`, not
the complete `cache.state`. It checks metadata graph size and final values.

| Check | Unpatched tested fork pin | Patched tested fork pin |
| --- | --- | --- |
| Metadata graph after 256 steps | Fails at 1,280 edges | Passes the at-most-eight-edge bound |
| State and metadata value assertions | Not reached after graph-size failure | Pass |

The exact baseline is `rltakashige/mlx-lm@6a3df6cd6b00a347ee40f12d97a182aaf86ea599`.
Its package reports `0.31.3`, which must not be mistaken for an unmodified PyPI
release. The tested stack reports MLX `0.32.0.dev20260522`, MLX-VLM `0.4.4`,
Transformers `5.6.2`, and EXO `0.3.70`. The combined EXO candidate is
`91d73db829c67cc15206ce73dc45e105d507d846` with unchanged dependency pins.

In that candidate checkout, using its MLX/MLX-LM Python environment, the retained
component reproduction is:

```bash
python nix/tests/arrays-cache-metadata-regression.py
```

This is an EXO-carried regression path, not a command available in a stock
MLX-LM checkout. A public, self-contained upstream reproduction and integration
into MLX-LM's own test suite remain pending.

On four Mac Studio M3 Ultra nodes with four Tensor/JACCL ranks, the combined
candidate produced 17,992 Q8 output tokens and 19,211 BF16 output tokens during
sustained generation. Both variants completed cold marker recall with 210,668
prompt tokens and follow-up generation with 243,192 prompt tokens, including
210,666 cached tokens. Gemma controls also passed.

These integration runs include the separate EXO processor correction. They do
not isolate this patch against current upstream, establish all-model support,
or prove fresh full-window prefill, concurrency, overnight stability, multimodal
inference, or generated-code correctness. Production was restored afterward.
The pinned cache patch and its carrier passed a Grok 4.6 source review; that
review did not rerun hardware tests or substitute for human code review.

## Supplemental: EXO Integration

**Companion EXO PR:** https://github.com/exo-explore/exo/pull/2301.

EXO is the downstream distributed-inference application in which this issue was
investigated. Its tested batch-generation path consumes MLX-LM model and cache
implementations while evaluating token and logprob outputs. That path exposed
the metadata-evaluation gap described above; four-node Tensor/JACCL execution
provided the integration test environment, not a demonstrated prerequisite for
the cache defect.

The contributions address different responsibilities:

| Contribution | Responsibility |
| --- | --- |
| This MLX-LM proposal | Bound lazy metadata growth within `ArraysCache` during decoding. No EXO model cards or processor-selection changes belong in this patch. |
| Companion EXO proposal | Resolve a separate image-processor initialization failure by supplying model configuration to the Transformers fallback, and include bundled cards for `mlx-community/Qwen3.8-27B-8bit` and `mlx-community/Qwen3.8-27B-bf16`. Both cards passed native registration tests on the public contribution; four-node qualification of that upstream port remains pending. |

The processor failure is distinct from the sustained-decoding resource failure.
Short text generation already worked on the baseline despite the caught processor
error. The complete onboarding result reported here was qualified on a combined
candidate containing both corrections; neither isolated PR should inherit that
result as proof of current-upstream compatibility.

Users reproducing that complete EXO result need the EXO changes and the cache
correction in the MLX-LM dependency their EXO build actually uses. The tested
candidate carried the cache patch through EXO's Nix dependency override without
changing dependency pins. Installing or checking out a corrected MLX-LM fork
elsewhere does not update that dependency. The final EXO contribution must
identify the corrected dependency revision or patch and the build steps needed
to consume it; that final installation path remains to be validated.

The dependency is asymmetric: EXO's complete tested onboarding outcome requires
both corrections, but the MLX-LM cache correction does not require EXO or its
processor change to function. Keep the patches independently reviewable, and
add a reciprocal link from the EXO PR once both PR URLs exist. The placeholder
above is reserved for the actual EXO PR, not an assumed issue number.

## Attribution and Human-AI Collaboration

This work was developed with GitHub Copilot under Mark Smeltzer's direction.
AI assistance included source and prior-art analysis, patch and regression
preparation, command execution, interpretation of captured results, source
review, and preparing an outline and supporting draft for the PR text. 
The reported hardware checks were agent-driven against real software and hardware
using a deterministic script, which is noted above.
