### PR TITLE
Fix detokenizer getting re-created for every generation

### DIFF
--- a/mlx_lm/generate.py
+++ b/mlx_lm/generate.py
@@ -702,6 +702,7 @@ def stream_generate(
         prompt = mx.array(prompt)
 
     detokenizer = tokenizer.detokenizer
+    detokenizer.reset()
 
     kwargs["max_tokens"] = max_tokens
 

--- a/mlx_lm/tokenizer_utils.py
+++ b/mlx_lm/tokenizer_utils.py
@@ -503,12 +503,12 @@ class TokenizerWrapper:
         """
         Get a stateful streaming detokenizer.
         """
-        return self._detokenizer_class(self)
+        if not hasattr(self, "_detokenizer"):
+            self._detokenizer = self._detokenizer_class(self)
+        return self._detokenizer
 
     def __getattr__(self, attr):
-        if attr == "detokenizer":
-            return self._detokenizer
-        elif attr == "eos_token_ids":
+        if attr == "eos_token_ids":
             return self._eos_token_ids
         elif attr.startswith("_"):
             return self.__getattribute__(attr)

--- a/tests/test_tokenizers.py
+++ b/tests/test_tokenizers.py
@@ -67,7 +67,9 @@ class TestTokenizers(unittest.TestCase):
 
         # Try one with a naive detokenizer
         tokenizer = load_tokenizer("mlx-community/Llama-3.2-1B-Instruct-4bit")
-        tokenizer._detokenizer = NaiveStreamingDetokenizer(tokenizer)
+        detokenizer = NaiveStreamingDetokenizer(tokenizer)
+        tokenizer._detokenizer = detokenizer
+        self.assertEqual(tokenizer.detokenizer, detokenizer)
         self.check_tokenizer(tokenizer)
 
     def test_special_tokens(self):


### PR DESCRIPTION
It used to be cached per tokenizer but #430 changed the behavior, not exactly sure of the reason but it does not seem reasonable creating a new object every time when the property is accessed.

Close https://github.com/ml-explore/mlx-lm/issues/1435