### PR TITLE
Reject unsupported compressed-tensors formats instead of 4-bit affine

### DIFF
--- a/mlx_lm/utils.py
+++ b/mlx_lm/utils.py
@@ -303,6 +303,27 @@ def hf_repo_to_path(hf_repo):
     )
 
 
+def compressed_tensors_quantization(quantization_config: dict) -> dict:
+    """Map a compressed-tensors config to an MLX quantization dict.
+
+    ``compressed-tensors`` is a container format. Only packed integer formats that
+    MLX already implements are accepted. Unknown formats such as ``float-quantized``
+    (FP8) used to fall through to 4-bit affine and silently misinterpret F8_E4M3
+    weights.
+    """
+    fmt = quantization_config.get("format")
+    if fmt == "nvfp4-pack-quantized":
+        return {"group_size": 16, "bits": 4, "mode": "nvfp4"}
+    if fmt == "mxfp4-pack-quantized":
+        return {"group_size": 32, "bits": 4, "mode": "mxfp4"}
+    if fmt == "pack-quantized":
+        return {"group_size": 32, "bits": 4, "mode": "affine"}
+    raise ValueError(
+        f"unsupported compressed-tensors format {fmt!r}; "
+        "dequantize to bf16 before converting"
+    )
+
+
 def load_config(model_path: Path) -> dict:
     with open(model_path / "config.json", "r") as f:
         config = json.load(f)
@@ -434,12 +455,7 @@ def load_model(
             config["quantization_config"] = quantization
             _quantize(quantization)
         elif quant_method == "compressed-tensors":
-            if quantization_config.get("format") == "nvfp4-pack-quantized":
-                quantization = {"group_size": 16, "bits": 4, "mode": "nvfp4"}
-            elif quantization_config.get("format") == "mxfp4-pack-quantized":
-                quantization = {"group_size": 32, "bits": 4, "mode": "mxfp4"}
-            else:
-                quantization = {"group_size": 32, "bits": 4, "mode": "affine"}
+            quantization = compressed_tensors_quantization(quantization_config)
             config["quantization"] = quantization
             config["quantization_config"] = quantization
             _quantize(quantization)

--- a/mlx_lm/utils.py
+++ b/mlx_lm/utils.py
@@ -303,7 +303,7 @@ def hf_repo_to_path(hf_repo):
     )
 
 
-def compressed_tensors_quantization(quantization_config: dict) -> dict:
+def _compressed_tensors_quantization(quantization_config: dict) -> dict:
     """Map a compressed-tensors config to an MLX quantization dict.
 
     ``compressed-tensors`` is a container format. Only packed integer formats that
@@ -455,7 +455,7 @@ def load_model(
             config["quantization_config"] = quantization
             _quantize(quantization)
         elif quant_method == "compressed-tensors":
-            quantization = compressed_tensors_quantization(quantization_config)
+            quantization = _compressed_tensors_quantization(quantization_config)
             config["quantization"] = quantization
             config["quantization_config"] = quantization
             _quantize(quantization)

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -288,6 +288,20 @@ class TestTrustRemoteCode(unittest.TestCase):
         self.assertIsInstance(model, nn.Module)
         self.assertEqual(loaded_config["model_type"], "llama")
 
+    def test_compressed_tensors_known_formats(self):
+        self.assertEqual(
+            utils.compressed_tensors_quantization({"format": "nvfp4-pack-quantized"}),
+            {"group_size": 16, "bits": 4, "mode": "nvfp4"},
+        )
+        self.assertEqual(
+            utils.compressed_tensors_quantization({"format": "pack-quantized"}),
+            {"group_size": 32, "bits": 4, "mode": "affine"},
+        )
+
+    def test_compressed_tensors_float_quantized_is_rejected(self):
+        with self.assertRaisesRegex(ValueError, "float-quantized"):
+            utils.compressed_tensors_quantization({"format": "float-quantized"})
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -290,17 +290,25 @@ class TestTrustRemoteCode(unittest.TestCase):
 
     def test_compressed_tensors_known_formats(self):
         self.assertEqual(
-            utils.compressed_tensors_quantization({"format": "nvfp4-pack-quantized"}),
+            utils._compressed_tensors_quantization(
+                {"format": "nvfp4-pack-quantized"}
+            ),
             {"group_size": 16, "bits": 4, "mode": "nvfp4"},
         )
         self.assertEqual(
-            utils.compressed_tensors_quantization({"format": "pack-quantized"}),
+            utils._compressed_tensors_quantization(
+                {"format": "mxfp4-pack-quantized"}
+            ),
+            {"group_size": 32, "bits": 4, "mode": "mxfp4"},
+        )
+        self.assertEqual(
+            utils._compressed_tensors_quantization({"format": "pack-quantized"}),
             {"group_size": 32, "bits": 4, "mode": "affine"},
         )
 
     def test_compressed_tensors_float_quantized_is_rejected(self):
         with self.assertRaisesRegex(ValueError, "float-quantized"):
-            utils.compressed_tensors_quantization({"format": "float-quantized"})
+            utils._compressed_tensors_quantization({"format": "float-quantized"})
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Fixes #1865.

`compressed-tensors` is a container. The old `else` branch treated every unrecognized format as 4-bit affine, including `float-quantized` FP8. Those checkpoints store F8_E4M3 weights, so they loaded and generated garbage instead of failing.

Known packed formats still map the same way. Anything else, including FP8, raises with a message to dequantize first.

Tested with `tests.test_utils` coverage for `pack-quantized`, `nvfp4-pack-quantized`, and `float-quantized`.
