### PR TITLE
Refactor/detokenizers

### DIFF
--- a/mlx_lm/tokenizer_utils.py
+++ b/mlx_lm/tokenizer_utils.py
@@ -106,7 +106,10 @@ class NaiveStreamingDetokenizer(StreamingDetokenizer):
     def text(self):
         if self._current_tokens:
             self._current_text = self._tokenizer.decode(self._current_tokens)
-            if self._current_text.endswith("\ufffd") or (
+            if self._current_text.endswith("\ufffd"):
+                # An incomplete character can decode to several replacements.
+                self._current_text = self._current_text.rstrip("\ufffd")
+            elif (
                 self._clean_spaces
                 and len(self._current_text) > 0
                 and self._current_text[-1] == " "
@@ -235,6 +238,8 @@ class BPEStreamingDetokenizer(StreamingDetokenizer):
 
     def add_token(self, token):
         self.tokens.append(token)
+        # Undocumented fallback from #418, likely for a padded model vocab.
+        # TODO(michalk8): check whether this is still needed.
         v = self.tokenmap[token] if token < len(self.tokenmap) else "!"
         self._unflushed += v
         text = self._decode_bytes(self._unflushed)

--- a/mlx_lm/tokenizer_utils.py
+++ b/mlx_lm/tokenizer_utils.py
@@ -118,15 +118,14 @@ class SPMStreamingDetokenizer(StreamingDetokenizer):
         self.trim_space = trim_space
         self._sep = "\u2581".encode()
 
-        # Extract the tokens in a list from id to text
-        vocab = tokenizer.get_vocab()
-        self.tokenmap = [""] * (max(vocab.values()) + 1)
-        for value, tokenid in vocab.items():
-            if value.startswith("<0x"):
-                # Replace bytes with their value
-                self.tokenmap[tokenid] = bytes([int(value[3:5], 16)])
-            else:
-                self.tokenmap[tokenid] = value.encode()
+        # Extract the tokens in a list from id to bytes
+        ids = list(range(len(tokenizer)))
+        tokens = tokenizer.convert_ids_to_tokens(ids)
+        self.tokenmap = [
+            # Replace bytes with their value
+            bytes([int(t[3:5], 16)]) if t.startswith("<0x") else t.encode()
+            for t in tokens
+        ]
 
         self.reset()
 
@@ -167,10 +166,8 @@ class BPEStreamingDetokenizer(StreamingDetokenizer):
 
     def __init__(self, tokenizer):
         # Extract the tokens in a list from id to text
-        vocab = tokenizer.get_vocab()
-        self.tokenmap = [None] * len(vocab)
-        for value, tokenid in vocab.items():
-            self.tokenmap[tokenid] = value
+        ids = list(range(len(tokenizer)))
+        self.tokenmap = tokenizer.convert_ids_to_tokens(ids)
 
         self.reset()
 
@@ -512,6 +509,10 @@ class TokenizerWrapper:
     @eos_token_ids.setter
     def eos_token_ids(self, value):
         self._eos_token_ids = set(value) if value is not None else set()
+
+    def __len__(self):
+        # Special methods bypass __getattr__, so proxy this one explicitly.
+        return len(self._tokenizer)
 
     def __getattr__(self, attr):
         # Only reached when normal lookup fails. Names this class defines are

--- a/mlx_lm/tokenizer_utils.py
+++ b/mlx_lm/tokenizer_utils.py
@@ -2,6 +2,7 @@
 
 import abc
 import copy
+import functools
 import importlib
 import inspect
 import json
@@ -166,14 +167,37 @@ class SPMStreamingDetokenizer(StreamingDetokenizer):
         self._unflushed = b""
 
 
+@functools.lru_cache(maxsize=1)
+def _byte_decoder():
+    """See https://github.com/openai/gpt-2/blob/master/src/encoder.py for the rationale."""
+    char_to_bytes = {}
+    limits = [
+        0,
+        ord("!"),
+        ord("~") + 1,
+        ord("¡"),
+        ord("¬") + 1,
+        ord("®"),
+        ord("ÿ") + 1,
+    ]
+    n = 0
+    for i, (start, stop) in enumerate(zip(limits, limits[1:])):
+        if i % 2 == 0:
+            for b in range(start, stop):
+                char_to_bytes[chr(2**8 + n)] = b
+                n += 1
+        else:
+            for b in range(start, stop):
+                char_to_bytes[chr(b)] = b
+    return char_to_bytes
+
+
 class BPEStreamingDetokenizer(StreamingDetokenizer):
     """A streaming detokenizer for OpenAI style BPE models.
 
     It adds tokens to the text if the next token starts with a space similar to
     the SPM detokenizer.
     """
-
-    _byte_decoder = None
 
     def __init__(self, tokenizer):
         super().__init__()
@@ -182,10 +206,6 @@ class BPEStreamingDetokenizer(StreamingDetokenizer):
 
         self.reset()
 
-        # Make the BPE byte decoder from
-        # https://github.com/openai/gpt-2/blob/master/src/encoder.py
-        self.make_byte_decoder()
-
     def reset(self):
         self.offset = 0
         self._unflushed = ""
@@ -193,9 +213,10 @@ class BPEStreamingDetokenizer(StreamingDetokenizer):
         self.tokens = []
 
     def _decode_bytes(self, seq):
+        byte_decoder = _byte_decoder()
         barr = bytearray()
         for c in seq:
-            res = self._byte_decoder.get(c, False)
+            res = byte_decoder.get(c, False)
             if res:
                 barr.append(res)
             else:
@@ -220,45 +241,19 @@ class BPEStreamingDetokenizer(StreamingDetokenizer):
         # For multi-byte utf-8 wait until they are complete
         # For single spaces wait until the next token to clean it if needed
         if not text.endswith("\ufffd") and not (
-            len(v) == 1 and self._byte_decoder.get(v[0]) == 32
+            len(v) == 1 and _byte_decoder().get(v[0]) == 32
         ):
             self.text += self._maybe_trim_space(text)
             self._unflushed = ""
 
     def finalize(self):
-        current_text = bytearray(self._byte_decoder[c] for c in self._unflushed).decode(
+        byte_decoder = _byte_decoder()
+        current_text = bytearray(byte_decoder[c] for c in self._unflushed).decode(
             "utf-8",
             "replace",
         )
         self.text += self._maybe_trim_space(current_text)
         self._unflushed = ""
-
-    @classmethod
-    def make_byte_decoder(cls):
-        """See https://github.com/openai/gpt-2/blob/master/src/encoder.py for the rationale."""
-        if cls._byte_decoder is not None:
-            return
-
-        char_to_bytes = {}
-        limits = [
-            0,
-            ord("!"),
-            ord("~") + 1,
-            ord("¡"),
-            ord("¬") + 1,
-            ord("®"),
-            ord("ÿ") + 1,
-        ]
-        n = 0
-        for i, (start, stop) in enumerate(zip(limits, limits[1:])):
-            if i % 2 == 0:
-                for b in range(start, stop):
-                    char_to_bytes[chr(2**8 + n)] = b
-                    n += 1
-            else:
-                for b in range(start, stop):
-                    char_to_bytes[chr(b)] = b
-        cls._byte_decoder = char_to_bytes
 
 
 def _infer_thinking(tokenizer):

--- a/mlx_lm/tokenizer_utils.py
+++ b/mlx_lm/tokenizer_utils.py
@@ -176,6 +176,7 @@ class BPEStreamingDetokenizer(StreamingDetokenizer):
     _byte_decoder = None
 
     def __init__(self, tokenizer):
+        super().__init__()
         ids = list(range(len(tokenizer)))
         self.tokenmap = tokenizer.convert_ids_to_tokens(ids)
 

--- a/mlx_lm/tokenizer_utils.py
+++ b/mlx_lm/tokenizer_utils.py
@@ -136,7 +136,7 @@ class SPMStreamingDetokenizer(StreamingDetokenizer):
         tokens = tokenizer.convert_ids_to_tokens(ids)
         self.tokenmap = [
             # Byte tokens carry their value in hex.
-            bytes([int(t[3:5], 16)]) if t.startswith("<0x") else t.encode()
+            bytes([int(t[3:5], 16)]) if t.startswith("<0x") else t.encode("utf-8")
             for t in tokens
         ]
 

--- a/mlx_lm/tokenizer_utils.py
+++ b/mlx_lm/tokenizer_utils.py
@@ -1,5 +1,6 @@
 # Copyright © 2024 Apple Inc.
 
+import copy
 import importlib
 import inspect
 import json
@@ -118,11 +119,10 @@ class SPMStreamingDetokenizer(StreamingDetokenizer):
         self.trim_space = trim_space
         self._sep = "\u2581".encode()
 
-        # Extract the tokens in a list from id to bytes
         ids = list(range(len(tokenizer)))
         tokens = tokenizer.convert_ids_to_tokens(ids)
         self.tokenmap = [
-            # Replace bytes with their value
+            # Byte tokens carry their value in hex.
             bytes([int(t[3:5], 16)]) if t.startswith("<0x") else t.encode()
             for t in tokens
         ]
@@ -165,7 +165,6 @@ class BPEStreamingDetokenizer(StreamingDetokenizer):
     _byte_decoder = None
 
     def __init__(self, tokenizer):
-        # Extract the tokens in a list from id to text
         ids = list(range(len(tokenizer)))
         self.tokenmap = tokenizer.convert_ids_to_tokens(ids)
 
@@ -341,7 +340,8 @@ class TokenizerWrapper:
         tool_parser=None,
     ):
         self._tokenizer = tokenizer
-        self._detokenizer_class = detokenizer_class
+        # Built once, since building the token map is expensive.
+        self._detokenizer = detokenizer_class(tokenizer)
         self._eos_token_ids = set(eos_token_ids or [])
         if tokenizer.eos_token_id is not None:
             self._eos_token_ids.add(tokenizer.eos_token_id)
@@ -500,7 +500,10 @@ class TokenizerWrapper:
         """
         Get a stateful streaming detokenizer.
         """
-        return self._detokenizer_class(self)
+        # A copy per caller, since requests are detokenized concurrently.
+        detokenizer = copy.copy(self._detokenizer)
+        detokenizer.reset()
+        return detokenizer
 
     @property
     def eos_token_ids(self):
@@ -515,9 +518,8 @@ class TokenizerWrapper:
         return len(self._tokenizer)
 
     def __getattr__(self, attr):
-        # Only reached when normal lookup fails. Names this class defines are
-        # not delegated, so a property that raises reports its own error
-        # instead of a misleading one about the wrapped tokenizer.
+        # Names this class defines are not delegated, so a property that
+        # raises reports its own error.
         if attr.startswith("_") or hasattr(type(self), attr):
             raise AttributeError(
                 f"{type(self).__name__!r} object has no attribute {attr!r}"

--- a/mlx_lm/tokenizer_utils.py
+++ b/mlx_lm/tokenizer_utils.py
@@ -1,5 +1,6 @@
 # Copyright © 2024 Apple Inc.
 
+import abc
 import copy
 import importlib
 import inspect
@@ -12,7 +13,7 @@ from transformers import AutoTokenizer, PreTrainedTokenizerFast
 from transformers.tokenization_utils_base import PreTrainedTokenizerBase
 
 
-class StreamingDetokenizer:
+class StreamingDetokenizer(abc.ABC):
     """The streaming detokenizer interface so that we can detokenize one token at a time.
 
     Example usage is as follows:
@@ -42,14 +43,17 @@ class StreamingDetokenizer:
         # Now detokenizer.text should match tokenizer.decode(detokenizer.tokens)
     """
 
+    @abc.abstractmethod
     def reset(self):
-        raise NotImplementedError()
+        """Drop all streaming state, keeping data derived from the tokenizer."""
 
+    @abc.abstractmethod
     def add_token(self, token):
-        raise NotImplementedError()
+        """Consume one token id."""
 
+    @abc.abstractmethod
     def finalize(self):
-        raise NotImplementedError()
+        """Flush any text held back waiting for more tokens."""
 
     @property
     def last_segment(self):

--- a/mlx_lm/tokenizer_utils.py
+++ b/mlx_lm/tokenizer_utils.py
@@ -41,8 +41,6 @@ class StreamingDetokenizer:
         # Now detokenizer.text should match tokenizer.decode(detokenizer.tokens)
     """
 
-    __slots__ = ("text", "tokens", "offset")
-
     def reset(self):
         raise NotImplementedError()
 
@@ -505,23 +503,27 @@ class TokenizerWrapper:
         """
         return self._detokenizer_class(self)
 
+    @property
+    def eos_token_ids(self):
+        return self._eos_token_ids
+
+    @eos_token_ids.setter
+    def eos_token_ids(self, value):
+        self._eos_token_ids = set(value) if value is not None else set()
+
     def __getattr__(self, attr):
-        if attr == "detokenizer":
-            return self._detokenizer
-        elif attr == "eos_token_ids":
-            return self._eos_token_ids
-        elif attr.startswith("_"):
-            return self.__getattribute__(attr)
-        else:
-            return getattr(self._tokenizer, attr)
+        # Only reached when normal lookup fails. Names this class defines are
+        # not delegated, so a property that raises reports its own error
+        # instead of a misleading one about the wrapped tokenizer.
+        if attr.startswith("_") or hasattr(type(self), attr):
+            raise AttributeError(
+                f"{type(self).__name__!r} object has no attribute {attr!r}"
+            )
+        return getattr(self._tokenizer, attr)
 
     def __setattr__(self, attr, value):
-        if attr in {"detokenizer", "eos_token_ids"}:
-            if attr == "detokenizer":
-                raise AttributeError("Cannot set the detokenizer.")
-            elif attr == "eos_token_ids":
-                self._eos_token_ids = set(value) if value is not None else set()
-        elif attr.startswith("_"):
+        # Defer to the class so properties keep their setters.
+        if attr.startswith("_") or hasattr(type(self), attr):
             super().__setattr__(attr, value)
         else:
             setattr(self._tokenizer, attr, value)

--- a/mlx_lm/tokenizer_utils.py
+++ b/mlx_lm/tokenizer_utils.py
@@ -119,8 +119,9 @@ class SPMStreamingDetokenizer(StreamingDetokenizer):
         self._sep = "\u2581".encode()
 
         # Extract the tokens in a list from id to text
-        self.tokenmap = [""] * (max(tokenizer.vocab.values()) + 1)
-        for value, tokenid in tokenizer.vocab.items():
+        vocab = tokenizer.get_vocab()
+        self.tokenmap = [""] * (max(vocab.values()) + 1)
+        for value, tokenid in vocab.items():
             if value.startswith("<0x"):
                 # Replace bytes with their value
                 self.tokenmap[tokenid] = bytes([int(value[3:5], 16)])
@@ -166,8 +167,9 @@ class BPEStreamingDetokenizer(StreamingDetokenizer):
 
     def __init__(self, tokenizer):
         # Extract the tokens in a list from id to text
-        self.tokenmap = [None] * len(tokenizer.vocab)
-        for value, tokenid in tokenizer.vocab.items():
+        vocab = tokenizer.get_vocab()
+        self.tokenmap = [None] * len(vocab)
+        for value, tokenid in vocab.items():
             self.tokenmap[tokenid] = value
 
         self.reset()

--- a/mlx_lm/tokenizer_utils.py
+++ b/mlx_lm/tokenizer_utils.py
@@ -126,10 +126,11 @@ class SPMStreamingDetokenizer(StreamingDetokenizer):
     underscore which results in linear complexity.
     """
 
+    _sep = "\u2581".encode("utf-8")
+
     def __init__(self, tokenizer, trim_space=True):
         super().__init__()
         self.trim_space = trim_space
-        self._sep = "\u2581".encode()
 
         ids = list(range(len(tokenizer)))
         tokens = tokenizer.convert_ids_to_tokens(ids)

--- a/mlx_lm/tokenizer_utils.py
+++ b/mlx_lm/tokenizer_utils.py
@@ -43,6 +43,11 @@ class StreamingDetokenizer(abc.ABC):
         # Now detokenizer.text should match tokenizer.decode(detokenizer.tokens)
     """
 
+    # Set by reset(); text is a property on some subclasses.
+    text: str
+    tokens: List[int]
+    offset: int
+
     @abc.abstractmethod
     def reset(self):
         """Drop all streaming state, keeping data derived from the tokenizer."""
@@ -73,6 +78,7 @@ class NaiveStreamingDetokenizer(StreamingDetokenizer):
     """
 
     def __init__(self, tokenizer):
+        super().__init__()
         self._tokenizer = tokenizer
         self._tokenizer.decode([0])
         probe = tokenizer.encode("a ,b", add_special_tokens=False)
@@ -120,6 +126,7 @@ class SPMStreamingDetokenizer(StreamingDetokenizer):
     """
 
     def __init__(self, tokenizer, trim_space=True):
+        super().__init__()
         self.trim_space = trim_space
         self._sep = "\u2581".encode()
 

--- a/tests/test_tokenizers.py
+++ b/tests/test_tokenizers.py
@@ -98,6 +98,19 @@ class TestTokenizers(unittest.TestCase):
         self.assertEqual(text_a, tokenizer.decode(a))
         self.assertEqual(text_b, tokenizer.decode(b))
 
+    def test_naive_detokenizer_holds_back_partial_characters(self):
+        tokenizer = load_tokenizer("mlx-community/Qwen1.5-0.5B-Chat-4bit")
+        tokenizer = TokenizerWrapper(
+            tokenizer._tokenizer, detokenizer_class=NaiveStreamingDetokenizer
+        )
+        # Half of a multi-byte character.
+        partial = 3219
+        self.assertEqual(tokenizer.decode([partial]).count("�"), 2)
+
+        detokenizer = tokenizer.detokenizer
+        detokenizer.add_token(partial)
+        self.assertEqual(detokenizer.last_segment, "")
+
     def test_special_tokens(self):
         tokenizer_repo = "mlx-community/DeepSeek-Coder-V2-Lite-Instruct-4bit-mlx"
         tokenizer = load_tokenizer(tokenizer_repo)

--- a/tests/test_tokenizers.py
+++ b/tests/test_tokenizers.py
@@ -67,13 +67,14 @@ class TestTokenizers(unittest.TestCase):
 
         # Try one with a naive detokenizer
         tokenizer = load_tokenizer("mlx-community/Llama-3.2-1B-Instruct-4bit")
-        tokenizer._detokenizer_class = NaiveStreamingDetokenizer
+        tokenizer = TokenizerWrapper(
+            tokenizer._tokenizer, detokenizer_class=NaiveStreamingDetokenizer
+        )
         self.assertIsInstance(tokenizer.detokenizer, NaiveStreamingDetokenizer)
         self.check_tokenizer(tokenizer)
 
     def test_detokenizers_are_independent(self):
-        # The batched server keeps one detokenizer per in-flight request, so
-        # shared state between them would mix their text.
+        # The batched server keeps one detokenizer per in-flight request.
         tokenizer = load_tokenizer("mlx-community/Llama-3.2-1B-Instruct-4bit")
         a = tokenizer.encode("over 40 years", add_special_tokens=False)
         b = tokenizer.encode("disengage, allowing now", add_special_tokens=False)

--- a/tests/test_tokenizers.py
+++ b/tests/test_tokenizers.py
@@ -67,8 +67,35 @@ class TestTokenizers(unittest.TestCase):
 
         # Try one with a naive detokenizer
         tokenizer = load_tokenizer("mlx-community/Llama-3.2-1B-Instruct-4bit")
-        tokenizer._detokenizer = NaiveStreamingDetokenizer(tokenizer)
+        tokenizer._detokenizer_class = NaiveStreamingDetokenizer
+        self.assertIsInstance(tokenizer.detokenizer, NaiveStreamingDetokenizer)
         self.check_tokenizer(tokenizer)
+
+    def test_detokenizers_are_independent(self):
+        # The batched server keeps one detokenizer per in-flight request, so
+        # shared state between them would mix their text.
+        tokenizer = load_tokenizer("mlx-community/Llama-3.2-1B-Instruct-4bit")
+        a = tokenizer.encode("over 40 years", add_special_tokens=False)
+        b = tokenizer.encode("disengage, allowing now", add_special_tokens=False)
+        n = min(len(a), len(b))
+        a, b = a[:n], b[:n]
+
+        da, db = tokenizer.detokenizer, tokenizer.detokenizer
+        self.assertIsNot(da, db)
+
+        text_a = text_b = ""
+        for ta, tb in zip(a, b):
+            da.add_token(ta)
+            text_a += da.last_segment
+            db.add_token(tb)
+            text_b += db.last_segment
+        da.finalize()
+        text_a += da.last_segment
+        db.finalize()
+        text_b += db.last_segment
+
+        self.assertEqual(text_a, tokenizer.decode(a))
+        self.assertEqual(text_b, tokenizer.decode(b))
 
     def test_special_tokens(self):
         tokenizer_repo = "mlx-community/DeepSeek-Coder-V2-Lite-Instruct-4bit-mlx"


### PR DESCRIPTION
- ☑️ I understand it is strictly prohibited to use AI to write PR description
- AI usage disclosure: ideation/parts of the refactor

The detokenizer is now constructed in __init__, the @detokenizer property copies it (the token map is just referenced) + resets the copy. This fixes TTFT regression and the access error.

supersedes #1873 
closes #1435
closes #1576