### PR TITLE
Recover qwen3_coder parameter names when the model drops the '>'

### DIFF
--- a/mlx_lm/tool_parsers/qwen3_coder.py
+++ b/mlx_lm/tool_parsers/qwen3_coder.py
@@ -13,6 +13,7 @@ import regex as re
 
 _function_regex = re.compile(r"<function=(.*?)</function>$", re.DOTALL)
 _parameter_regex = re.compile(r"<parameter=(.*?)</parameter>", re.DOTALL)
+_name_regex = re.compile(r"\s*([^\s<>]+)>?")
 
 _string_types = {"string", "str", "text", "varchar", "char", "enum"}
 _bool_types = {"boolean", "bool", "binary"}
@@ -87,7 +88,7 @@ def _convert_param_value(param_value: str, param_name: str, param_config: dict) 
 
 
 def _parse_xml_function_call(function_call_str: str, tools: Optional[Any]):
-    name_match = re.match(r"\s*([^\s<>]+)>?", function_call_str)
+    name_match = _name_regex.match(function_call_str)
     if name_match is None:
         raise ValueError("No function name provided.")
     function_name = name_match.group(1)
@@ -95,9 +96,11 @@ def _parse_xml_function_call(function_call_str: str, tools: Optional[Any]):
     parameters = function_call_str[name_match.end() :]
     param_dict = {}
     for match_text in _parameter_regex.findall(parameters):
-        idx = match_text.index(">")
-        param_name = match_text[:idx]
-        param_value = str(match_text[idx + 1 :])
+        param_match = _name_regex.match(match_text)
+        if param_match is None:
+            continue
+        param_name = param_match.group(1)
+        param_value = str(match_text[param_match.end() :])
         if param_value.startswith("\n"):
             param_value = param_value[1:]
         if param_value.endswith("\n"):

--- a/tests/test_tool_parsing.py
+++ b/tests/test_tool_parsing.py
@@ -579,6 +579,34 @@ class TestToolParsing(unittest.TestCase):
         self.assertEqual(tool_call["name"], "get_current_time")
         self.assertEqual(tool_call["arguments"], {})
 
+    def test_qwen3_coder_missing_parameter_tag_close(self):
+        """Recover the parameter name when the model drops the ">" after it."""
+        tools = [
+            {
+                "type": "function",
+                "function": {
+                    "name": "read_file",
+                    "description": "Read a file",
+                    "parameters": {
+                        "type": "object",
+                        "required": ["path"],
+                        "properties": {"path": {"type": "string"}},
+                    },
+                },
+            }
+        ]
+        # Missing ">" after the parameter name
+        test_case = (
+            "<function=read_file>\n"
+            "<parameter=path\n"
+            "/etc/hosts\n"
+            "</parameter>\n"
+            "</function>"
+        )
+        tool_call = qwen3_coder.parse_tool_call(test_case, tools)
+        self.assertEqual(tool_call["name"], "read_file")
+        self.assertEqual(tool_call["arguments"]["path"], "/etc/hosts")
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
Qwen3 coder (and related models with the same parser) dropping closing tags for parameter names. 
_parse_xml_function_call located parameter names with match_text.index(">"), which misses a dropped '>', scanning past it to the next one in the buffer breaking the parameter name parsing, and raises ValueError when none is present. 
Reusing the same tolerant pattern which is already used for the function name, but added to a module-level _name_regex, utilizing a similar fix from #1811. Alternatively there have been similar fixes for parameter values, but never parameter names on a module-level. 

- ☑️ I understand it is strictly prohibited to use AI to write PR description
- AI usage disclosure: Utilized claude opus 5 to fix this as i came across this bug while working with Qwen3.6-35B-A3B-4bit, used it to check the issue across by benchmarking multiple tool call loops to verify issue before fixes. 